### PR TITLE
Correctly filter source comments

### DIFF
--- a/skyportal/handlers/comment.py
+++ b/skyportal/handlers/comment.py
@@ -8,8 +8,8 @@ class SourceCommentsHandler(BaseHandler):
     def get(self, source_id):
         results = (DBSession
                    .query(Comment, User.username)
-                   .filter(Source.id == source_id)
-                   .filter(User.id == Comment.user_id))
+                   .join(User)
+                   .filter(Comment.source_id == source_id))
         comments = [
             {**comment.to_dict(), 'username': username}
             for (comment, username) in results

--- a/skyportal/model_util.py
+++ b/skyportal/model_util.py
@@ -50,14 +50,17 @@ if __name__ == "__main__":
         models.DBSession().commit()
 
     with status("Creating dummy sources"):
-        SOURCES = [{'id': '14gqr', 'ra': 353.36647, 'dec': 33.656149, 'red_shift': 0.063},
-                   {'id': '16fil', 'ra': 322.718872, 'dec': 27.574113, 'red_shift': 0.0}]
+        SOURCES = [{'id': '14gqr', 'ra': 353.36647, 'dec': 33.656149, 'red_shift': 0.063,
+                    'comments': ["No source at transient location to R>26 in LRIS imaging"
+                                 "Strong calcium lines have emerged."]},
+                   {'id': '16fil', 'ra': 322.718872, 'dec': 27.574113, 'red_shift': 0.0,
+                    'comments': ["Frogs in the pond", "The eagle has landed"]}]
+
         for source_info in SOURCES:
+            comments = source_info.pop('comments')
+
             s = models.Source(**source_info)
-            s.comments = [models.Comment(text="No source at transient location to"
-                                         "R>26 in LRIS imaging", user=u),
-                          models.Comment(text="Strong calcium lines have emerged.",
-                                         user=u)]
+            s.comments = [models.Comment(text=comment, user=u) for comment in comments]
 
             phot_file = os.path.join(os.path.dirname(__file__), 'tests', 'data',
                                      'phot.csv')

--- a/static/js/components/CommentList.jsx
+++ b/static/js/components/CommentList.jsx
@@ -8,7 +8,7 @@ const CommentList = ({source, comments, addComment}) => {
   const items = comments.map(({id, username, created_at, text}) => (
     <span key={id}>
       <div className={styles.commentHeader}>
-        On {created}, {username} wrote:
+        On {created_at}, {username} wrote:
       </div>
       <div className={styles.commentMessage}>
         {text}


### PR DESCRIPTION
- Correct the SQLAlchemy query
- Add different comments to different sources, so that filtering
  can be visually inspected
- Fix incorrect `created_at` field in rendering