### PR TITLE
Log WebSocket actions, and use more intuitive API action names

### DIFF
--- a/static/js/API.js
+++ b/static/js/API.js
@@ -36,7 +36,7 @@ function API(endpoint, actionType,
 
         let json = await response.json();
         if (json.status == "success") {
-          dispatch({type: actionType, ...json});
+          dispatch({type: actionType + "_OK", ...json});
           return json["data"];
         } else {
           /* In case of an error, dispatch an action that contains

--- a/static/js/CustomMessageHandler.js
+++ b/static/js/CustomMessageHandler.js
@@ -5,6 +5,8 @@ let CustomMessageHandler = dispatch => {
   return new MessageHandler(dispatch, message => {
     let {action, payload} = message;
 
+    console.log('WebSocket', action, payload);
+
     switch (action) {
 
     default:

--- a/static/js/actions.js
+++ b/static/js/actions.js
@@ -1,39 +1,51 @@
-export const RECEIVE_SOURCES = 'skyportal/RECEIVE_SOURCES';
-export const RECEIVE_LOADED_SOURCE = 'skyportal/RECEIVE_LOADED_SOURCE';
-export const RECEIVE_LOADED_SOURCE_FAIL = 'skyportal/RECEIVE_LOADED_SOURCE_FAIL';
-export const RECEIVE_SOURCE_PLOT = 'skyportal/RECEIVE_SOURCE_PLOT';
-export const RECEIVE_SOURCE_PLOT_FAIL = 'skyportal/RECEIVE_SOURCE_PLOT_FAIL';
-export const RECEIVE_GROUPS = 'skyportal/RECEIVE_GROUPS';
-export const RECEIVE_GROUP = 'skyportal/RECEIVE_GROUP';
-export const RECEIVE_GROUP_FAIL = 'skyportal/RECEIVE_GROUP_FAIL';
+export const FETCH_SOURCES = 'skyportal/FETCH_SOURCES';
+export const FETCH_SOURCES_OK = 'skyportal/FETCH_SOURCES_OK';
+
+export const FETCH_LOADED_SOURCE = 'skyportal/FETCH_LOADED_SOURCE';
+export const FETCH_LOADED_SOURCE_OK = 'skyportal/FETCH_LOADED_SOURCE_OK';
+export const FETCH_LOADED_SOURCE_FAIL = 'skyportal/FETCH_LOADED_SOURCE_FAIL';
+
+export const FETCH_SOURCE_PLOT = 'skyportal/FETCH_SOURCE_PLOT';
+export const FETCH_SOURCE_PLOT_OK = 'skyportal/FETCH_SOURCE_PLOT_OK';
+export const FETCH_SOURCE_PLOT_FAIL = 'skyportal/FETCH_SOURCE_PLOT_FAIL';
+
+export const FETCH_GROUPS = 'skyportal/FETCH_GROUPS';
+export const FETCH_GROUPS_OK = 'skyportal/FETCH_GROUPS_OK';
+
+export const FETCH_GROUP = 'skyportal/FETCH_GROUP';
+export const FETCH_GROUP_OK = 'skyportal/FETCH_GROUP_OK';
+
 export const ADD_COMMENT = 'skyportal/ADD_COMMENT';
+export const ADD_COMMENT_OK = 'skyportal/ADD_COMMENT_OK';
+
 export const FETCH_COMMENTS = 'skyportal/FETCH_COMMENTS';
-export const RECEIVE_COMMENTS = 'skyportal/RECEIVE_COMMENTS';
-export const RECEIVE_COMMENTS_FAIL = 'skyportal/RECEIVE_COMMENTS_FAIL';
-export const RECEIVE_USER_PROFILE = 'skyportal/RECEIVE_USER_PROFILE';
+export const FETCH_COMMENTS_OK = 'skyportal/FETCH_COMMENTS_OK';
+
+export const FETCH_USER_PROFILE = 'skyportal/FETCH_USER_PROFILE';
+export const FETCH_USER_PROFILE_OK = 'skyportal/FETCH_USER_PROFILE_OK';
 
 
 import * as API from './API';
 
 
 export function fetchSource(id) {
-  return API.GET(`/api/sources/${id}`, RECEIVE_LOADED_SOURCE);
+  return API.GET(`/api/sources/${id}`, FETCH_LOADED_SOURCE);
 }
 
 export function fetchSources() {
-  return API.GET('/api/sources', RECEIVE_SOURCES);
+  return API.GET('/api/sources', FETCH_SOURCES);
 }
 
 export function fetchGroup(id) {
-  return API.GET(`/api/groups/${id}`, RECEIVE_GROUP);
+  return API.GET(`/api/groups/${id}`, FETCH_GROUP);
 }
 
 export function fetchGroups() {
-  return API.GET('/api/groups', RECEIVE_GROUPS);
+  return API.GET('/api/groups', FETCH_GROUPS);
 }
 
 export function fetchUserProfile() {
-  return API.GET('/api/profile', RECEIVE_USER_PROFILE);
+  return API.GET('/api/profile', FETCH_USER_PROFILE);
 }
 
 export function hydrate() {

--- a/static/js/containers/PlotContainer.jsx
+++ b/static/js/containers/PlotContainer.jsx
@@ -2,11 +2,11 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import Plot from '../components/Plot';
-import { RECEIVE_SOURCE_PLOT } from '../actions';
+import { FETCH_SOURCE_PLOT } from '../actions';
 import * as API from '../API';
 
 let fetchPlotData = (url) => (
-  API.GET(url, RECEIVE_SOURCE_PLOT)
+  API.GET(url, FETCH_SOURCE_PLOT)
 );
 
 const PlotContainer = connect(null, {fetchPlotData})(Plot);

--- a/static/js/reducers.js
+++ b/static/js/reducers.js
@@ -7,14 +7,14 @@ import * as Action from './actions';
 // Reducer for currently displayed source
 export function sourceReducer(state={ source: null, loadError: false }, action) {
   switch (action.type) {
-    case Action.RECEIVE_LOADED_SOURCE:
+    case Action.FETCH_LOADED_SOURCE_OK:
       let source = action.data;
       return {
         ...state,
         ...source,
         loadError: false
       };
-    case Action.RECEIVE_LOADED_SOURCE_FAIL:
+    case Action.FETCH_LOADED_SOURCE_FAIL:
       return {
         ...state,
         loadError: true
@@ -26,7 +26,7 @@ export function sourceReducer(state={ source: null, loadError: false }, action) 
 
 export function sourcesReducer(state={ latest: [] }, action) {
   switch (action.type) {
-    case Action.RECEIVE_SOURCES:
+    case Action.FETCH_SOURCES_OK:
       let sources = action.data;
       return {
         ...state,
@@ -39,7 +39,7 @@ export function sourcesReducer(state={ latest: [] }, action) {
 
 export function groupReducer(state={}, action) {
   switch (action.type) {
-    case Action.RECEIVE_GROUP:
+    case Action.FETCH_GROUP_OK:
       return action.data;
     default:
       return state;
@@ -48,7 +48,7 @@ export function groupReducer(state={}, action) {
 
 export function groupsReducer(state={ latest: [] }, action) {
   switch (action.type) {
-    case Action.RECEIVE_GROUPS:
+    case Action.FETCH_GROUPS_OK:
       let groups = action.data;
       return {
         ...state,
@@ -61,7 +61,7 @@ export function groupsReducer(state={ latest: [] }, action) {
 
 export function profileReducer(state={ username: '' }, action) {
   switch (action.type) {
-    case Action.RECEIVE_USER_PROFILE:
+    case Action.FETCH_USER_PROFILE_OK:
       return action.data;
     default:
       return state;


### PR DESCRIPTION
This is an attempt to make the console messages easier to debug.  They
should now look like this:

- WebSocket skyportal/FETCH_COMMENTS {source_id: "14gqr"}
- Action API_CALL
- Action FETCH_COMMENTS_OK