### PR TITLE
Add `public` flag to `Group`s

### DIFF
--- a/skyportal/tests/conftest.py
+++ b/skyportal/tests/conftest.py
@@ -55,9 +55,20 @@ variable injection performed by `pytest_factoryboy.register` is working.
 #         group=LazyFixture("group"))
 
 
+# TODO can we remove `autouse` here?
 @pytest.fixture(autouse=True)
 def public_group():
-    return GroupFactory()
+    return GroupFactory(public=True)
+
+
+@pytest.fixture(autouse=True)
+def owned_group():
+    return GroupFactory(public=False)
+
+
+@pytest.fixture(autouse=True)
+def private_group():
+    return GroupFactory(public=False)
 
 
 @pytest.fixture(autouse=True)
@@ -66,11 +77,16 @@ def public_source(public_group):
 
 
 @pytest.fixture(autouse=True)
-def private_source():
-    return SourceFactory(groups=[])
+def owned_source(owned_group):
+    return SourceFactory(groups=[owned_group])
 
 
 @pytest.fixture(autouse=True)
-def user(public_group):
-    return UserFactory(groups=[public_group],
+def private_source(private_group):
+    return SourceFactory(groups=[private_group])
+
+
+@pytest.fixture(autouse=True)
+def user(owned_group):
+    return UserFactory(groups=[owned_group],
                        roles=[models.Role.query.get('Full user')])

--- a/skyportal/tests/fixtures.py
+++ b/skyportal/tests/fixtures.py
@@ -121,16 +121,3 @@ class UserFactory(factory.alchemy.SQLAlchemyModelFactory):
                 obj.groups.append(group)
                 DBSession().add(obj)
                 DBSession().commit()
-
-
-#    @classmethod
-#    def _create(cls, model_class, *args, **kwargs):
-#        """Get `User` if it already exists, otherwise create/add a new one."""
-#        q = cls._meta.sqlalchemy_session.query(model_class)
-#        for key, value in kwargs.items():
-#            q = q.filter(getattr(model_class, key) == value)
-#        obj = q.first()
-#        if obj is None:
-#            return super(UserFactory, cls)._create(model_class, *args, **kwargs)
-#        else:
-#            return obj

--- a/skyportal/tests/frontend/test_frontpage.py
+++ b/skyportal/tests/frontend/test_frontpage.py
@@ -3,10 +3,11 @@ from selenium import webdriver
 from selenium.webdriver.common.by import By
 
 
-def test_front_page(driver, user, public_source, private_source):
+def test_front_page(driver, user, public_source, owned_source, private_source):
     driver.get(f"/become_user/{user.id}")  # TODO decorator/context manager?
     assert 'localhost' in driver.current_url
     driver.wait_for_xpath("//div[contains(@title,'connected')]")
     driver.wait_for_xpath('//h2[contains(text(), "List of Sources")]')
     driver.wait_for_xpath(f'//a[text()="{public_source.id}"]')
+    driver.wait_for_xpath(f'//a[text()="{owned_source.id}"]')
     driver.wait_for_xpath_missing('//a[text()="{private_source.id}"]')

--- a/skyportal/tests/frontend/test_sources.py
+++ b/skyportal/tests/frontend/test_sources.py
@@ -3,10 +3,18 @@ from selenium import webdriver
 from selenium.webdriver.common.by import By
 
 
-def test_source_page(driver, user, public_source):
+def test_public_source_page(driver, user, public_source):
     driver.get(f"/become_user/{user.id}")  # TODO decorator/context manager?
     driver.get(f"/source/{public_source.id}")
     driver.wait_for_xpath(f'//div[text()="{public_source.id}"]')
+    driver.wait_for_xpath('//label[contains(text(), "band")]')  # TODO how to check plot?
+    driver.wait_for_xpath('//label[contains(text(), "Fe III")]')
+
+
+def test_owned_source_page(driver, user, owned_source):
+    driver.get(f"/become_user/{user.id}")  # TODO decorator/context manager?
+    driver.get(f"/source/{owned_source.id}")
+    driver.wait_for_xpath(f'//div[text()="{owned_source.id}"]')
     driver.wait_for_xpath('//label[contains(text(), "band")]')  # TODO how to check plot?
     driver.wait_for_xpath('//label[contains(text(), "Fe III")]')
 


### PR DESCRIPTION
Sources that belong to a public group are viewable to all users; specific actions (commenting, uploading files, etc.) still require the relevant ACLs.

Closes #48.