### PR TITLE
Refactor server launching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,12 +24,19 @@ ENV LANG=C.UTF-8
 ADD . /skyportal
 WORKDIR /skyportal
 
-RUN bash -c "source /skyportal_env/bin/activate && \
+RUN bash -c "\
+    source /skyportal_env/bin/activate && \
+    \
     make paths && \
-    make dependencies || echo 'npm: failed first run, trying again' && \
-    make dependencies && \
+    (make dependencies || make dependencies) && \
+    \
+    make bundle && \
+    rm -rf node_modules && \
+    \
     chown -R skyportal.skyportal /skyportal_env && \
-    chown -R skyportal.skyportal /skyportal"
+    chown -R skyportal.skyportal /skyportal && \
+    \
+    cp docker.yaml config.yaml"
 
 USER skyportal
 
@@ -37,4 +44,4 @@ EXPOSE 5000
 
 CMD bash -c "source /skyportal_env/bin/activate && \
              (make log &) && \
-	     make dockerrun"
+             make run_production"

--- a/Makefile
+++ b/Makefile
@@ -48,14 +48,30 @@ log: paths
 	./baselayer/tools/watch_logs.py
 
 run: paths dependencies
-	@echo "Supervisor will now fire up various micro-services."
+	@echo "Supervisor will now fire up various services."
 	@echo
-	@echo " - Please run \`make log\` in another terminal to view logs"
-	@echo " - Press Ctrl-C to abort the server"
+	@echo " - Run \`make log\` in another terminal to view logs"
 	@echo " - Run \`make monitor\` in another terminal to restart services"
 	@echo
-	@$(ENV_SUMMARY)
-	@$(SUPERVISORD)
+	@echo "The server is in debug mode:"
+	@echo "  JavaScript and Python files will be reloaded upon change."
+	@echo
+
+	@FLAGS="--debug" && \
+	$(ENV_SUMMARY) && echo && \
+	echo "Press Ctrl-C to abort the server" && \
+	echo && \
+	$(SUPERVISORD)
+
+run_production:
+	export FLAGS="--config config.yaml" && \
+	$(ENV_SUMMARY) && \
+	$(SUPERVISORD)
+
+run_testing: paths dependencies
+	export FLAGS="--config _test_config.yaml" && \
+	$(ENV_SUMMARY) && \
+	$(SUPERVISORD)
 
 monitor:
 	@echo "Entering supervisor control panel."
@@ -65,25 +81,6 @@ monitor:
 # Attach to terminal of running webserver; useful to, e.g., use pdb
 attach:
 	$(SUPERVISORCTL) fg app
-
-testrun: paths dependencies
-	export FLAGS="--config _test_config.yaml" && \
-	$(ENV_SUMMARY) && \
-	$(SUPERVISORD)
-
-dockerrun: paths dependencies
-	export FLAGS="--config docker.yaml" && \
-	$(ENV_SUMMARY) && \
-	$(SUPERVISORD)
-
-debug:
-	@echo
-	@echo "Starting web service in debug mode"
-	@echo "Press Ctrl-D to stop"
-	@echo
-	@FLAGS="--debug" && $(ENV_SUMMARY) && $(SUPERVISORD) &
-	@sleep 1 && $(SUPERVISORCTL) -i status
-	@$(SUPERVISORCTL) shutdown
 
 clean:
 	rm $(bundle)

--- a/tools/test_frontend.py
+++ b/tools/test_frontend.py
@@ -69,7 +69,7 @@ if __name__ == '__main__':
 
     clear_tables()
 
-    web_client = subprocess.Popen(['make', 'testrun'], cwd=base_dir,
+    web_client = subprocess.Popen(['make', 'run_testing'], cwd=base_dir,
                                   preexec_fn=os.setsid)
 
     print('[test_frontend] Waiting for supervisord to launch all server processes...')


### PR DESCRIPTION
- The old `make debug` is now `make run` (i.e., `make run` always
  starts in debug mode)
- A new target, `run_production`, is added, which starts without the
  `--debug` flag, and loads `config.yaml`.
- The `testrun` target is now called `run_testing`.
- The `rundocker` target has been removed, use `run_production`.
- Switch to the newest baselayer, which allows switching off the
  `webpack` service.  This is necessary to fire up the server without
  `node_modules` present---something we want to do in the Docker
  container.  (All Javascript files are packed into
  `static/bundle.js`.)