### PR TITLE
Fetch sources when source lists are loaded

### DIFF
--- a/skyportal/tests/frontend/test_frontpage.py
+++ b/skyportal/tests/frontend/test_frontpage.py
@@ -7,6 +7,6 @@ def test_front_page(driver, user, public_source, private_source):
     driver.get(f"/become_user/{user.id}")  # TODO decorator/context manager?
     assert 'localhost' in driver.current_url
     driver.wait_for_xpath("//div[contains(@title,'connected')]")
-    driver.wait_for_xpath('//h2[contains(text(), "List of Sources")]')
+    driver.wait_for_xpath('//h2[contains(text(), "Sources")]')
     driver.wait_for_xpath(f'//a[text()="{public_source.id}"]')
     driver.wait_for_xpath_missing('//a[text()="{private_source.id}"]')

--- a/static/js/actions.js
+++ b/static/js/actions.js
@@ -50,8 +50,6 @@ export function fetchUserProfile() {
 export function hydrate() {
   return (dispatch) => {
     dispatch(fetchUserProfile());
-    dispatch(fetchSources());
-    dispatch(fetchGroups());
   };
 }
 

--- a/static/js/components/SourceList.jsx
+++ b/static/js/components/SourceList.jsx
@@ -5,7 +5,7 @@ import { Link } from 'react-router-dom';
 
 const SourceList = ({ sources }) => (
   <div>
-    <h2>List of Sources</h2>
+    <h2>Sources</h2>
     <ul>
       {
         sources.map((source, idx) => (

--- a/static/js/containers/SourceListContainer.jsx
+++ b/static/js/containers/SourceListContainer.jsx
@@ -1,6 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
+import * as Action from '../actions';
+
 import SourceList from '../components/SourceList';
+
+
+class SourceListContainer extends React.Component {
+  componentDidMount() {
+    if (!this.props.sources) {
+      this.props.dispatch(Action.fetchSources());
+    }
+  }
+
+  render() {
+    if (this.props.sources) {
+      return <SourceList sources={this.props.sources} />;
+    } else {
+      return "Loading sources...";
+    }
+  }
+}
+
+SourceListContainer.propTypes = {
+  dispatch: PropTypes.func.isRequired,
+  sources: PropTypes.arrayOf(PropTypes.object)
+};
+
+SourceListContainer.defaultProps = {
+  sources: null
+};
 
 const mapStateToProps = (state, ownProps) => (
   {
@@ -8,4 +38,4 @@ const mapStateToProps = (state, ownProps) => (
   }
 );
 
-export default connect(mapStateToProps)(SourceList);
+export default connect(mapStateToProps)(SourceListContainer);

--- a/static/js/reducers.js
+++ b/static/js/reducers.js
@@ -25,7 +25,7 @@ export function sourceReducer(state={ source: null, loadError: false }, action) 
   }
 }
 
-export function sourcesReducer(state={ latest: [] }, action) {
+export function sourcesReducer(state={ latest: null }, action) {
   switch (action.type) {
     case Action.FETCH_SOURCES_OK: {
       const sources = action.data;
@@ -48,7 +48,7 @@ export function groupReducer(state={}, action) {
   }
 }
 
-export function groupsReducer(state={ latest: [] }, action) {
+export function groupsReducer(state={ latest: null }, action) {
   switch (action.type) {
     case Action.FETCH_GROUPS_OK: {
       const groups = action.data;


### PR DESCRIPTION
Previously, the sources were fetched upon hydration; i.e., with each
and every page fetch.  Now, only the profile information is retrieved
during hydration.

Closes #60 