### PR TITLE
Update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,97 +20,10 @@ Please see the <a href="https://skyportal.io">project homepage</a> for more info
 
 <a href="https://github.com/openjournals/joss-reviews/issues/"><img src="http://joss.theoj.org/papers/28a83ab43ff3ca23cdd831e82877365a/status.svg"></a>
 
-## Installation on a Mac
+## Installation
 
-- Clone the repo and start the virtual env:
+Please see <a href="https://skyportal.io/docs/setup.html#installation">installation docs on the website</a>.
 
-```
-git clone https://github.com/skyportal/skyportal.git
-cd skyportal/
-virtualenv skyportal_env
-source skyportal_env/bin/activate
-```
+## Usage
 
-- Install dependencies and start postgres
-
-```
-brew install install supervisor nginx postgresql node geckodriver
-brew services start postgresql
-```
-
-- Create the database
-
-```
-make db_init
-```
-
-- Start
-
-```
-cp docker.yaml config.yaml
-```
-
-edit `config.yaml` so that the database points to `localhost` then
-
-```
-PYTHONPATH=$PYTHONPATH:"." python skyportal/initial_setup.py  \
-           --adminuser=<email>
-make run
-```
-This will create an admin user with the username=`<email>`. If you want to add a normal user later on include
-the `--nodrop` flag:
-
-```
-PYTHONPATH=$PYTHONPATH:"." python skyportal/initial_setup.py  \
-          --nodrop --user=<anotheremail>
-```
-
-## To Use Locally with Docker-Compose
-
-Make the docker image:
-
-```
-make docker-local
-```
-
-Start the docker compose
-
-```
-docker-compose up
-```
-
-Connect to the front-end at <a href="http://localhost:9000">http://localhost:9000</a>
-
-## Developer notes
-
-### Important Makefile targets
-
-General:
-
-- help : Describe make targets
-
-DB preparation:
-
-- db_init : Create database
-- db_clear : Drop and re-create DB
-
-Launching:
-
-- debug : Launch app in debug mode, which auto-refreshes files and
-          monitors micro-services
-- log : Tail all log files
-
-Testing:
-
-- test : Launch web app & execute frontend tests
-- test_headless : (Linux only) The above, but without a visible
-                  browser
-
-Development:
-
-- lint : Run ESLint on all files.  Installs ESLint if necessary.
-- lint-unix : Same as above, but outputs in a format that most text
-              editors can parse
-- lint-githook : Install a Git pre-commit hook that lints staged
-                 chunks (this is done automatically when you lint
-                 for the first time).
+Please see <a href="https://skyportal.io/docs/usage.html">usage docs on the website</a>.

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -1,22 +1,46 @@
 # Setup
 ## Installation
 - A Python 3.6 or later installation is required
-- Install the following dependencies: Supervisor, NGINX, PostgreSQL, Node.JS
+- Install the following dependencies:
+  - Supervisor (v>=3.0b2)
+  - NGINX (v>=1.7)
+  - PostgreSQL (v>=9.6)
+  - Node.JS/npm (v>=5.8.0)
+
   - On macOS:
-    - Using [Homebrew](http://brew.sh/): `brew install supervisor nginx postgresql node`
+    - Clone the repo and start the virtual env:
+
+      ```
+      git clone https://github.com/skyportal/skyportal.git
+      cd skyportal/
+      virtualenv skyportal_env
+      source skyportal_env/bin/activate
+      ```
+    - If using [Homebrew](http://brew.sh/): `brew install supervisor nginx postgresql node`
+      - If running the test suite, `geckodriver` is also needed: `brew install geckodriver`
     - Start the postgresql server:
       - to start automatically at login: `brew services start postgresql`
       - to start manually: `pg_ctl -D /usr/local/var/postgres start`
   - On Linux:
-    - Using `apt-get`: `sudo apt-get install nginx supervisor postgresql libpq-dev npm nodejs-legacy`
+    - Using `apt`: `sudo apt install nginx supervisor postgresql libpq-dev npm nodejs-legacy`
     - It may be necessary to configure your database permissions: at the end of your `pg_hba.conf` (typically in `/etc/postgresql/9.6/main`), add the following lines and restart PostgreSQL (`sudo service postgresql restart`):
       ```
       local all postgres peer
       local skyportal skyportal trust
       local skyportal_test skyportal trust
       ```
+    - If running the test suite, install `geckodriver`:
+      ```
+      GECKO_VER=0.24.0
+      wget https://github.com/mozilla/geckodriver/releases/download/v${GECKO_VER}/geckodriver-v${GECKO_VER}-linux64.tar.gz
+      sudo tar -xzf geckodriver-v${GECKO_VER}-linux64.tar.gz -C /usr/local/bin
+      rm geckodriver-v${GECKO_VER}-linux64.tar.gz
+      which geckodriver
+      geckodriver --version
+      ```
+
 - Initialize the database with `make db_init` (also tests that your permissions have been properly configured)
-- Run `make` to start the server and navigate to `localhost:5000`
+- Run `make run` to start the server and navigate to `localhost:5000`
 
 ## Configuration
 - Copy `config.yaml.defaults` to `config.yaml` and customize.

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -11,3 +11,33 @@ Access to resources in Skyportal is controlled in two ways:
 - Groups membership can be managed on the `/groups/` page  # TODO not fully implemented
 ## Connecting streams and groups
 - Not yet implemented
+## Important Makefile targets
+
+General:
+
+- help : Describe make targets
+
+DB preparation:
+
+- db_init : Create database
+- db_clear : Drop and re-create DB
+
+Launching:
+
+- run : Launch the web application
+- log : Tail all log files
+
+Testing:
+
+- test : Launch web app & execute frontend tests
+- test_headless : (Linux only) The above, but without a visible
+                  browser
+
+Development:
+
+- lint : Run ESLint on all files.  Installs ESLint if necessary.
+- lint-unix : Same as above, but outputs in a format that most text
+              editors can parse
+- lint-githook : Install a Git pre-commit hook that lints staged
+                 chunks (this is done automatically when you lint
+                 for the first time).


### PR DESCRIPTION
- Have installation instructions in one place only (on the website)
- Correctly include `geckodriver` installation instructions
- Clarify that homebrew is a mechanism of installing dependencies, but not the only avenue
- Expand usage docs on website

Partially addresses https://github.com/skyportal/skyportal/issues/127 