### PR TITLE
Return skyportal version with each API response

### DIFF
--- a/skyportal/handlers/__init__.py
+++ b/skyportal/handlers/__init__.py
@@ -1,4 +1,4 @@
-from baselayer.app.handlers import (BaseHandler, MainPageHandler,
+from baselayer.app.handlers import (MainPageHandler,
                                     SocketAuthTokenHandler, ProfileHandler,
                                     LogoutHandler)
 from baselayer.app.custom_exceptions import AccessError
@@ -14,4 +14,4 @@ from .photometry import PhotometryHandler
 from .token import TokenHandler
 from .sysinfo import SysInfoHandler
 from .userinfo import UserInfoHandler
-
+from .base import BaseHandler

--- a/skyportal/handlers/base.py
+++ b/skyportal/handlers/base.py
@@ -1,0 +1,16 @@
+from baselayer.app.handlers.base import BaseHandler as BaselayerHandler
+import skyportal
+
+
+class BaseHandler(BaselayerHandler):
+    def success(self, *args, **kwargs):
+        data = kwargs.get('data', {})
+        data['version'] = skyportal.__version__
+        kwargs['data'] = data
+        super().success(*args, **kwargs)
+
+    def error(self, *args, **kwargs):
+        data = kwargs.get('data', {})
+        data['version'] = skyportal.__version__
+        kwargs['data'] = data
+        super().error(*args, **kwargs)

--- a/skyportal/handlers/base.py
+++ b/skyportal/handlers/base.py
@@ -1,16 +1,16 @@
 from baselayer.app.handlers.base import BaseHandler as BaselayerHandler
-import skyportal
+from .. import __version__
 
 
 class BaseHandler(BaselayerHandler):
     def success(self, *args, **kwargs):
         data = kwargs.get('data', {})
-        data['version'] = skyportal.__version__
+        data['version'] = __version__
         kwargs['data'] = data
         super().success(*args, **kwargs)
 
     def error(self, *args, **kwargs):
         data = kwargs.get('data', {})
-        data['version'] = skyportal.__version__
+        data['version'] = __version__
         kwargs['data'] = data
         super().error(*args, **kwargs)

--- a/skyportal/handlers/become_user.py
+++ b/skyportal/handlers/become_user.py
@@ -1,4 +1,4 @@
-from baselayer.app.handlers.base import BaseHandler
+from .base import BaseHandler
 from baselayer.app.access import permissions
 from baselayer.app.models import ACL
 from ..models import User

--- a/skyportal/handlers/comment.py
+++ b/skyportal/handlers/comment.py
@@ -1,7 +1,7 @@
 import tornado.web
 import base64
 from baselayer.app.access import permissions, auth_or_token
-from baselayer.app.handlers.base import BaseHandler
+from .base import BaseHandler
 from ..models import DBSession, Source, User, Comment, Role
 
 

--- a/skyportal/handlers/group.py
+++ b/skyportal/handlers/group.py
@@ -1,7 +1,7 @@
 import tornado.web
 from sqlalchemy.orm import joinedload
 from baselayer.app.access import permissions, auth_or_token
-from baselayer.app.handlers.base import BaseHandler
+from .base import BaseHandler
 from ..models import DBSession, Group, GroupUser, User
 
 
@@ -39,26 +39,27 @@ class GroupHandler(BaseHandler):
                 application/json:
                   schema: Error
         """
+        info = {}
         if group_id is not None:
             if 'Super admin' in [role.id for role in self.current_user.roles]:
-                info = Group.query.options(joinedload(Group.users)).options(
+                group = Group.query.options(joinedload(Group.users)).options(
                     joinedload(Group.group_users)).get(group_id)
             else:
-                info = Group.get_if_owned_by(
+                group = Group.get_if_owned_by(
                     group_id, self.current_user,
                     options=[joinedload(Group.users),
                              joinedload(Group.group_users)])
+            info['group'] = group
         else:
-            info = {}
             info['user_groups'] = list(self.current_user.groups)
             info['all_groups'] = (list(Group.query) if 'Super admin' in
                                   [role.id for role in self.current_user.roles]
                                   else None)
         if info is not None:
-            return self.success(info)
+            return self.success(data=info)
         else:
             return self.error(f"Could not load group {group_id}",
-                              {"group_id": group_id})
+                              data={"group_id": group_id})
 
     @permissions(['Manage groups'])
     def post(self):
@@ -97,7 +98,7 @@ class GroupHandler(BaseHandler):
         DBSession().commit()
 
         self.push_all(action='skyportal/FETCH_GROUPS')
-        return self.success({"id": g.id})
+        return self.success(data={"id": g.id})
 
     @permissions(['Manage groups'])
     def put(self, group_id):
@@ -202,8 +203,8 @@ class GroupUserHandler(BaseHandler):
 
         self.push_all(action='skyportal/REFRESH_GROUP',
                       payload={'group_id': gu.group_id})
-        return self.success({'group_id': gu.group_id, 'user_id': gu.user_id,
-                             'admin': gu.admin})
+        return self.success(data={'group_id': gu.group_id, 'user_id': gu.user_id,
+                                  'admin': gu.admin})
 
     @permissions(['Manage groups'])
     def delete(self, group_id, username):

--- a/skyportal/handlers/logout.py
+++ b/skyportal/handlers/logout.py
@@ -1,4 +1,4 @@
-from baselayer.app.handlers.base import BaseHandler
+from .base import BaseHandler
 from baselayer.app.access import auth_or_token
 
 import tornado.web

--- a/skyportal/handlers/photometry.py
+++ b/skyportal/handlers/photometry.py
@@ -2,7 +2,7 @@ import tornado.web
 from astropy.time import Time
 from sqlalchemy.orm import joinedload
 from baselayer.app.access import permissions, auth_or_token
-from baselayer.app.handlers.base import BaseHandler
+from .base import BaseHandler
 from ..models import DBSession, Photometry, Comment
 
 
@@ -62,7 +62,7 @@ class PhotometryHandler(BaseHandler):
             DBSession().add(p)
         DBSession().commit()
 
-        return self.success({"ids": ids})
+        return self.success(data={"ids": ids})
 
     """TODO any need for get/put/delete?
     @auth_or_token

--- a/skyportal/handlers/plot.py
+++ b/skyportal/handlers/plot.py
@@ -1,4 +1,4 @@
-from baselayer.app.handlers.base import BaseHandler
+from .base import BaseHandler
 from baselayer.app.access import auth_or_token
 from .. import plot
 
@@ -13,9 +13,9 @@ class PlotPhotometryHandler(BaseHandler):
         if docs_json is None:
             self.error(f"Note: no photometry available for source {source_id}")
         else:
-            self.success({'docs_json': docs_json, 'render_items': render_items,
-                          'custom_model_js': custom_model_js,
-                          'url': self.request.path})
+            self.success(data={'docs_json': docs_json, 'render_items': render_items,
+                               'custom_model_js': custom_model_js,
+                               'url': self.request.path})
 
 
 class PlotSpectroscopyHandler(BaseHandler):
@@ -25,6 +25,6 @@ class PlotSpectroscopyHandler(BaseHandler):
         if docs_json is None:
             self.error(f"Note: no spectroscopy available for source {source_id}")
         else:
-            self.success({'docs_json': docs_json, 'render_items': render_items,
-                          'custom_model_js': custom_model_js,
-                          'url': self.request.path})
+            self.success(data={'docs_json': docs_json, 'render_items': render_items,
+                               'custom_model_js': custom_model_js,
+                               'url': self.request.path})

--- a/skyportal/handlers/profile.py
+++ b/skyportal/handlers/profile.py
@@ -1,4 +1,4 @@
-from baselayer.app.handlers.base import BaseHandler
+from .base import BaseHandler
 from baselayer.app.access import auth_or_token
 from ..models import User
 
@@ -26,7 +26,7 @@ class ProfileHandler(BaseHandler):
                         'acls': [acl.id for acl in token.acls],
                         'created_at': token.created_at}
                        for token in user.tokens]
-        return self.success({'username': self.current_user.username,
-                             'roles': user_roles,
-                             'acls': user_acls,
-                             'tokens': user_tokens})
+        return self.success(data={'username': self.current_user.username,
+                                  'roles': user_roles,
+                                  'acls': user_acls,
+                                  'tokens': user_tokens})

--- a/skyportal/handlers/source.py
+++ b/skyportal/handlers/source.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import joinedload
 from sqlalchemy import func
 import arrow
 from baselayer.app.access import permissions, auth_or_token
-from baselayer.app.handlers import BaseHandler
+from .base import BaseHandler
 from ..models import (DBSession, Comment, Instrument, Photometry, Source,
                       Thumbnail, GroupSource, Token, User)
 from functools import reduce
@@ -80,16 +80,16 @@ class SourceHandler(BaseHandler):
         else:
             if isinstance(self.current_user, Token):
                 token = self.current_user
-                sources = reduce(set.union,
-                                 (set(group.sources) for group in token.groups))
+                info['sources'] = list(reduce(
+                    set.union, (set(group.sources) for group in token.groups)))
             else:
-                sources = self.current_user.sources
+                info['sources'] = self.current_user.sources
 
         if info['sources'] is not None:
-            return self.success(info)
+            return self.success(data=info)
         else:
             return self.error(f"Could not load source {source_id}",
-                              {"source_id": source_id_or_page_num})
+                              data={"source_id": source_id_or_page_num})
 
     @permissions(['Manage sources'])
     def post(self):
@@ -120,7 +120,7 @@ class SourceHandler(BaseHandler):
         DBSession().add(s)
         DBSession().commit()
 
-        return self.success({"id": s.id}, 'cesium/FETCH_SOURCES')
+        return self.success(data={"id": s.id}, action='cesium/FETCH_SOURCES')
 
     @permissions(['Manage sources'])
     def put(self, source_id):
@@ -214,4 +214,4 @@ class FilterSourcesHandler(BaseHandler):
         if info['totalMatches'] == 0:
             info['sourceNumberingStart'] = 0
 
-        return self.success(info)
+        return self.success(data=info)

--- a/skyportal/handlers/spectrum.py
+++ b/skyportal/handlers/spectrum.py
@@ -1,7 +1,7 @@
 import tornado.web
 from sqlalchemy.orm import joinedload
 from baselayer.app.access import permissions, auth_or_token
-from baselayer.app.handlers.base import BaseHandler
+from .base import BaseHandler
 from ..models import DBSession, Spectrum, Comment
 
 
@@ -20,7 +20,7 @@ class SpectrumHandler(BaseHandler):
         DBSession().add(p)
         DBSession().commit()
 
-        return self.success({"id": s.id}, 'cesium/FETCH_SOURCES')
+        return self.success(data={"id": s.id}, action='cesium/FETCH_SOURCES')
 
     """TODO any need for get/put/delete?
     @auth_or_token

--- a/skyportal/handlers/sysinfo.py
+++ b/skyportal/handlers/sysinfo.py
@@ -1,4 +1,4 @@
-from baselayer.app.handlers.base import BaseHandler
+from .base import BaseHandler
 from baselayer.app.access import auth_or_token
 from ..models import Source, DBSession
 import skyportal
@@ -30,6 +30,6 @@ class SysInfoHandler(BaseHandler):
         """
         info = {
             'sources_table_empty': DBSession.query(Source).first() is None,
-            'skyportal_version':skyportal.__version__
+            'skyportal_version': skyportal.__version__
         }
-        return self.success(info)
+        return self.success(data=info)

--- a/skyportal/handlers/token.py
+++ b/skyportal/handlers/token.py
@@ -1,4 +1,4 @@
-from baselayer.app.handlers.base import BaseHandler
+from .base import BaseHandler
 from baselayer.app.access import permissions, auth_or_token
 from ..models import User, Token, DBSession
 from ..model_util import create_token
@@ -34,7 +34,7 @@ class TokenHandler(BaseHandler):
                                 permissions=token_acls,
                                 created_by_id=user.id,
                                 description=data['description'])
-        return self.success(token_id, 'skyportal/FETCH_USER_PROFILE')
+        return self.success(data=token_id, action='skyportal/FETCH_USER_PROFILE')
 
     @auth_or_token
     def delete(self, token_id):

--- a/skyportal/handlers/userinfo.py
+++ b/skyportal/handlers/userinfo.py
@@ -1,4 +1,4 @@
-from baselayer.app.handlers.base import BaseHandler
+from .base import BaseHandler
 from baselayer.app.access import permissions
 from ..models import User
 
@@ -10,6 +10,6 @@ class UserInfoHandler(BaseHandler):
     def get(self, user_id=None):
         user = User.query.get(user_id)
         if user is None:
-            return self.success({'id': user_id, 'username': 'Not found'})
+            return self.success(data={'id': user_id, 'username': 'Not found'})
         else:
-            return self.success(user)
+            return self.success(data={'user': user})

--- a/skyportal/tests/frontend/test_groups.py
+++ b/skyportal/tests/frontend/test_groups.py
@@ -96,4 +96,4 @@ def test_token_user_update_group(driver, super_admin_user, public_group):
         headers={'Authorization': f'token {auth_token}'}
     ).json()
     assert response['status'] == 'success'
-    assert response['data']['name'] == 'new name'
+    assert response['data']['group']['name'] == 'new name'

--- a/skyportal/tests/frontend/test_versioned_requests.py
+++ b/skyportal/tests/frontend/test_versioned_requests.py
@@ -8,6 +8,5 @@ def test_versioned_request(driver, public_group, public_source):
     auth_token = create_token(public_group.id, ['Manage sources'])
     response = requests.get(f'{driver.server_url}/api/sources/{public_source.id}',
                             headers={'Authorization': f'token {auth_token}'}).json()
-    print("RESPONSE:", response)
     assert response['status'] == 'success'
     assert response['data']['version'] == skyportal.__version__

--- a/skyportal/tests/frontend/test_versioned_requests.py
+++ b/skyportal/tests/frontend/test_versioned_requests.py
@@ -1,0 +1,13 @@
+import requests
+
+import skyportal
+from skyportal.model_util import create_token
+
+
+def test_versioned_request(driver, public_group, public_source):
+    auth_token = create_token(public_group.id, ['Manage sources'])
+    response = requests.get(f'{driver.server_url}/api/sources/{public_source.id}',
+                            headers={'Authorization': f'token {auth_token}'}).json()
+    print("RESPONSE:", response)
+    assert response['status'] == 'success'
+    assert response['data']['version'] == skyportal.__version__

--- a/static/js/reducers.js
+++ b/static/js/reducers.js
@@ -96,7 +96,7 @@ export function groupsReducer(state={ latest: [], all: null }, action) {
 export function usersReducer(state={}, action) {
   switch (action.type) {
     case Action.FETCH_USER_OK: {
-      const { id, ...user_info } = action.data['user'];
+      const { id, ...user_info } = action.data.user;
       return {
         ...state,
         [id]: user_info

--- a/static/js/reducers.js
+++ b/static/js/reducers.js
@@ -69,8 +69,10 @@ export function sysinfoReducer(state={}, action) {
 
 export function groupReducer(state={}, action) {
   switch (action.type) {
-    case Action.FETCH_GROUP_OK:
-      return action.data;
+    case Action.FETCH_GROUP_OK: {
+      const { group } = action.data;
+      return group;
+    }
     default:
       return state;
   }
@@ -94,7 +96,7 @@ export function groupsReducer(state={ latest: [], all: null }, action) {
 export function usersReducer(state={}, action) {
   switch (action.type) {
     case Action.FETCH_USER_OK: {
-      const { id, ...user_info } = action.data;
+      const { id, ...user_info } = action.data['user'];
       return {
         ...state,
         [id]: user_info


### PR DESCRIPTION
This PR introduces a change to how we call the `success` and `error` handler methods: when passing in `data`, this must always be an explicit keyword argument (e.g. `self.success(data=data)`).

Closes #143. 