### PR TITLE
Infer source group(s) from user/token group membership 

### DIFF
--- a/skyportal/handlers/source.py
+++ b/skyportal/handlers/source.py
@@ -91,7 +91,7 @@ class SourceHandler(BaseHandler):
     def post(self):
         """
         ---
-        description: Upload a source
+        description: Upload a source. If group_ids is not specified, the user or token's groups will be used.
         parameters:
           - in: path
             name: source
@@ -111,16 +111,26 @@ class SourceHandler(BaseHandler):
         """
         data = self.get_json()
         schema = Source.__schema__()
+        user_group_ids = [g.id for g in self.current_user.groups]
+        if not user_group_ids:
+            return self.error("You must belong to one or more groups before "
+                              "you can add sources.")
         try:
-            group_ids = data.pop('group_ids')
+            group_ids = [id for id in data.pop('group_ids') if id in user_group_ids]
         except KeyError:
-            return self.error("Missing required fields: group_ids is a required field.")
+            group_ids = user_group_ids
+        if not group_ids:
+            return self.error("Invalid group_ids field. Please specify at least "
+                              "one valid group ID that you belong to.")
         try:
             s = schema.load(data)
         except ValidationError as e:
             return self.error('Invalid/missing parameters: '
                               f'{e.normalized_messages()}')
         groups = Group.query.filter(Group.id.in_(group_ids)).all()
+        if not groups:
+            return self.error("Invalid group_ids field. Please specify at least "
+                              "one valid group ID that you belong to.")
         s.groups = groups
         DBSession.add(s)
         DBSession().commit()

--- a/skyportal/tests/api/test_sources.py
+++ b/skyportal/tests/api/test_sources.py
@@ -68,15 +68,19 @@ def test_token_user_post_new_source(upload_data_token, view_only_token, public_g
     npt.assert_almost_equal(data['data']['sources']['ra'], 234.22)
 
 
-def test_cannot_add_source_without_group_id(upload_data_token, view_only_token,
-                                            public_group):
+def test_add_source_without_group_id(upload_data_token, view_only_token,
+                                     public_group):
     status, data = api('POST', 'sources',
-                       data={'id': 'testID',
+                       data={'id': 'testID2',
                              'ra': 234.22,
                              'dec': -22.33,
                              'redshift': 3,
                              'transient': False,
                              'ra_dis': 2.3},
                        token=upload_data_token)
-    assert status == 400
-    assert data['message'] == 'Missing required fields: group_ids is a required field.'
+    assert status == 200
+    status, data = api('GET', 'sources/testID2',
+                       token=view_only_token)
+    assert status == 200
+    assert data['data']['sources']['id'] == 'testID2'
+    npt.assert_almost_equal(data['data']['sources']['ra'], 234.22)


### PR DESCRIPTION
Infer source group(s) from user/token group membership if IDs not explicitly specified in POST handler