### PR TITLE
Add groups property to tokens

### DIFF
--- a/skyportal/handlers/group.py
+++ b/skyportal/handlers/group.py
@@ -51,7 +51,8 @@ class GroupHandler(BaseHandler):
                 group = Group.query.options([
                     joinedload(Group.users).load_only(User.id, User.username),
                     joinedload(Group.sources)]).get(group_id)
-                if group is not None and group not in self.current_user.groups:
+                if group is not None and group.id not in [
+                        g.id for g in self.current_user.groups]:
                     return self.error('Insufficient permissions.')
             info['group'] = group
         else:

--- a/skyportal/handlers/group.py
+++ b/skyportal/handlers/group.py
@@ -42,8 +42,7 @@ class GroupHandler(BaseHandler):
         """
         info = {}
         if group_id is not None:
-            if (hasattr(self.current_user, 'roles') and
-                'Super admin' in [role.id for role in self.current_user.roles]):
+            if 'Manage groups' in [acl.id for acl in self.current_user.acls]:
                 group = Group.query.options(joinedload(Group.users)).options(
                     joinedload(Group.group_users)).options(
                         joinedload(Group.sources)).get(group_id)

--- a/skyportal/handlers/source.py
+++ b/skyportal/handlers/source.py
@@ -261,8 +261,9 @@ class SourcePhotometryHandler(BaseHandler):
               application/json:
                 schema: Error
         """
-        source = Source.get_if_owned_by(source_id, self.current_user)
+        source = Source.query.get(source_id)
         if not source:
-            return self.error('Invalid source ID, or inadequate permissions to '
-                              'access source.')
+            return self.error('Invalid source ID.')
+        if not set(source.groups).intersection(set(self.current_user.groups)):
+            return self.error('Inadequate permissions.')
         return self.success(data={'photometry': source.photometry})

--- a/skyportal/handlers/token.py
+++ b/skyportal/handlers/token.py
@@ -30,8 +30,7 @@ class TokenHandler(BaseHandler):
         requested_acls = {k.replace('acls_', '') for k, v in data.items() if
                           k.startswith('acls_') and v == True}
         token_acls = requested_acls & user_acls
-        token_id = create_token(group_id=data['group_id'],
-                                permissions=token_acls,
+        token_id = create_token(permissions=token_acls,
                                 created_by_id=user.id,
                                 name=data['name'])
         return self.success(data={'token_id': token_id},

--- a/skyportal/model_util.py
+++ b/skyportal/model_util.py
@@ -54,16 +54,12 @@ def setup_permissions():
     DBSession().commit()
 
 
-def create_token(group_id, permissions=[], created_by_id=None, name=None):
-    group = Group.query.get(group_id)
-    t = Token(permissions=permissions, created_by_id=created_by_id,
-              name=name)
-    t.groups.append(group)
-    if created_by_id:
-        u = User.query.get(created_by_id)
-        u.tokens.append(t)
-        t.created_by = u
-        DBSession().add(u)
+def create_token(permissions, created_by_id, name):
+    t = Token(permissions=permissions, name=name)
+    u = User.query.get(created_by_id)
+    u.tokens.append(t)
+    t.created_by = u
+    DBSession().add(u)
     DBSession().add(t)
     DBSession().commit()
     return t.id

--- a/skyportal/tests/api/test_groups.py
+++ b/skyportal/tests/api/test_groups.py
@@ -2,13 +2,13 @@ import uuid
 from skyportal.tests import api
 
 
-def test_token_user_create_new_group_no_sources(manage_groups_token, user):
+def test_token_user_create_new_group_no_sources(manage_groups_token, super_admin_user):
     group_name = str(uuid.uuid4())
     status, data = api(
         'POST',
         'groups',
         data={'name': group_name,
-              'group_admins': [user.username]},
+              'group_admins': [super_admin_user.username]},
         token=manage_groups_token)
     assert status == 200
     assert data['status'] == 'success'
@@ -21,13 +21,13 @@ def test_token_user_create_new_group_no_sources(manage_groups_token, user):
     assert len(data['data']['group']['sources']) == 0
 
 
-def test_token_user_request_all_groups(manage_groups_token, user):
+def test_token_user_request_all_groups(manage_groups_token, super_admin_user):
     group_name = str(uuid.uuid4())
     status, data = api(
         'POST',
         'groups',
         data={'name': group_name,
-              'group_admins': [user.username]},
+              'group_admins': [super_admin_user.username]},
         token=manage_groups_token)
     assert status == 200
     assert data['status'] == 'success'
@@ -40,13 +40,13 @@ def test_token_user_request_all_groups(manage_groups_token, user):
     assert data['data']['all_groups'] is None
 
 
-def test_token_user_create_new_group_with_source(manage_groups_token, user, public_source):
+def test_token_user_create_new_group_with_source(manage_groups_token, super_admin_user, public_source):
     group_name = str(uuid.uuid4())
     status, data = api(
         'POST',
         'groups',
         data={'name': group_name,
-              'group_admins': [user.username],
+              'group_admins': [super_admin_user.username],
               'source_ids': [public_source.id]},
         token=manage_groups_token)
     assert status == 200

--- a/skyportal/tests/api/test_user.py
+++ b/skyportal/tests/api/test_user.py
@@ -26,8 +26,8 @@ def test_delete_user(manage_users_token, user):
 
 def test_delete_user_cascades_to_tokens(manage_users_token, user, public_group):
     token_name = str(uuid.uuid4())
-    token_id = create_token(group_id=public_group.id, permissions=[],
-                            created_by_id=user.id, name=token_name)
+    token_id = create_token(permissions=[], created_by_id=user.id,
+                            name=token_name)
     assert Token.query.get(token_id)
 
     status, data = api('DELETE', f'user/{user.id}', token=manage_users_token)
@@ -44,7 +44,7 @@ def test_delete_user_cascades_to_groupuser(manage_users_token, manage_groups_tok
                                            user, public_group):
     status, data = api('GET', f'groups/{public_group.id}',
                        token=manage_groups_token)
-    assert len(data['data']['group']['users']) == 1
+    orig_num_users = len(data['data']['group']['users'])
 
     status, data = api('DELETE', f'user/{user.id}', token=manage_users_token)
     assert status == 200
@@ -55,4 +55,4 @@ def test_delete_user_cascades_to_groupuser(manage_users_token, manage_groups_tok
 
     status, data = api('GET', f'groups/{public_group.id}',
                        token=manage_groups_token)
-    assert len(data['data']['group']['users']) == 0
+    assert len(data['data']['group']['users']) == orig_num_users - 1

--- a/skyportal/tests/conftest.py
+++ b/skyportal/tests/conftest.py
@@ -2,6 +2,7 @@
 
 import pytest
 import os
+import uuid
 import pathlib
 from psycopg2 import OperationalError
 from baselayer.app import models
@@ -48,48 +49,59 @@ def view_only_user(public_group):
 
 
 @pytest.fixture()
+def group_admin_user(public_group):
+    return UserFactory(groups=[public_group],
+                       roles=[models.Role.query.get('Group admin')])
+
+
+@pytest.fixture()
 def super_admin_user(public_group):
     return UserFactory(groups=[public_group],
                        roles=[models.Role.query.get('Super admin')])
 
 
 @pytest.fixture()
-def view_only_token(public_group):
-    token_id = create_token(public_group.id, permissions=[])
+def view_only_token(user):
+    token_id = create_token(permissions=[], created_by_id=user.id,
+                            name=str(uuid.uuid4()))
     return token_id
 
 
 @pytest.fixture()
-def manage_sources_token(public_group):
-    token_id = create_token(public_group.id, permissions=['Manage sources'])
+def manage_sources_token(group_admin_user):
+    token_id = create_token(permissions=['Manage sources'],
+                            created_by_id=group_admin_user.id,
+                            name=str(uuid.uuid4()))
     return token_id
 
 
 @pytest.fixture()
-def upload_data_token(public_group):
-    token_id = create_token(public_group.id, permissions=['Upload data'])
+def upload_data_token(user):
+    token_id = create_token(permissions=['Upload data'],
+                            created_by_id=user.id,
+                            name=str(uuid.uuid4()))
     return token_id
 
 
 @pytest.fixture()
-def manage_groups_token(public_group):
-    token_id = create_token(public_group.id, permissions=['Manage groups'])
+def manage_groups_token(super_admin_user):
+    token_id = create_token(permissions=['Manage groups'],
+                            created_by_id=super_admin_user.id,
+                            name=str(uuid.uuid4()))
     return token_id
 
 
 @pytest.fixture()
-def manage_users_token(public_group):
-    token_id = create_token(public_group.id, permissions=['Manage users'])
+def manage_users_token(super_admin_user):
+    token_id = create_token(permissions=['Manage users'],
+                            created_by_id=super_admin_user.id,
+                            name=str(uuid.uuid4()))
     return token_id
 
 
 @pytest.fixture()
-def comment_token(public_group):
-    token_id = create_token(public_group.id, permissions=['Comment'])
-    return token_id
-
-
-@pytest.fixture()
-def view_only_token_created_by_fulluser(public_group, user):
-    token_id = create_token(public_group.id, permissions=[], created_by_id=user.id)
+def comment_token(user):
+    token_id = create_token(permissions=['Comment'],
+                            created_by_id=user.id,
+                            name=str(uuid.uuid4()))
     return token_id

--- a/skyportal/tests/frontend/test_groups.py
+++ b/skyportal/tests/frontend/test_groups.py
@@ -4,8 +4,6 @@ from selenium.webdriver.common.by import By
 import uuid
 import requests
 
-from skyportal.model_util import create_token
-
 
 def test_public_groups_list(driver, user, public_group):
     driver.get(f'/become_user/{user.id}')  # TODO decorator/context manager?

--- a/skyportal/tests/frontend/test_sources.py
+++ b/skyportal/tests/frontend/test_sources.py
@@ -10,7 +10,6 @@ import requests
 import numpy.testing as npt
 
 from skyportal.models import Source, DBSession
-from skyportal.model_util import create_token
 from baselayer.app.config import load_config
 
 

--- a/skyportal/tests/frontend/test_tokens.py
+++ b/skyportal/tests/frontend/test_tokens.py
@@ -17,12 +17,10 @@ def test_add_token(driver, user, public_group):
     driver.wait_for_xpath(f'//td[contains(.,"{token_name}")]')
 
 
-def test_delete_token(driver, user, public_group,
-                      view_only_token_created_by_fulluser):
-    token_id = view_only_token_created_by_fulluser
+def test_delete_token(driver, user, public_group, view_only_token):
     driver.get(f'/become_user/{user.id}')
     driver.get('/profile')
-    driver.wait_for_xpath(f'//input[@value="{view_only_token_created_by_fulluser}"]')
+    driver.wait_for_xpath(f'//input[@value="{view_only_token}"]')
     driver.wait_for_xpath('//a[contains(text(),"Delete")]').click()
-    driver.wait_for_xpath(f'//div[contains(text(),"Token {token_id} deleted.")]')
-    driver.wait_for_xpath_to_disappear(f'//input[@value="{token_id}"]')
+    driver.wait_for_xpath(f'//div[contains(text(),"Token {view_only_token} deleted.")]')
+    driver.wait_for_xpath_to_disappear(f'//input[@value="{view_only_token}"]')

--- a/static/js/ducks/group.js
+++ b/static/js/ducks/group.js
@@ -4,6 +4,7 @@ export const REFRESH_GROUP = 'skyportal/REFRESH_GROUP';
 
 export const FETCH_GROUP = 'skyportal/FETCH_GROUP';
 export const FETCH_GROUP_OK = 'skyportal/FETCH_GROUP_OK';
+const FETCH_GROUP_FAIL = 'skyportal/FETCH_GROUP_FAIL';
 
 export function fetchGroup(id) {
   return API.GET(`/api/groups/${id}`, FETCH_GROUP);
@@ -14,6 +15,9 @@ export default function reducer(state={}, action) {
     case FETCH_GROUP_OK: {
       const { group } = action.data;
       return group;
+    }
+    case FETCH_GROUP_FAIL: {
+      return {};
     }
     default:
       return state;


### PR DESCRIPTION
`Token.groups` now points to `Token.created_by.groups` for simplified token group membership logic.

Tokens now belong to all groups that the creating user is a member of.

Closes https://github.com/skyportal/skyportal/issues/255 