### PR TITLE
Changed thumbnail storage from disk to database.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "bokehjs": "0.12.9",
-    "check-dependencies": "^1.1.0",
+    "check-dependencies": "1.1.0",
     "classnames": "2.2.6",
     "css-loader": "0.28.4",
     "exports-loader": "0.6.4",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "bokehjs": "0.12.9",
-    "check-dependencies": "1.1.0",
+    "check-dependencies": "^1.1.0",
     "classnames": "2.2.6",
     "css-loader": "0.28.4",
     "exports-loader": "0.6.4",

--- a/skyportal/handlers/thumbnail.py
+++ b/skyportal/handlers/thumbnail.py
@@ -171,9 +171,10 @@ def create_thumbnail(thumbnail_data, thumbnail_type, source_id, photometry_obj):
     if not (100, 100) <= im.size <= (500, 500):
         raise ValueError('Invalid thumbnail size. Only thumbnails '
                         'between (100, 100) and (500, 500) allowed.')
+    print(type(im))
     t = Thumbnail(type=thumbnail_type,
                   photometry=photometry_obj,
-                  file_uri=file_uri,
+                  image = im,
                   public_url=f'/static/thumbnails/{source_id}_{thumbnail_type}.png')
     DBSession.add(t)
     DBSession.flush()

--- a/skyportal/handlers/thumbnail.py
+++ b/skyportal/handlers/thumbnail.py
@@ -166,12 +166,12 @@ def create_thumbnail(thumbnail_data, thumbnail_type, source_id, photometry_obj):
         (basedir/'static/thumbnails').mkdir(parents=True)
     file_bytes = base64.b64decode(thumbnail_data)
     im = Image.open(io.BytesIO(file_bytes))
-    im64 = base64.b64encode(open(file_uri, 'rb').read())
     if im.format != 'PNG':
         raise ValueError('Invalid thumbnail image type. Only PNG are supported.')
     if not (100, 100) <= im.size <= (500, 500):
         raise ValueError('Invalid thumbnail size. Only thumbnails '
                         'between (100, 100) and (500, 500) allowed.')
+    im64 = base64.b64encode(open(file_uri, 'rb').read())
     t = Thumbnail(type=thumbnail_type,
                   photometry=photometry_obj,
                   image = im64,

--- a/skyportal/handlers/thumbnail.py
+++ b/skyportal/handlers/thumbnail.py
@@ -166,6 +166,7 @@ def create_thumbnail(thumbnail_data, thumbnail_type, source_id, photometry_obj):
         (basedir/'static/thumbnails').mkdir(parents=True)
     file_bytes = base64.b64decode(thumbnail_data)
     im = Image.open(io.BytesIO(file_bytes))
+    im64 = base64.b64encode(open(file_uri, 'rb').read())
     if im.format != 'PNG':
         raise ValueError('Invalid thumbnail image type. Only PNG are supported.')
     if not (100, 100) <= im.size <= (500, 500):
@@ -173,7 +174,7 @@ def create_thumbnail(thumbnail_data, thumbnail_type, source_id, photometry_obj):
                         'between (100, 100) and (500, 500) allowed.')
     t = Thumbnail(type=thumbnail_type,
                   photometry=photometry_obj,
-                  image = im,
+                  image = im64,
                   public_url=f'/static/thumbnails/{source_id}_{thumbnail_type}.png')
     DBSession.add(t)
     DBSession.flush()

--- a/skyportal/handlers/thumbnail.py
+++ b/skyportal/handlers/thumbnail.py
@@ -171,6 +171,7 @@ def create_thumbnail(thumbnail_data, thumbnail_type, source_id, photometry_obj):
     if not (100, 100) <= im.size <= (500, 500):
         raise ValueError('Invalid thumbnail size. Only thumbnails '
                         'between (100, 100) and (500, 500) allowed.')
+    print(type(im))
     t = Thumbnail(type=thumbnail_type,
                   photometry=photometry_obj,
                   image = im,

--- a/skyportal/handlers/thumbnail.py
+++ b/skyportal/handlers/thumbnail.py
@@ -171,7 +171,6 @@ def create_thumbnail(thumbnail_data, thumbnail_type, source_id, photometry_obj):
     if not (100, 100) <= im.size <= (500, 500):
         raise ValueError('Invalid thumbnail size. Only thumbnails '
                         'between (100, 100) and (500, 500) allowed.')
-    print(type(im))
     t = Thumbnail(type=thumbnail_type,
                   photometry=photometry_obj,
                   image = im,

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -315,8 +315,8 @@ class Thumbnail(Base):
     type = sa.Column(sa.Enum('new', 'ref', 'sub', 'sdss', 'dr8', "new_gz",
                              'ref_gz', 'sub_gz',
                              name='thumbnail_types', validate_strings=True))
-    file_uri = sa.Column(sa.String(), nullable=True, index=False, unique=False)
-    public_url = sa.Column(sa.String(), nullable=True, index=False, unique=False)
+    file_uri = sa.Column(sa.types.LargeBinary(), nullable=True, index=False, unique=False)
+    public_url = sa.Column(sa.types.LargeBinary(), nullable=True, index=False, unique=False)
     origin = sa.Column(sa.String, nullable=True)
     photometry_id = sa.Column(sa.ForeignKey('photometry.id', ondelete='CASCADE'),
                               nullable=False, index=True)

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -316,7 +316,8 @@ class Thumbnail(Base):
                              'ref_gz', 'sub_gz',
                              name='thumbnail_types', validate_strings=True))
     image = sa.Column(sa.types.LargeBinary, nullable=True, index=False, unique=False)
-    public_url = sa.Column(sa.String, nullable=True, index=False, unique=False)
+    file_uri = sa.Column(sa.String(), nullable=True, index=False, unique=False)
+    public_url = sa.Column(sa.String(), nullable=True, index=False, unique=False)
     origin = sa.Column(sa.String, nullable=True)
     photometry_id = sa.Column(sa.ForeignKey('photometry.id', ondelete='CASCADE'),
                               nullable=False, index=True)

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -315,8 +315,8 @@ class Thumbnail(Base):
     type = sa.Column(sa.Enum('new', 'ref', 'sub', 'sdss', 'dr8', "new_gz",
                              'ref_gz', 'sub_gz',
                              name='thumbnail_types', validate_strings=True))
-    file_uri = sa.Column(sa.types.LargeBinary(), nullable=True, index=False, unique=False)
-    public_url = sa.Column(sa.types.LargeBinary(), nullable=True, index=False, unique=False)
+    image = sa.Column(sa.types.LargeBinary, nullable=True, index=False, unique=False)
+    public_url = sa.Column(sa.String, nullable=True, index=False, unique=False)
     origin = sa.Column(sa.String, nullable=True)
     photometry_id = sa.Column(sa.ForeignKey('photometry.id', ondelete='CASCADE'),
                               nullable=False, index=True)

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -316,8 +316,7 @@ class Thumbnail(Base):
                              'ref_gz', 'sub_gz',
                              name='thumbnail_types', validate_strings=True))
     image = sa.Column(sa.types.LargeBinary, nullable=True, index=False, unique=False)
-    file_uri = sa.Column(sa.String(), nullable=True, index=False, unique=False)
-    public_url = sa.Column(sa.String(), nullable=True, index=False, unique=False)
+    public_url = sa.Column(sa.String, nullable=True, index=False, unique=False)
     origin = sa.Column(sa.String, nullable=True)
     photometry_id = sa.Column(sa.ForeignKey('photometry.id', ondelete='CASCADE'),
                               nullable=False, index=True)

--- a/static/js/components/ThumbnailList.jsx
+++ b/static/js/components/ThumbnailList.jsx
@@ -5,8 +5,31 @@ import classnames from 'classnames';
 
 import styles from "./ThumbnailList.css";
 
+const ThumbnailList = ({ ra, dec, thumbnails }) => {
+  const thumbnail_order = ['new', 'ref', 'sub', 'sdss', 'dr8'];
+  // Sort thumbnails by order of appearance in `thumbnail_order`
+  thumbnails.sort((a, b) => (thumbnail_order.indexOf(a.type) <
+                             thumbnail_order.indexOf(b.type) ? -1 : 1));
+  return (
+    <div className={styles.ThumbnailList}>
+      {thumbnails.map((t) => (
+        <Thumbnail
+          key={`thumb_${t.type}`}
+          ra={ra}
+          dec={dec}
+          name={t.type}
+          url={t.public_url}
+          image={`data:image/png;base64, ${t.image}`}
+          telescope={t.photometry.instrument.telescope.nickname}
+          observed_at={t.photometry.observed_at}
+        />
+      ))}
+    </div>
+  );
+};
 
-const Thumbnail = ({ ra, dec, telescope, observed_at, name, url }) => {
+
+const Thumbnail = ({ ra, dec, telescope, observed_at, name, url, image }) => {
   const observed_at_str = moment(observed_at).calendar();
 
   let alt = null;
@@ -14,12 +37,15 @@ const Thumbnail = ({ ra, dec, telescope, observed_at, name, url }) => {
   switch (name) {
     case "new":
       alt = `${telescope} discovery image (${observed_at_str})`;
+      url = image;
       break;
     case "ref":
       alt = `${telescope} pre-discovery (reference) image (${observed_at_str})`;
+      url = image;
       break;
     case "sub":
       alt = `${telescope} subtracted image (${observed_at_str})`;
+      url = image;
       break;
     case "sdss":
       alt = "Link to SDSS Navigate tool";
@@ -60,30 +86,6 @@ Thumbnail.propTypes = {
   name: PropTypes.string.isRequired,
   url: PropTypes.string.isRequired,
   observed_at: PropTypes.string.isRequired
-};
-
-
-const ThumbnailList = ({ ra, dec, thumbnails }) => {
-  const thumbnail_order = ['new', 'ref', 'sub', 'sdss', 'dr8'];
-  // Sort thumbnails by order of appearance in `thumbnail_order`
-  thumbnails.sort((a, b) => (thumbnail_order.indexOf(a.type) <
-                             thumbnail_order.indexOf(b.type) ? -1 : 1));
-
-  return (
-    <div className={styles.ThumbnailList}>
-      {thumbnails.map((t) => (
-        <Thumbnail
-          key={`thumb_${t.type}`}
-          ra={ra}
-          dec={dec}
-          name={t.type}
-          url={t.public_url}
-          telescope={t.photometry.instrument.telescope.nickname}
-          observed_at={t.photometry.observed_at}
-        />
-      ))}
-    </div>
-  );
 };
 
 ThumbnailList.propTypes = {

--- a/static/js/components/ThumbnailList.jsx
+++ b/static/js/components/ThumbnailList.jsx
@@ -85,7 +85,8 @@ Thumbnail.propTypes = {
   telescope: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   url: PropTypes.string.isRequired,
-  observed_at: PropTypes.string.isRequired
+  observed_at: PropTypes.string.isRequired,
+  image: PropTypes.string.isRequired
 };
 
 ThumbnailList.propTypes = {

--- a/tools/import_ptf.py
+++ b/tools/import_ptf.py
@@ -3,7 +3,9 @@ from datetime import datetime
 from glob import glob
 import re
 import os.path
+import base64
 
+import numpy as np
 import pandas as pd
 import sqlalchemy as sa
 from sqlalchemy import create_engine
@@ -12,7 +14,7 @@ from sqlalchemy.orm import Session
 
 from baselayer.app import load_config
 from skyportal.models import (DBSession, init_db, Comment, Group, Photometry,
-                              Source, Spectrum, User)
+                              Source, Spectrum, User, Thumbnail)
 from skyportal.model_util import create_tables
 
 pBase = automap_base()
@@ -117,7 +119,8 @@ if __name__ == '__main__':
     phot_map = {source_id: phot_id for phot_id, source_id in phot_info}
     for f in cutout_files:
         source_id, thumb_type = re.split('[\/_\.]', f)[-3:-1]
-        DBSession().add(Thumbnail(file_uri=f, type=thumb_type,
+        im = base64.b64encode(open(f, 'rb').read())
+        DBSession().add(Thumbnail(image=im, public_url=f, type=thumb_type,
                                   photometry_id=phot_map[source_id]))
         DBSession().commit()
 

--- a/tools/load_demo_data.py
+++ b/tools/load_demo_data.py
@@ -108,9 +108,8 @@ if __name__ == "__main__":
                 file_path = os.path.abspath(basedir/f'skyportal/tests/data/{fname}')
                 im = base64.b64encode(open(file_path, 'rb').read())
                 t = Thumbnail(type=ttype, photometry_id=s.photometry[0].id,
-                              file_uri = im,
-                              public_url = im)
-                print(type(im))
+                              image = im,
+                              public_url = f'/static/thumbnails/{fname}')
                 DBSession().add(t)
 
             s.add_linked_thumbnails()

--- a/tools/load_demo_data.py
+++ b/tools/load_demo_data.py
@@ -3,6 +3,7 @@ import os
 from pathlib import Path
 import shutil
 import pandas as pd
+import base64
 
 from baselayer.app.env import load_env
 from baselayer.app.model_util import status, create_tables, drop_tables
@@ -104,10 +105,12 @@ if __name__ == "__main__":
 
             for ttype in ['new', 'ref', 'sub']:
                 fname = f'{s.id}_{ttype}.png'
+                file_path = os.path.abspath(basedir/f'skyportal/tests/data/{fname}')
+                im = base64.b64encode(open(file_path, 'rb').read())
                 t = Thumbnail(type=ttype, photometry_id=s.photometry[0].id,
-                              file_uri=f'static/thumbnails/{fname}',
-                              public_url=f'/static/thumbnails/{fname}')
+                              file_uri = im,
+                              public_url = im)
+                print(type(im))
                 DBSession().add(t)
-                shutil.copy(basedir/f'skyportal/tests/data/{fname}', basedir/'static/thumbnails/')
 
             s.add_linked_thumbnails()

--- a/tools/ztf_upload_avro.py
+++ b/tools/ztf_upload_avro.py
@@ -5,8 +5,15 @@ make db_init
 PYTHONPATH=$PYTHONPATH:"." python skyportal/initial_setup.py \
       --adminuser=<google_email_address>
 
+PYTHONPATH=$PYTHONPATH:"." python skyportal/initial_setup.py \
+      --adminuser=testuser@cesium-ml.org
+
+
 PYTHONPATH=$PYTHONPATH:"." python tools/ztf_upload_avro.py \
      <google_email_address> https://ztf.uw.edu/alerts/public/ztf_public_20180626.tar.gz
+
+PYTHONPATH=$PYTHONPATH:"." python tools/ztf_upload_avro.py \
+     testuser@cesium-ml.org https://ztf.uw.edu/alerts/public/ztf_public_20180626.tar.gz
 
 """
 import os

--- a/tools/ztf_upload_avro.py
+++ b/tools/ztf_upload_avro.py
@@ -5,15 +5,8 @@ make db_init
 PYTHONPATH=$PYTHONPATH:"." python skyportal/initial_setup.py \
       --adminuser=<google_email_address>
 
-PYTHONPATH=$PYTHONPATH:"." python skyportal/initial_setup.py \
-      --adminuser=testuser@cesium-ml.org
-
-
 PYTHONPATH=$PYTHONPATH:"." python tools/ztf_upload_avro.py \
      <google_email_address> https://ztf.uw.edu/alerts/public/ztf_public_20180626.tar.gz
-
-PYTHONPATH=$PYTHONPATH:"." python tools/ztf_upload_avro.py \
-     testuser@cesium-ml.org https://ztf.uw.edu/alerts/public/ztf_public_20180626.tar.gz
 
 """
 import os

--- a/tools/ztf_upload_avro.py
+++ b/tools/ztf_upload_avro.py
@@ -25,6 +25,7 @@ import shutil
 from tqdm import tqdm
 import tarfile
 import json
+import base64
 
 import warnings
 warnings.filterwarnings("ignore", category=RuntimeWarning)
@@ -292,13 +293,16 @@ class ZTFAvro():
             for ttype, ztftype in [('new', 'Science'), ('ref', 'Template'), ('sub', 'Difference')]:
                 fname = f'{packet["candid"]}_{ttype}.png'
                 gzname = f'{packet["candid"]}_{ttype}.fits.gz'
-
+                t_filepath = f'static/thumbnails/{packet["objectId"]}/{fname}'
+                t_im = base64.b64encode(open(t_filepath, 'rb').read())
+                tgz_filepath = f'static/thumbnails/{packet["objectId"]}/{gzname}'
+                tgz_im = base64.b64encode(open(tgz_filepath, 'rb').read())
                 t = Thumbnail(type=ttype, photometry_id=s.photometry[0].id,
-                              file_uri=f'static/thumbnails/{packet["objectId"]}/{fname}',
+                              image=t_im,
                               origin=f"{os.path.basename(self.fname)}",
                               public_url=f'/static/thumbnails/{packet["objectId"]}/{fname}')
                 tgz = Thumbnail(type=ttype + "_gz", photometry_id=s.photometry[0].id,
-                              file_uri=f'static/thumbnails/{packet["objectId"]}/{gzname}',
+                              image=tgz_im,
                               origin=f"{os.path.basename(self.fname)}",
                               public_url=f'/static/thumbnails/{packet["objectId"]}/{gzname}')
                 DBSession().add(t)


### PR DESCRIPTION
Updated models.py and thumbnail.py to be able to handle thumbnails as .png files under the image attribute, which replaced the old file_uri attribute. Additionally, in ThumbnailList.jsx I made it so that the "new", "ref", and "sub" thumbnails got their image data from the new pngs on database instead of reading them from a filepath. If we ever want to display other types of thumbnails the only thing that needs to be changed is their src must be set to the png image not the url or filepath (line 71).