### PR TITLE
Add API security checks

### DIFF
--- a/skyportal/handlers/instrument.py
+++ b/skyportal/handlers/instrument.py
@@ -29,7 +29,7 @@ class InstrumentHandler(BaseHandler):
         """
         data = self.get_json()
         telescope_id = data.pop('telescope_id')
-        telescope = Telescope.query.get(telescope_id)
+        telescope = Telescope.get_if_owned_by(telescope_id, self.current_user)
         if not telescope:
             return self.error('Invalid telescope ID.')
 
@@ -66,11 +66,12 @@ class InstrumentHandler(BaseHandler):
               application/json:
                 schema: Error
         """
-        info = {}
-        info['instrument'] = Instrument.query.get(int(instrument_id))
+        instrument = Instrument.query.get(int(instrument_id))
 
-        if info['instrument'] is not None:
-            return self.success(data=info)
+        if instrument is not None:
+            telescope = Telescope.get_if_owned_by(instrument.telescope_id,
+                                                  self.current_user)
+            return self.success(data={'instrument': instrument})
         else:
             return self.error(f"Could not load instrument {instrument_id}",
                               data={"instrument_id": instrument_id})
@@ -94,6 +95,9 @@ class InstrumentHandler(BaseHandler):
               application/json:
                 schema: Error
         """
+        instrument = Instrument.query.get(int(instrument_id))
+        telescope = Telescope.get_if_owned_by(instrument.telescope_id,
+                                              self.current_user)
         data = self.get_json()
         data['id'] = int(instrument_id)
 
@@ -128,6 +132,9 @@ class InstrumentHandler(BaseHandler):
               application/json:
                 schema: Error
         """
+        instrument = Instrument.query.get(int(instrument_id))
+        telescope = Telescope.get_if_owned_by(instrument.telescope_id,
+                                              self.current_user)
         DBSession.query(Instrument).filter(Instrument.id == int(instrument_id)).delete()
         DBSession().commit()
 

--- a/skyportal/handlers/photometry.py
+++ b/skyportal/handlers/photometry.py
@@ -102,7 +102,7 @@ class PhotometryHandler(BaseHandler):
         instrument = Instrument.query.get(data['instrument_id'])
         if not instrument:
             raise Exception('Invalid instrument ID') # TODO: handle invalid instrument ID
-        source = Source.query.get(data['source_id'])
+        source = Source.get_if_owned_by(data['source_id'], self.current_user)
         if not source:
             raise Exception('Invalid source ID') # TODO: handle invalid source ID
         for i in range(len(data['mag'])):
@@ -156,12 +156,13 @@ class PhotometryHandler(BaseHandler):
         """
         info = {}
         info['photometry'] = Photometry.query.get(photometry_id)
+        if info['photometry'] is None:
+            return self.error ('Invalid photometry ID')
+        # Ensure user/token has access to parent source
+        s = Source.get_if_owned_by(info['photometry'].source_id,
+                                   self.current_user)
 
-        if info['photometry'] is not None:
-            return self.success(data=info)
-        else:
-            return self.error(f"Could not load photometry {photometry_id}",
-                              data={"photometry_id": photometry_id})
+        return self.success(data=info)
 
     @permissions(['Manage sources'])
     def put(self, photometry_id):
@@ -182,6 +183,9 @@ class PhotometryHandler(BaseHandler):
               application/json:
                 schema: Error
         """
+        # Ensure user/token has access to parent source
+        s = Source.get_if_owned_by(Photometry.query.get(photometry_id).source_id,
+                                   self.current_user)
         data = self.get_json()
         data['id'] = photometry_id
 
@@ -216,6 +220,9 @@ class PhotometryHandler(BaseHandler):
               application/json:
                 schema: Error
         """
+        # Ensure user/token has access to parent source
+        s = Source.get_if_owned_by(Photometry.query.get(photometry_id).source_id,
+                                   self.current_user)
         DBSession.query(Photometry).filter(Photometry.id == int(photometry_id)).delete()
         DBSession().commit()
 

--- a/skyportal/handlers/source.py
+++ b/skyportal/handlers/source.py
@@ -157,6 +157,7 @@ class SourceHandler(BaseHandler):
               application/json:
                 schema: Error
         """
+        s = Source.get_if_owned_by(source_id, self.current_user)
         data = self.get_json()
         data['id'] = source_id
 
@@ -186,6 +187,7 @@ class SourceHandler(BaseHandler):
               application/json:
                 schema: Success
         """
+        s = Source.get_if_owned_by(source_id, self.current_user)
         DBSession.query(Source).filter(Source.id == source_id).delete()
         DBSession().commit()
 

--- a/skyportal/handlers/thumbnail.py
+++ b/skyportal/handlers/thumbnail.py
@@ -53,16 +53,20 @@ class ThumbnailHandler(BaseHandler):
         data = self.get_json()
         if 'photometry_id' in data:
             phot = Photometry.query.get(int(data['photometry_id']))
-            source = phot.source
+            source_id = phot.source.id
+            # Ensure user/token has access to parent source
+            source = Source.get_if_owned_by(source_id, self.current_user)
         elif 'source_id' in data:
-            source = Source.query.get(data['source_id'])
+            source_id = data['source_id']
+            # Ensure user/token has access to parent source
+            source = Source.get_if_owned_by(source_id, self.current_user)
             try:
                 phot = source.photometry[0]
             except IndexError:
                 return self.error('Specified source does not yet have any photometry data.')
         else:
             return self.error('One of either source_id or photometry_id are required.')
-        t = create_thumbnail(data['data'], data['ttype'], source.id, phot)
+        t = create_thumbnail(data['data'], data['ttype'], source_id, phot)
         DBSession().commit()
 
         return self.success(data={"id": t.id})
@@ -88,14 +92,14 @@ class ThumbnailHandler(BaseHandler):
               application/json:
                 schema: Error
         """
-        info = {}
-        info['thumbnail'] = Thumbnail.query.get(thumbnail_id)
-
-        if info['thumbnail'] is not None:
-            return self.success(data=info)
-        else:
+        t = Thumbnail.query.get(thumbnail_id)
+        if t is None:
             return self.error(f"Could not load thumbnail {thumbnail_id}",
                               data={"thumbnail_id": thumbnail_id})
+        # Ensure user/token has access to parent source
+        s = Source.get_if_owned_by(t.source.id, self.current_user)
+
+        return self.success(data={'thumbnail': t})
 
     @permissions(['Manage sources'])
     def put(self, thumbnail_id):
@@ -116,6 +120,12 @@ class ThumbnailHandler(BaseHandler):
               application/json:
                 schema: Error
         """
+        t = Thumbnail.query.get(thumbnail_id)
+        if t is None:
+            return self.error('Invalid thumbnail ID.')
+        # Ensure user/token has access to parent source
+        s = Source.get_if_owned_by(t.source.id, self.current_user)
+
         data = self.get_json()
         data['id'] = thumbnail_id
 
@@ -150,6 +160,12 @@ class ThumbnailHandler(BaseHandler):
               application/json:
                 schema: Error
         """
+        t = Thumbnail.query.get(thumbnail_id)
+        if t is None:
+            return self.error('Invalid thumbnail ID.')
+        # Ensure user/token has access to parent source
+        s = Source.get_if_owned_by(t.source.id, self.current_user)
+
         DBSession.query(Thumbnail).filter(Thumbnail.id == int(thumbnail_id)).delete()
         DBSession().commit()
 

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -48,12 +48,12 @@ class Group(Base):
     sources = relationship('Source', secondary='group_sources')
     streams = relationship('Stream', secondary='stream_groups',
                            back_populates='groups')
+    telescopes = relationship('Telescope', secondary='group_telescopes')
     group_users = relationship('GroupUser', back_populates='group',
                                cascade='save-update, merge, refresh-expire, expunge',
                                passive_deletes=True)
     users = relationship('User', secondary='group_users',
                          back_populates='groups')
-
 
 
 GroupUser = join_model('group_users', Group, User)
@@ -196,9 +196,13 @@ class Telescope(Base):
     elevation = sa.Column(sa.Float, nullable=False)
     diameter = sa.Column(sa.Float, nullable=False)
 
+    groups = relationship('Group', secondary='group_telescopes')
     instruments = relationship('Instrument', back_populates='telescope',
                                cascade='save-update, merge, refresh-expire, expunge',
                                passive_deletes=True)
+
+
+GroupTelescope = join_model('group_telescopes', Group, Telescope)
 
 
 class Instrument(Base):

--- a/skyportal/tests/api/test_instrument.py
+++ b/skyportal/tests/api/test_instrument.py
@@ -3,7 +3,7 @@ from skyportal.tests import api
 from skyportal.models import Telescope, Instrument, DBSession
 
 
-def test_token_user_post_get_instrument(upload_data_token):
+def test_token_user_post_get_instrument(upload_data_token, public_group):
     name = str(uuid.uuid4())
     status, data = api('POST', 'telescope',
                        data={'name': name,
@@ -11,7 +11,8 @@ def test_token_user_post_get_instrument(upload_data_token):
                              'lat': 0.0,
                              'lon': 0.0,
                              'elevation': 0.0,
-                             'diameter': 10.0
+                             'diameter': 10.0,
+                             'group_ids': [public_group.id]
                        },
                        token=upload_data_token)
     assert status == 200
@@ -38,7 +39,8 @@ def test_token_user_post_get_instrument(upload_data_token):
     assert data['data']['instrument']['band'] == 'V'
 
 
-def test_token_user_update_instrument(upload_data_token, manage_sources_token):
+def test_token_user_update_instrument(upload_data_token, manage_sources_token,
+                                      public_group):
     name = str(uuid.uuid4())
     status, data = api('POST', 'telescope',
                        data={'name': name,
@@ -46,7 +48,8 @@ def test_token_user_update_instrument(upload_data_token, manage_sources_token):
                              'lat': 0.0,
                              'lon': 0.0,
                              'elevation': 0.0,
-                             'diameter': 10.0
+                             'diameter': 10.0,
+                             'group_ids': [public_group.id]
                        },
                        token=upload_data_token)
     assert status == 200
@@ -92,7 +95,8 @@ def test_token_user_update_instrument(upload_data_token, manage_sources_token):
     assert data['data']['instrument']['name'] == 'new_name'
 
 
-def test_token_user_delete_instrument(upload_data_token, manage_sources_token):
+def test_token_user_delete_instrument(upload_data_token, manage_sources_token,
+                                      public_group):
     name = str(uuid.uuid4())
     status, data = api('POST', 'telescope',
                        data={'name': name,
@@ -100,7 +104,8 @@ def test_token_user_delete_instrument(upload_data_token, manage_sources_token):
                              'lat': 0.0,
                              'lon': 0.0,
                              'elevation': 0.0,
-                             'diameter': 10.0
+                             'diameter': 10.0,
+                             'group_ids': [public_group.id]
                        },
                        token=upload_data_token)
     assert status == 200

--- a/skyportal/tests/api/test_telescope.py
+++ b/skyportal/tests/api/test_telescope.py
@@ -3,7 +3,7 @@ from skyportal.tests import api
 from skyportal.models import Telescope, DBSession
 
 
-def test_token_user_post_get_telescope(upload_data_token):
+def test_token_user_post_get_telescope(upload_data_token, public_group):
     name = str(uuid.uuid4())
     status, data = api('POST', 'telescope',
                        data={'name': name,
@@ -11,7 +11,8 @@ def test_token_user_post_get_telescope(upload_data_token):
                              'lat': 0.0,
                              'lon': 0.0,
                              'elevation': 0.0,
-                             'diameter': 10.0
+                             'diameter': 10.0,
+                             'group_ids': [public_group.id]
                        },
                        token=upload_data_token)
     assert status == 200
@@ -27,7 +28,8 @@ def test_token_user_post_get_telescope(upload_data_token):
     assert data['data']['telescope']['diameter'] == 10.0
 
 
-def test_token_user_update_telescope(upload_data_token, manage_sources_token):
+def test_token_user_update_telescope(upload_data_token, manage_sources_token,
+                                     public_group):
     name = str(uuid.uuid4())
     status, data = api('POST', 'telescope',
                        data={'name': name,
@@ -35,7 +37,8 @@ def test_token_user_update_telescope(upload_data_token, manage_sources_token):
                              'lat': 0.0,
                              'lon': 0.0,
                              'elevation': 0.0,
-                             'diameter': 10.0
+                             'diameter': 10.0,
+                             'group_ids': [public_group.id]
                        },
                        token=upload_data_token)
     assert status == 200
@@ -73,7 +76,8 @@ def test_token_user_update_telescope(upload_data_token, manage_sources_token):
     assert data['data']['telescope']['diameter'] == 12.0
 
 
-def test_token_user_delete_telescope(upload_data_token, manage_sources_token):
+def test_token_user_delete_telescope(upload_data_token, manage_sources_token,
+                                     public_group):
     name = str(uuid.uuid4())
     status, data = api('POST', 'telescope',
                        data={'name': name,
@@ -81,7 +85,8 @@ def test_token_user_delete_telescope(upload_data_token, manage_sources_token):
                              'lat': 0.0,
                              'lon': 0.0,
                              'elevation': 0.0,
-                             'diameter': 10.0
+                             'diameter': 10.0,
+                             'group_ids': [public_group.id]
                        },
                        token=upload_data_token)
     assert status == 200

--- a/tools/load_demo_data.py
+++ b/tools/load_demo_data.py
@@ -57,13 +57,13 @@ if __name__ == "__main__":
     with status("Creating dummy instruments"):
         t1 = Telescope(name='Palomar 1.5m', nickname='P60',
                        lat=33.3633675, lon=-116.8361345, elevation=1870,
-                       diameter=1.5)
+                       diameter=1.5, groups=[g])
         i1 = Instrument(telescope=t1, name='P60 Camera', type='phot',
                         band='optical')
 
         t2 = Telescope(name='Nordic Optical Telescope', nickname='NOT',
                        lat=28.75, lon=17.88, elevation=2327,
-                       diameter=2.56)
+                       diameter=2.56, groups=[g])
         i2 = Instrument(telescope=t2, name='ALFOSC', type='both',
                         band='optical')
         DBSession().add_all([i1, i2])


### PR DESCRIPTION
Ensures that tokens/users initiating requests have requisite permissions (group membership and ACLs) before creating/reading/updating/deleting entries for the following endpoints:
- `source`
- `photometry`
- `spectrum`
- `thumbnail`
- `comment`
- `group`
- `telescope`
- `instrument`

Also adds group membership for telescopes (and thereby their child instruments) for access control.

Closes #155 and #244 