### PR TITLE
Bump & unpin versions for apispec and all marshmallow packages in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,8 +15,8 @@ tqdm>=4.23.2
 matplotlib>=3
 astroquery>=0.3.8
 sqlalchemy-utils
-apispec==2.0.2
-marshmallow==3.0.0rc5
-marshmallow-sqlalchemy==0.17.0
-marshmallow-enum==1.4.1
+apispec>=3.2.0
+marshmallow>=3.4.0
+marshmallow-sqlalchemy>=0.21.0
+marshmallow-enum>=1.5.1
 Pillow>=6


### PR DESCRIPTION
This will allow us to use newer marshmallow features such as `Schema.from_dict`