### PR TITLE
Wrap Plot component with React.memo

### DIFF
--- a/static/js/components/Plot.jsx
+++ b/static/js/components/Plot.jsx
@@ -137,4 +137,4 @@ Plot.defaultProps = {
   className: ""
 };
 
-export default Plot;
+export default React.memo(Plot);


### PR DESCRIPTION
This fixes a bug where the bokeh plots re-render whenever any part of `state.source` is updated, included when adding comments. This significantly speeds up updates to the source page.