### PR TITLE
Pin astropy version to 3.2.3 because latest aplpy breaks with astropy >=4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ joblib>=0.11
 bokeh==0.12.9
 pytest-randomly>=2.1.1
 factory-boy==2.11.1
-astropy>=3.0.3
+astropy==3.2.3
 aplpy>=1.1.1
 avro-python3==1.8.2
 fastavro==0.21.7


### PR DESCRIPTION
`aplpy` hasn't been updated since Feb 2019 and breaks with `astropy` version >=4.0 