### PR TITLE
Bump minimum required astroquery version 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ avro-python3==1.8.2
 fastavro==0.21.7
 tqdm>=4.23.2
 matplotlib>=3
-astroquery>=0.3.8
+astroquery>=0.4
 sqlalchemy-utils
 apispec>=3.2.0
 marshmallow>=3.4.0


### PR DESCRIPTION
`astroquery` 0.3.8 (previous minimum required version) breaks with newest `astropy` 4.0