### PR TITLE
Set initial state for profile and newsFeed reducers.

### DIFF
--- a/skyportal/handlers/api/internal/profile.py
+++ b/skyportal/handlers/api/internal/profile.py
@@ -27,11 +27,13 @@ class ProfileHandler(BaseHandler):
                         'acls': [acl.id for acl in token.acls],
                         'created_at': token.created_at}
                        for token in user.tokens]
-        return self.success(data={'username': self.current_user.username,
-                                  'roles': user_roles,
-                                  'acls': user_acls,
-                                  'tokens': user_tokens,
-                                  'preferences': self.current_user.preferences})
+        return self.success(data={
+            'username': self.current_user.username,
+            'roles': user_roles,
+            'acls': user_acls,
+            'tokens': user_tokens,
+            'preferences': self.current_user.preferences or {}
+        })
 
     def put(self):
         """

--- a/skyportal/handlers/api/news_feed.py
+++ b/skyportal/handlers/api/news_feed.py
@@ -19,7 +19,7 @@ class NewsFeedHandler(BaseHandler):
                     - Success
                     - type: object
                       properties:
-                        news_feed_items:
+                        newsFeedItems:
                           type: arrayOfNewsFeedItems
                           description: List of recent activity
           400:

--- a/skyportal/tests/frontend/test_tokens.py
+++ b/skyportal/tests/frontend/test_tokens.py
@@ -22,5 +22,4 @@ def test_delete_token(driver, user, public_group, view_only_token):
     driver.get('/profile')
     driver.wait_for_xpath(f'//input[@value="{view_only_token}"]')
     driver.wait_for_xpath('//a[contains(text(),"Delete")]').click()
-    driver.wait_for_xpath(f'//div[contains(text(),"Token {view_only_token} deleted.")]')
     driver.wait_for_xpath_to_disappear(f'//input[@value="{view_only_token}"]')

--- a/skyportal/tests/frontend/test_user.py
+++ b/skyportal/tests/frontend/test_user.py
@@ -19,4 +19,4 @@ def test_user_info(driver, super_admin_user):
 def test_user_info_forbidden(driver, user):
     driver.get(f'/become_user/{user.id}')
     driver.get(f'/user/{user.id}')
-    driver.wait_for_xpath('//div[contains(.,"API error")]')
+    driver.wait_for_xpath('//div[contains(.,"Backend error")]')

--- a/static/js/components/GroupList.jsx
+++ b/static/js/components/GroupList.jsx
@@ -8,7 +8,7 @@ import SourceList from './SourceList';
 
 const GroupList = ({ title, listSources, groups }) => {
   if (!groups || groups.length === 0) {
-    groups = useSelector((state) => state.groups.latest);
+    groups = useSelector((state) => state.groups.user);
   }
   return (
     <div style={{ border: "1px solid #DDD", padding: "10px" }}>

--- a/static/js/components/HomePage.jsx
+++ b/static/js/components/HomePage.jsx
@@ -7,7 +7,7 @@ import NewsFeed from './NewsFeed';
 
 
 const HomePage = () => {
-  const groups = useSelector((state) => state.groups.latest);
+  const groups = useSelector((state) => state.groups.user);
   return (
     <div>
       <div style={{ float: "left", paddingRight: "40px" }}>

--- a/static/js/components/NewTokenForm.jsx
+++ b/static/js/components/NewTokenForm.jsx
@@ -5,7 +5,7 @@ import { useDispatch } from 'react-redux';
 import * as Action from '../ducks/profile';
 
 
-const CreateTokenForm = ({ acls, groups }) => {
+const NewTokenForm = ({ acls, groups }) => {
   const dispatch = useDispatch();
   const [formState, setFormState] = useState({
     group_id: "",
@@ -111,9 +111,9 @@ const CreateTokenForm = ({ acls, groups }) => {
     </div>
   );
 };
-CreateTokenForm.propTypes = {
+NewTokenForm.propTypes = {
   acls: PropTypes.arrayOf(PropTypes.string).isRequired,
-  groups: PropTypes.arrayOf(PropTypes.string).isRequired
+  groups: PropTypes.arrayOf(PropTypes.object).isRequired
 };
 
-export default CreateTokenForm;
+export default NewTokenForm;

--- a/static/js/components/NewsFeed.jsx
+++ b/static/js/components/NewsFeed.jsx
@@ -12,23 +12,10 @@ dayjs.extend(relativeTime);
 
 
 const NewsFeed = () => {
-  const { newsFeedItems } = useSelector((state) => state.newsFeed);
+  const { items } = useSelector((state) => state.newsFeed);
   const profile = useSelector((state) => state.profile);
 
-  const newsFeedPrefs = (
-    profile != null &&
-    Object.prototype.hasOwnProperty.call(profile, "preferences") &&
-    profile.preferences != null &&
-    Object.prototype.hasOwnProperty.call(profile.preferences, "newsFeed")
-  ) ?
-    profile.preferences.newsFeed : { numItems: "" };
-  if (newsFeedItems === undefined) {
-    return (
-      <div>
-        No new items to display...
-      </div>
-    );
-  }
+  const newsFeedPrefs = profile.preferences.newsFeed;
   return (
     <div style={{ border: "1px solid #DDD", padding: "10px" }}>
       <h2 style={{ display: "inline-block" }}>
@@ -48,7 +35,7 @@ const NewsFeed = () => {
         </h4>
         <ul>
           {
-            newsFeedItems.map((item) => (
+            items.map((item) => (
               <li key={`newsFeedItem_${item.time}`}>
                 <span className={styles.entryTime}>
                   {dayjs().to(dayjs(item.time))}

--- a/static/js/components/NewsFeed.jsx
+++ b/static/js/components/NewsFeed.jsx
@@ -11,11 +11,17 @@ import styles from './NewsFeed.css';
 dayjs.extend(relativeTime);
 
 
+const defaultPrefs = {
+  numItems: ""
+};
+
+
 const NewsFeed = () => {
   const { items } = useSelector((state) => state.newsFeed);
-  const profile = useSelector((state) => state.profile);
+  const newsFeedPrefs = useSelector(
+    (state) => state.profile.preferences.newsFeed
+  ) || defaultPrefs;
 
-  const newsFeedPrefs = profile.preferences.newsFeed;
   return (
     <div style={{ border: "1px solid #DDD", padding: "10px" }}>
       <h2 style={{ display: "inline-block" }}>

--- a/static/js/components/Profile.jsx
+++ b/static/js/components/Profile.jsx
@@ -7,7 +7,7 @@ import TokenList from './TokenList';
 
 const Profile = () => {
   const profile = useSelector((state) => state.profile);
-  const groups = useSelector((state) => state.groups.latest);
+  const groups = useSelector((state) => state.groups.user);
   return (
     <div>
       <div>

--- a/static/js/ducks/groups.js
+++ b/static/js/ducks/groups.js
@@ -57,13 +57,13 @@ messageHandler.add((actionType, payload, dispatch) => {
 });
 
 
-function reducer(state={ latest: [], all: null }, action) {
+function reducer(state={ user: [], all: null }, action) {
   switch (action.type) {
     case FETCH_GROUPS_OK: {
       const { user_groups, all_groups } = action.data;
       return {
         ...state,
-        latest: user_groups,
+        user: user_groups,
         all: all_groups
       };
     }

--- a/static/js/ducks/newsFeed.js
+++ b/static/js/ducks/newsFeed.js
@@ -19,14 +19,17 @@ messageHandler.add((actionType, payload, dispatch) => {
   }
 });
 
+const initialState = {
+  items: []
+};
 
-const reducer = (state=[], action) => {
+const reducer = (state=initialState, action) => {
   switch (action.type) {
     case FETCH_NEWSFEED_OK: {
       const { newsFeedItems } = action.data;
       return {
         ...state,
-        newsFeedItems
+        items: newsFeedItems
       };
     }
     default:

--- a/static/js/ducks/profile.js
+++ b/static/js/ducks/profile.js
@@ -52,7 +52,9 @@ const initialState = {
   roles: [],
   acls: [],
   tokens: [],
-  preferences: {}
+  preferences: {
+    newsFeed: {}
+  }
 };
 
 const reducer = (state=initialState, action) => {

--- a/static/js/ducks/profile.js
+++ b/static/js/ducks/profile.js
@@ -52,9 +52,7 @@ const initialState = {
   roles: [],
   acls: [],
   tokens: [],
-  preferences: {
-    newsFeed: {}
-  }
+  preferences: {}
 };
 
 const reducer = (state=initialState, action) => {


### PR DESCRIPTION
This avoids checks inside components to ensure that state is defined and
of correct form.

It would be good to review other components that do this kind of checking too.

---

The major changes here are now:

- The backend never returns undefined for profile preferences, but rather an empty dictionary.
- The newsfeed component now checks for its preferences, and if not found applies a set of default preferences.
  - TODO: The default preferences should probably be merged with whatever is provided by the user, so we can ensure that the widget always has all of its configuration parameters.
- Random cleanups, but specifically API.js, which I rewrote to give more logical error responses: a) connection error b) JSON decoding error c) actual 400 and similar errors that are reported by the backend.