### PR TITLE
Most viewed sources widget

### DIFF
--- a/skyportal/app_server.py
+++ b/skyportal/app_server.py
@@ -9,7 +9,7 @@ from skyportal.handlers.api import (
     InstrumentHandler,
     NewsFeedHandler,
     PhotometryHandler,
-    SourceHandler, SourcePhotometryHandler,
+    SourceViewsHandler, SourceHandler, SourcePhotometryHandler,
     SpectrumHandler,
     SysInfoHandler,
     TelescopeHandler,
@@ -65,6 +65,7 @@ def make_app(cfg, baselayer_handlers, baselayer_settings):
         (r'/api/internal/tokens(/.*)?', TokenHandler),
         (r'/api/internal/profile', ProfileHandler),
         (r'/api/internal/dbinfo', DBInfoHandler),
+        (r'/api/internal/source_views(/.*)?', SourceViewsHandler),
         (r'/api/internal/plot/photometry/(.*)', PlotPhotometryHandler),
         (r'/api/internal/plot/spectroscopy/(.*)', PlotSpectroscopyHandler),
 

--- a/skyportal/app_server.py
+++ b/skyportal/app_server.py
@@ -9,7 +9,7 @@ from skyportal.handlers.api import (
     InstrumentHandler,
     NewsFeedHandler,
     PhotometryHandler,
-    SourceViewsHandler, SourceHandler, SourcePhotometryHandler,
+    SourceHandler, SourcePhotometryHandler,
     SpectrumHandler,
     SysInfoHandler,
     TelescopeHandler,
@@ -17,8 +17,8 @@ from skyportal.handlers.api import (
     UserHandler
 )
 from skyportal.handlers.api.internal import (
-    PlotPhotometryHandler, PlotSpectroscopyHandler, TokenHandler,
-    DBInfoHandler, ProfileHandler
+    PlotPhotometryHandler, PlotSpectroscopyHandler, SourceViewsHandler,
+    TokenHandler, DBInfoHandler, ProfileHandler
 )
 
 from . import models, model_util, openapi

--- a/skyportal/handlers/api/__init__.py
+++ b/skyportal/handlers/api/__init__.py
@@ -3,7 +3,7 @@ from .group import GroupHandler, GroupUserHandler
 from .instrument import InstrumentHandler
 from .news_feed import NewsFeedHandler
 from .photometry import PhotometryHandler
-from .source import SourceViewsHandler, SourceHandler, SourcePhotometryHandler
+from .source import SourceHandler, SourcePhotometryHandler
 from .spectrum import SpectrumHandler
 from .sysinfo import SysInfoHandler
 from .telescope import TelescopeHandler

--- a/skyportal/handlers/api/__init__.py
+++ b/skyportal/handlers/api/__init__.py
@@ -3,7 +3,7 @@ from .group import GroupHandler, GroupUserHandler
 from .instrument import InstrumentHandler
 from .news_feed import NewsFeedHandler
 from .photometry import PhotometryHandler
-from .source import SourceHandler, SourcePhotometryHandler
+from .source import SourceViewsHandler, SourceHandler, SourcePhotometryHandler
 from .spectrum import SpectrumHandler
 from .sysinfo import SysInfoHandler
 from .telescope import TelescopeHandler

--- a/skyportal/handlers/api/internal/__init__.py
+++ b/skyportal/handlers/api/internal/__init__.py
@@ -2,3 +2,4 @@ from .plot import PlotPhotometryHandler, PlotSpectroscopyHandler
 from .token import TokenHandler
 from .dbinfo import DBInfoHandler
 from .profile import ProfileHandler
+from .source_views import SourceViewsHandler

--- a/skyportal/handlers/api/internal/profile.py
+++ b/skyportal/handlers/api/internal/profile.py
@@ -66,6 +66,8 @@ class ProfileHandler(BaseHandler):
         self.current_user.preferences = user_prefs
         DBSession.add(self.current_user)
         DBSession.commit()
-        if "newsFeed" in preferences:
+        if 'newsFeed' in preferences:
             self.push(action='skyportal/FETCH_NEWSFEED')
+        if 'topSources' in preferences:
+            self.push(action='skyportal/FETCH_TOP_SOURCES')
         return self.success(action="skyportal/FETCH_USER_PROFILE")

--- a/skyportal/handlers/api/internal/profile.py
+++ b/skyportal/handlers/api/internal/profile.py
@@ -58,6 +58,10 @@ class ProfileHandler(BaseHandler):
         if 'preferences' not in data:
             return self.error('Invalid request body: missing required "preferences" parameter')
         preferences = data['preferences']
+        # Do not save blank fields (empty strings)
+        for k, v in preferences.items():
+            if isinstance(v, dict):
+                preferences[k] = {key: val for key, val in v.items() if val != ''}
         user_prefs = deepcopy(self.current_user.preferences)
         if not user_prefs:
             user_prefs = preferences

--- a/skyportal/handlers/api/internal/source_views.py
+++ b/skyportal/handlers/api/internal/source_views.py
@@ -1,0 +1,50 @@
+import datetime
+from sqlalchemy import func, desc
+from baselayer.app.access import permissions, auth_or_token
+from ...base import BaseHandler
+from ....models import (
+    DBSession, Source, SourceView, GroupSource
+)
+
+
+class SourceViewsHandler(BaseHandler):
+    @auth_or_token
+    def get(self):
+        prefs = (self.current_user.preferences if
+                 hasattr(self.current_user, 'preferences') and
+                 self.current_user.preferences else {})
+        if 'topSources' in prefs and 'maxNumSources' in prefs['topSources']:
+            max_num_sources = int(prefs['topSources']['maxNumSources'])
+        else:
+            max_num_sources = 10
+        if 'topSources' in prefs and 'sinceDaysAgo' in prefs['topSources']:
+            since_days_ago = int(prefs['topSources']['sinceDaysAgo'])
+        else:
+            since_days_ago = 30
+        cutoff_day = datetime.datetime.now() - datetime.timedelta(days=since_days_ago)
+        q = (DBSession.query(func.count(SourceView.source_id).label('views'),
+                             SourceView.source_id).group_by(SourceView.source_id)
+             .filter(SourceView.source_id.in_(DBSession.query(
+                 GroupSource.source_id).filter(GroupSource.group_id.in_(
+                     [g.id for g in self.current_user.groups]))))
+             .filter(SourceView.created_at >= cutoff_day)
+             .order_by(desc('views')).limit(max_num_sources))
+        return self.success(data={'sourceViews': q.all()})
+
+    @auth_or_token
+    def post(self, source_id):
+        # Ensure token/user has access to source
+        s = Source.get_if_owned_by(source_id, self.current_user)
+        # This endpoint will only be hit by front-end, so this will never be a token
+        register_source_view(source_id=source_id,
+                             username_or_token_id=self.current_user.username,
+                             is_token=False)
+        return self.success()
+
+
+def register_source_view(source_id, username_or_token_id, is_token):
+    sv = SourceView(source_id=source_id,
+                    username_or_token_id=username_or_token_id,
+                    is_token=is_token)
+    DBSession.add(sv)
+    DBSession.commit()

--- a/skyportal/handlers/api/internal/source_views.py
+++ b/skyportal/handlers/api/internal/source_views.py
@@ -1,6 +1,7 @@
 import datetime
 from sqlalchemy import func, desc
-from baselayer.app.access import permissions, auth_or_token
+import tornado.web
+from baselayer.app.access import auth_or_token
 from ...base import BaseHandler
 from ....models import (
     DBSession, Source, SourceView, GroupSource
@@ -12,7 +13,7 @@ class SourceViewsHandler(BaseHandler):
     def get(self):
         prefs = (self.current_user.preferences if
                  hasattr(self.current_user, 'preferences') and
-                 self.current_user.preferences else {})
+                 self.current_user.preferences is not None else {})
         if 'topSources' in prefs and 'maxNumSources' in prefs['topSources']:
             max_num_sources = int(prefs['topSources']['maxNumSources'])
         else:
@@ -31,9 +32,9 @@ class SourceViewsHandler(BaseHandler):
              .order_by(desc('views')).limit(max_num_sources))
         return self.success(data={'sourceViews': q.all()})
 
-    @auth_or_token
+    @tornado.web.authenticated
     def post(self, source_id):
-        # Ensure token/user has access to source
+        # Ensure user has access to source
         s = Source.get_if_owned_by(source_id, self.current_user)
         # This endpoint will only be hit by front-end, so this will never be a token
         register_source_view(source_id=source_id,

--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -11,6 +11,7 @@ from ...models import (
     DBSession, Comment, Instrument, Photometry, Source, SourceView,
     Thumbnail, GroupSource, Token, User, Group
 )
+from .internal.source_views import register_source_view
 
 
 SOURCES_PER_PAGE = 100
@@ -284,46 +285,3 @@ class SourcePhotometryHandler(BaseHandler):
         if not set(source.groups).intersection(set(self.current_user.groups)):
             return self.error('Inadequate permissions.')
         return self.success(data={'photometry': source.photometry})
-
-
-class SourceViewsHandler(BaseHandler):
-    @auth_or_token
-    def get(self):
-        prefs = (self.current_user.preferences if
-                 hasattr(self.current_user, 'preferences') and
-                 self.current_user.preferences else {})
-        if 'topSources' in prefs and 'maxNumSources' in prefs['topSources']:
-            max_num_sources = int(prefs['topSources']['maxNumSources'])
-        else:
-            max_num_sources = 10
-        if 'topSources' in prefs and 'sinceDaysAgo' in prefs['topSources']:
-            since_days_ago = int(prefs['topSources']['sinceDaysAgo'])
-        else:
-            since_days_ago = 30
-        cutoff_day = datetime.datetime.now() - datetime.timedelta(days=since_days_ago)
-        q = (DBSession.query(func.count(SourceView.source_id).label('views'),
-                             SourceView.source_id).group_by(SourceView.source_id)
-             .filter(SourceView.source_id.in_(DBSession.query(
-                 GroupSource.source_id).filter(GroupSource.group_id.in_(
-                     [g.id for g in self.current_user.groups]))))
-             .filter(SourceView.created_at >= cutoff_day)
-             .order_by(desc('views')).limit(max_num_sources))
-        return self.success(data={'sourceViews': q.all()})
-
-    @auth_or_token
-    def post(self, source_id):
-        # Ensure token/user has access to source
-        s = Source.get_if_owned_by(source_id, self.current_user)
-        # This endpoint will only be hit by front-end, so this will never be a token
-        register_source_view(source_id=source_id,
-                             username_or_token_id=self.current_user.username,
-                             is_token=False)
-        return self.success()
-
-
-def register_source_view(source_id, username_or_token_id, is_token):
-    sv = SourceView(source_id=source_id,
-                    username_or_token_id=username_or_token_id,
-                    is_token=is_token)
-    DBSession.add(sv)
-    DBSession.commit()

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -188,6 +188,14 @@ User.sources = relationship('Source', backref='users',
                             primaryjoin='group_users.c.user_id == users.c.id')
 
 
+class SourceView(Base):
+    source_id = sa.Column(sa.ForeignKey('sources.id'),
+                          nullable=False, index=True, unique=False)
+    username_or_token_id = sa.Column(sa.String, nullable=False, index=True,
+                                     unique=False)
+    is_token = sa.Column(sa.Boolean, nullable=False, default=False)
+
+
 class Telescope(Base):
     name = sa.Column(sa.String, nullable=False)
     nickname = sa.Column(sa.String, nullable=False)

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import os.path
 import re
 import requests
@@ -190,9 +191,11 @@ User.sources = relationship('Source', backref='users',
 
 class SourceView(Base):
     source_id = sa.Column(sa.ForeignKey('sources.id', ondelete='CASCADE'),
-                          nullable=False, index=True, unique=False)
+                          nullable=False, unique=False)
     username_or_token_id = sa.Column(sa.String, nullable=False, unique=False)
     is_token = sa.Column(sa.Boolean, nullable=False, default=False)
+    created_at = sa.Column(sa.DateTime, nullable=False, default=datetime.now,
+                           index=True)
 
 
 class Telescope(Base):

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -189,10 +189,9 @@ User.sources = relationship('Source', backref='users',
 
 
 class SourceView(Base):
-    source_id = sa.Column(sa.ForeignKey('sources.id'),
+    source_id = sa.Column(sa.ForeignKey('sources.id', ondelete='CASCADE'),
                           nullable=False, index=True, unique=False)
-    username_or_token_id = sa.Column(sa.String, nullable=False, index=True,
-                                     unique=False)
+    username_or_token_id = sa.Column(sa.String, nullable=False, unique=False)
     is_token = sa.Column(sa.Boolean, nullable=False, default=False)
 
 

--- a/skyportal/tests/frontend/test_top_sources.py
+++ b/skyportal/tests/frontend/test_top_sources.py
@@ -23,9 +23,16 @@ def test_top_sources(driver, user, public_source, public_group, upload_data_toke
     driver.get(f'/become_user/{user.id}')
     driver.get('/')
     driver.wait_for_xpath(f'//td[text()="RRLyr"]')
-    driver.wait_for_xpath_to_disappear(f'//em[contains(.,"views)")]')
+
+    # Test that front-end views register as source views
     driver.get(f'/source/{source_id}')
     driver.wait_for_xpath(f'//div[text()="{source_id}"]')
     driver.get('/')
     driver.wait_for_xpath(f'//td[text()="RRLyr"]')
-    driver.wait_for_xpath(f'//*[contains(.,"views)")]')
+    driver.wait_for_xpath(f'//*[contains(.,"1\u00a0view(s)")]')
+
+    # Test that token requests are registered as source views
+    status, data = api('GET', f'sources/{source_id}', token=upload_data_token)
+    assert status == 200
+    driver.refresh()
+    driver.wait_for_xpath(f'//*[contains(.,"2\u00a0view(s)")]')

--- a/skyportal/tests/frontend/test_top_sources.py
+++ b/skyportal/tests/frontend/test_top_sources.py
@@ -1,0 +1,31 @@
+import uuid
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+
+from skyportal.tests import api
+
+
+def test_top_sources(driver, user, public_source, public_group, upload_data_token):
+    source_id = str(uuid.uuid4())
+    status, data = api('POST', 'sources',
+                       data={'id': source_id,
+                             'ra': 50.4,
+                             'dec': 22.33,
+                             'redshift': 2.1,
+                             'simbad_class': 'RRLyr',
+                             'transient': False,
+                             'ra_dis': 2.3,
+                             'group_ids': [public_group.id]},
+                       token=upload_data_token)
+    assert status == 200
+    assert data['data']['id'] == source_id
+
+    driver.get(f'/become_user/{user.id}')
+    driver.get('/')
+    driver.wait_for_xpath(f'//td[text()="RRLyr"]')
+    driver.wait_for_xpath_to_disappear(f'//em[contains(.,"views)")]')
+    driver.get(f'/source/{source_id}')
+    driver.wait_for_xpath(f'//div[text()="{source_id}"]')
+    driver.get('/')
+    driver.wait_for_xpath(f'//td[text()="RRLyr"]')
+    driver.wait_for_xpath(f'//*[contains(.,"views)")]')

--- a/static/js/actions.js
+++ b/static/js/actions.js
@@ -3,6 +3,7 @@ import * as profileActions from './ducks/profile';
 import * as sysInfoActions from './ducks/sysInfo';
 import * as dbInfoActions from './ducks/dbInfo';
 import * as newsFeedActions from './ducks/newsFeed';
+import * as topSourcesActions from './ducks/topSources';
 
 
 export default function hydrate() {
@@ -12,5 +13,6 @@ export default function hydrate() {
     dispatch(profileActions.fetchUserProfile());
     dispatch(groupsActions.fetchGroups());
     dispatch(newsFeedActions.fetchNewsFeed());
+    dispatch(topSourcesActions.fetchTopSources());
   };
 }

--- a/static/js/components/HomePage.css
+++ b/static/js/components/HomePage.css
@@ -1,0 +1,5 @@
+.homePageWidgetDiv {
+    float: left;
+    padding-right: 40px;
+    padding-bottom: 40px;
+}

--- a/static/js/components/HomePage.jsx
+++ b/static/js/components/HomePage.jsx
@@ -4,6 +4,7 @@ import { useSelector } from 'react-redux';
 import SourceList from './SourceList';
 import GroupList from './GroupList';
 import NewsFeed from './NewsFeed';
+import TopSources from './TopSources';
 
 
 const HomePage = () => {
@@ -15,6 +16,9 @@ const HomePage = () => {
       </div>
       <div style={{ float: "left", paddingRight: "40px", paddingBottom: "40px" }}>
         <NewsFeed />
+      </div>
+      <div style={{ float: "left", paddingRight: "40px", paddingBottom: "40px" }}>
+        <TopSources />
       </div>
       <div style={{ float: "left", paddingRight: "40px" }}>
         <GroupList title="My Groups" groups={groups} />

--- a/static/js/components/HomePage.jsx
+++ b/static/js/components/HomePage.jsx
@@ -5,22 +5,23 @@ import SourceList from './SourceList';
 import GroupList from './GroupList';
 import NewsFeed from './NewsFeed';
 import TopSources from './TopSources';
+import styles from './HomePage.css';
 
 
 const HomePage = () => {
   const groups = useSelector((state) => state.groups.user);
   return (
     <div>
-      <div style={{ float: "left", paddingRight: "40px" }}>
+      <div className={styles.homePageWidgetDiv}>
         <SourceList />
       </div>
-      <div style={{ float: "left", paddingRight: "40px", paddingBottom: "40px" }}>
+      <div className={styles.homePageWidgetDiv}>
         <NewsFeed />
       </div>
-      <div style={{ float: "left", paddingRight: "40px", paddingBottom: "40px" }}>
+      <div className={styles.homePageWidgetDiv}>
         <TopSources />
       </div>
-      <div style={{ float: "left", paddingRight: "40px" }}>
+      <div className={styles.homePageWidgetDiv}>
         <GroupList title="My Groups" groups={groups} />
       </div>
     </div>

--- a/static/js/components/NewsFeed.jsx
+++ b/static/js/components/NewsFeed.jsx
@@ -5,7 +5,7 @@ import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 
 import WidgetPrefsDialog from './WidgetPrefsDialog';
-import * as ProfileActions from '../ducks/profile';
+import * as profileActions from '../ducks/profile';
 import styles from './NewsFeed.css';
 
 dayjs.extend(relativeTime);
@@ -32,7 +32,7 @@ const NewsFeed = () => {
           formValues={newsFeedPrefs}
           stateBranchName="newsFeed"
           title="News Feed Preferences"
-          onSubmit={ProfileActions.updateUserPreferences}
+          onSubmit={profileActions.updateUserPreferences}
         />
       </div>
       <div>

--- a/static/js/components/Source.jsx
+++ b/static/js/components/Source.jsx
@@ -24,6 +24,7 @@ const Source = ({ route }) => {
   useEffect(() => {
     if (!isCached()) {
       dispatch(Action.fetchSource(route.id));
+      dispatch(Action.addSourceView(route.id));
     }
   }, []);
   if (source.loadError) {

--- a/static/js/components/TopSources.jsx
+++ b/static/js/components/TopSources.jsx
@@ -42,12 +42,14 @@ const TopSources = () => {
                   {source_id}
                 </Link>
               </span>
-              &nbsp;
-              <em>
-                (
-                {views}
-                &nbsp;views)
-              </em>
+              <span>
+                <em>
+                  &nbsp;
+                  -&nbsp;
+                  {views}
+                  &nbsp;view(s)
+                </em>
+              </span>
             </li>
           ))
         }

--- a/static/js/components/TopSources.jsx
+++ b/static/js/components/TopSources.jsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { Link } from 'react-router-dom';
+
+import * as profileActions from '../ducks/profile';
+import WidgetPrefsDialog from './WidgetPrefsDialog';
+
+
+const defaultPrefs = {
+  maxNumSources: "",
+  sinceDaysAgo: ""
+};
+
+const TopSources = () => {
+  const { sourceViews } = useSelector((state) => state.topSources);
+  const topSourcesPrefs = useSelector(
+    (state) => state.profile.preferences.topSources
+  ) || defaultPrefs;
+
+  return (
+    <div style={{ border: "1px solid #DDD", padding: "10px" }}>
+      <h2 style={{ display: "inline-block" }}>
+        Top Sources
+      </h2>
+      <div style={{ display: "inline-block", float: "right" }}>
+        <WidgetPrefsDialog
+          formValues={topSourcesPrefs}
+          stateBranchName="topSources"
+          title="Top Sources Preferences"
+          onSubmit={profileActions.updateUserPreferences}
+        />
+      </div>
+      <p>
+        Displaying most-viewed sources
+      </p>
+      <ul>
+        {
+          sourceViews.map(({ source_id, views }) => (
+            <li key={`topSources_${source_id}_${views}`}>
+              <span>
+                <Link to={`/source/${source_id}`}>
+                  {source_id}
+                </Link>
+              </span>
+              &nbsp;
+              <em>
+                (
+                {views}
+                &nbsp;views)
+              </em>
+            </li>
+          ))
+        }
+      </ul>
+    </div>
+  );
+};
+
+export default TopSources;

--- a/static/js/ducks/source.js
+++ b/static/js/ducks/source.js
@@ -16,6 +16,9 @@ export const ADD_COMMENT_OK = 'skyportal/ADD_COMMENT_OK';
 export const DELETE_COMMENT = 'skyportal/DELETE_COMMENT';
 export const DELETE_COMMENT_OK = 'skyportal/DELETE_COMMENT_OK';
 
+export const ADD_SOURCE_VIEW = 'skyportal/ADD_SOURCE_VIEW';
+export const ADD_SOURCE_VIEW_OK = 'skyportal/ADD_SOURCE_VIEW_OK';
+
 
 export function addComment(form) {
   function fileReaderPromise(file) {
@@ -46,6 +49,10 @@ export function deleteComment(comment_id) {
 
 export function fetchSource(id) {
   return API.GET(`/api/sources/${id}`, FETCH_LOADED_SOURCE);
+}
+
+export function addSourceView(id) {
+  return API.POST(`/api/internal/source_views/${id}`, ADD_SOURCE_VIEW);
 }
 
 

--- a/static/js/ducks/topSources.js
+++ b/static/js/ducks/topSources.js
@@ -1,0 +1,34 @@
+import messageHandler from 'baselayer/MessageHandler';
+
+import * as API from '../API';
+import store from '../store';
+
+
+export const FETCH_TOP_SOURCES = 'skyportal/FETCH_TOP_SOURCES';
+export const FETCH_TOP_SOURCES_OK = 'skyportal/FETCH_TOP_SOURCES_OK';
+
+export const fetchTopSources = () => (
+  API.GET('/api/internal/source_views', FETCH_TOP_SOURCES)
+);
+
+// Websocket message handler
+messageHandler.add((actionType, payload, dispatch) => {
+  if (actionType === FETCH_TOP_SOURCES) {
+    dispatch(fetchTopSources());
+  }
+});
+
+const reducer = (state={ sourceViews: [] }, action) => {
+  switch (action.type) {
+    case FETCH_TOP_SOURCES_OK: {
+      const { sourceViews } = action.data;
+      return {
+        sourceViews
+      };
+    }
+    default:
+      return state;
+  }
+};
+
+store.injectReducer('topSources', reducer);


### PR DESCRIPTION
This PR adds a most viewed sources widget to the home page. The number of sources displayed, and the time range to include are customizable by the user and are persisted in the DB. The `/api/internal/source_views` endpoint and associated handlers are added (handlers for POST, for registering new source views, and GET, for fetching the list of top sources, are implemented). Front-end source views (fetching of non-cached source) and token `/api/sources/<id>` GET requests are added to the new `SourceViews` table, along with the username/token ID (and a bool indicating whether it was a token or a front-end user) and timestamp. 