### PR TITLE
webpack: do not monitor changes in node_modules

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -106,6 +106,11 @@ const config = {
     },
     extensions: ['.js', '.jsx']
   },
+  watchOptions: {
+    ignored: /node_modules/,
+    // Set to true if you have trouble with JS change monitoring
+    poll: false
+  },
   mode: 'development'
 };
 


### PR DESCRIPTION
On some OSs, you can run out of notification handles doing this. Not
monitoring node_modules should make monitoring the rest of skyportal +
baselayer more reliable.

Closes #363 