### PR TITLE
Allow specification of JS routes in config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ static/thumbnails
 *.dirlock
 package-lock.json
 .jobs_timestamps.yaml
+skyportal_image_cache
+static/js/components/Main.jsx

--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -8,6 +8,25 @@ app:
                           # base64.b64encode(os.urandom(50)).decode('ascii')
     factory: skyportal.app_server.make_app
 
+    # See https://stackoverflow.com/a/35604855 for syntax
+    # These are Javascript component routes
+    routes:
+    - path: "/"
+      component: HomePage
+      exact: True
+    - path: "/source/:id"
+      component: Source
+    - path: "/groups"
+      component: Groups
+    - path: "/group/:id"
+      component: Group
+    - path: "/profile"
+      component: Profile
+    - path: "/sources"
+      component: SourceList
+    - path: "/user/:id"
+      component: UserInfo
+
 database:
     database: skyportal
     host: localhost

--- a/static/js/components/Main.jsx.template
+++ b/static/js/components/Main.jsx.template
@@ -27,17 +27,13 @@ import PropsRoute from '../route';
 import NoMatchingRoute from './NoMatchingRoute';
 import Responsive from './Responsive';
 
-import Source from './Source';
-import Group from './Group';
-import SourceList from './SourceList';
-import HomePage from './HomePage';
-import Groups from './Groups';
-import Profile from './Profile';
+{% for route in app.routes %}
+import {{ route.component }} from './{{ route.component }}';
+{% endfor %}
+
 import ProfileDropdown from './ProfileDropdown';
 import Logo from './Logo';
 import Footer from './Footer';
-import UserInfo from './UserInfo';
-
 
 messageHandler.init(store.dispatch, store.getState);
 
@@ -78,14 +74,9 @@ class MainContent extends React.Component {
           <Notifications />
 
           <Switch>
-            <PropsRoute exact path="/" component={HomePage} />
-            See https://stackoverflow.com/a/35604855 for syntax
-            <PropsRoute path="/source/:id" component={Source} />
-            <PropsRoute exact path="/groups/" component={Groups} />
-            <PropsRoute path="/group/:id" component={Group} />
-            <PropsRoute path="/profile" component={Profile} />
-            <PropsRoute path="/sources" component={SourceList} />
-            <PropsRoute path="/user/:id" component={UserInfo} />
+            {% for route in app.routes %}
+            <PropsRoute exact="True" path="{{ route.path }}" component={ {{ route.component }} } />
+            {% endfor %}
             <PropsRoute component={NoMatchingRoute} />
           </Switch>
 


### PR DESCRIPTION
This allows external developers to add new components to SkyPortal, and to have them render on `/their_choice_of_url`.

Currently, those components are expected to live in the same directory
as the SkyPortal components, but this can be addressed later.

To add text or components to the frontpage, you have to build a new component that renders `static/js/components/HomePage` inside of it (or just replace `HomePage` entirely, if you wish).