### PR TITLE
Memoize reset with acls argument and use in useEffect

### DIFF
--- a/static/js/components/NewTokenForm.jsx
+++ b/static/js/components/NewTokenForm.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
 
@@ -27,11 +27,15 @@ const NewTokenForm = ({ acls }) => {
 
   const { handleSubmit, register, errors, reset, control } = useForm();
 
-  useEffect(() => {
+  const resetForm = useCallback(() => {
     reset({
       acls: Array(acls.length).fill(false)
     });
-  }, [reset, acls]);
+  }, [acls, reset]);
+
+  useEffect(() => {
+    resetForm();
+  }, [resetForm]);
 
   const onSubmit = async (data) => {
     const selectedACLs = acls.filter((include, idx) => data.acls[idx]);


### PR DESCRIPTION
As per https://overreacted.io/a-complete-guide-to-useeffect/#tldr: 

> 🤔 Question: Do I need to specify functions as effect dependencies or not?
> 
> The recommendation is to hoist functions that don’t need props or state outside of your component, and pull the ones that are used only by an effect inside of that effect. If after that your effect still ends up using functions in the render scope (including function from props), wrap them into useCallback where they’re defined, and repeat the process. Why does it matter? Functions can “see” values from props and state — so they participate in the data flow. There’s a more detailed answer in our FAQ.