### PR TITLE
Fix & expand API docs; update API response data structure; update front-end and tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ doc_reqs:
 
 api-docs: | doc_reqs
 	@PYTHONPATH=. python tools/openapi/build-spec.py
-	npx redoc-cli@0.8.3 bundle openapi.json --title "SkyPortal API docs" --cdn
+	npx redoc-cli@0.9.8 bundle openapi.json --title "SkyPortal API docs" --cdn
 	rm -f openapi.{yml,json}
 	mkdir -p doc/_build/html
 	mv redoc-static.html doc/openapi.html

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "react-responsive": "8.0.3",
     "react-router-dom": "5.2.0",
     "react-simple-dropdown": "3.2.3",
-    "redoc": "2.0.0-rc.28",
+    "redoc": "2.0.0-rc.29",
     "redoc-cli": "0.9.8",
     "redux": "4.0.5",
     "redux-logger": "3.0.6",

--- a/skyportal/handlers/api/comment.py
+++ b/skyportal/handlers/api/comment.py
@@ -33,7 +33,7 @@ class CommentHandler(BaseHandler):
         # Ensure user/token has access to parent source
         _ = Source.get_if_owned_by(comment.obj_id, self.current_user)
         if comment is not None:
-            return self.success(data={'comment': comment})
+            return self.success(data=comment)
         return self.error('Invalid comment ID.')
 
     @permissions(['Comment'])
@@ -44,19 +44,40 @@ class CommentHandler(BaseHandler):
         requestBody:
           content:
             application/json:
-              schema: CommentNoID
+              schema:
+                type: object
+                properties:
+                  obj_id:
+                    type: string
+                  text:
+                    type: string
+                  attachment:
+                    type: object
+                    properties:
+                      body:
+                        type: string
+                        format: byte
+                        description: base64-encoded file contents
+                      name:
+                        type: string
+                required:
+                  - obj_id
+                  - text
         responses:
           200:
             content:
               application/json:
                 schema:
                   allOf:
-                    - Success
+                    - $ref: '#/components/schemas/Success'
                     - type: object
                       properties:
-                        obj_id:
-                          type: integer
-                          description: Associated source ID
+                        data:
+                          type: object
+                          properties:
+                            comment_id:
+                              type: integer
+                              description: New comment ID
         """
         data = self.get_json()
         obj_id = data['obj_id']

--- a/skyportal/handlers/api/filter.py
+++ b/skyportal/handlers/api/filter.py
@@ -46,13 +46,13 @@ class FilterHandler(BaseHandler):
             f = Filter.get_if_owned_by(filter_id, self.current_user)
             if f is None:
                 return self.error("Invalid filter ID.")
-            return self.success(data={"filters": f})
+            return self.success(data=f)
         filters = (
             DBSession.query(Filter)
             .filter(Filter.group_id.in_([g.id for g in self.current_user.groups]))
             .all()
         )
-        return self.success(data={"filters": filters})
+        return self.success(data=filters)
 
     @permissions(["Manage groups"])
     def post(self):
@@ -62,19 +62,22 @@ class FilterHandler(BaseHandler):
         requestBody:
           content:
             application/json:
-              schema: Filter
+              schema: FilterNoID
         responses:
           200:
             content:
               application/json:
                 schema:
                   allOf:
-                    - Success
+                    - $ref: '#/components/schemas/Success'
                     - type: object
                       properties:
-                        id:
-                          type: string
-                          description: New filter ID
+                        data:
+                          type: object
+                          properties:
+                            id:
+                              type: integer
+                              description: New filter ID
         """
         data = self.get_json()
         schema = Filter.__schema__()

--- a/skyportal/handlers/api/followup_request.py
+++ b/skyportal/handlers/api/followup_request.py
@@ -15,19 +15,22 @@ class FollowupRequestHandler(BaseHandler):
         requestBody:
           content:
             application/json:
-              schema: FollowupRequest
+              schema: FollowupRequestNoID
         responses:
           200:
             content:
               application/json:
                 schema:
                   allOf:
-                    - Success
+                    - $ref: '#/components/schemas/Success'
                     - type: object
                       properties:
-                        id:
-                          type: string
-                          description: New follow-up request ID
+                        data:
+                          type: object
+                          properties:
+                            id:
+                              type: integer
+                              description: New follow-up request ID
         """
         data = self.get_json()
         _ = Source.get_if_owned_by(data["obj_id"], self.current_user)
@@ -54,7 +57,7 @@ class FollowupRequestHandler(BaseHandler):
         parameters:
           - in: path
             name: request_id
-            required: True
+            required: true
             schema:
               type: string
         requestBody:

--- a/skyportal/handlers/api/internal/dbinfo.py
+++ b/skyportal/handlers/api/internal/dbinfo.py
@@ -17,15 +17,18 @@ class DBInfoHandler(BaseHandler):
               application/json:
                 schema:
                   allOf:
-                    - Success
+                    - $ref: '#/components/schemas/Success'
                     - type: object
                       properties:
-                        source_table_empty:
-                          type: boolean
-                          description: Boolean indicating whether source table is empty
-                        postgres_version:
-                          type: string
-                          description: Installed Postgres version
+                        data:
+                          type: object
+                          properties:
+                            source_table_empty:
+                              type: boolean
+                              description: Boolean indicating whether source table is empty
+                            postgres_version:
+                              type: string
+                              description: Installed Postgres version
         """
         p = subprocess.Popen(['psql', '--version'], stdout=subprocess.PIPE)
         out, err = p.communicate()

--- a/skyportal/handlers/api/internal/instrument_observation_params.py
+++ b/skyportal/handlers/api/internal/instrument_observation_params.py
@@ -14,4 +14,4 @@ class InstrumentObservationParamsHandler(BaseHandler):
         except json.JSONDecodeError:
             return self.error("JSON parse error: instrument observation parameters file "
                               "does not contain properly formatted JSON.")
-        return self.success(data={"instrumentObsParams": instrument_data})
+        return self.success(data=instrument_data)

--- a/skyportal/handlers/api/internal/profile.py
+++ b/skyportal/handlers/api/internal/profile.py
@@ -16,7 +16,41 @@ class ProfileHandler(BaseHandler):
           200:
             content:
               application/json:
-                schema: SingleUser
+                schema:
+                  allOf:
+                    - $ref: '#/components/schemas/Success'
+                    - type: object
+                      properties:
+                        data:
+                          type: object
+                          properties:
+                            username:
+                              type: string
+                            acls:
+                              type: array
+                              items:
+                                type: string
+                            roles:
+                              type: array
+                              items:
+                                type: string
+                            tokens:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  id:
+                                    type: string
+                                  name:
+                                    type: string
+                                  acls:
+                                    type: array
+                                    items:
+                                      type: string
+                                  created_at:
+                                    type: string
+                            preferences:
+                              type: object
         """
         user = (User.query.filter(User.username == self.current_user.username)
                     .first())

--- a/skyportal/handlers/api/internal/source_views.py
+++ b/skyportal/handlers/api/internal/source_views.py
@@ -32,7 +32,7 @@ class SourceViewsHandler(BaseHandler):
                      [g.id for g in self.current_user.groups]))))
              .filter(SourceView.created_at >= cutoff_day)
              .order_by(desc('views')).limit(max_num_sources))
-        return self.success(data={'sourceViews': q.all()})
+        return self.success(data=q.all())
 
     @tornado.web.authenticated
     def post(self, obj_id):

--- a/skyportal/handlers/api/internal/token.py
+++ b/skyportal/handlers/api/internal/token.py
@@ -22,12 +22,15 @@ class TokenHandler(BaseHandler):
               application/json:
                 schema:
                   allOf:
-                    - Success
+                    - $ref: '#/components/schemas/Success'
                     - type: object
                       properties:
-                        token_id:
-                          type: string
-                          description: Token ID
+                        data:
+                          type: object
+                          properties:
+                            token_id:
+                              type: string
+                              description: Token ID
         """
         data = self.get_json()
 

--- a/skyportal/handlers/api/news_feed.py
+++ b/skyportal/handlers/api/news_feed.py
@@ -16,12 +16,20 @@ class NewsFeedHandler(BaseHandler):
               application/json:
                 schema:
                   allOf:
-                    - Success
-                    - type: object
-                      properties:
-                        newsFeedItems:
-                          type: arrayOfNewsFeedItems
-                          description: List of recent activity
+                  - $ref: '#/components/schemas/Success'
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            type:
+                              type: string
+                            time:
+                              type: string
+                            message:
+                              type: string
           400:
             content:
               application/json:
@@ -49,4 +57,4 @@ class NewsFeedHandler(BaseHandler):
         news_feed_items.sort(key=lambda x: x['time'], reverse=True)
         news_feed_items = news_feed_items[:n_items]
 
-        return self.success(data={'newsFeedItems': news_feed_items})
+        return self.success(data=news_feed_items)

--- a/skyportal/handlers/api/photometry.py
+++ b/skyportal/handlers/api/photometry.py
@@ -38,12 +38,17 @@ class PhotometryHandler(BaseHandler):
               application/json:
                 schema:
                   allOf:
-                    - Success
+                    - $ref: '#/components/schemas/Success'
                     - type: object
                       properties:
-                        ids:
-                          type: array
-                          description: List of new photometry IDs
+                        data:
+                          type: object
+                          properties:
+                            ids:
+                              type: array
+                              items:
+                                type: integer
+                              description: List of new photometry IDs
         """
 
         data = self.get_json()
@@ -121,14 +126,13 @@ class PhotometryHandler(BaseHandler):
               application/json:
                 schema: Error
         """
-        info = {}
-        info['photometry'] = Photometry.query.get(photometry_id)
-        if info['photometry'] is None:
+        phot = Photometry.query.get(photometry_id)
+        if phot is None:
             return self.error('Invalid photometry ID')
         # Ensure user/token has access to parent source
-        _ = Source.get_if_owned_by(info['photometry'].obj_id, self.current_user)
+        _ = Source.get_if_owned_by(phot.obj_id, self.current_user)
 
-        return self.success(data=info)
+        return self.success(data=phot)
 
     @permissions(['Manage sources'])
     def put(self, photometry_id):

--- a/skyportal/handlers/api/spectrum.py
+++ b/skyportal/handlers/api/spectrum.py
@@ -22,12 +22,15 @@ class SpectrumHandler(BaseHandler):
               application/json:
                 schema:
                   allOf:
-                    - Success
+                    - $ref: '#/components/schemas/Success'
                     - type: object
                       properties:
-                        id:
-                          type: integer
-                          description: New spectrum ID
+                        data:
+                          type: object
+                          properties:
+                            id:
+                              type: integer
+                              description: New spectrum ID
           400:
             content:
               application/json:
@@ -74,10 +77,9 @@ class SpectrumHandler(BaseHandler):
 
         if spectrum is not None:
             source = Source.get_if_owned_by(spectrum.obj_id, self.current_user)
-            return self.success(data={'spectrum': spectrum})
+            return self.success(data=spectrum)
         else:
-            return self.error(f"Could not load spectrum {spectrum_id}",
-                              data={"spectrum_id": spectrum_id})
+            return self.error(f"Could not load spectrum with ID {spectrum_id}")
 
     @permissions(['Manage sources'])
     def put(self, spectrum_id):

--- a/skyportal/handlers/api/sysinfo.py
+++ b/skyportal/handlers/api/sysinfo.py
@@ -14,7 +14,10 @@ class SysInfoHandler(BaseHandler):
               application/json:
                 schema:
                   allOf:
-                    - Success
+                    - $ref: '#/components/schemas/Success'
                     - type: object
+                      properties:
+                        data:
+                          type: object
         """
         return self.success(data={})

--- a/skyportal/handlers/api/telescope.py
+++ b/skyportal/handlers/api/telescope.py
@@ -20,12 +20,15 @@ class TelescopeHandler(BaseHandler):
               application/json:
                 schema:
                   allOf:
-                    - Success
+                    - $ref: '#/components/schemas/Success'
                     - type: object
                       properties:
-                        id:
-                          type: integer
-                          description: New telescope ID
+                        data:
+                          type: object
+                          properties:
+                            id:
+                              type: integer
+                              description: New telescope ID
           400:
             content:
               application/json:
@@ -75,10 +78,9 @@ class TelescopeHandler(BaseHandler):
         t = Telescope.get_if_owned_by(int(telescope_id), self.current_user)
 
         if t is not None:
-            return self.success(data={'telescope': t})
+            return self.success(data=t)
         else:
-            return self.error(f"Could not load telescope {telescope_id}",
-                              data={"telescope_id": telescope_id})
+            return self.error(f"Could not load telescope with ID {telescope_id}")
 
     @permissions(['Manage sources'])
     def put(self, telescope_id):

--- a/skyportal/handlers/api/thumbnail.py
+++ b/skyportal/handlers/api/thumbnail.py
@@ -43,12 +43,15 @@ class ThumbnailHandler(BaseHandler):
               application/json:
                 schema:
                   allOf:
-                    - Success
+                    - $ref: '#/components/schemas/Success'
                     - type: object
                       properties:
-                        id:
-                          type: int
-                          description: New thumbnail ID
+                        data:
+                          type: object
+                          properties:
+                            id:
+                              type: integer
+                              description: New thumbnail ID
           400:
             content:
               application/json:
@@ -101,12 +104,11 @@ class ThumbnailHandler(BaseHandler):
         """
         t = Thumbnail.query.get(thumbnail_id)
         if t is None:
-            return self.error(f"Could not load thumbnail {thumbnail_id}",
-                              data={"thumbnail_id": thumbnail_id})
+            return self.error(f"Could not load thumbnail with ID {thumbnail_id}")
         # Ensure user/token has access to parent source
         _ = Source.get_if_owned_by(t.obj.id, self.current_user)
 
-        return self.success(data={'thumbnail': t})
+        return self.success(data=t)
 
     @permissions(['Manage sources'])
     def put(self, thumbnail_id):

--- a/skyportal/handlers/api/user.py
+++ b/skyportal/handlers/api/user.py
@@ -29,9 +29,9 @@ class UserHandler(BaseHandler):
         """
         user = User.query.options(joinedload(User.acls)).get(int(user_id))
         if user is None:
-            return self.error('Invalid user ID.', data={'id': user_id})
+            return self.error(f'Invalid user ID ({user_id}).')
         else:
-            return self.success(data={'user': user})
+            return self.success(data=user)
 
     @permissions(['Manage users'])
     def delete(self, user_id=None):
@@ -57,4 +57,4 @@ class UserHandler(BaseHandler):
         user_id = int(user_id)
         DBSession.query(User).filter(User.id == user_id).delete()
         DBSession.commit()
-        return self.success(data={'user_id': user_id})
+        return self.success()

--- a/skyportal/schema.py
+++ b/skyportal/schema.py
@@ -59,12 +59,6 @@ class UpdateUserPreferencesRequestJSON(_Schema):
     preferences = fields.Nested(UserPreferences)
 
 
-class NewsFeedItem(_Schema):
-    type = fields.String()
-    time = fields.String()
-    message = fields.String()
-
-
 def success(schema_name, base_schema=None):
     schema_fields = {
         'status': ApispecEnumField(Enum('status', ['success']), required=True),
@@ -111,7 +105,8 @@ def setup_schema():
                 """
                 schema_class_meta = type(f'{schema_class_name}_meta', (),
                                          {'model': class_, 'sqla_session': _DBSession,
-                                          'ordered': True, 'exclude': [], 'include_fk': True}
+                                          'ordered': True, 'exclude': [], 'include_fk': True,
+                                          'include_relationships': False}
                                          )
                 for exclude_attr in exclude:
                     if hasattr(class_, exclude_attr) and getattr(class_, exclude_attr) is not None:
@@ -128,9 +123,9 @@ def setup_schema():
                         schema_class())
 
             schema_class_name = class_.__name__
-            add_schema(schema_class_name, exclude=['created_at'],
+            add_schema(schema_class_name, exclude=['created_at', 'modified'],
                        add_to_model=True)
-            add_schema(f'{schema_class_name}NoID', exclude=['created_at', 'id'])
+            add_schema(f'{schema_class_name}NoID', exclude=['created_at', 'id', 'modified'])
 
 
 def register_components(spec):

--- a/skyportal/tests/api/test_candidates.py
+++ b/skyportal/tests/api/test_candidates.py
@@ -17,7 +17,7 @@ def test_token_user_retrieving_candidate(view_only_token, public_candidate):
     assert data["status"] == "success"
     print(data["data"])
     assert all(
-        k in data["data"]["candidates"]
+        k in data["data"]
         for k in ["ra", "dec", "redshift"]
     )
 
@@ -43,8 +43,8 @@ def test_token_user_update_candidate(manage_sources_token, public_candidate):
     )
     assert status == 200
     assert data["status"] == "success"
-    npt.assert_almost_equal(data["data"]["candidates"]["ra"], 234.22)
-    npt.assert_almost_equal(data["data"]["candidates"]["redshift"], 3.0)
+    npt.assert_almost_equal(data["data"]["ra"], 234.22)
+    npt.assert_almost_equal(data["data"]["redshift"], 3.0)
 
 
 def test_cannot_update_candidate_without_permission(view_only_token, public_candidate):
@@ -87,8 +87,8 @@ def test_token_user_post_new_candidate(
 
     status, data = api("GET", f"candidates/{candidate_id}", token=view_only_token)
     assert status == 200
-    assert data["data"]["candidates"]["id"] == candidate_id
-    npt.assert_almost_equal(data["data"]["candidates"]["ra"], 234.22)
+    assert data["data"]["id"] == candidate_id
+    npt.assert_almost_equal(data["data"]["ra"], 234.22)
 
 
 def test_cannot_add_candidate_without_filter_id(upload_data_token):

--- a/skyportal/tests/api/test_comments.py
+++ b/skyportal/tests/api/test_comments.py
@@ -11,7 +11,7 @@ def test_add_and_retrieve_comment(comment_token, public_source):
     status, data = api('GET', f'comment/{comment_id}', token=comment_token)
 
     assert status == 200
-    assert data['data']['comment']['text'] == 'Comment text'
+    assert data['data']['text'] == 'Comment text'
 
 
 def test_cannot_add_comment_without_permission(view_only_token, public_source):
@@ -31,7 +31,7 @@ def test_delete_comment(comment_token, public_source):
 
     status, data = api('GET', f'comment/{comment_id}', token=comment_token)
     assert status == 200
-    assert data['data']['comment']['text'] == 'Comment text'
+    assert data['data']['text'] == 'Comment text'
 
     status, data = api('DELETE', f'comment/{comment_id}', token=comment_token)
     assert status == 200

--- a/skyportal/tests/api/test_filters.py
+++ b/skyportal/tests/api/test_filters.py
@@ -7,7 +7,7 @@ def test_filter_list(view_only_token, public_filter):
     assert status == 200
     assert data["status"] == "success"
     assert all(
-        k in data["data"]["filters"][0]
+        k in data["data"][0]
         for k in ["query_string", "group_id"]
     )
 
@@ -20,7 +20,7 @@ def test_token_user_retrieving_filter(view_only_token, public_filter):
     assert data["status"] == "success"
     print(data["data"])
     assert all(
-        k in data["data"]["filters"]
+        k in data["data"]
         for k in ["query_string", "group_id"]
     )
 
@@ -42,7 +42,7 @@ def test_token_user_update_filter(manage_groups_token, public_filter):
     )
     assert status == 200
     assert data["status"] == "success"
-    assert data["data"]["filters"]["query_string"] == "new_qstr"
+    assert data["data"]["query_string"] == "new_qstr"
 
 
 def test_cannot_update_filter_without_permission(view_only_token, public_filter):
@@ -73,4 +73,4 @@ def test_token_user_post_new_filter(manage_groups_token, public_group):
 
     status, data = api("GET", f"filters/{filter_id}", token=manage_groups_token)
     assert status == 200
-    assert data["data"]["filters"]["id"] == filter_id
+    assert data["data"]["id"] == filter_id

--- a/skyportal/tests/api/test_groups.py
+++ b/skyportal/tests/api/test_groups.py
@@ -18,7 +18,7 @@ def test_token_user_create_new_group(manage_groups_token, super_admin_user):
     status, data = api('GET', f'groups/{new_group_id}',
                        token=manage_groups_token)
     assert data['status'] == 'success'
-    assert data['data']['group']['name'] == group_name
+    assert data['data']['name'] == group_name
 
 
 def test_token_user_request_all_groups(manage_groups_token, super_admin_user):
@@ -53,7 +53,7 @@ def test_token_user_update_group(manage_groups_token, public_group):
     status, data = api('GET', f'groups/{public_group.id}',
                        token=manage_groups_token)
     assert data['status'] == 'success'
-    assert data['data']['group']['name'] == new_name
+    assert data['data']['name'] == new_name
 
 
 def test_token_user_delete_group(manage_groups_token, public_group):
@@ -90,4 +90,4 @@ def test_manage_groups_token_get_unowned_group(manage_groups_token, user,
     status, data = api('GET', f'groups/{new_group_id}',
                        token=token_id)
     assert data['status'] == 'success'
-    assert data['data']['group']['name'] == group_name
+    assert data['data']['name'] == group_name

--- a/skyportal/tests/api/test_instrument.py
+++ b/skyportal/tests/api/test_instrument.py
@@ -13,7 +13,7 @@ def test_token_user_post_get_instrument(upload_data_token, public_group):
                              'elevation': 0.0,
                              'diameter': 10.0,
                              'group_ids': [public_group.id]
-                       },
+                             },
                        token=upload_data_token)
     assert status == 200
     assert data['status'] == 'success'
@@ -24,7 +24,7 @@ def test_token_user_post_get_instrument(upload_data_token, public_group):
                              'type': 'type',
                              'band': 'V',
                              'telescope_id': telescope_id
-                       },
+                             },
                        token=upload_data_token)
     assert status == 200
     assert data['status'] == 'success'
@@ -36,7 +36,7 @@ def test_token_user_post_get_instrument(upload_data_token, public_group):
         token=upload_data_token)
     assert status == 200
     assert data['status'] == 'success'
-    assert data['data']['instrument']['band'] == 'V'
+    assert data['data']['band'] == 'V'
 
 
 def test_token_user_update_instrument(upload_data_token, manage_sources_token,
@@ -50,7 +50,7 @@ def test_token_user_update_instrument(upload_data_token, manage_sources_token,
                              'elevation': 0.0,
                              'diameter': 10.0,
                              'group_ids': [public_group.id]
-                       },
+                             },
                        token=upload_data_token)
     assert status == 200
     assert data['status'] == 'success'
@@ -61,7 +61,7 @@ def test_token_user_update_instrument(upload_data_token, manage_sources_token,
                              'type': 'type',
                              'band': 'V',
                              'telescope_id': telescope_id
-                       },
+                             },
                        token=upload_data_token)
     assert status == 200
     assert data['status'] == 'success'
@@ -73,7 +73,7 @@ def test_token_user_update_instrument(upload_data_token, manage_sources_token,
         token=upload_data_token)
     assert status == 200
     assert data['status'] == 'success'
-    assert data['data']['instrument']['band'] == 'V'
+    assert data['data']['band'] == 'V'
 
     status, data = api(
         'PUT',
@@ -81,7 +81,7 @@ def test_token_user_update_instrument(upload_data_token, manage_sources_token,
         data={'name': 'new_name',
               'band': 'V',
               'type': 'type'
-        },
+              },
         token=manage_sources_token)
     assert status == 200
     assert data['status'] == 'success'
@@ -92,7 +92,7 @@ def test_token_user_update_instrument(upload_data_token, manage_sources_token,
         token=upload_data_token)
     assert status == 200
     assert data['status'] == 'success'
-    assert data['data']['instrument']['name'] == 'new_name'
+    assert data['data']['name'] == 'new_name'
 
 
 def test_token_user_delete_instrument(upload_data_token, manage_sources_token,
@@ -106,7 +106,7 @@ def test_token_user_delete_instrument(upload_data_token, manage_sources_token,
                              'elevation': 0.0,
                              'diameter': 10.0,
                              'group_ids': [public_group.id]
-                       },
+                             },
                        token=upload_data_token)
     assert status == 200
     assert data['status'] == 'success'
@@ -117,7 +117,7 @@ def test_token_user_delete_instrument(upload_data_token, manage_sources_token,
                              'type': 'type',
                              'band': 'V',
                              'telescope_id': telescope_id
-                       },
+                             },
                        token=upload_data_token)
     assert status == 200
     assert data['status'] == 'success'

--- a/skyportal/tests/api/test_photometry.py
+++ b/skyportal/tests/api/test_photometry.py
@@ -15,7 +15,7 @@ def test_token_user_post_get_photometry_data(upload_data_token, public_source):
                              'zp': 25.,
                              'zpsys': 'ab',
                              'filter': 'bessellv'
-                       },
+                             },
                        token=upload_data_token)
     assert status == 200
     assert data['status'] == 'success'
@@ -27,7 +27,7 @@ def test_token_user_post_get_photometry_data(upload_data_token, public_source):
         token=upload_data_token)
     assert status == 200
     assert data['status'] == 'success'
-    assert data['data']['photometry']['flux'] == 12.24
+    assert data['data']['flux'] == 12.24
 
 
 def test_token_user_post_photometry_data_series(upload_data_token, public_source):
@@ -53,7 +53,7 @@ def test_token_user_post_photometry_data_series(upload_data_token, public_source
         token=upload_data_token)
     assert status == 200
     assert data['status'] == 'success'
-    assert data['data']['photometry']['flux'] == 12.52
+    assert data['data']['flux'] == 12.52
 
 
 def test_post_photometry_no_access_token(view_only_token, public_source):
@@ -66,7 +66,7 @@ def test_post_photometry_no_access_token(view_only_token, public_source):
                              'zp': 25.,
                              'zpsys': 'ab',
                              'filter': 'bessellv'
-                       },
+                             },
                        token=view_only_token)
     assert status == 400
     assert data['status'] == 'error'
@@ -84,7 +84,7 @@ def test_token_user_update_photometry(upload_data_token,
                              'zp': 25.,
                              'zpsys': 'ab',
                              'filter': 'bessellv'
-                       },
+                             },
                        token=upload_data_token)
     assert status == 200
     assert data['status'] == 'success'
@@ -96,7 +96,7 @@ def test_token_user_update_photometry(upload_data_token,
         token=upload_data_token)
     assert status == 200
     assert data['status'] == 'success'
-    assert data['data']['photometry']['flux'] == 12.24
+    assert data['data']['flux'] == 12.24
 
     status, data = api(
         'PUT',
@@ -107,7 +107,7 @@ def test_token_user_update_photometry(upload_data_token,
         'GET',
         f'photometry/{photometry_id}',
         token=upload_data_token)
-    assert data['data']['photometry']['flux'] == 11.0
+    assert data['data']['flux'] == 11.0
 
 
 def test_delete_photometry_data(upload_data_token, manage_sources_token,
@@ -121,7 +121,7 @@ def test_delete_photometry_data(upload_data_token, manage_sources_token,
                              'zp': 25.,
                              'zpsys': 'ab',
                              'filter': 'bessellv'
-                       },
+                             },
                        token=upload_data_token)
     assert status == 200
     assert data['status'] == 'success'
@@ -133,7 +133,7 @@ def test_delete_photometry_data(upload_data_token, manage_sources_token,
         token=upload_data_token)
     assert status == 200
     assert data['status'] == 'success'
-    assert data['data']['photometry']['flux'] == 12.24
+    assert data['data']['flux'] == 12.24
 
     status, data = api(
         'DELETE',
@@ -183,7 +183,7 @@ def test_token_user_post_photometry_thumbnail(upload_data_token, public_source):
                              'zpsys': 'ab',
                              'filter': 'bessellv',
                              'thumbnails': thumbnails
-                       },
+                             },
                        token=upload_data_token)
     assert status == 200
     assert data['status'] == 'success'
@@ -195,7 +195,7 @@ def test_token_user_post_photometry_thumbnail(upload_data_token, public_source):
         token=upload_data_token)
     assert status == 200
     assert data['status'] == 'success'
-    assert data['data']['photometry']['flux'] == 12.24
+    assert data['data']['flux'] == 12.24
 
     assert len(DBSession.query(Photometry).filter(Photometry.id == photometry_id)
                .first().thumbnails) == 3

--- a/skyportal/tests/api/test_sources.py
+++ b/skyportal/tests/api/test_sources.py
@@ -15,8 +15,8 @@ def test_token_user_retrieving_source(view_only_token, public_source):
                        token=view_only_token)
     assert status == 200
     assert data['status'] == 'success'
-    assert all(k in data['data']['sources'] for k in ['ra', 'dec', 'redshift',
-                                                      'created_at', 'id'])
+    assert all(k in data['data'] for k in ['ra', 'dec', 'redshift',
+                                           'created_at', 'id'])
 
 
 def test_token_user_retrieving_source_photometry(view_only_token, public_source):
@@ -24,8 +24,8 @@ def test_token_user_retrieving_source_photometry(view_only_token, public_source)
                        token=view_only_token)
     assert status == 200
     assert data['status'] == 'success'
-    assert isinstance(data['data']['photometry'], list)
-    assert 'mjd' in data['data']['photometry'][0]
+    assert isinstance(data['data'], list)
+    assert 'mjd' in data['data'][0]
 
 
 def test_token_user_update_source(manage_sources_token, public_source):
@@ -43,8 +43,8 @@ def test_token_user_update_source(manage_sources_token, public_source):
                        token=manage_sources_token)
     assert status == 200
     assert data['status'] == 'success'
-    npt.assert_almost_equal(data['data']['sources']['ra'], 234.22)
-    npt.assert_almost_equal(data['data']['sources']['redshift'], 3.0)
+    npt.assert_almost_equal(data['data']['ra'], 234.22)
+    npt.assert_almost_equal(data['data']['redshift'], 3.0)
 
 
 def test_cannot_update_source_without_permission(view_only_token, public_source):
@@ -76,8 +76,8 @@ def test_token_user_post_new_source(upload_data_token, view_only_token, public_g
     status, data = api('GET', f'sources/{obj_id}',
                        token=view_only_token)
     assert status == 200
-    assert data['data']['sources']['id'] == obj_id
-    npt.assert_almost_equal(data['data']['sources']['ra'], 234.22)
+    assert data['data']['id'] == obj_id
+    npt.assert_almost_equal(data['data']['ra'], 234.22)
 
 
 def test_add_source_without_group_id(upload_data_token, view_only_token,
@@ -95,8 +95,8 @@ def test_add_source_without_group_id(upload_data_token, view_only_token,
     status, data = api('GET', f'sources/{obj_id}',
                        token=view_only_token)
     assert status == 200
-    assert data['data']['sources']['id'] == obj_id
-    npt.assert_almost_equal(data['data']['sources']['ra'], 234.22)
+    assert data['data']['id'] == obj_id
+    npt.assert_almost_equal(data['data']['ra'], 234.22)
 
 
 def test_starlist(manage_sources_token, public_source):

--- a/skyportal/tests/api/test_spectrum.py
+++ b/skyportal/tests/api/test_spectrum.py
@@ -10,7 +10,7 @@ def test_token_user_post_get_spectrum_data(upload_data_token, public_source):
                              'instrument_id': 1,
                              'wavelengths': [664, 665, 666],
                              'fluxes': [234.2, 232.1, 235.3]
-                       },
+                             },
                        token=upload_data_token)
     assert status == 200
     assert data['status'] == 'success'
@@ -22,8 +22,8 @@ def test_token_user_post_get_spectrum_data(upload_data_token, public_source):
         token=upload_data_token)
     assert status == 200
     assert data['status'] == 'success'
-    assert data['data']['spectrum']['fluxes'][0] == 234.2
-    assert data['data']['spectrum']['obj_id'] == public_source.id
+    assert data['data']['fluxes'][0] == 234.2
+    assert data['data']['obj_id'] == public_source.id
 
 
 def test_token_user_post_spectrum_no_access(view_only_token, public_source):
@@ -33,11 +33,10 @@ def test_token_user_post_spectrum_no_access(view_only_token, public_source):
                              'instrument_id': 1,
                              'wavelengths': [664, 665, 666],
                              'fluxes': [234.2, 232.1, 235.3]
-                       },
+                             },
                        token=view_only_token)
     assert status == 400
     assert data['status'] == 'error'
-
 
 
 def test_token_user_update_spectrum(upload_data_token,
@@ -49,7 +48,7 @@ def test_token_user_update_spectrum(upload_data_token,
                              'instrument_id': 1,
                              'wavelengths': [664, 665, 666],
                              'fluxes': [234.2, 232.1, 235.3]
-                       },
+                             },
                        token=upload_data_token)
     assert status == 200
     assert data['status'] == 'success'
@@ -61,7 +60,7 @@ def test_token_user_update_spectrum(upload_data_token,
         token=upload_data_token)
     assert status == 200
     assert data['status'] == 'success'
-    assert data['data']['spectrum']['fluxes'][0] == 234.2
+    assert data['data']['fluxes'][0] == 234.2
 
     status, data = api(
         'PUT',
@@ -76,7 +75,7 @@ def test_token_user_update_spectrum(upload_data_token,
         token=upload_data_token)
     assert status == 200
     assert data['status'] == 'success'
-    assert data['data']['spectrum']['fluxes'][0] == 222.2
+    assert data['data']['fluxes'][0] == 222.2
 
 
 def test_delete_spectrum_data(upload_data_token, manage_sources_token,
@@ -87,7 +86,7 @@ def test_delete_spectrum_data(upload_data_token, manage_sources_token,
                              'instrument_id': 1,
                              'wavelengths': [664, 665, 666],
                              'fluxes': [234.2, 232.1, 235.3]
-                       },
+                             },
                        token=upload_data_token)
     assert status == 200
     assert data['status'] == 'success'
@@ -99,8 +98,8 @@ def test_delete_spectrum_data(upload_data_token, manage_sources_token,
         token=upload_data_token)
     assert status == 200
     assert data['status'] == 'success'
-    assert data['data']['spectrum']['fluxes'][0] == 234.2
-    assert data['data']['spectrum']['obj_id'] == public_source.id
+    assert data['data']['fluxes'][0] == 234.2
+    assert data['data']['obj_id'] == public_source.id
 
     status, data = api(
         'DELETE',

--- a/skyportal/tests/api/test_telescope.py
+++ b/skyportal/tests/api/test_telescope.py
@@ -13,7 +13,7 @@ def test_token_user_post_get_telescope(upload_data_token, public_group):
                              'elevation': 0.0,
                              'diameter': 10.0,
                              'group_ids': [public_group.id]
-                       },
+                             },
                        token=upload_data_token)
     assert status == 200
     assert data['status'] == 'success'
@@ -25,7 +25,7 @@ def test_token_user_post_get_telescope(upload_data_token, public_group):
         token=upload_data_token)
     assert status == 200
     assert data['status'] == 'success'
-    assert data['data']['telescope']['diameter'] == 10.0
+    assert data['data']['diameter'] == 10.0
 
 
 def test_token_user_update_telescope(upload_data_token, manage_sources_token,
@@ -39,7 +39,7 @@ def test_token_user_update_telescope(upload_data_token, manage_sources_token,
                              'elevation': 0.0,
                              'diameter': 10.0,
                              'group_ids': [public_group.id]
-                       },
+                             },
                        token=upload_data_token)
     assert status == 200
     assert data['status'] == 'success'
@@ -51,7 +51,7 @@ def test_token_user_update_telescope(upload_data_token, manage_sources_token,
         token=upload_data_token)
     assert status == 200
     assert data['status'] == 'success'
-    assert data['data']['telescope']['diameter'] == 10.0
+    assert data['data']['diameter'] == 10.0
 
     status, data = api(
         'PUT',
@@ -62,7 +62,7 @@ def test_token_user_update_telescope(upload_data_token, manage_sources_token,
               'lon': 0.0,
               'elevation': 0.0,
               'diameter': 12.0
-        },
+              },
         token=manage_sources_token)
     assert status == 200
     assert data['status'] == 'success'
@@ -73,7 +73,7 @@ def test_token_user_update_telescope(upload_data_token, manage_sources_token,
         token=upload_data_token)
     assert status == 200
     assert data['status'] == 'success'
-    assert data['data']['telescope']['diameter'] == 12.0
+    assert data['data']['diameter'] == 12.0
 
 
 def test_token_user_delete_telescope(upload_data_token, manage_sources_token,
@@ -87,7 +87,7 @@ def test_token_user_delete_telescope(upload_data_token, manage_sources_token,
                              'elevation': 0.0,
                              'diameter': 10.0,
                              'group_ids': [public_group.id]
-                       },
+                             },
                        token=upload_data_token)
     assert status == 200
     assert data['status'] == 'success'
@@ -99,7 +99,7 @@ def test_token_user_delete_telescope(upload_data_token, manage_sources_token,
         token=upload_data_token)
     assert status == 200
     assert data['status'] == 'success'
-    assert data['data']['telescope']['diameter'] == 10.0
+    assert data['data']['diameter'] == 10.0
 
     status, data = api(
         'DELETE',

--- a/skyportal/tests/api/test_thumbnail.py
+++ b/skyportal/tests/api/test_thumbnail.py
@@ -30,11 +30,10 @@ def test_token_user_post_get_thumbnail(upload_data_token, public_group):
                              'zp': 25.,
                              'zpsys': 'ab',
                              'filter': 'bessellv'
-                       },
+                             },
                        token=upload_data_token)
     assert status == 200
     assert data['status'] == 'success'
-
 
     orig_source_thumbnail_count = len(DBSession.query(Obj).filter(
         Obj.id == obj_id).first().thumbnails)
@@ -58,7 +57,7 @@ def test_token_user_post_get_thumbnail(upload_data_token, public_group):
         token=upload_data_token)
     assert status == 200
     assert data['status'] == 'success'
-    assert data['data']['thumbnail']['type'] == 'new'
+    assert data['data']['type'] == 'new'
 
     assert (DBSession.query(Thumbnail).filter(Thumbnail.id == thumbnail_id)
             .first().obj.id) == obj_id
@@ -92,7 +91,7 @@ def test_token_user_delete_thumbnail_cascade_source(upload_data_token,
                              'zp': 25.,
                              'zpsys': 'ab',
                              'filter': 'bessellv'
-                       },
+                             },
                        token=upload_data_token)
     assert status == 200
     assert data['status'] == 'success'
@@ -119,7 +118,7 @@ def test_token_user_delete_thumbnail_cascade_source(upload_data_token,
         token=upload_data_token)
     assert status == 200
     assert data['status'] == 'success'
-    assert data['data']['thumbnail']['type'] == 'new'
+    assert data['data']['type'] == 'new'
 
     assert (DBSession.query(Thumbnail).filter(Thumbnail.id == thumbnail_id)
             .first().obj.id) == obj_id
@@ -161,7 +160,7 @@ def test_token_user_post_get_thumbnail_phot_id(upload_data_token, public_group):
                              'zp': 25.,
                              'zpsys': 'ab',
                              'filter': 'bessellv'
-                       },
+                             },
                        token=upload_data_token)
     assert status == 200
     assert data['status'] == 'success'
@@ -189,7 +188,7 @@ def test_token_user_post_get_thumbnail_phot_id(upload_data_token, public_group):
         token=upload_data_token)
     assert status == 200
     assert data['status'] == 'success'
-    assert data['data']['thumbnail']['type'] == 'new'
+    assert data['data']['type'] == 'new'
 
     assert (DBSession.query(Thumbnail).filter(Thumbnail.id == thumbnail_id)
             .first().obj.id) == obj_id
@@ -219,7 +218,7 @@ def test_cannot_post_thumbnail_invalid_ttype(upload_data_token, public_group):
                              'zp': 25.,
                              'zpsys': 'ab',
                              'filter': 'bessellv'
-                       },
+                             },
                        token=upload_data_token)
     assert status == 200
     assert data['status'] == 'success'
@@ -231,7 +230,7 @@ def test_cannot_post_thumbnail_invalid_ttype(upload_data_token, public_group):
                        data={'obj_id': obj_id,
                              'data': data,
                              'ttype': ttype
-                       },
+                             },
                        token=upload_data_token)
     assert status == 400
     assert data['status'] == 'error'
@@ -260,7 +259,7 @@ def test_cannot_post_thumbnail_invalid_image_type(upload_data_token, public_grou
                              'zp': 25.,
                              'zpsys': 'ab',
                              'filter': 'bessellv'
-                       },
+                             },
                        token=upload_data_token)
     assert status == 200
     assert data['status'] == 'success'
@@ -272,7 +271,7 @@ def test_cannot_post_thumbnail_invalid_image_type(upload_data_token, public_grou
                        data={'obj_id': obj_id,
                              'data': data,
                              'ttype': ttype
-                       },
+                             },
                        token=upload_data_token)
     assert status == 400
     assert data['status'] == 'error'
@@ -301,7 +300,7 @@ def test_cannot_post_thumbnail_invalid_size(upload_data_token, public_group):
                              'zp': 25.,
                              'zpsys': 'ab',
                              'filter': 'bessellv'
-                       },
+                             },
                        token=upload_data_token)
     assert status == 200
     assert data['status'] == 'success'
@@ -313,7 +312,7 @@ def test_cannot_post_thumbnail_invalid_size(upload_data_token, public_group):
                        data={'obj_id': obj_id,
                              'data': data,
                              'ttype': ttype
-                       },
+                             },
                        token=upload_data_token)
     assert status == 400
     assert data['status'] == 'error'
@@ -342,7 +341,7 @@ def test_cannot_post_thumbnail_invalid_file_type(upload_data_token, public_group
                              'zp': 25.,
                              'zpsys': 'ab',
                              'filter': 'bessellv'
-                       },
+                             },
                        token=upload_data_token)
     assert status == 200
     assert data['status'] == 'success'
@@ -354,7 +353,7 @@ def test_cannot_post_thumbnail_invalid_file_type(upload_data_token, public_group
                        data={'obj_id': obj_id,
                              'data': data,
                              'ttype': ttype
-                       },
+                             },
                        token=upload_data_token)
     assert status == 400
     assert data['status'] == 'error'

--- a/skyportal/tests/api/test_user.py
+++ b/skyportal/tests/api/test_user.py
@@ -7,7 +7,7 @@ from skyportal.models import DBSession, Token
 def test_get_user_info(manage_users_token, user):
     status, data = api('GET', f'user/{user.id}', token=manage_users_token)
     assert status == 200
-    assert data['data']['user']['id'] == user.id
+    assert data['data']['id'] == user.id
 
 
 def test_get_user_info_access_denied(view_only_token, user):
@@ -18,7 +18,6 @@ def test_get_user_info_access_denied(view_only_token, user):
 def test_delete_user(manage_users_token, user):
     status, data = api('DELETE', f'user/{user.id}', token=manage_users_token)
     assert status == 200
-    assert data['data']['user_id'] == user.id
 
     status, data = api('GET', f'user/{user.id}', token=manage_users_token)
     assert status == 400
@@ -32,7 +31,6 @@ def test_delete_user_cascades_to_tokens(manage_users_token, user, public_group):
 
     status, data = api('DELETE', f'user/{user.id}', token=manage_users_token)
     assert status == 200
-    assert data['data']['user_id'] == user.id
 
     status, data = api('GET', f'user/{user.id}', token=manage_users_token)
     assert status == 400
@@ -44,15 +42,14 @@ def test_delete_user_cascades_to_groupuser(manage_users_token, manage_groups_tok
                                            user, public_group):
     status, data = api('GET', f'groups/{public_group.id}',
                        token=manage_groups_token)
-    orig_num_users = len(data['data']['group']['users'])
+    orig_num_users = len(data['data']['users'])
 
     status, data = api('DELETE', f'user/{user.id}', token=manage_users_token)
     assert status == 200
-    assert data['data']['user_id'] == user.id
 
     status, data = api('GET', f'user/{user.id}', token=manage_users_token)
     assert status == 400
 
     status, data = api('GET', f'groups/{public_group.id}',
                        token=manage_groups_token)
-    assert len(data['data']['group']['users']) == orig_num_users - 1
+    assert len(data['data']['users']) == orig_num_users - 1

--- a/static/js/ducks/group.js
+++ b/static/js/ducks/group.js
@@ -34,7 +34,7 @@ messageHandler.add((actionType, payload, dispatch, getState) => {
 const reducer = (state={}, action) => {
   switch (action.type) {
     case FETCH_GROUP_OK: {
-      const { group } = action.data;
+      const group = action.data;
       return group;
     }
     case FETCH_GROUP_FAIL:

--- a/static/js/ducks/instruments.js
+++ b/static/js/ducks/instruments.js
@@ -19,14 +19,14 @@ export const fetchInstrumentObsParams = () => (
 const reducer = (state={ instrumentList: [], instrumentObsParams: {} }, action) => {
   switch (action.type) {
     case FETCH_INSTRUMENTS_OK: {
-      const { instruments } = action.data;
+      const instruments = action.data;
       return {
         ...state,
         instrumentList: instruments
       };
     }
     case FETCH_INSTRUMENT_OBS_PARAMS_OK: {
-      const { instrumentObsParams } = action.data;
+      const instrumentObsParams = action.data;
       return {
         ...state,
         instrumentObsParams

--- a/static/js/ducks/newsFeed.js
+++ b/static/js/ducks/newsFeed.js
@@ -26,7 +26,7 @@ const initialState = {
 const reducer = (state=initialState, action) => {
   switch (action.type) {
     case FETCH_NEWSFEED_OK: {
-      const { newsFeedItems } = action.data;
+      const newsFeedItems = action.data;
       return {
         ...state,
         items: newsFeedItems

--- a/static/js/ducks/source.js
+++ b/static/js/ducks/source.js
@@ -97,7 +97,7 @@ messageHandler.add((actionType, payload, dispatch, getState) => {
 const reducer = (state={ source: null, loadError: false }, action) => {
   switch (action.type) {
     case FETCH_LOADED_SOURCE_OK: {
-      const source = action.data.sources;
+      const source = action.data;
       return {
         ...state,
         ...source,

--- a/static/js/ducks/topSources.js
+++ b/static/js/ducks/topSources.js
@@ -21,7 +21,7 @@ messageHandler.add((actionType, payload, dispatch) => {
 const reducer = (state={ sourceViews: [] }, action) => {
   switch (action.type) {
     case FETCH_TOP_SOURCES_OK: {
-      const { sourceViews } = action.data;
+      const sourceViews = action.data;
       return {
         sourceViews
       };

--- a/static/js/ducks/users.js
+++ b/static/js/ducks/users.js
@@ -14,7 +14,7 @@ export function fetchUser(id) {
 const reducer = (state={}, action) => {
   switch (action.type) {
     case FETCH_USER_OK: {
-      const { id, ...user_info } = action.data.user;
+      const { id, ...user_info } = action.data;
       return {
         ...state,
         [id]: user_info


### PR DESCRIPTION
API docs previously described incorrect JSON response structures throughout and were missing many fields.
We move away from the pattern of wrapping all response data in a `dict` in API handlers (e.g. `return self.success(data={'sources': q.all()})`) to passing the relevant data directly to `data` whenever applicable (e.g. `return self.success(data=q.all())`). The API docs are updated accordingly. 
Closes https://github.com/skyportal/skyportal/issues/352 