### PR TITLE
Refine Instrument data model

### DIFF
--- a/skyportal/handlers/api/instrument.py
+++ b/skyportal/handlers/api/instrument.py
@@ -146,6 +146,8 @@ class InstrumentHandler(BaseHandler):
         return self.success()
 
 
+fdoc = "List of filters on the instrument. If the instrument has no filters " \
+       "(e.g., because it is a spectrograph) leave blank or pass the empty list."
 InstrumentHandler.post.__doc__ = f"""
         ---
         description: Add a new instrument
@@ -162,6 +164,8 @@ InstrumentHandler.post.__doc__ = f"""
                       items:
                         type: string
                         enum: {list(ALLOWED_BANDPASSES)}
+                      description: "{fdoc}" 
+                      default: []
         responses:
           200:
             content:

--- a/skyportal/handlers/api/instrument.py
+++ b/skyportal/handlers/api/instrument.py
@@ -6,7 +6,7 @@ from ...models import (DBSession, Instrument, Telescope, GroupTelescope,
 
 
 class InstrumentHandler(BaseHandler):
-    @permissions(['Upload data'])
+    @permissions(['System admin'])
     def post(self):
         data = self.get_json()
         telescope_id = data.get('telescope_id')
@@ -75,7 +75,7 @@ class InstrumentHandler(BaseHandler):
             ))))
         return self.success(data=query.all())
 
-    @permissions(['Manage sources'])
+    @permissions(['System admin'])
     def put(self, instrument_id):
         """
         ---
@@ -116,7 +116,7 @@ class InstrumentHandler(BaseHandler):
 
         return self.success()
 
-    @permissions(['Manage sources'])
+    @permissions(['System admin'])
     def delete(self, instrument_id):
         """
         ---

--- a/skyportal/handlers/api/instrument.py
+++ b/skyportal/handlers/api/instrument.py
@@ -149,8 +149,6 @@ class InstrumentHandler(BaseHandler):
         return self.success()
 
 
-fdoc = "List of filters on the instrument. If the instrument has no filters " \
-       "(e.g., because it is a spectrograph) leave blank or pass the empty list."
 InstrumentHandler.post.__doc__ = f"""
         ---
         description: Add a new instrument
@@ -167,7 +165,10 @@ InstrumentHandler.post.__doc__ = f"""
                       items:
                         type: string
                         enum: {list(ALLOWED_BANDPASSES)}
-                      description: "{fdoc}" 
+                      description: >-
+                        List of filters on the instrument. If the instrument
+                        has no filters (e.g., because it is a spectrograph),
+                        leave blank or pass the empty list. 
                       default: []
         responses:
           200:

--- a/skyportal/handlers/api/instrument.py
+++ b/skyportal/handlers/api/instrument.py
@@ -8,6 +8,9 @@ from ...models import (DBSession, Instrument, Telescope, GroupTelescope,
 class InstrumentHandler(BaseHandler):
     @permissions(['System admin'])
     def post(self):
+        # See bottom of this file for redoc docstring -- moved it there so that
+        # it could be made an f-string.
+
         data = self.get_json()
         telescope_id = data.get('telescope_id')
         telescope = Telescope.get_if_owned_by(telescope_id, self.current_user)

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -20,6 +20,9 @@ from sncosmo.magsystems import _MAGSYSTEMS
 ALLOWED_MAGSYSTEMS = tuple(l['name'] for l in _MAGSYSTEMS.get_loaders_metadata())
 ALLOWED_BANDPASSES = tuple(l['name'] for l in _BANDPASSES.get_loaders_metadata())
 
+allowed_magsystems = sa.Enum(*ALLOWED_MAGSYSTEMS, name="zpsys", validate_strings=True)
+allowed_bandpasses = sa.Enum(*ALLOWED_BANDPASSES, name="bandpasses", validate_strings=True)
+
 FIDUCIAL_ZP = 25.
 
 
@@ -282,19 +285,54 @@ class Telescope(Base):
 
 GroupTelescope = join_model('group_telescopes', Group, Telescope)
 
+import re
+from sqlalchemy.dialects.postgresql import ARRAY
+from sqlalchemy import cast
+
+
+class ArrayOfEnum(ARRAY):
+    def bind_expression(self, bindvalue):
+        return cast(bindvalue, self)
+
+    def result_processor(self, dialect, coltype):
+        super_rp = super(ArrayOfEnum, self).result_processor(dialect, coltype)
+
+        def handle_raw_string(value):
+            if value==None:
+                return []
+            inner = re.match(r"^{(.*)}$", value).group(1)
+            return inner.split(",")
+
+        def process(value):
+            return super_rp(handle_raw_string(value))
+        return process
+
 
 class Instrument(Base):
+
     name = sa.Column(sa.String, nullable=False)
-    type = sa.Column(sa.String, nullable=False)
-    band = sa.Column(sa.String, nullable=False)
+    modes = sa.Column(psql.ARRAY(instrument_modes), nullable=False)
+
+    # example
+    # name: 'ZTF'
+    # modes: ['imaging']
+    # properties: {'imaging': {'filters': ['ztfg', 'ztfr', 'ztfi']}}
+
+    properties = sa.Column(psql.JSONB, nullable=False)
 
     telescope_id = sa.Column(sa.ForeignKey('telescopes.id',
                                            ondelete='CASCADE'),
                              nullable=False, index=True)
     telescope = relationship('Telescope', back_populates='instruments')
+
+    followup_requests = relationship('FollowupRequest',
+                                     back_populates='instrument')
+
     photometry = relationship('Photometry', back_populates='instrument')
     spectra = relationship('Spectrum', back_populates='instrument')
-    followup_requests = relationship('FollowupRequest', back_populates='instrument')
+
+    # can be [] if an instrument is spec only
+    filters = sa.Column(ArrayOfEnum(allowed_bandpasses), nullable=False)
 
 
 class Comment(Base):
@@ -320,10 +358,8 @@ class Photometry(Base):
     flux = sa.Column(sa.Float)
     fluxerr = sa.Column(sa.Float, nullable=False)
     zp = sa.Column(sa.Float, nullable=False)
-    zpsys = sa.Column(sa.Enum(*ALLOWED_MAGSYSTEMS, name="zpsys",
-                              validate_strings=True), nullable=False)
-    filter = sa.Column(sa.Enum(*ALLOWED_BANDPASSES, name="bandpasses",
-                               validate_strings=True), nullable=False)
+    zpsys = sa.Column(allowed_magsystems, nullable=False)
+    filter = sa.Column(allowed_bandpasses, nullable=False)
 
     ra = sa.Column(sa.Float)
     dec = sa.Column(sa.Float)

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -311,15 +311,6 @@ class ArrayOfEnum(ARRAY):
 class Instrument(Base):
 
     name = sa.Column(sa.String, nullable=False)
-    modes = sa.Column(psql.ARRAY(instrument_modes), nullable=False)
-
-    # example
-    # name: 'ZTF'
-    # modes: ['imaging']
-    # properties: {'imaging': {'filters': ['ztfg', 'ztfr', 'ztfi']}}
-
-    properties = sa.Column(psql.JSONB, nullable=False)
-
     telescope_id = sa.Column(sa.ForeignKey('telescopes.id',
                                            ondelete='CASCADE'),
                              nullable=False, index=True)
@@ -332,7 +323,8 @@ class Instrument(Base):
     spectra = relationship('Spectrum', back_populates='instrument')
 
     # can be [] if an instrument is spec only
-    filters = sa.Column(ArrayOfEnum(allowed_bandpasses), nullable=False)
+    filters = sa.Column(ArrayOfEnum(allowed_bandpasses), nullable=False,
+                        default=[])
 
 
 class Comment(Base):

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -298,7 +298,7 @@ class ArrayOfEnum(ARRAY):
         super_rp = super(ArrayOfEnum, self).result_processor(dialect, coltype)
 
         def handle_raw_string(value):
-            if value==None:
+            if value == None or value == '{}':  # 2nd case, empty array
                 return []
             inner = re.match(r"^{(.*)}$", value).group(1)
             return inner.split(",")
@@ -311,6 +311,8 @@ class ArrayOfEnum(ARRAY):
 class Instrument(Base):
 
     name = sa.Column(sa.String, nullable=False)
+    type = sa.Column(sa.String)
+    band = sa.Column(sa.String)
     telescope_id = sa.Column(sa.ForeignKey('telescopes.id',
                                            ondelete='CASCADE'),
                              nullable=False, index=True)

--- a/skyportal/tests/api/test_instrument.py
+++ b/skyportal/tests/api/test_instrument.py
@@ -3,7 +3,7 @@ from skyportal.tests import api
 from skyportal.models import Telescope, Instrument, DBSession
 
 
-def test_token_user_post_get_instrument(upload_data_token, public_group):
+def test_token_user_post_get_instrument(super_admin_token, public_group):
     name = str(uuid.uuid4())
     status, data = api('POST', 'telescope',
                        data={'name': name,
@@ -14,7 +14,7 @@ def test_token_user_post_get_instrument(upload_data_token, public_group):
                              'diameter': 10.0,
                              'group_ids': [public_group.id]
                              },
-                       token=upload_data_token)
+                       token=super_admin_token)
     assert status == 200
     assert data['status'] == 'success'
     telescope_id = data['data']['id']
@@ -25,7 +25,7 @@ def test_token_user_post_get_instrument(upload_data_token, public_group):
                              'band': 'V',
                              'telescope_id': telescope_id
                              },
-                       token=upload_data_token)
+                       token=super_admin_token)
     assert status == 200
     assert data['status'] == 'success'
 
@@ -33,14 +33,14 @@ def test_token_user_post_get_instrument(upload_data_token, public_group):
     status, data = api(
         'GET',
         f'instrument/{instrument_id}',
-        token=upload_data_token)
+        token=super_admin_token)
     assert status == 200
     assert data['status'] == 'success'
     assert data['data']['band'] == 'V'
 
 
-def test_token_user_update_instrument(upload_data_token, manage_sources_token,
-                                      public_group):
+def test_token_user_update_instrument(super_admin_token, manage_sources_token,
+                                      view_only_token, public_group):
     name = str(uuid.uuid4())
     status, data = api('POST', 'telescope',
                        data={'name': name,
@@ -51,7 +51,7 @@ def test_token_user_update_instrument(upload_data_token, manage_sources_token,
                              'diameter': 10.0,
                              'group_ids': [public_group.id]
                              },
-                       token=upload_data_token)
+                       token=super_admin_token)
     assert status == 200
     assert data['status'] == 'success'
     telescope_id = data['data']['id']
@@ -62,7 +62,7 @@ def test_token_user_update_instrument(upload_data_token, manage_sources_token,
                              'band': 'V',
                              'telescope_id': telescope_id
                              },
-                       token=upload_data_token)
+                       token=super_admin_token)
     assert status == 200
     assert data['status'] == 'success'
 
@@ -70,7 +70,7 @@ def test_token_user_update_instrument(upload_data_token, manage_sources_token,
     status, data = api(
         'GET',
         f'instrument/{instrument_id}',
-        token=upload_data_token)
+        token=super_admin_token)
     assert status == 200
     assert data['status'] == 'success'
     assert data['data']['band'] == 'V'
@@ -83,19 +83,30 @@ def test_token_user_update_instrument(upload_data_token, manage_sources_token,
               'type': 'type'
               },
         token=manage_sources_token)
+    assert status == 400
+    assert data['status'] == 'error'
+
+    status, data = api(
+        'PUT',
+        f'instrument/{instrument_id}',
+        data={'name': 'new_name',
+              'band': 'V',
+              'type': 'type'
+              },
+        token=super_admin_token)
     assert status == 200
     assert data['status'] == 'success'
 
     status, data = api(
         'GET',
         f'instrument/{instrument_id}',
-        token=upload_data_token)
+        token=view_only_token)
     assert status == 200
     assert data['status'] == 'success'
     assert data['data']['name'] == 'new_name'
 
 
-def test_token_user_delete_instrument(upload_data_token, manage_sources_token,
+def test_token_user_delete_instrument(super_admin_token, view_only_token,
                                       public_group):
     name = str(uuid.uuid4())
     status, data = api('POST', 'telescope',
@@ -107,7 +118,7 @@ def test_token_user_delete_instrument(upload_data_token, manage_sources_token,
                              'diameter': 10.0,
                              'group_ids': [public_group.id]
                              },
-                       token=upload_data_token)
+                       token=super_admin_token)
     assert status == 200
     assert data['status'] == 'success'
     telescope_id = data['data']['id']
@@ -118,7 +129,7 @@ def test_token_user_delete_instrument(upload_data_token, manage_sources_token,
                              'band': 'V',
                              'telescope_id': telescope_id
                              },
-                       token=upload_data_token)
+                       token=super_admin_token)
     assert status == 200
     assert data['status'] == 'success'
     instrument_id = data['data']['id']
@@ -126,12 +137,12 @@ def test_token_user_delete_instrument(upload_data_token, manage_sources_token,
     status, data = api(
         'DELETE',
         f'instrument/{instrument_id}',
-        token=manage_sources_token)
+        token=super_admin_token)
     assert status == 200
     assert data['status'] == 'success'
 
     status, data = api(
         'GET',
         f'instrument/{instrument_id}',
-        token=upload_data_token)
+        token=view_only_token)
     assert status == 400

--- a/skyportal/tests/conftest.py
+++ b/skyportal/tests/conftest.py
@@ -148,7 +148,6 @@ def super_admin_token(super_admin_user):
     return token_id
 
 
-
 @pytest.fixture()
 def comment_token(user):
     token_id = create_token(

--- a/skyportal/tests/conftest.py
+++ b/skyportal/tests/conftest.py
@@ -21,7 +21,7 @@ from skyportal.tests.fixtures import (
     FilterFactory,
 )
 from skyportal.model_util import create_token
-from skyportal.models import DBSession, Source, Candidate
+from skyportal.models import DBSession, Source, Candidate, Role
 
 
 print("Loading test configuration from _test_config.yaml")
@@ -135,6 +135,18 @@ def manage_users_token(super_admin_user):
         name=str(uuid.uuid4()),
     )
     return token_id
+
+
+@pytest.fixture()
+def super_admin_token(super_admin_user):
+    role = Role.query.get('Super admin')
+    token_id = create_token(
+        permissions=[a.id for a in role.acls],
+        created_by_id=super_admin_user.id,
+        name=str(uuid.uuid4()),
+    )
+    return token_id
+
 
 
 @pytest.fixture()

--- a/skyportal/tests/frontend/test_followup_requests.py
+++ b/skyportal/tests/frontend/test_followup_requests.py
@@ -42,9 +42,9 @@ def add_telescope_and_instrument(instrument_name, group_ids, token):
 
 
 def test_submit_new_followup_request(
-    driver, user, public_source, public_group, upload_data_token
+    driver, user, public_source, public_group, super_admin_token
 ):
-    add_telescope_and_instrument("P60 Camera", [public_group.id], upload_data_token)
+    add_telescope_and_instrument("P60 Camera", [public_group.id], super_admin_token)
     driver.get(f"/become_user/{user.id}")
     driver.get(f"/source/{public_source.id}")
     instrument_select_element = driver.wait_for_xpath('//select[@name="instrument_id"]')
@@ -88,9 +88,9 @@ def test_submit_new_followup_request(
 
 
 def test_edit_existing_followup_request(
-    driver, user, public_source, public_group, upload_data_token
+    driver, user, public_source, public_group, super_admin_token
 ):
-    add_telescope_and_instrument("P60 Camera", [public_group.id], upload_data_token)
+    add_telescope_and_instrument("P60 Camera", [public_group.id], super_admin_token)
 
     driver.get(f"/become_user/{user.id}")
     driver.get(f"/source/{public_source.id}")
@@ -139,9 +139,9 @@ def test_edit_existing_followup_request(
 
 
 def test_delete_followup_request(
-    driver, user, public_source, public_group, upload_data_token
+    driver, user, public_source, public_group, super_admin_token
 ):
-    add_telescope_and_instrument("P60 Camera", [public_group.id], upload_data_token)
+    add_telescope_and_instrument("P60 Camera", [public_group.id], super_admin_token)
 
     driver.get(f"/become_user/{user.id}")
     driver.get(f"/source/{public_source.id}")
@@ -190,9 +190,9 @@ def test_delete_followup_request(
 
 
 def test_cannot_edit_uneditable_followup_request(
-    driver, user, public_source, public_group, upload_data_token
+    driver, user, public_source, public_group, super_admin_token
 ):
-    add_telescope_and_instrument("ALFOSC", [public_group.id], upload_data_token)
+    add_telescope_and_instrument("ALFOSC", [public_group.id], super_admin_token)
 
     driver.get(f"/become_user/{user.id}")
     driver.get(f"/source/{public_source.id}")


### PR DESCRIPTION
This PR introduces some slight refinements of the `Instrument` data model, namely:

   * The introduction of a `filters` field, that is an `Array` of `Enum`. The allowed Enum values are the filters defined by our photometry library, `sncosmo`. The `filters` of an instrument can be `[]`, indicating no filters. This would be appropriate for, e.g., a Spectrograph without any imaging capabilities. 
   * Update of the `InstrumentHandler` to this modification and proper rendering of the allowed filter values for new instruments in the api docs:

<img width="1164" alt="Screen Shot 2020-05-26 at 10 39 22 PM" src="https://user-images.githubusercontent.com/2769632/82971915-db899780-9fa1-11ea-8674-50548aa71e3a.png">

   * Requirement that a user be a system admin to update or delete instruments. This is because follow-up requests will assume a certain schema for instruments, and we dont want anyone messing around with the capabilities of the instruments or it could affect other users' follow-up requests. 
