### PR TITLE
Implement photometry-level permission checking

### DIFF
--- a/skyportal/handlers/api/internal/plot.py
+++ b/skyportal/handlers/api/internal/plot.py
@@ -10,7 +10,7 @@ class PlotPhotometryHandler(BaseHandler):
         height = self.get_query_argument("plotHeight", 300)
         width = self.get_query_argument("plotWidth", 600)
         docs_json, render_items, custom_model_js = plot.photometry_plot(
-            obj_id, height=int(height), width=int(width),
+            obj_id, self.current_user, height=int(height), width=int(width),
         )
         if docs_json is None:
             self.success(data={'docs_json': None, 'url': self.request.path})

--- a/skyportal/handlers/api/photometry.py
+++ b/skyportal/handlers/api/photometry.py
@@ -141,6 +141,10 @@ class PhotometryHandler(BaseHandler):
         except KeyError:
             return self.error("Missing required field: group_ids")
         groups = Group.query.filter(Group.id.in_(group_ids)).all()
+        if "Super admin" not in [r.id for r in self.associated_user_object.roles]:
+            if not all([group in self.current_user.groups for group in groups]):
+                return self.error("Cannot upload photometry to groups that you "
+                                  "are not a member of.")
 
         if allscalar(data):
             data = [data]

--- a/skyportal/handlers/api/photometry.py
+++ b/skyportal/handlers/api/photometry.py
@@ -144,9 +144,8 @@ class PhotometryHandler(BaseHandler):
 
         if allscalar(data):
             data = [data]
-            bulk_upload_id = None
-        else:
-            bulk_upload_id = str(uuid.uuid4())
+
+        bulk_upload_id = str(uuid.uuid4())
 
         try:
             df = pd.DataFrame(data)

--- a/skyportal/handlers/api/photometry.py
+++ b/skyportal/handlers/api/photometry.py
@@ -167,6 +167,9 @@ class PhotometryHandler(BaseHandler):
                 except ValueError:
                     return self.error('Unable to coerce passed JSON to a series of packets. '
                                       f'Error was: "{e}"')
+            else:
+                return self.error('Unable to coerce passed JSON to a series of packets. '
+                                  f'Error was: "{e}"')
 
         # pop out thumbnails and process what's left using schemas
 

--- a/skyportal/handlers/api/photometry.py
+++ b/skyportal/handlers/api/photometry.py
@@ -274,7 +274,7 @@ class PhotometryHandler(BaseHandler):
         phot.original_user_data = packet
         phot.id = photometry_id
         DBSession().merge(phot)
-        DBSession.commit()
+        DBSession.flush()
         # Update groups, if relevant
         if group_ids is not None:
             photometry = Photometry.query.get(photometry_id)
@@ -287,7 +287,7 @@ class PhotometryHandler(BaseHandler):
                     return self.error("Cannot upload photometry to groups you "
                                       "are not a member of.")
             photometry.groups = groups
-            DBSession().commit()
+        DBSession().commit()
         return self.success()
 
     @permissions(['Manage sources'])

--- a/skyportal/handlers/api/photometry.py
+++ b/skyportal/handlers/api/photometry.py
@@ -141,6 +141,9 @@ class PhotometryHandler(BaseHandler):
         except KeyError:
             return self.error("Missing required field: group_ids")
         groups = Group.query.filter(Group.id.in_(group_ids)).all()
+        if not groups:
+            return self.error("Invalid group_ids field. "
+                              "Specify at least one valid group ID.")
         if "Super admin" not in [r.id for r in self.associated_user_object.roles]:
             if not all([group in self.current_user.groups for group in groups]):
                 return self.error("Cannot upload photometry to groups that you "

--- a/skyportal/handlers/api/photometry.py
+++ b/skyportal/handlers/api/photometry.py
@@ -124,9 +124,9 @@ class PhotometryHandler(BaseHandler):
                             upload_id:
                               type: string
                               description: |
-                                If multiple data points are posted, a bulk upload ID is
-                                provided so that they may all be deleted in one request.
-                                Otherwise null.
+                                Upload ID associated with all photometry points
+                                added in request. Can be used to later delete all
+                                points in a single request.
         """
 
         data = self.get_json()

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -67,6 +67,8 @@ class Group(Base):
     users = relationship('User', secondary='group_users',
                          back_populates='groups')
     filter = relationship("Filter", uselist=False, back_populates="group")
+    photometry = relationship("Photometry", secondary="group_photometry",
+                              back_populates="groups")
 
 
 GroupUser = join_model('group_users', Group, User)
@@ -389,6 +391,8 @@ class Photometry(Base):
     obj_id = sa.Column(sa.ForeignKey('objs.id', ondelete='CASCADE'),
                        nullable=False, index=True)
     obj = relationship('Obj', back_populates='photometry')
+    groups = relationship("Group", secondary="group_photometry",
+                          back_populates="photometry")
     instrument_id = sa.Column(sa.ForeignKey('instruments.id'),
                               nullable=False, index=True)
     instrument = relationship('Instrument', back_populates='photometry')
@@ -427,6 +431,9 @@ class Photometry(Base):
             ],
             else_=None
         )
+
+
+GroupPhotometry = join_model("group_photometry", Group, Photometry)
 
 
 class Spectrum(Base):

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -264,8 +264,10 @@ def get_obj_if_owned_by(obj_id, user_or_token, options=[]):
             # If user can't view associated Source, and there's no Candidate they can
             # view, raise AccessError
             raise
-    if obj is None:  # There is no associated Source, so just return the Obj
-        return Obj.query.options(options).get(obj_id)
+    if obj is None:  # There is no associated Source/Cand, so check based on photometry
+        if Obj.get_photometry_owned_by_user(obj_id, user_or_token):
+            return Obj.query.options(options).get(obj_id)
+        raise AccessError("Insufficient permissions.")
     # If we get here, the user has access to either the associated Source or Candidate
     return obj
 

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -401,7 +401,7 @@ class Photometry(Base):
                                               'schema.PhotometryFlux or schema.PhotometryMag '
                                               '(depending on how the data was passed).')
     altdata = sa.Column(JSONB)
-    bulk_upload_id = sa.Column(sa.String, nullable=True)
+    bulk_upload_id = sa.Column(sa.String, nullable=False)
 
     obj_id = sa.Column(sa.ForeignKey('objs.id', ondelete='CASCADE'),
                        nullable=False, index=True)

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -401,7 +401,7 @@ class Photometry(Base):
                                               'schema.PhotometryFlux or schema.PhotometryMag '
                                               '(depending on how the data was passed).')
     altdata = sa.Column(JSONB)
-    bulk_upload_id = sa.Column(sa.String, nullable=False)
+    upload_id = sa.Column(sa.String, nullable=False)
 
     obj_id = sa.Column(sa.ForeignKey('objs.id', ondelete='CASCADE'),
                        nullable=False, index=True)

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -273,6 +273,19 @@ def get_obj_if_owned_by(obj_id, user_or_token, options=[]):
 Obj.get_if_owned_by = get_obj_if_owned_by
 
 
+def get_photometry_owned_by_user(obj_id, user_or_token):
+    return (
+        Photometry.query.filter(Photometry.obj_id == obj_id)
+        .filter(
+            Photometry.groups.any(Group.id.in_([g.id for g in user_or_token.groups]))
+        )
+        .all()
+    )
+
+
+Obj.get_photometry_owned_by_user = get_photometry_owned_by_user
+
+
 User.sources = relationship('Obj', backref='users',
                             secondary='join(Group, sources).join(group_users)',
                             primaryjoin='group_users.c.user_id == users.c.id')

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -1,3 +1,4 @@
+import uuid
 import re
 from datetime import datetime
 import numpy as np
@@ -401,7 +402,8 @@ class Photometry(Base):
                                               'schema.PhotometryFlux or schema.PhotometryMag '
                                               '(depending on how the data was passed).')
     altdata = sa.Column(JSONB)
-    upload_id = sa.Column(sa.String, nullable=False)
+    upload_id = sa.Column(sa.String, nullable=False,
+                          default=lambda: str(uuid.uuid4()))
 
     obj_id = sa.Column(sa.ForeignKey('objs.id', ondelete='CASCADE'),
                        nullable=False, index=True)

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -69,7 +69,8 @@ class Group(Base):
                          back_populates='groups')
     filter = relationship("Filter", uselist=False, back_populates="group")
     photometry = relationship("Photometry", secondary="group_photometry",
-                              back_populates="groups")
+                              back_populates="groups",
+                              cascade="save-update, merge, refresh-expire, expunge")
 
 
 GroupUser = join_model('group_users', Group, User)
@@ -409,7 +410,8 @@ class Photometry(Base):
                        nullable=False, index=True)
     obj = relationship('Obj', back_populates='photometry')
     groups = relationship("Group", secondary="group_photometry",
-                          back_populates="photometry")
+                          back_populates="photometry",
+                          cascade="save-update, merge, refresh-expire, expunge")
     instrument_id = sa.Column(sa.ForeignKey('instruments.id'),
                               nullable=False, index=True)
     instrument = relationship('Instrument', back_populates='photometry')

--- a/skyportal/plot.py
+++ b/skyportal/plot.py
@@ -16,7 +16,7 @@ from matplotlib import cm
 from matplotlib.colors import rgb2hex
 
 import os
-from skyportal.models import (DBSession, Obj, Photometry,
+from skyportal.models import (DBSession, Obj, Photometry, Group,
                               Instrument, Telescope, PHOT_ZP)
 
 import sncosmo
@@ -173,7 +173,7 @@ def get_color(bandpass_name, cmap_limits=(3000., 10000.)):
 
 
 # TODO make async so that thread isn't blocked
-def photometry_plot(obj_id, width=600, height=300):
+def photometry_plot(obj_id, user, width=600, height=300):
     """Create scatter plot of photometry for object.
     Parameters
     ----------
@@ -185,12 +185,21 @@ def photometry_plot(obj_id, width=600, height=300):
         Returns (docs_json, render_items) json for the desired plot.
     """
 
-    data = pd.read_sql(DBSession()
-                       .query(Photometry, Telescope.nickname.label('telescope'),
-                              Instrument.name.label('instrument'))
-                       .join(Instrument).join(Telescope)
-                       .filter(Photometry.obj_id == obj_id)
-                       .statement, DBSession().bind)
+    data = pd.read_sql(
+        DBSession()
+        .query(
+            Photometry,
+            Telescope.nickname.label("telescope"),
+            Instrument.name.label("instrument"),
+        )
+        .join(Instrument)
+        .join(Telescope)
+        .filter(Photometry.obj_id == obj_id)
+        .filter(Photometry.groups.any(Group.id.in_([g.id for g in user.groups])))
+        .statement,
+        DBSession().bind
+    )
+
     if data.empty:
         return None, None, None
 
@@ -203,8 +212,8 @@ def photometry_plot(obj_id, width=600, height=300):
     data['alpha'] = 1.
     data['lim_mag'] = -2.5 * np.log10(data['fluxerr'] * DETECT_THRESH) + data['zp']
 
-    # Passing a dictionary to a bokeh datasource causes the frontend to die, 
-    # deleting the dictionary column fixes that 
+    # Passing a dictionary to a bokeh datasource causes the frontend to die,
+    # deleting the dictionary column fixes that
     del data['original_user_data']
 
     # keep track of things that are only upper limits
@@ -310,7 +319,6 @@ def photometry_plot(obj_id, width=600, height=300):
     plot.yaxis.axis_label = 'Flux (μJy)'
     plot.toolbar.logo = None
 
-
     toggle = CheckboxWithLegendGroup(
         labels=list(data.label.unique()),
         active=list(range(len(data.label.unique()))),
@@ -332,11 +340,11 @@ def photometry_plot(obj_id, width=600, height=300):
                         code=open(os.path.join(os.path.dirname(__file__),
                                                '../static/js/plotjs',
                                                'stackf.js')).read().replace(
-                                   'default_zp', str(PHOT_ZP)
-                               ).replace(
-                                   'detect_thresh', str(DETECT_THRESH)
-                               )
-                        )
+        'default_zp', str(PHOT_ZP)
+    ).replace(
+        'detect_thresh', str(DETECT_THRESH)
+    )
+    )
 
     slider.js_on_change('value', callback)
 
@@ -455,7 +463,7 @@ def photometry_plot(obj_id, width=600, height=300):
         model_dict[key] = ColumnDataSource(df)
 
         key = f'bold{i}'
-        model_dict[key] = ColumnDataSource(df[['mjd', 'flux', 'fluxerr','mag',
+        model_dict[key] = ColumnDataSource(df[['mjd', 'flux', 'fluxerr', 'mag',
                                                'magerr', 'filter', 'zp',
                                                'magsys', 'lim_mag', 'stacked']])
 
@@ -496,10 +504,10 @@ def photometry_plot(obj_id, width=600, height=300):
                         code=open(os.path.join(os.path.dirname(__file__),
                                                '../static/js/plotjs',
                                                'stackm.js')).read().replace(
-                                   'default_zp', str(PHOT_ZP)
-                               ).replace(
-                                   'detect_thresh', str(DETECT_THRESH)
-                               ))
+        'default_zp', str(PHOT_ZP)
+    ).replace(
+        'detect_thresh', str(DETECT_THRESH)
+    ))
     slider.js_on_change('value', callback)
 
     layout = row(plot, toggle)
@@ -593,4 +601,3 @@ def spectroscopy_plot(obj_id):
 
     layout = row(plot, toggle, elements, column(z, v_exp))
     return _plot_to_json(layout)
-

--- a/skyportal/schema.py
+++ b/skyportal/schema.py
@@ -202,6 +202,11 @@ class PhotBaseFlexible(object):
                                        'given as lists. Null values allowed.',
                            required=False)
 
+    group_ids = fields.List(fields.Integer(),
+                            description="List of group IDs to which photometry "
+                                        "points will be visible.",
+                            required=True)
+
 
 class PhotFluxFlexible(_Schema, PhotBaseFlexible):
     """This is one of two classes used for rendering the
@@ -330,7 +335,7 @@ class PhotBase(object):
 
 
 class PhotometryFlux(_Schema, PhotBase):
-    """This is one of  two classes that are used for deserializing
+    """This is one of two classes that are used for deserializing
     and validating the postprocessed input data of `PhotometryHandler.post`
     and `PhotometryHandler.put` and for generating the API docs of
     PhotometryHandler.get`.

--- a/skyportal/tests/api/test_bulk_delete_photometry.py
+++ b/skyportal/tests/api/test_bulk_delete_photometry.py
@@ -20,10 +20,10 @@ def test_bulk_delete_photometry(upload_data_token, public_source, public_group):
     )
     assert status == 200
     assert data["status"] == "success"
-    bulk_upload_id = data["data"]["bulk_upload_id"]
+    upload_id = data["data"]["upload_id"]
 
     status, data = api(
-        "DELETE", f"photometry/bulk_delete/{bulk_upload_id}", token=upload_data_token
+        "DELETE", f"photometry/bulk_delete/{upload_id}", token=upload_data_token
     )
     assert status == 200
     assert data["data"] == "Deleted 3 photometry points."

--- a/skyportal/tests/api/test_bulk_delete_photometry.py
+++ b/skyportal/tests/api/test_bulk_delete_photometry.py
@@ -1,7 +1,7 @@
 from skyportal.tests import api
 
 
-def test_bulk_delete_photometry(upload_data_token, public_source):
+def test_bulk_delete_photometry(upload_data_token, public_source, public_group):
     status, data = api(
         "POST",
         "photometry",
@@ -14,6 +14,7 @@ def test_bulk_delete_photometry(upload_data_token, public_source):
             "filter": ["ztfg", "ztfg", "ztfg"],
             "zp": [25.0, 25.0, 25.0],
             "magsys": ["ab", "ab", "ab"],
+            "group_ids": [public_group.id],
         },
         token=upload_data_token,
     )

--- a/skyportal/tests/api/test_photometry.py
+++ b/skyportal/tests/api/test_photometry.py
@@ -42,6 +42,173 @@ def test_token_user_post_get_photometry_data(upload_data_token, public_source,
                                12.24 * 10**(-0.4 * (25. - 23.9)))
 
 
+def test_post_photometry_multiple_groups(upload_data_token_two_groups,
+                                         public_source_two_groups, public_group,
+                                         public_group2, ztf_camera):
+    upload_data_token = upload_data_token_two_groups
+    public_source = public_source_two_groups
+    status, data = api('POST', 'photometry',
+                       data={'obj_id': str(public_source.id),
+                             'mjd': 58000.,
+                             'instrument_id': ztf_camera.id,
+                             'flux': 12.24,
+                             'fluxerr': 0.031,
+                             'zp': 25.,
+                             'magsys': 'ab',
+                             'filter': 'ztfg',
+                             'group_ids': [public_group.id,
+                                           public_group2.id]
+                             },
+                       token=upload_data_token)
+    assert status == 200
+    assert data['status'] == 'success'
+
+    photometry_id = data['data']['ids'][0]
+    status, data = api(
+        'GET',
+        f'photometry/{photometry_id}?format=flux',
+        token=upload_data_token)
+    assert status == 200
+    assert data['status'] == 'success'
+
+    assert data['data']['ra'] is None
+    assert data['data']['dec'] is None
+    assert data['data']['ra_unc'] is None
+    assert data['data']['dec_unc'] is None
+
+    np.testing.assert_allclose(data['data']['flux'],
+                               12.24 * 10**(-0.4 * (25. - 23.9)))
+
+
+def test_retrieve_photometry_group_membership_posted_by_other(
+        upload_data_token_two_groups, view_only_token, public_source_two_groups,
+        public_group, public_group2, ztf_camera
+):
+    upload_data_token = upload_data_token_two_groups
+    public_source = public_source_two_groups
+    status, data = api('POST', 'photometry',
+                       data={'obj_id': str(public_source.id),
+                             'mjd': 58000.,
+                             'instrument_id': ztf_camera.id,
+                             'flux': 12.24,
+                             'fluxerr': 0.031,
+                             'zp': 25.,
+                             'magsys': 'ab',
+                             'filter': 'ztfg',
+                             'group_ids': [public_group.id,
+                                           public_group2.id]
+                             },
+                       token=upload_data_token)
+    assert status == 200
+    assert data['status'] == 'success'
+
+    photometry_id = data['data']['ids'][0]
+    status, data = api(
+        'GET',
+        f'photometry/{photometry_id}?format=flux',
+        token=view_only_token)
+    assert status == 200
+    assert data['status'] == 'success'
+
+    assert data['data']['ra'] is None
+    assert data['data']['dec'] is None
+    assert data['data']['ra_unc'] is None
+    assert data['data']['dec_unc'] is None
+
+    np.testing.assert_allclose(data['data']['flux'],
+                               12.24 * 10**(-0.4 * (25. - 23.9)))
+
+
+def test_retrieve_photometry_error_group_membership_posted_by_other(
+        upload_data_token_two_groups, view_only_token, public_source_two_groups,
+        public_group, public_group2, ztf_camera
+):
+    upload_data_token = upload_data_token_two_groups
+    public_source = public_source_two_groups
+    status, data = api('POST', 'photometry',
+                       data={'obj_id': str(public_source.id),
+                             'mjd': 58000.,
+                             'instrument_id': ztf_camera.id,
+                             'flux': 12.24,
+                             'fluxerr': 0.031,
+                             'zp': 25.,
+                             'magsys': 'ab',
+                             'filter': 'ztfg',
+                             'group_ids': [public_group2.id]
+                             },
+                       token=upload_data_token)
+    assert status == 200
+    assert data['status'] == 'success'
+
+    photometry_id = data['data']['ids'][0]
+    status, data = api(
+        'GET',
+        f'photometry/{photometry_id}?format=flux',
+        token=view_only_token)
+    # `view_only_token only` belongs to `public_group`, not `public_group2`
+    assert status == 400
+    assert data['status'] == 'error'
+    assert "Insufficient permissions" in data['message']
+
+
+def test_post_photometry_unaccessed_group(upload_data_token,
+                                          public_source, public_group,
+                                          public_group2, ztf_camera):
+    status, data = api('POST', 'photometry',
+                       data={'obj_id': str(public_source.id),
+                             'mjd': 58000.,
+                             'instrument_id': ztf_camera.id,
+                             'flux': 12.24,
+                             'fluxerr': 0.031,
+                             'zp': 25.,
+                             'magsys': 'ab',
+                             'filter': 'ztfg',
+                             'group_ids': [public_group.id,
+                                           public_group2.id]
+                             },
+                       token=upload_data_token)
+    assert status == 400
+    assert data['status'] == 'error'
+    assert "Cannot upload photometry to groups" in data["message"]
+
+
+def test_cannot_post_photometry_no_groups(upload_data_token,
+                                          public_source, public_group, ztf_camera):
+    status, data = api('POST', 'photometry',
+                       data={'obj_id': str(public_source.id),
+                             'mjd': 58000.,
+                             'instrument_id': ztf_camera.id,
+                             'flux': 12.24,
+                             'fluxerr': 0.031,
+                             'zp': 25.,
+                             'magsys': 'ab',
+                             'filter': 'ztfg',
+                             },
+                       token=upload_data_token)
+    assert status == 400
+    assert data['status'] == 'error'
+    assert "group_ids" in data["message"]
+
+
+def test_cannot_post_photometry_empty_groups_list(upload_data_token,
+                                                  public_source, public_group, ztf_camera):
+    status, data = api('POST', 'photometry',
+                       data={'obj_id': str(public_source.id),
+                             'mjd': 58000.,
+                             'instrument_id': ztf_camera.id,
+                             'flux': 12.24,
+                             'fluxerr': 0.031,
+                             'zp': 25.,
+                             'magsys': 'ab',
+                             'filter': 'ztfg',
+                             'group_ids': []
+                             },
+                       token=upload_data_token)
+    assert status == 400
+    assert data['status'] == 'error'
+    assert "Invalid group_ids field" in data["message"]
+
+
 def test_token_user_post_mag_photometry_data_and_convert(upload_data_token,
                                                          public_source,
                                                          ztf_camera,
@@ -232,7 +399,8 @@ def test_token_user_mixed_photometry_post(upload_data_token, public_source,
                              'magerr': [0.2, 0.1],
                              'limiting_mag': 22.3,
                              'magsys': 'ab',
-                             'filter': 'ztfg'
+                             'filter': 'ztfg',
+                             'group_ids': [public_group.id]
                              },
                        token=upload_data_token)
     assert status == 400
@@ -265,7 +433,8 @@ def test_token_user_mixed_mag_none_photometry_post(upload_data_token, public_sou
                              'magerr': [0.2, 0.1],
                              'limiting_mag': 22.3,
                              'magsys': 'ab',
-                             'filter': 'ztfg'
+                             'filter': 'ztfg',
+                             'group_ids': [public_group.id]
                              },
                        token=upload_data_token)
     assert status == 400
@@ -279,7 +448,8 @@ def test_token_user_mixed_mag_none_photometry_post(upload_data_token, public_sou
                              'magerr': [None, 0.1],
                              'limiting_mag': 22.3,
                              'magsys': 'ab',
-                             'filter': 'ztfg'
+                             'filter': 'ztfg',
+                             'group_ids': [public_group.id]
                              },
                        token=upload_data_token)
     assert status == 400

--- a/skyportal/tests/api/test_photometry.py
+++ b/skyportal/tests/api/test_photometry.py
@@ -9,7 +9,7 @@ import sncosmo
 
 
 def test_token_user_post_get_photometry_data(upload_data_token, public_source,
-                                             ztf_camera):
+                                             public_group, ztf_camera):
     status, data = api('POST', 'photometry',
                        data={'obj_id': str(public_source.id),
                              'mjd': 58000.,
@@ -18,7 +18,8 @@ def test_token_user_post_get_photometry_data(upload_data_token, public_source,
                              'fluxerr': 0.031,
                              'zp': 25.,
                              'magsys': 'ab',
-                             'filter': 'ztfg'
+                             'filter': 'ztfg',
+                             'group_ids': [public_group.id]
                              },
                        token=upload_data_token)
     assert status == 200
@@ -43,7 +44,8 @@ def test_token_user_post_get_photometry_data(upload_data_token, public_source,
 
 def test_token_user_post_mag_photometry_data_and_convert(upload_data_token,
                                                          public_source,
-                                                         ztf_camera):
+                                                         ztf_camera,
+                                                         public_group):
 
     status, data = api('POST', 'photometry',
                        data={'obj_id': str(public_source.id),
@@ -53,7 +55,8 @@ def test_token_user_post_mag_photometry_data_and_convert(upload_data_token,
                              'magerr': 0.2,
                              'limiting_mag': 22.3,
                              'magsys': 'vega',
-                             'filter': 'ztfg'
+                             'filter': 'ztfg',
+                             'group_ids': [public_group.id]
                              },
                        token=upload_data_token)
     assert status == 200
@@ -72,7 +75,7 @@ def test_token_user_post_mag_photometry_data_and_convert(upload_data_token,
     correction = 2.5 * np.log10(vega.zpbandflux('ztfg') / ab.zpbandflux('ztfg'))
 
     np.testing.assert_allclose(data['data']['flux'],
-                               10**(-0.4 * (21. - correction - 23.9 )))
+                               10**(-0.4 * (21. - correction - 23.9)))
 
     np.testing.assert_allclose(data['data']['fluxerr'],
                                0.2 / (2.5 / np.log(10)) * data['data']['flux'])
@@ -92,8 +95,9 @@ def test_token_user_post_mag_photometry_data_and_convert(upload_data_token,
 
 
 def test_token_user_post_and_get_different_systems_mag(upload_data_token,
-                                                   public_source,
-                                                   ztf_camera):
+                                                       public_source,
+                                                       ztf_camera,
+                                                       public_group):
 
     status, data = api('POST', 'photometry',
                        data={'obj_id': str(public_source.id),
@@ -103,7 +107,8 @@ def test_token_user_post_and_get_different_systems_mag(upload_data_token,
                              'magerr': 0.2,
                              'limiting_mag': 22.3,
                              'magsys': 'vega',
-                             'filter': 'ztfg'
+                             'filter': 'ztfg',
+                             'group_ids': [public_group.id]
                              },
                        token=upload_data_token)
     assert status == 200
@@ -139,8 +144,9 @@ def test_token_user_post_and_get_different_systems_mag(upload_data_token,
 
 
 def test_token_user_post_and_get_different_systems_flux(upload_data_token,
-                                                   public_source,
-                                                   ztf_camera):
+                                                        public_source,
+                                                        ztf_camera,
+                                                        public_group):
 
     status, data = api('POST', 'photometry',
                        data={'obj_id': str(public_source.id),
@@ -150,7 +156,8 @@ def test_token_user_post_and_get_different_systems_flux(upload_data_token,
                              'magerr': 0.2,
                              'limiting_mag': 22.3,
                              'magsys': 'vega',
-                             'filter': 'ztfg'
+                             'filter': 'ztfg',
+                             'group_ids': [public_group.id]
                              },
                        token=upload_data_token)
     assert status == 200
@@ -167,7 +174,6 @@ def test_token_user_post_and_get_different_systems_flux(upload_data_token,
     ab = sncosmo.get_magsystem('ab')
     vega = sncosmo.get_magsystem('vega')
     correction = 2.5 * np.log10(vega.zpbandflux('ztfg') / ab.zpbandflux('ztfg'))
-
 
     np.testing.assert_allclose(data['data']['flux'], 10**(-0.4 * (21 - correction - 23.9)))
     np.testing.assert_allclose(data['data']['fluxerr'], 0.2 / (2.5 / np.log(10)) * data['data']['flux'])
@@ -186,7 +192,7 @@ def test_token_user_post_and_get_different_systems_flux(upload_data_token,
 
 
 def test_token_user_mixed_photometry_post(upload_data_token, public_source,
-                                          ztf_camera):
+                                          ztf_camera, public_group):
 
     status, data = api('POST', 'photometry',
                        data={'obj_id': str(public_source.id),
@@ -196,7 +202,8 @@ def test_token_user_mixed_photometry_post(upload_data_token, public_source,
                              'magerr': [0.2, 0.1],
                              'limiting_mag': 22.3,
                              'magsys': 'ab',
-                             'filter': 'ztfg'
+                             'filter': 'ztfg',
+                             'group_ids': [public_group.id]
                              },
                        token=upload_data_token)
     assert status == 200
@@ -211,7 +218,7 @@ def test_token_user_mixed_photometry_post(upload_data_token, public_source,
     assert data['status'] == 'success'
 
     np.testing.assert_allclose(data['data']['flux'],
-                               10**(-0.4 * (21. - 23.9 )))
+                               10**(-0.4 * (21. - 23.9)))
 
     np.testing.assert_allclose(data['data']['fluxerr'],
                                0.1 / (2.5 / np.log(10)) * data['data']['flux'])
@@ -233,7 +240,7 @@ def test_token_user_mixed_photometry_post(upload_data_token, public_source,
 
 
 def test_token_user_mixed_mag_none_photometry_post(upload_data_token, public_source,
-                                                   ztf_camera):
+                                                   ztf_camera, public_group):
 
     status, data = api('POST', 'photometry',
                        data={'obj_id': str(public_source.id),
@@ -243,7 +250,8 @@ def test_token_user_mixed_mag_none_photometry_post(upload_data_token, public_sou
                              'magerr': [0.2, 0.1],
                              'limiting_mag': 22.3,
                              'magsys': 'ab',
-                             'filter': 'ztfg'
+                             'filter': 'ztfg',
+                             'group_ids': [public_group.id]
                              },
                        token=upload_data_token)
     assert status == 400
@@ -277,8 +285,9 @@ def test_token_user_mixed_mag_none_photometry_post(upload_data_token, public_sou
     assert status == 400
     assert data['status'] == 'error'
 
+
 def test_token_user_post_photometry_limits(upload_data_token, public_source,
-                                           ztf_camera):
+                                           ztf_camera, public_group):
 
     status, data = api('POST', 'photometry',
                        data={'obj_id': str(public_source.id),
@@ -288,7 +297,8 @@ def test_token_user_post_photometry_limits(upload_data_token, public_source,
                              'magerr': None,
                              'limiting_mag': 22.3,
                              'magsys': 'ab',
-                             'filter': 'ztfg'
+                             'filter': 'ztfg',
+                             'group_ids': [public_group.id]
                              },
                        token=upload_data_token)
     assert status == 200
@@ -314,7 +324,8 @@ def test_token_user_post_photometry_limits(upload_data_token, public_source,
                              'fluxerr': 0.031,
                              'zp': 25.,
                              'magsys': 'ab',
-                             'filter': 'ztfg'
+                             'filter': 'ztfg',
+                             'group_ids': [public_group.id]
                              },
                        token=upload_data_token)
     assert status == 200
@@ -334,7 +345,7 @@ def test_token_user_post_photometry_limits(upload_data_token, public_source,
 
 
 def test_token_user_post_invalid_filter(upload_data_token, public_source,
-                                        ztf_camera):
+                                        ztf_camera, public_group):
 
     status, data = api('POST', 'photometry',
                        data={'obj_id': str(public_source.id),
@@ -344,7 +355,8 @@ def test_token_user_post_invalid_filter(upload_data_token, public_source,
                              'magerr': None,
                              'limiting_mag': 22.3,
                              'magsys': 'ab',
-                             'filter': 'bessellv'
+                             'filter': 'bessellv',
+                             'group_ids': [public_group.id]
                              },
                        token=upload_data_token)
     assert status == 400
@@ -352,7 +364,7 @@ def test_token_user_post_invalid_filter(upload_data_token, public_source,
 
 
 def test_token_user_post_photometry_data_series(upload_data_token, public_source,
-                                                ztf_camera):
+                                                ztf_camera, public_group):
     # valid request
     status, data = api(
         'POST',
@@ -367,7 +379,9 @@ def test_token_user_post_photometry_data_series(upload_data_token, public_source
               'magsys': ['ab', 'ab', 'ab'],
               'ra': 264.1947917,
               'dec': [50.5478333, 50.5478333 + 0.00001, 50.5478333],
-              'dec_unc': 0.2},
+              'dec_unc': 0.2,
+              'group_ids': [public_group.id]
+              },
         token=upload_data_token)
     assert status == 200
     assert data['status'] == 'success'
@@ -389,19 +403,19 @@ def test_token_user_post_photometry_data_series(upload_data_token, public_source
     assert np.allclose(data['data']['dec_unc'], 0.2)
     assert data['data']['ra_unc'] is None
 
-
     # invalid request
     status, data = api(
         'POST',
         'photometry',
         data=[{'obj_id': str(public_source.id),
-              'mjd': 58000,
-              'instrument_id': ztf_camera.id,
-              'flux': 12.24,
-              'fluxerr': 0.031,
-              'filter': 'ztfg',
-              'zp': 25.,
-              'magsys': 'ab'},
+               'mjd': 58000,
+               'instrument_id': ztf_camera.id,
+               'flux': 12.24,
+               'fluxerr': 0.031,
+               'filter': 'ztfg',
+               'zp': 25.,
+               'magsys': 'ab',
+               'group_ids': [public_group.id]},
               {'obj_id': str(public_source.id),
                'mjd': 58001,
                'instrument_id': ztf_camera.id,
@@ -409,7 +423,8 @@ def test_token_user_post_photometry_data_series(upload_data_token, public_source
                'fluxerr': 0.031,
                'filter': 'ztfg',
                'zp': 30.,
-               'magsys': 'ab'},
+               'magsys': 'ab',
+               'group_ids': [public_group.id]},
               {'obj_id': str(public_source.id),
                'mjd': 58002,
                'instrument_id': ztf_camera.id,
@@ -417,7 +432,8 @@ def test_token_user_post_photometry_data_series(upload_data_token, public_source
                'fluxerr': 0.031,
                'filter': 'ztfg',
                'zp': 21.2,
-               'magsys': 'vega'}],
+               'magsys': 'vega',
+               'group_ids': [public_group.id]}],
         token=upload_data_token)
 
     assert status == 400
@@ -425,7 +441,7 @@ def test_token_user_post_photometry_data_series(upload_data_token, public_source
 
 
 def test_post_photometry_no_access_token(view_only_token, public_source,
-                                         ztf_camera):
+                                         ztf_camera, public_group):
     status, data = api('POST', 'photometry',
                        data={'obj_id': str(public_source.id),
                              'mjd': 58000.,
@@ -434,7 +450,8 @@ def test_post_photometry_no_access_token(view_only_token, public_source,
                              'fluxerr': 0.031,
                              'zp': 25.,
                              'magsys': 'ab',
-                             'filter': 'ztfg'
+                             'filter': 'ztfg',
+                             'group_ids': [public_group.id]
                              },
                        token=view_only_token)
     assert status == 400
@@ -443,7 +460,8 @@ def test_post_photometry_no_access_token(view_only_token, public_source,
 
 def test_token_user_update_photometry(upload_data_token,
                                       manage_sources_token,
-                                      public_source, ztf_camera):
+                                      public_source, ztf_camera,
+                                      public_group):
     status, data = api('POST', 'photometry',
                        data={'obj_id': str(public_source.id),
                              'mjd': 58000.,
@@ -452,7 +470,8 @@ def test_token_user_update_photometry(upload_data_token,
                              'fluxerr': 0.031,
                              'zp': 25.,
                              'magsys': 'ab',
-                             'filter': 'ztfi'
+                             'filter': 'ztfi',
+                             'group_ids': [public_group.id]
                              },
                        token=upload_data_token)
     assert status == 200
@@ -478,7 +497,8 @@ def test_token_user_update_photometry(upload_data_token,
               'fluxerr': 0.031,
               'zp': 25.,
               'magsys': 'ab',
-              'filter': 'ztfi'},
+              'filter': 'ztfi'
+              },
         token=manage_sources_token)
     assert status == 200
     assert data['status'] == 'success'
@@ -492,7 +512,7 @@ def test_token_user_update_photometry(upload_data_token,
 
 
 def test_delete_photometry_data(upload_data_token, manage_sources_token,
-                                public_source, ztf_camera):
+                                public_source, ztf_camera, public_group):
     status, data = api('POST', 'photometry',
                        data={'obj_id': str(public_source.id),
                              'mjd': 58000.,
@@ -501,7 +521,8 @@ def test_delete_photometry_data(upload_data_token, manage_sources_token,
                              'fluxerr': 0.031,
                              'zp': 25.,
                              'magsys': 'ab',
-                             'filter': 'ztfi'
+                             'filter': 'ztfi',
+                             'group_ids': [public_group.id],
                              },
                        token=upload_data_token)
     assert status == 200
@@ -540,10 +561,10 @@ def test_token_user_retrieving_source_photometry_and_convert(view_only_token, pu
     assert 'ra_unc' in data['data'][0]
 
     mag1_ab = -2.5 * np.log10(data['data'][0]['flux']) + data['data'][0]['zp']
-    magerr1_ab = 2.5 / np.log(10) * data['data'][0]['fluxerr']/ data['data'][0]['flux']
+    magerr1_ab = 2.5 / np.log(10) * data['data'][0]['fluxerr'] / data['data'][0]['flux']
 
     maglast_ab = -2.5 * np.log10(data['data'][-1]['flux']) + data['data'][-1]['zp']
-    magerrlast_ab = 2.5 / np.log(10) * data['data'][-1]['fluxerr']/ data['data'][-1]['flux']
+    magerrlast_ab = 2.5 / np.log(10) * data['data'][-1]['fluxerr'] / data['data'][-1]['flux']
 
     status, data = api('GET', f'sources/{public_source.id}/photometry?format=mag&magsys=ab',
                        token=view_only_token)
@@ -556,16 +577,14 @@ def test_token_user_retrieving_source_photometry_and_convert(view_only_token, pu
     assert np.allclose(maglast_ab, data['data'][-1]['mag'])
     assert np.allclose(magerrlast_ab, data['data'][-1]['magerr'])
 
-
     status, data = api('GET', f'sources/{public_source.id}/photometry?format=flux&magsys=vega',
                        token=view_only_token)
 
     mag1_vega = -2.5 * np.log10(data['data'][0]['flux']) + data['data'][0]['zp']
-    magerr1_vega = 2.5 / np.log(10) * data['data'][0]['fluxerr']/ data['data'][0]['flux']
+    magerr1_vega = 2.5 / np.log(10) * data['data'][0]['fluxerr'] / data['data'][0]['flux']
 
     maglast_vega = -2.5 * np.log10(data['data'][-1]['flux']) + data['data'][-1]['zp']
-    magerrlast_vega = 2.5 / np.log(10) * data['data'][-1]['fluxerr']/ data['data'][-1]['flux']
-
+    magerrlast_vega = 2.5 / np.log(10) * data['data'][-1]['fluxerr'] / data['data'][-1]['flux']
 
     assert status == 200
     assert data['status'] == 'success'
@@ -577,7 +596,6 @@ def test_token_user_retrieving_source_photometry_and_convert(view_only_token, pu
         for filter in ['ztfg', 'ztfr', 'ztfi']
     }
 
-
     assert np.allclose(mag1_ab, mag1_vega + vega_to_ab[data['data'][0]['filter']])
     assert np.allclose(magerr1_ab, magerr1_vega)
 
@@ -586,7 +604,7 @@ def test_token_user_retrieving_source_photometry_and_convert(view_only_token, pu
 
 
 def test_token_user_retrieve_null_photometry(upload_data_token, public_source,
-                                             ztf_camera):
+                                             ztf_camera, public_group):
 
     status, data = api('POST', 'photometry',
                        data={'obj_id': str(public_source.id),
@@ -596,7 +614,8 @@ def test_token_user_retrieve_null_photometry(upload_data_token, public_source,
                              'magerr': None,
                              'limiting_mag': 22.3,
                              'magsys': 'ab',
-                             'filter': 'ztfg'
+                             'filter': 'ztfg',
+                             'group_ids': [public_group.id]
                              },
                        token=upload_data_token)
     assert status == 200

--- a/skyportal/tests/api/test_thumbnail.py
+++ b/skyportal/tests/api/test_thumbnail.py
@@ -30,7 +30,8 @@ def test_token_user_post_get_thumbnail(upload_data_token, public_group,
                              'fluxerr': 0.031,
                              'zp': 25.,
                              'magsys': 'ab',
-                             'filter': 'ztfg'
+                             'filter': 'ztfg',
+                             'group_ids': [public_group.id]
                              },
                        token=upload_data_token)
     assert status == 200
@@ -92,7 +93,8 @@ def test_token_user_delete_thumbnail_cascade_source(upload_data_token,
                              'fluxerr': 0.031,
                              'zp': 25.,
                              'magsys': 'ab',
-                             'filter': 'ztfr'
+                             'filter': 'ztfr',
+                             'group_ids': [public_group.id]
                              },
                        token=upload_data_token)
     assert status == 200
@@ -162,7 +164,8 @@ def test_token_user_post_get_thumbnail_phot_id(upload_data_token, public_group,
                              'fluxerr': 0.031,
                              'zp': 25.,
                              'magsys': 'ab',
-                             'filter': 'ztfg'
+                             'filter': 'ztfg',
+                             'group_ids': [public_group.id]
                              },
                        token=upload_data_token)
     assert status == 200
@@ -221,7 +224,8 @@ def test_cannot_post_thumbnail_invalid_ttype(upload_data_token, public_group,
                              'fluxerr': 0.031,
                              'zp': 25.,
                              'magsys': 'ab',
-                             'filter': 'ztfi'
+                             'filter': 'ztfi',
+                             'group_ids': [public_group.id]
                              },
                        token=upload_data_token)
     assert status == 200
@@ -263,7 +267,8 @@ def test_cannot_post_thumbnail_invalid_image_type(upload_data_token, public_grou
                              'fluxerr': 0.031,
                              'zp': 25.,
                              'magsys': 'ab',
-                             'filter': 'ztfr'
+                             'filter': 'ztfr',
+                             'group_ids': [public_group.id]
                              },
                        token=upload_data_token)
     assert status == 200
@@ -304,7 +309,8 @@ def test_cannot_post_thumbnail_invalid_size(upload_data_token, public_group, ztf
                              'fluxerr': 0.031,
                              'zp': 25.,
                              'magsys': 'ab',
-                             'filter': 'ztfg'
+                             'filter': 'ztfg',
+                             'group_ids': [public_group.id]
                              },
                        token=upload_data_token)
     assert status == 200
@@ -346,7 +352,8 @@ def test_cannot_post_thumbnail_invalid_file_type(upload_data_token, public_group
                              'fluxerr': 0.031,
                              'zp': 25.,
                              'magsys': 'ab',
-                             'filter': 'ztfi'
+                             'filter': 'ztfi',
+                             'group_ids': [public_group.id]
                              },
                        token=upload_data_token)
     assert status == 200

--- a/skyportal/tests/conftest.py
+++ b/skyportal/tests/conftest.py
@@ -112,6 +112,14 @@ def group_admin_user(public_group):
 
 
 @pytest.fixture()
+def group_admin_user_two_groups(public_group, public_group2):
+    return UserFactory(
+        groups=[public_group, public_group2],
+        roles=[models.Role.query.get("Group admin")],
+    )
+
+
+@pytest.fixture()
 def super_admin_user(public_group):
     return UserFactory(
         groups=[public_group], roles=[models.Role.query.get("Super admin")]
@@ -147,6 +155,16 @@ def manage_sources_token(group_admin_user):
     token_id = create_token(
         permissions=["Manage sources"],
         created_by_id=group_admin_user.id,
+        name=str(uuid.uuid4()),
+    )
+    return token_id
+
+
+@pytest.fixture()
+def manage_sources_token_two_groups(group_admin_user_two_groups):
+    token_id = create_token(
+        permissions=["Manage sources"],
+        created_by_id=group_admin_user_two_groups.id,
         name=str(uuid.uuid4()),
     )
     return token_id

--- a/skyportal/tests/conftest.py
+++ b/skyportal/tests/conftest.py
@@ -19,7 +19,7 @@ from skyportal.tests.fixtures import (
     GroupFactory,
     UserFactory,
     FilterFactory,
-    InstrumentFactory
+    InstrumentFactory,
 )
 from skyportal.model_util import create_token
 from skyportal.models import DBSession, Source, Candidate, Role
@@ -52,6 +52,15 @@ def public_filter(public_group):
 def public_source(public_group):
     obj = ObjFactory(groups=[public_group])
     DBSession.add(Source(obj_id=obj.id, group_id=public_group.id))
+    DBSession.commit()
+    return obj
+
+
+@pytest.fixture()
+def public_source_two_groups(public_group, public_group2):
+    obj = ObjFactory(groups=[public_group, public_group2])
+    for group in [public_group, public_group2]:
+        DBSession.add(Source(obj_id=obj.id, group_id=group.id))
     DBSession.commit()
     return obj
 
@@ -112,7 +121,8 @@ def super_admin_user(public_group):
 @pytest.fixture()
 def super_admin_user_two_groups(public_group, public_group2):
     return UserFactory(
-        groups=[public_group, public_group2], roles=[models.Role.query.get("Super admin")]
+        groups=[public_group, public_group2],
+        roles=[models.Role.query.get("Super admin")],
     )
 
 
@@ -153,7 +163,9 @@ def upload_data_token(user):
 @pytest.fixture()
 def upload_data_token_two_groups(user_two_groups):
     token_id = create_token(
-        permissions=["Upload data"], created_by_id=user_two_groups.id, name=str(uuid.uuid4())
+        permissions=["Upload data"],
+        created_by_id=user_two_groups.id,
+        name=str(uuid.uuid4()),
     )
     return token_id
 
@@ -180,7 +192,7 @@ def manage_users_token(super_admin_user):
 
 @pytest.fixture()
 def super_admin_token(super_admin_user):
-    role = Role.query.get('Super admin')
+    role = Role.query.get("Super admin")
     token_id = create_token(
         permissions=[a.id for a in role.acls],
         created_by_id=super_admin_user.id,
@@ -191,7 +203,7 @@ def super_admin_token(super_admin_user):
 
 @pytest.fixture()
 def super_admin_token_two_groups(super_admin_user_two_groups):
-    role = Role.query.get('Super admin')
+    role = Role.query.get("Super admin")
     token_id = create_token(
         permissions=[a.id for a in role.acls],
         created_by_id=super_admin_user_two_groups.id,

--- a/skyportal/tests/conftest.py
+++ b/skyportal/tests/conftest.py
@@ -39,6 +39,11 @@ def public_group():
 
 
 @pytest.fixture()
+def public_group2():
+    return GroupFactory()
+
+
+@pytest.fixture()
 def public_filter(public_group):
     return FilterFactory(group=public_group)
 
@@ -77,6 +82,13 @@ def user(public_group):
 
 
 @pytest.fixture()
+def user_two_groups(public_group, public_group2):
+    return UserFactory(
+        groups=[public_group, public_group2], roles=[models.Role.query.get("Full user")]
+    )
+
+
+@pytest.fixture()
 def view_only_user(public_group):
     return UserFactory(
         groups=[public_group], roles=[models.Role.query.get("View only")]
@@ -98,9 +110,24 @@ def super_admin_user(public_group):
 
 
 @pytest.fixture()
+def super_admin_user_two_groups(public_group, public_group2):
+    return UserFactory(
+        groups=[public_group, public_group2], roles=[models.Role.query.get("Super admin")]
+    )
+
+
+@pytest.fixture()
 def view_only_token(user):
     token_id = create_token(
         permissions=[], created_by_id=user.id, name=str(uuid.uuid4())
+    )
+    return token_id
+
+
+@pytest.fixture()
+def view_only_token_two_groups(user_two_groups):
+    token_id = create_token(
+        permissions=[], created_by_id=user_two_groups.id, name=str(uuid.uuid4())
     )
     return token_id
 
@@ -119,6 +146,14 @@ def manage_sources_token(group_admin_user):
 def upload_data_token(user):
     token_id = create_token(
         permissions=["Upload data"], created_by_id=user.id, name=str(uuid.uuid4())
+    )
+    return token_id
+
+
+@pytest.fixture()
+def upload_data_token_two_groups(user_two_groups):
+    token_id = create_token(
+        permissions=["Upload data"], created_by_id=user_two_groups.id, name=str(uuid.uuid4())
     )
     return token_id
 
@@ -149,6 +184,17 @@ def super_admin_token(super_admin_user):
     token_id = create_token(
         permissions=[a.id for a in role.acls],
         created_by_id=super_admin_user.id,
+        name=str(uuid.uuid4()),
+    )
+    return token_id
+
+
+@pytest.fixture()
+def super_admin_token_two_groups(super_admin_user_two_groups):
+    role = Role.query.get('Super admin')
+    token_id = create_token(
+        permissions=[a.id for a in role.acls],
+        created_by_id=super_admin_user_two_groups.id,
         name=str(uuid.uuid4()),
     )
     return token_id

--- a/skyportal/tests/conftest.py
+++ b/skyportal/tests/conftest.py
@@ -45,7 +45,7 @@ def public_filter(public_group):
 
 @pytest.fixture()
 def public_source(public_group):
-    obj = ObjFactory()
+    obj = ObjFactory(groups=[public_group])
     DBSession.add(Source(obj_id=obj.id, group_id=public_group.id))
     DBSession.commit()
     return obj
@@ -53,10 +53,11 @@ def public_source(public_group):
 
 @pytest.fixture()
 def public_candidate(public_filter):
-    obj = ObjFactory()
+    obj = ObjFactory(groups=[public_filter.group])
     DBSession.add(Candidate(obj=obj, filter=public_filter))
     DBSession.commit()
     return obj
+
 
 @pytest.fixture()
 def ztf_camera():
@@ -65,7 +66,7 @@ def ztf_camera():
 
 @pytest.fixture()
 def private_source():
-    return ObjFactory()
+    return ObjFactory(groups=[])
 
 
 @pytest.fixture()

--- a/skyportal/tests/fixtures.py
+++ b/skyportal/tests/fixtures.py
@@ -98,18 +98,22 @@ class ObjFactory(factory.alchemy.SQLAlchemyModelFactory):
     altdata = {"simbad": {"class": "RRLyr"}}
 
     @factory.post_generation
-    def add_phot_spec(obj, create, value, *args, **kwargs):
+    def groups(obj, create, passed_groups, *args, **kwargs):
+        if not passed_groups:
+            passed_groups = []
         instruments = [InstrumentFactory(), InstrumentFactory()]
         filters = ['ztfg', 'ztfr', 'ztfi']
         for instrument, filter in islice(zip(cycle(instruments), cycle(filters)), 10):
             phot1 = PhotometryFactory(obj_id=obj.id,
                                       instrument=instrument,
-                                      filter=filter)
+                                      filter=filter,
+                                      groups=passed_groups)
             DBSession().add(phot1)
             DBSession().add(PhotometryFactory(obj_id=obj.id, flux=99.,
                                               fluxerr=99.,
                                               instrument=instrument,
-                                              filter=filter))
+                                              filter=filter,
+                                              groups=passed_groups))
 
             DBSession().add(ThumbnailFactory(photometry=phot1))
             DBSession().add(CommentFactory(obj_id=obj.id))

--- a/skyportal/tests/frontend/test_scanning_page.py
+++ b/skyportal/tests/frontend/test_scanning_page.py
@@ -165,6 +165,7 @@ def test_candidate_date_filtering(
                 "zp": 25.0,
                 "magsys": "ab",
                 "filter": "ztfr",
+                "group_ids": [public_group.id],
             },
             token=upload_data_token,
         )

--- a/skyportal/tests/frontend/test_upload_photometry.py
+++ b/skyportal/tests/frontend/test_upload_photometry.py
@@ -21,8 +21,49 @@ def test_upload_photometry(
     driver.wait_for_xpath('//*[@id="mui-component-select-instrumentID"]').click()
     driver.wait_for_xpath(f'//li[text()="P60 Camera (ID: {inst_id})"]').click()
     driver.wait_for_xpath_to_be_clickable('//div[@id="selectGroups"]').click()
+    driver.wait_for_xpath_to_be_clickable(f'//li[text()="{public_group.name}"]').click()
+    # Click away (blank area) to close group select pop-up
+    driver.wait_for_xpath("//html").click()
+    driver.scroll_to_element_and_click(
+        driver.wait_for_xpath_to_be_clickable('//*[text()="Preview in Tabular Form"]')
+    )
+    driver.wait_for_xpath('//td[text()="58001"]')
+    driver.scroll_to_element_and_click(
+        driver.wait_for_xpath('//*[text()="Upload Photometry"]')
+    )
+    driver.wait_for_xpath(
+        '//*[contains(.,"Upload successful. Your upload ID is")]'
+    )
+
+
+def test_upload_photometry_multiple_groups(
+    driver,
+    user_two_groups,
+    public_group,
+    public_group2,
+    public_source_two_groups,
+    super_admin_token,
+):
+    user = user_two_groups
+    public_source = public_source_two_groups
+    data = add_telescope_and_instrument(
+        "P60 Camera", [public_group.id], super_admin_token
+    )
+    inst_id = data["data"]["id"]
+    driver.get(f"/become_user/{user.id}")
+    driver.get(f"/upload_photometry/{public_source.id}")
+    csv_text_input = driver.wait_for_xpath('//textarea[@name="csvData"]')
+    csv_text_input.send_keys(
+        "mjd,flux,fluxerr,zp,magsys,filter\n"
+        "58001,55,1,25,ab,ztfg\n"
+        "58002,53,1,25,ab,ztfg"
+    )
+    driver.wait_for_xpath('//*[@id="mui-component-select-instrumentID"]').click()
+    driver.wait_for_xpath(f'//li[text()="P60 Camera (ID: {inst_id})"]').click()
+    driver.wait_for_xpath_to_be_clickable('//div[@id="selectGroups"]').click()
+    driver.wait_for_xpath_to_be_clickable(f'//li[text()="{public_group.name}"]').click()
     driver.wait_for_xpath_to_be_clickable(
-        f'//li[text()="{public_group.name}"]'
+        f'//li[text()="{public_group2.name}"]'
     ).click()
     # Click away (blank area) to close group select pop-up
     driver.wait_for_xpath("//html").click()
@@ -34,7 +75,7 @@ def test_upload_photometry(
         driver.wait_for_xpath('//*[text()="Upload Photometry"]')
     )
     driver.wait_for_xpath(
-        '//*[contains(.,"Upload successful. Your bulk upload ID is")]'
+        '//*[contains(.,"Upload successful. Your upload ID is")]'
     )
 
 
@@ -56,9 +97,7 @@ def test_upload_photometry_with_altdata(
     driver.wait_for_xpath('//*[@id="mui-component-select-instrumentID"]').click()
     driver.wait_for_xpath(f'//li[text()="P60 Camera (ID: {inst_id})"]').click()
     driver.wait_for_xpath_to_be_clickable('//div[@id="selectGroups"]').click()
-    driver.wait_for_xpath_to_be_clickable(
-        f'//li[text()="{public_group.name}"]'
-    ).click()
+    driver.wait_for_xpath_to_be_clickable(f'//li[text()="{public_group.name}"]').click()
     # Click away (blank area) to close group select pop-up
     driver.wait_for_xpath("//html").click()
     driver.scroll_to_element_and_click(
@@ -69,7 +108,7 @@ def test_upload_photometry_with_altdata(
         driver.wait_for_xpath('//*[text()="Upload Photometry"]')
     )
     driver.wait_for_xpath(
-        '//*[contains(.,"Upload successful. Your bulk upload ID is")]'
+        '//*[contains(.,"Upload successful. Your upload ID is")]'
     )
 
 
@@ -117,10 +156,10 @@ def test_upload_photometry_form_validation(
     driver.wait_for_xpath(f'//li[text()="P60 Camera (ID: {inst_id})"]').click()
     driver.wait_for_xpath('//div[contains(.,"Select at least one group")]')
     driver.wait_for_xpath_to_be_clickable('//div[@id="selectGroups"]').click()
-    driver.wait_for_xpath_to_be_clickable(
-        f'//li[text()="{public_group.name}"]'
-    ).click()
+    driver.wait_for_xpath_to_be_clickable(f'//li[text()="{public_group.name}"]').click()
     # Click away (blank area) to close group select pop-up
     driver.wait_for_xpath("//html").click()
-    driver.wait_for_xpath_to_be_clickable('//*[text()="Preview in Tabular Form"]').click()
+    driver.wait_for_xpath_to_be_clickable(
+        '//*[text()="Preview in Tabular Form"]'
+    ).click()
     driver.wait_for_xpath('//td[text()="58001"]')

--- a/skyportal/tests/frontend/test_upload_photometry.py
+++ b/skyportal/tests/frontend/test_upload_photometry.py
@@ -20,6 +20,12 @@ def test_upload_photometry(
     )
     driver.wait_for_xpath('//*[@id="mui-component-select-instrumentID"]').click()
     driver.wait_for_xpath(f'//li[text()="P60 Camera (ID: {inst_id})"]').click()
+    driver.wait_for_xpath_to_be_clickable('//div[@id="selectGroups"]').click()
+    driver.wait_for_xpath_to_be_clickable(
+        f'//li[text()="{public_group.name}"]'
+    ).click()
+    # Click away (blank area) to close group select pop-up
+    driver.wait_for_xpath("//html").click()
     driver.scroll_to_element_and_click(
         driver.wait_for_xpath_to_be_clickable('//*[text()="Preview in Tabular Form"]')
     )
@@ -49,6 +55,12 @@ def test_upload_photometry_with_altdata(
     )
     driver.wait_for_xpath('//*[@id="mui-component-select-instrumentID"]').click()
     driver.wait_for_xpath(f'//li[text()="P60 Camera (ID: {inst_id})"]').click()
+    driver.wait_for_xpath_to_be_clickable('//div[@id="selectGroups"]').click()
+    driver.wait_for_xpath_to_be_clickable(
+        f'//li[text()="{public_group.name}"]'
+    ).click()
+    # Click away (blank area) to close group select pop-up
+    driver.wait_for_xpath("//html").click()
     driver.scroll_to_element_and_click(
         driver.wait_for_xpath_to_be_clickable('//*[text()="Preview in Tabular Form"]')
     )
@@ -103,5 +115,12 @@ def test_upload_photometry_form_validation(
     driver.wait_for_xpath('//div[contains(.,"Select an instrument")]')
     driver.wait_for_xpath('//*[@id="mui-component-select-instrumentID"]').click()
     driver.wait_for_xpath(f'//li[text()="P60 Camera (ID: {inst_id})"]').click()
+    driver.wait_for_xpath('//div[contains(.,"Select at least one group")]')
+    driver.wait_for_xpath_to_be_clickable('//div[@id="selectGroups"]').click()
+    driver.wait_for_xpath_to_be_clickable(
+        f'//li[text()="{public_group.name}"]'
+    ).click()
+    # Click away (blank area) to close group select pop-up
+    driver.wait_for_xpath("//html").click()
     driver.wait_for_xpath_to_be_clickable('//*[text()="Preview in Tabular Form"]').click()
     driver.wait_for_xpath('//td[text()="58001"]')

--- a/static/js/components/UploadPhotometry.jsx
+++ b/static/js/components/UploadPhotometry.jsx
@@ -158,10 +158,10 @@ const UploadPhotometryForm = () => {
     if (result.status === "success") {
       handleReset();
       const rootURL = `${window.location.protocol}//${window.location.host}`;
-      setSuccessMessage(`Upload successful. Your bulk upload ID is ${result.data.bulk_upload_id}
+      setSuccessMessage(`Upload successful. Your upload ID is ${result.data.upload_id}
                         To delete these data, use a valid token to make a request of the form:
                         curl -X DELETE -i -H "Authorization: token <your_token_id>" \
-                        ${rootURL}/api/photometry/bulk_delete/${result.data.bulk_upload_id}`);
+                        ${rootURL}/api/photometry/bulk_delete/${result.data.upload_id}`);
     }
   };
 

--- a/static/js/components/UploadPhotometry.jsx
+++ b/static/js/components/UploadPhotometry.jsx
@@ -8,13 +8,15 @@ import MenuItem from "@material-ui/core/MenuItem";
 import Button from "@material-ui/core/Button";
 import InputLabel from "@material-ui/core/InputLabel";
 import FormControl from "@material-ui/core/FormControl";
+import Chip from "@material-ui/core/Chip";
+import Input from "@material-ui/core/Input";
 import Card from "@material-ui/core/Card";
 import CardContent from "@material-ui/core/CardContent";
 import Box from "@material-ui/core/Box";
 import Tooltip from "@material-ui/core/Tooltip";
-import HelpOutlineIcon from '@material-ui/icons/HelpOutline';
+import HelpOutlineIcon from "@material-ui/icons/HelpOutline";
 import Typography from "@material-ui/core/Typography";
-import { makeStyles, withStyles } from "@material-ui/core/styles";
+import { makeStyles, withStyles, useTheme } from "@material-ui/core/styles";
 import { useForm, Controller } from "react-hook-form";
 
 import FormValidationError from "./FormValidationError";
@@ -28,17 +30,27 @@ const textAreaPlaceholderText = `mjd,flux,fluxerr,zp,magsys,instrument_id,filter
 
 const HtmlTooltip = withStyles((theme) => ({
   tooltip: {
-    backgroundColor: '#f9f9ff',
-    color: 'rgba(0, 0, 0, 0.87)',
+    backgroundColor: "#f9f9ff",
+    color: "rgba(0, 0, 0, 0.87)",
     maxWidth: 700,
     fontSize: theme.typography.pxToRem(12),
-    border: '1px solid #dadde9',
+    border: "1px solid #dadde9",
   },
 }))(Tooltip);
+
+const getStyles = (groupID, groupIDs, theme) => (
+  {
+    fontWeight:
+      groupIDs.indexOf(groupID) === -1 ?
+        theme.typography.fontWeightRegular :
+        theme.typography.fontWeightMedium,
+  }
+);
 
 const UploadPhotometryForm = () => {
   const dispatch = useDispatch();
   const { instrumentList } = useSelector((state) => state.instruments);
+  const userGroups = useSelector((state) => state.groups.user);
   const [showPreview, setShowPreview] = useState(false);
   const [csvData, setCsvData] = useState({});
   const [successMessage, setSuccessMessage] = useState("");
@@ -96,6 +108,11 @@ const UploadPhotometryForm = () => {
     return true;
   };
 
+  const validateGroups = () => {
+    formState = getValues({ nest: true });
+    return formState.groupIDs.length >= 1;
+  };
+
   const handleClickPreview = async (data) => {
     let [header, ...dataRows] = data.csvData.trim().split("\n");
     const delim = new RegExp(data.delimiter);
@@ -112,7 +129,8 @@ const UploadPhotometryForm = () => {
     reset({
       delimiter: ",",
       csvData: "",
-      instrumentID: "multiple"
+      instrumentID: "",
+      groupIDs: []
     }, {
       dirty: false
     });
@@ -123,6 +141,7 @@ const UploadPhotometryForm = () => {
     formState = getValues();
     const data = {
       obj_id: id,
+      group_ids: formState.groupIDs,
       altdata: {}
     };
     if (formState.instrumentID !== "multiple") {
@@ -146,10 +165,22 @@ const UploadPhotometryForm = () => {
     }
   };
 
+  const groupIDToName = {};
+  userGroups.forEach((g) => {
+    groupIDToName[g.id] = g.name;
+  });
+
   const useStyles = makeStyles((theme) => ({
     formControl: {
       margin: theme.spacing(1),
       minWidth: 120,
+    },
+    chips: {
+      display: "flex",
+      flexWrap: "wrap",
+    },
+    chip: {
+      margin: 2,
     },
     textarea: {
       "::-webkit-input-placeholder": {
@@ -164,6 +195,18 @@ const UploadPhotometryForm = () => {
     }
   }));
   const classes = useStyles();
+  const theme = useTheme();
+
+  const ITEM_HEIGHT = 48;
+  const ITEM_PADDING_TOP = 8;
+  const MenuProps = {
+    PaperProps: {
+      style: {
+        maxHeight: ITEM_HEIGHT * 4.5 + ITEM_PADDING_TOP,
+        width: 250,
+      },
+    },
+  };
 
   return (
     <div>
@@ -257,6 +300,55 @@ const UploadPhotometryForm = () => {
                   />
                 </FormControl>
               </Box>
+              <br />
+              <Box component="span" m={1}>
+                {
+                  errors.groupIDs && (
+                    <FormValidationError
+                      message="Select at least one group"
+                    />
+                  )
+                }
+                <FormControl className={classes.formControl}>
+                  <InputLabel id="select-groups-label">Groups</InputLabel>
+                  <Controller
+                    as={(
+                      <Select
+                        labelId="select-groups-label"
+                        id="selectGroups"
+                        multiple
+                        input={<Input id="selectGroupsChip" />}
+                        renderValue={(selected) => (
+                          <div className={classes.chips}>
+                            {selected.map((value) => (
+                              <Chip
+                                key={value}
+                                label={groupIDToName[value]}
+                                className={classes.chip}
+                              />
+                            ))}
+                          </div>
+                        )}
+                        MenuProps={MenuProps}
+                      >
+                        {userGroups.map((group) => (
+                          <MenuItem
+                            key={group.id}
+                            value={group.id}
+                            style={getStyles(group.name, formState.groupIDs, theme)}
+                          >
+                            {group.name}
+                          </MenuItem>
+                        ))}
+                      </Select>
+                    )}
+                    name="groupIDs"
+                    rules={{ validate: validateGroups }}
+                    control={control}
+                    defaultValue={[]}
+                  />
+                </FormControl>
+              </Box>
             </Box>
             <Box m={1}>
               <HtmlTooltip
@@ -279,26 +371,26 @@ const UploadPhotometryForm = () => {
                         API docs
                       </a>
                       &nbsp;for other allowable fields (note: omit
-                      {' '}
+                      {" "}
                       <code>obj_id</code>
-                      {' '}
+                      {" "}
                       here).
                     </p>
                     <p>
                       Other miscellanous metadata can be supplied by preceding the column
                       name with
-                      {' '}
+                      {" "}
                       <code>&quot;altdata.&quot;</code>
-                      {' '}
+                      {" "}
                       (e.g.
-                      {' '}
+                      {" "}
                       <code>&quot;altdata.calibrated_to&quot;</code>
                       ).
                       Such fields will ultimately be stored in the photometry table&apos;s
-                      {' '}
+                      {" "}
                       <code>altdata</code>
                       &nbsp;JSONB column, e.g.
-                      {' '}
+                      {" "}
                       <code>
                         {"{"}
                         &quot;calibrated_to&quot;: &quot;ps1&quot;, ...

--- a/tools/load_demo_data.py
+++ b/tools/load_demo_data.py
@@ -252,6 +252,7 @@ if __name__ == "__main__":
                             "zp": phot_data.zp.tolist(),
                             "magsys": phot_data.magsys.tolist(),
                             "filter": phot_data["filter"].tolist(),
+                            "group_ids": [group_id],
                         },
                     )
                     data = assert_post(
@@ -265,6 +266,7 @@ if __name__ == "__main__":
                             "zp": phot_data.zp.tolist(),
                             "magsys": phot_data.magsys.tolist(),
                             "filter": phot_data["filter"].tolist(),
+                            "group_ids": [group_id],
                         },
                     )
 


### PR DESCRIPTION
This PR introduces photometry-level permissions checking. Each `Photometry` point has its own `groups` relationship, and the intersection between a user's group list and a photometry point's group list determines access. 

- The photometry POST API endpoint handler now requires a `group_ids` field;
- `Obj.get_if_owned_by` now first checks whether an associated candidate or source is part of the given user's group, and if not, then checks whether the user has access to any of the object's photometry, raising an access error if not;
- `Obj.get_photometry_owned_by_user` is added;
- `photometry_plot` has been updated to only render those photometry points that should be visible to the current user;
- `SourcePhotometryHandler` now returns only those photometry points a user should have access to
- A (required) groups multi-select input is added to the upload source photometry page (gif below)

![group_select_chips](https://user-images.githubusercontent.com/7230285/83926967-3fe5ed00-a740-11ea-846a-03a41d52a7c2.gif)
