### PR TITLE
Add unique alert_id column to Photometry table & update Photometry handler

### DIFF
--- a/skyportal/handlers/api/photometry.py
+++ b/skyportal/handlers/api/photometry.py
@@ -152,7 +152,8 @@ class PhotometryHandler(BaseHandler):
                                   "are not a member of.")
         if "alert_id" in data:
             phot = Photometry.query.filter(
-                Photometry.alert_id == data["alert_id"]).first()
+                Photometry.alert_id == data["alert_id"]
+            ).filter(Photometry.alert_id.isnot(None)).first()
             if phot is not None:
                 phot.groups = groups
                 DBSession().commit()

--- a/skyportal/handlers/api/photometry.py
+++ b/skyportal/handlers/api/photometry.py
@@ -38,7 +38,8 @@ def serialize(phot, outsys, format):
         'mjd': phot.mjd,
         'instrument_id': phot.instrument_id,
         'ra_unc': phot.ra_unc,
-        'dec_unc': phot.dec_unc
+        'dec_unc': phot.dec_unc,
+        'alert_id': phot.alert_id
     }
 
     filter = phot.filter
@@ -134,6 +135,7 @@ class PhotometryHandler(BaseHandler):
         if not isinstance(data, dict):
             return self.error('Top level JSON must be an instance of `dict`, got '
                               f'{type(data)}.')
+
         if "altdata" in data and not data["altdata"]:
             del data["altdata"]
         try:
@@ -148,6 +150,14 @@ class PhotometryHandler(BaseHandler):
             if not all([group in self.current_user.groups for group in groups]):
                 return self.error("Cannot upload photometry to groups that you "
                                   "are not a member of.")
+        if "alert_id" in data:
+            phot = Photometry.query.filter(
+                Photometry.alert_id == data["alert_id"]).first()
+            if phot is not None:
+                phot.groups = groups
+                DBSession().commit()
+                return self.success(data={"ids": [phot.id],
+                                          "upload_id": phot.upload_id})
 
         if allscalar(data):
             data = [data]

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -463,8 +463,7 @@ class Photometry(Base):
     altdata = sa.Column(JSONB)
     upload_id = sa.Column(sa.String, nullable=False,
                           default=lambda: str(uuid.uuid4()))
-    alert_id = sa.Column(sa.BigInteger, nullable=False, unique=True,
-                         default=lambda: np.random.randint(100, 9223372036854775807))
+    alert_id = sa.Column(sa.BigInteger, nullable=True, unique=True)
 
     obj_id = sa.Column(sa.ForeignKey('objs.id', ondelete='CASCADE'),
                        nullable=False, index=True)

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -463,6 +463,8 @@ class Photometry(Base):
     altdata = sa.Column(JSONB)
     upload_id = sa.Column(sa.String, nullable=False,
                           default=lambda: str(uuid.uuid4()))
+    alert_id = sa.Column(sa.BigInteger, nullable=False, unique=True,
+                         default=lambda: np.random.randint(100, 9223372036854775807))
 
     obj_id = sa.Column(sa.ForeignKey('objs.id', ondelete='CASCADE'),
                        nullable=False, index=True)

--- a/skyportal/schema.py
+++ b/skyportal/schema.py
@@ -202,6 +202,11 @@ class PhotBaseFlexible(object):
                                        'given as lists. Null values allowed.',
                            required=False)
 
+    alert_id = fields.Field(description="Corresponding alert ID. If a record is "
+                            "already present with identical alert ID, only the "
+                            "groups list will be updated (other alert data assumed "
+                            "identical). If omitted, defaults to random integer.")
+
     group_ids = fields.List(fields.Integer(),
                             description="List of group IDs to which photometry "
                                         "points will be visible.",
@@ -323,6 +328,12 @@ class PhotBase(object):
     dec_unc = fields.Number(description='Uncertainty on dec [arcsec].',
                             missing=None, default=None)
 
+    alert_id = fields.Integer(description="Corresponding alert ID. If a record is "
+                              "already present with identical alert ID, only the "
+                              "groups list will be updated (other alert data assumed "
+                              "identical). If omitted, defaults to random integer.",
+                              missing=None, default=None)
+
     altdata = fields.Dict(description='Misc. alternative metadata.',
                           missing=None, default=None)
 
@@ -412,9 +423,10 @@ class PhotometryFlux(_Schema, PhotBase):
                        ra=data['ra'],
                        dec=data['dec'],
                        ra_unc=data['ra_unc'],
-                       dec_unc=data['dec_unc']
+                       dec_unc=data['dec_unc'],
                        )
-
+        if 'alert_id' in data and data['alert_id'] is not None:
+            p.alert_id = data['alert_id']
         return p
 
 
@@ -525,8 +537,10 @@ class PhotometryMag(_Schema, PhotBase):
                        ra=data['ra'],
                        dec=data['dec'],
                        ra_unc=data['ra_unc'],
-                       dec_unc=data['dec_unc'])
-
+                       dec_unc=data['dec_unc'],
+                       )
+        if 'alert_id' in data and data['alert_id'] is not None:
+            p.alert_id = data['alert_id']
         return p
 
 

--- a/skyportal/schema.py
+++ b/skyportal/schema.py
@@ -205,7 +205,7 @@ class PhotBaseFlexible(object):
     alert_id = fields.Field(description="Corresponding alert ID. If a record is "
                             "already present with identical alert ID, only the "
                             "groups list will be updated (other alert data assumed "
-                            "identical). If omitted, defaults to random integer.")
+                            "identical). Defaults to None.")
 
     group_ids = fields.List(fields.Integer(),
                             description="List of group IDs to which photometry "
@@ -331,7 +331,7 @@ class PhotBase(object):
     alert_id = fields.Integer(description="Corresponding alert ID. If a record is "
                               "already present with identical alert ID, only the "
                               "groups list will be updated (other alert data assumed "
-                              "identical). If omitted, defaults to random integer.",
+                              "identical). Defaults to None.",
                               missing=None, default=None)
 
     altdata = fields.Dict(description='Misc. alternative metadata.',

--- a/skyportal/tests/api/test_photometry.py
+++ b/skyportal/tests/api/test_photometry.py
@@ -740,6 +740,68 @@ def test_token_user_update_photometry_groups(upload_data_token_two_groups,
     assert "Insufficient permissions" in data["message"]
 
 
+def test_post_same_alertid_update_groups(upload_data_token_two_groups,
+                                         manage_sources_token_two_groups,
+                                         public_source_two_groups, ztf_camera,
+                                         public_group, public_group2,
+                                         view_only_token):
+    upload_data_token = upload_data_token_two_groups
+    manage_sources_token = manage_sources_token_two_groups
+    public_source = public_source_two_groups
+    alert_id = np.random.randint(100, 9223372036854775807)
+
+    status, data = api('POST', 'photometry',
+                       data={'obj_id': str(public_source.id),
+                             'mjd': 58000.,
+                             'instrument_id': ztf_camera.id,
+                             'flux': 12.24,
+                             'fluxerr': 0.031,
+                             'zp': 25.,
+                             'magsys': 'ab',
+                             'filter': 'ztfi',
+                             'alert_id': alert_id,
+                             'group_ids': [public_group2.id]
+                             },
+                       token=upload_data_token)
+    assert status == 200
+    assert data['status'] == 'success'
+    phot_id = data['data']['ids'][0]
+
+    photometry_id = data['data']['ids'][0]
+    status, data = api(
+        'GET',
+        f'photometry/{photometry_id}?format=flux',
+        token=view_only_token)
+    assert status == 400
+    assert data['status'] == 'error'
+    assert "Insufficient permissions" in data["message"]
+
+    status, data = api('POST', 'photometry',
+                       data={'obj_id': str(public_source.id),
+                             'mjd': 58000.,
+                             'instrument_id': ztf_camera.id,
+                             'flux': 12.24,
+                             'fluxerr': 0.031,
+                             'zp': 25.,
+                             'magsys': 'ab',
+                             'filter': 'ztfi',
+                             'alert_id': alert_id,
+                             'group_ids': [public_group.id]
+                             },
+                       token=upload_data_token)
+    assert status == 200
+    assert data['status'] == 'success'
+    assert data['data']['ids'][0] == phot_id
+
+    status, data = api(
+        'GET',
+        f'photometry/{photometry_id}?format=flux',
+        token=view_only_token)
+    assert status == 200
+    assert data['status'] == 'success'
+    assert data['data']['alert_id'] == alert_id
+
+
 def test_delete_photometry_data(upload_data_token, manage_sources_token,
                                 public_source, ztf_camera, public_group):
     status, data = api('POST', 'photometry',

--- a/skyportal/tests/fixtures.py
+++ b/skyportal/tests/fixtures.py
@@ -104,16 +104,19 @@ class ObjFactory(factory.alchemy.SQLAlchemyModelFactory):
         instruments = [InstrumentFactory(), InstrumentFactory()]
         filters = ['ztfg', 'ztfr', 'ztfi']
         for instrument, filter in islice(zip(cycle(instruments), cycle(filters)), 10):
+            np.random.seed()
             phot1 = PhotometryFactory(obj_id=obj.id,
                                       instrument=instrument,
                                       filter=filter,
-                                      groups=passed_groups)
+                                      groups=passed_groups,
+                                      alert_id=np.random.randint(100, 9223372036854775807))
             DBSession().add(phot1)
             DBSession().add(PhotometryFactory(obj_id=obj.id, flux=99.,
                                               fluxerr=99.,
                                               instrument=instrument,
                                               filter=filter,
-                                              groups=passed_groups))
+                                              groups=passed_groups,
+                                              alert_id=np.random.randint(100, 9223372036854775807)))
 
             DBSession().add(ThumbnailFactory(photometry=phot1))
             DBSession().add(CommentFactory(obj_id=obj.id, groups=passed_groups))


### PR DESCRIPTION
This PR introduces a unique `alert_id` column to the `Photometry` table and updates the handler such that when a POST request is received with an alert ID that already exists in the DB, only the associated photometry entry's groups list is updated. Schema, tests and test fixtures are updated.