### PR TITLE
Implement simple status monitor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ package-lock.json
 .jobs_timestamps.yaml
 skyportal_image_cache
 static/js/components/Main.jsx
+static/status.html

--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -64,3 +64,15 @@ cron:
   - interval: 1440
     script: jobs/delete_unsaved_candidates.py
     limit: ["01:00", "02:00"]
+
+monitor:
+  interval: 60
+  output: "static/status.html"
+  probes:
+    - name: SkyPortal
+      type: http
+      url: http://localhost:5000/api/sysinfo
+    - name: PostgreSQL
+      type: tcp
+      host: localhost
+      port: 5433

--- a/services/news.yaml
+++ b/services/news.yaml
@@ -1,0 +1,2 @@
+- time: 2020-06-24T15:20:00
+  message: "There is currently nothing to report."

--- a/services/status.html.tmpl
+++ b/services/status.html.tmpl
@@ -1,0 +1,98 @@
+<!doctype html>
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+
+    <title>SkyPortal Status Monitor</title>
+
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-pink.min.css">
+    <script defer src="https://code.getmdl.io/1.3.0/material.min.js"></script>
+
+    <style>
+      body {
+          padding: 2rem;
+      }
+      .service-name {
+          font-weight: bold;
+      }
+      .status_OK {
+          color: green;
+      }
+      .status_FAIL {
+          color: red;
+      }
+      .news {
+          padding-top: 2rem;
+      }
+      .news-time {
+          font-weight: bold;
+          padding-right: 1rem;
+      }
+      .news-text {
+      }
+    </style>
+  </head>
+
+  <body>
+
+    <h3>SkyPortal Status Monitor</h3>
+
+    <table class="mdl-data-table mdl-js-data-table mdl-shadow--2dp">
+      <thead>
+        <tr>
+          <th class="mdl-data-table__cell--non-numeric">Service</th>
+          <th class="mdl-data-table__cell--non-numeric">Status</th>
+          <th class="mdl-data-table__cell--non-numeric">Time</th>
+          <th class="mdl-data-table__cell--non-numeric">Additional Information</th>
+        </tr>
+      </thead>
+      <tbody>
+
+        {% for probe, info in probes.items() %}
+        <tr>
+          <td class="mdl-data-table__cell--non-numeric service-name">{{ probe }}</td>
+          <td
+            class="mdl-data-table__cell--non-numeric {{
+            'status_OK' if info['status_code'] == 0 else 'status_FAIL' }}">
+            {{ info['status'] }}
+          </td>
+          <td class="mdl-data-table__cell--non-numeric">{{ info['time'] }}</td>
+          {% if info['extra'] %}
+          <td class="mdl-data-table__cell--non-numeric">{{ info['extra'] }}</td>
+          {% else %}
+          <td></td>
+          {% endif %}
+        </tr>
+        {% endfor %}
+
+      </tbody>
+
+    </table>
+
+    {% if news %}
+    <div class="news">
+      <h5>Updates</h5>
+
+      <ul class="mdl-list">
+
+        {% for update in news %}
+
+        <li class="mdl-list__item">
+          <span class="mdl-list__item-primary-content">
+            <span class="news-time">{{ update['time'] }}</span>
+            <span class="news-text">{{ update['message'] }}</span>
+          </span>
+        </li>
+
+        {% endfor %}
+
+      </ul>
+    </div>
+
+    {% endif %}
+
+  </body>
+
+</html>

--- a/services/status_monitor.py
+++ b/services/status_monitor.py
@@ -1,0 +1,92 @@
+import requests
+import telnetlib
+import time
+import os
+import datetime
+
+import jinja2
+import yaml
+
+from baselayer.app.env import load_env
+from baselayer.log import make_log
+
+env, cfg = load_env()
+log = make_log('status_monitor')
+
+
+def probe():
+    probes = {}
+
+    def health(status, status_code=-1, extra=None):
+        now = datetime.datetime.now().replace(microsecond=0).isoformat()
+        now = now.replace('T', ' ')
+        return {
+            'time': now,
+            'status': status,
+            'status_code': status_code,  # 0 for success
+            'extra': extra or '',
+        }
+
+    def success(*args, **kwargs):
+        kwargs['status_code'] = 0
+        return health(*args, **kwargs)
+
+    def failure(*args, **kwargs):
+        kwargs['status_code'] = -1
+        return health(*args, **kwargs)
+
+    for probe in cfg['monitor.probes']:
+        name = probe['name']
+        ptype = probe['type']
+
+        log(f'Executing probe {name}')
+
+        if ptype == 'http':
+            try:
+                req = requests.get(probe['url'])
+            except requests.exceptions.ConnectionError:
+                status = failure('Down', extra=f'Server down')
+            else:
+                http_status = req.status_code
+                if http_status == 200:
+                    status = success('Up')
+                else:
+                    status = failure('Down', extra=f'HTTP status {http_status}')
+
+        if ptype == 'tcp':
+            try:
+                telnetlib.Telnet(probe['host'], port=probe['port'])
+            except ConnectionRefusedError:
+                status = failure('Down')
+            else:
+                status = success('Up')
+
+        probes[name] = status
+
+    return probes
+
+
+def watch_status():
+    delay = int(cfg['monitor.interval'])
+    while True:
+        news_file = os.path.join(os.path.dirname(__file__), 'news.yaml')
+        news = yaml.load(open(news_file, 'r'), Loader=yaml.Loader)
+
+        render_status_page({
+            'news': news,
+            'probes': probe()
+        })
+        time.sleep(delay)
+
+
+def render_status_page(status):
+    template_file = os.path.join(os.path.dirname(__file__), 'status.html.tmpl')
+    template = jinja2.Template(open(template_file, 'r').read())
+    rendered = template.render(status)
+
+    with open(cfg['monitor.output'], 'w') as f:
+        f.write(rendered)
+
+
+if __name__ == '__main__':
+    watch_status()


### PR DESCRIPTION
This adds a very simple status monitor that can be run on a different host from SkyPortal.  It probes services once in a set interval, and writes out a static html report, that can be served whichever way preferred.  The monitor is simple, because it should be easily deployable, should run with minimal support, and should be easy to maintain/run to ensure maximal uptime.

![2020-06-24_15:30:35](https://user-images.githubusercontent.com/45071/85566138-9c705580-b5e4-11ea-950b-3500c786a9eb.png)

Currently served at `/static/status.html`.