### PR TITLE
Implement comment-level group access; clean up front-end tests

### DIFF
--- a/skyportal/handlers/api/candidate.py
+++ b/skyportal/handlers/api/candidate.py
@@ -149,6 +149,7 @@ class CandidateHandler(BaseHandler):
             c = Candidate.get_if_owned_by(obj_id, self.current_user)
             if c is None:
                 return self.error("Invalid ID")
+            c.comments = c.get_comments_owned_by(self.current_user)
             return self.success(data=c)
 
         page_number = self.get_query_argument("pageNumber", None) or 1
@@ -194,7 +195,6 @@ class CandidateHandler(BaseHandler):
         q = (
             Obj.query.options(
                 [
-                    joinedload(Obj.comments),
                     joinedload(Obj.thumbnails)
                     .joinedload(Thumbnail.photometry)
                     .joinedload(Photometry.instrument)

--- a/skyportal/handlers/api/candidate.py
+++ b/skyportal/handlers/api/candidate.py
@@ -242,6 +242,7 @@ class CandidateHandler(BaseHandler):
             .all()
         )
         for obj in query_results["candidates"]:
+            obj.comments = obj.get_comments_owned_by(self.current_user)
             obj.is_source = (obj.id,) in matching_source_ids
             obj.passing_group_ids = [
                 f.group_id

--- a/skyportal/handlers/api/comment.py
+++ b/skyportal/handlers/api/comment.py
@@ -103,8 +103,7 @@ class CommentHandler(BaseHandler):
         else:
             attachment_bytes, attachment_name = None, None
 
-        author = (self.current_user.username if hasattr(self.current_user, 'username')
-                  else self.current_user.name)
+        author = self.associated_user_object.username
         comment = Comment(text=data['text'],
                           obj_id=obj_id, attachment_bytes=attachment_bytes,
                           attachment_name=attachment_name,
@@ -201,8 +200,8 @@ class CommentHandler(BaseHandler):
               application/json:
                 schema: Success
         """
-        user = (self.current_user.username if hasattr(self.current_user, 'username') else self.current_user.name)
-        roles = (self.current_user.roles if hasattr(self.current_user, 'roles') else '')
+        user = self.associated_user_object.username
+        roles = (self.current_user.roles if hasattr(self.current_user, 'roles') else [])
         c = Comment.query.get(comment_id)
         if c is None:
             return self.error("Invalid comment ID")

--- a/skyportal/handlers/api/comment.py
+++ b/skyportal/handlers/api/comment.py
@@ -89,8 +89,6 @@ class CommentHandler(BaseHandler):
         _ = Source.get_if_owned_by(obj_id, self.current_user)
         user_group_ids = [g.id for g in self.current_user.groups]
         group_ids = data.pop("group_ids", user_group_ids)
-        if group_ids == []:
-            group_ids = user_group_ids
         group_ids = [gid for gid in group_ids if gid in user_group_ids]
         if not group_ids:
             return self.error(f"Invalid group IDs field ({group_ids}): "

--- a/skyportal/handlers/api/comment.py
+++ b/skyportal/handlers/api/comment.py
@@ -2,7 +2,7 @@ import base64
 from marshmallow.exceptions import ValidationError
 from baselayer.app.access import permissions, auth_or_token
 from ..base import BaseHandler
-from ...models import DBSession, Source, Comment
+from ...models import DBSession, Source, Comment, Group
 
 
 class CommentHandler(BaseHandler):
@@ -27,14 +27,10 @@ class CommentHandler(BaseHandler):
               application/json:
                 schema: Error
         """
-        comment = Comment.query.get(comment_id)
+        comment = Comment.get_if_owned_by(comment_id, self.current_user)
         if comment is None:
             return self.error('Invalid comment ID.')
-        # Ensure user/token has access to parent source
-        _ = Source.get_if_owned_by(comment.obj_id, self.current_user)
-        if comment is not None:
-            return self.success(data=comment)
-        return self.error('Invalid comment ID.')
+        return self.success(data=comment)
 
     @permissions(['Comment'])
     def post(self):
@@ -51,6 +47,14 @@ class CommentHandler(BaseHandler):
                     type: string
                   text:
                     type: string
+                  group_ids:
+                    type: array
+                    items:
+                      type: integer
+                    description: |
+                      List of group IDs corresponding to which groups should be
+                      able to view comment. Defaults to all of requesting user's
+                      groups.
                   attachment:
                     type: object
                     properties:
@@ -83,6 +87,15 @@ class CommentHandler(BaseHandler):
         obj_id = data['obj_id']
         # Ensure user/token has access to parent source
         _ = Source.get_if_owned_by(obj_id, self.current_user)
+        user_group_ids = [g.id for g in self.current_user.groups]
+        group_ids = data.pop("group_ids", user_group_ids)
+        if group_ids == []:
+            group_ids = user_group_ids
+        group_ids = [gid for gid in group_ids if gid in user_group_ids]
+        if not group_ids:
+            return self.error(f"Invalid group IDs field ({group_ids}): "
+                              "You must provide one or more valid group IDs.")
+        groups = Group.query.filter(Group.id.in_(group_ids)).all()
         if 'attachment' in data and 'body' in data['attachment']:
             attachment_bytes = str.encode(data['attachment']['body']
                                           .split('base64,')[-1])
@@ -95,7 +108,7 @@ class CommentHandler(BaseHandler):
         comment = Comment(text=data['text'],
                           obj_id=obj_id, attachment_bytes=attachment_bytes,
                           attachment_name=attachment_name,
-                          author=author)
+                          author=author, groups=groups)
 
         DBSession().add(comment)
         DBSession().commit()
@@ -118,7 +131,18 @@ class CommentHandler(BaseHandler):
         requestBody:
           content:
             application/json:
-              schema: CommentNoID
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/CommentNoID'
+                  - type: object
+                    properties:
+                      group_ids:
+                        type: array
+                        items:
+                          type: integer
+                        description: |
+                          List of group IDs corresponding to which groups should be
+                          able to view comment.
         responses:
           200:
             content:
@@ -129,24 +153,33 @@ class CommentHandler(BaseHandler):
               application/json:
                 schema: Error
         """
-        c = Comment.query.get(comment_id)
+        c = Comment.get_if_owned_by(comment_id, self.current_user)
         if c is None:
             return self.error('Invalid comment ID.')
-        # Ensure user/token has access to parent source
-        _ = Source.get_if_owned_by(c.obj_id, self.current_user)
 
         data = self.get_json()
+        group_ids = data.pop("group_ids", None)
         data['id'] = comment_id
 
         schema = Comment.__schema__()
         try:
-            schema.load(data)
+            schema.load(data, partial=True)
         except ValidationError as e:
             return self.error('Invalid/missing parameters: '
                               f'{e.normalized_messages()}')
-
+        DBSession().flush()
+        if group_ids is not None:
+            c = Comment.get_if_owned_by(comment_id, self.current_user)
+            groups = Group.query.filter(Group.id.in_(group_ids)).all()
+            if not groups:
+                return self.error("Invalid group_ids field. "
+                                  "Specify at least one valid group ID.")
+            if "Super admin" not in [r.id for r in self.associated_user_object.roles]:
+                if not all([group in self.current_user.groups for group in groups]):
+                    return self.error("Cannot associate comment with groups you are "
+                                      "not a member of.")
+            c.groups = groups
         DBSession().commit()
-
         self.push_all(action='skyportal/REFRESH_SOURCE',
                       payload={'obj_id': c.obj_id})
         return self.success()
@@ -206,11 +239,9 @@ class CommentAttachmentHandler(BaseHandler):
                   format: base64
                   description: base64-encoded contents of attachment
         """
-        comment = Comment.query.get(comment_id)
+        comment = Comment.get_if_owned_by(comment_id, self.current_user)
         if comment is None:
             return self.error('Invalid comment ID.')
-        # Ensure user/token has access to parent source
-        _ = Source.get_if_owned_by(comment.obj_id, self.current_user)
         self.set_header(
             "Content-Disposition", "attachment; "
             f"filename={comment.attachment_name}")

--- a/skyportal/handlers/api/photometry.py
+++ b/skyportal/handlers/api/photometry.py
@@ -256,22 +256,22 @@ class PhotometryHandler(BaseHandler):
                 schema: Error
         """
         _ = Photometry.get_if_owned_by(photometry_id, self.current_user)
-        packet = self.get_json()
-        group_ids = packet.pop("group_ids", None)
+        data = self.get_json()
+        group_ids = data.pop("group_ids", None)
 
         try:
-            phot = PhotometryFlux.load(packet)
+            phot = PhotometryFlux.load(data)
         except ValidationError as e1:
             try:
-                phot = PhotometryMag.load(packet)
+                phot = PhotometryMag.load(data)
             except ValidationError as e2:
                 return self.error('Invalid input format: Tried to parse '
-                                  f'{packet} as PhotometryFlux, got: '
+                                  f'{data} as PhotometryFlux, got: '
                                   f'"{e1.normalized_messages()}." Tried '
-                                  f'to parse {packet} as PhotometryMag, got:'
+                                  f'to parse {data} as PhotometryMag, got:'
                                   f' "{e2.normalized_messages()}."')
 
-        phot.original_user_data = packet
+        phot.original_user_data = data
         phot.id = photometry_id
         DBSession().merge(phot)
         DBSession.flush()

--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -186,6 +186,8 @@ class SourceHandler(BaseHandler):
                          .joinedload(Thumbnail.photometry)
                          .joinedload(Photometry.instrument)
                          .joinedload(Instrument.telescope)])
+            if s is None:
+                return self.error("Invalid source ID.")
             s.comments = s.get_comments_owned_by(self.current_user)
             return self.success(data=s)
         if page_number:

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -277,6 +277,13 @@ def get_obj_if_owned_by(obj_id, user_or_token, options=[]):
 Obj.get_if_owned_by = get_obj_if_owned_by
 
 
+def get_obj_comments_owned_by(self, user_or_token):
+    return [comment for comment in self.comments if comment.is_owned_by(user_or_token)]
+
+
+Obj.get_comments_owned_by = get_obj_comments_owned_by
+
+
 def get_photometry_owned_by_user(obj_id, user_or_token):
     return (
         Photometry.query.filter(Photometry.obj_id == obj_id)
@@ -373,6 +380,11 @@ class Comment(Base):
     obj_id = sa.Column(sa.ForeignKey('objs.id', ondelete='CASCADE'),
                        nullable=False, index=True)
     obj = relationship('Obj', back_populates='comments')
+    groups = relationship("Group", secondary="group_comments",
+                          cascade="save-update, merge, refresh-expire, expunge")
+
+
+GroupComment = join_model("group_comments", Group, Comment)
 
 
 class Photometry(Base):

--- a/skyportal/tests/api/test_candidates.py
+++ b/skyportal/tests/api/test_candidates.py
@@ -15,7 +15,6 @@ def test_token_user_retrieving_candidate(view_only_token, public_candidate):
     )
     assert status == 200
     assert data["status"] == "success"
-    print(data["data"])
     assert all(
         k in data["data"]
         for k in ["ra", "dec", "redshift"]

--- a/skyportal/tests/api/test_comments.py
+++ b/skyportal/tests/api/test_comments.py
@@ -1,7 +1,21 @@
 from skyportal.tests import api
 
 
-def test_add_and_retrieve_comment(comment_token, public_source):
+def test_add_and_retrieve_comment_group_id(comment_token, public_source, public_group):
+    status, data = api('POST', 'comment', data={'obj_id': public_source.id,
+                                                'text': 'Comment text',
+                                                'group_ids': [public_group.id]},
+                       token=comment_token)
+    assert status == 200
+    comment_id = data['data']['comment_id']
+
+    status, data = api('GET', f'comment/{comment_id}', token=comment_token)
+
+    assert status == 200
+    assert data['data']['text'] == 'Comment text'
+
+
+def test_add_and_retrieve_comment_no_group_id(comment_token, public_source):
     status, data = api('POST', 'comment', data={'obj_id': public_source.id,
                                                 'text': 'Comment text'},
                        token=comment_token)
@@ -12,6 +26,83 @@ def test_add_and_retrieve_comment(comment_token, public_source):
 
     assert status == 200
     assert data['data']['text'] == 'Comment text'
+
+
+def test_add_and_retrieve_comment_group_access(comment_token_two_groups,
+                                               public_source_two_groups,
+                                               public_group2, public_group,
+                                               comment_token):
+    status, data = api('POST', 'comment', data={'obj_id': public_source_two_groups.id,
+                                                'text': 'Comment text',
+                                                'group_ids': [public_group2.id]},
+                       token=comment_token_two_groups)
+    assert status == 200
+    comment_id = data['data']['comment_id']
+
+    # This token belongs to public_group2
+    status, data = api('GET', f'comment/{comment_id}', token=comment_token_two_groups)
+    assert status == 200
+    assert data['data']['text'] == 'Comment text'
+
+    # This token does not belnog to public_group2
+    status, data = api('GET', f'comment/{comment_id}', token=comment_token)
+    assert status == 400
+    assert data["message"] == "Insufficient permissions."
+
+    # Both tokens should be able to view this comment
+    status, data = api('POST', 'comment', data={'obj_id': public_source_two_groups.id,
+                                                'text': 'Comment text',
+                                                'group_ids': [public_group.id,
+                                                              public_group2.id]},
+                       token=comment_token_two_groups)
+    assert status == 200
+    comment_id = data['data']['comment_id']
+
+    status, data = api('GET', f'comment/{comment_id}', token=comment_token_two_groups)
+    assert status == 200
+    assert data['data']['text'] == 'Comment text'
+
+    status, data = api('GET', f'comment/{comment_id}', token=comment_token)
+    assert status == 200
+    assert data['data']['text'] == 'Comment text'
+
+
+def test_update_comment_group_list(comment_token_two_groups,
+                                   public_source_two_groups,
+                                   public_group2, public_group,
+                                   comment_token):
+    status, data = api('POST', 'comment', data={'obj_id': public_source_two_groups.id,
+                                                'text': 'Comment text',
+                                                'group_ids': [public_group2.id]},
+                       token=comment_token_two_groups)
+    assert status == 200
+    comment_id = data['data']['comment_id']
+
+    # This token belongs to public_group2
+    status, data = api('GET', f'comment/{comment_id}', token=comment_token_two_groups)
+    assert status == 200
+    assert data['data']['text'] == 'Comment text'
+
+    # This token does not belnog to public_group2
+    status, data = api('GET', f'comment/{comment_id}', token=comment_token)
+    assert status == 400
+    assert data["message"] == "Insufficient permissions."
+
+    # Both tokens should be able to view comment after updating group list
+    status, data = api('PUT', f'comment/{comment_id}',
+                       data={
+                           'text': 'Comment text new',
+                           'group_ids': [public_group.id, public_group2.id]},
+                       token=comment_token_two_groups)
+    assert status == 200
+
+    status, data = api('GET', f'comment/{comment_id}', token=comment_token_two_groups)
+    assert status == 200
+    assert data['data']['text'] == 'Comment text new'
+
+    status, data = api('GET', f'comment/{comment_id}', token=comment_token)
+    assert status == 200
+    assert data['data']['text'] == 'Comment text new'
 
 
 def test_cannot_add_comment_without_permission(view_only_token, public_source):

--- a/skyportal/tests/api/test_filters.py
+++ b/skyportal/tests/api/test_filters.py
@@ -18,7 +18,6 @@ def test_token_user_retrieving_filter(view_only_token, public_filter):
     )
     assert status == 200
     assert data["status"] == "success"
-    print(data["data"])
     assert all(
         k in data["data"]
         for k in ["query_string", "group_id"]

--- a/skyportal/tests/conftest.py
+++ b/skyportal/tests/conftest.py
@@ -236,3 +236,11 @@ def comment_token(user):
         permissions=["Comment"], created_by_id=user.id, name=str(uuid.uuid4())
     )
     return token_id
+
+
+@pytest.fixture()
+def comment_token_two_groups(user_two_groups):
+    token_id = create_token(
+        permissions=["Comment"], created_by_id=user_two_groups.id, name=str(uuid.uuid4())
+    )
+    return token_id

--- a/skyportal/tests/fixtures.py
+++ b/skyportal/tests/fixtures.py
@@ -116,7 +116,7 @@ class ObjFactory(factory.alchemy.SQLAlchemyModelFactory):
                                               groups=passed_groups))
 
             DBSession().add(ThumbnailFactory(photometry=phot1))
-            DBSession().add(CommentFactory(obj_id=obj.id))
+            DBSession().add(CommentFactory(obj_id=obj.id, groups=passed_groups))
         DBSession().add(SpectrumFactory(obj_id=obj.id,
                                         instrument=instruments[0]))
         DBSession().commit()

--- a/skyportal/tests/frontend/test_groups.py
+++ b/skyportal/tests/frontend/test_groups.py
@@ -66,7 +66,6 @@ def test_add_new_group_user_admin(driver, super_admin_user, user, public_group):
     driver.wait_for_xpath('//input[@type="checkbox"]').click()
     driver.wait_for_xpath('//input[@value="Add user"]').click()
     driver.wait_for_xpath(f'//a[contains(.,"{user.username}")]')
-    print(user.username)
     assert len(driver.find_elements_by_xpath(
         f'//a[contains(.,"{user.username}")]/..//span')) == 1
 

--- a/skyportal/tests/frontend/test_sources.py
+++ b/skyportal/tests/frontend/test_sources.py
@@ -38,7 +38,7 @@ def test_comment_groups_validation(driver, user, public_source):
     comment_box = driver.wait_for_xpath("//input[@name='text']")
     comment_text = str(uuid.uuid4())
     comment_box.send_keys(comment_text)
-    driver.wait_for_xpath("//div[text()='Customize Group Access']").click()
+    driver.wait_for_xpath("//*[text()='Customize Group Access']").click()
     group_checkbox = driver.wait_for_xpath("//input[@name='group_ids[0]']")
     assert group_checkbox.is_selected()
     group_checkbox.click()

--- a/skyportal/tests/frontend/test_sources.py
+++ b/skyportal/tests/frontend/test_sources.py
@@ -28,10 +28,7 @@ def test_comments(driver, user, public_source):
     comment_box.send_keys(comment_text)
     driver.scroll_to_element_and_click(driver.find_element_by_css_selector('[type=submit]'))
     driver.wait_for_xpath(f'//div[text()="{comment_text}"]')
-    driver.wait_for_xpath('//span[contains(@class,"commentTime")]')
-    timestamp_text = driver.find_element(By.XPATH,
-                                         '//span[contains(@class,"commentTime")]').text
-    assert timestamp_text == 'a few seconds ago'
+    driver.wait_for_xpath('//span[text()="a few seconds ago"]')
 
 
 def test_comment_groups_validation(driver, user, public_source):
@@ -51,10 +48,7 @@ def test_comment_groups_validation(driver, user, public_source):
     driver.wait_for_xpath_to_disappear('//div[contains(.,"Select at least one group")]')
     driver.scroll_to_element_and_click(driver.find_element_by_css_selector('[type=submit]'))
     driver.wait_for_xpath(f'//div[text()="{comment_text}"]')
-    driver.wait_for_xpath('//span[contains(@class,"commentTime")]')
-    timestamp_text = driver.find_element(By.XPATH,
-                                         '//span[contains(@class,"commentTime")]').text
-    assert timestamp_text == 'a few seconds ago'
+    driver.wait_for_xpath('//span[text()="a few seconds ago"]')
 
 
 def test_upload_comment_attachment(driver, user, public_source):
@@ -130,8 +124,9 @@ def test_delete_comment(driver, user, public_source):
     driver.find_element_by_css_selector('[type=submit]').click()
     comment_text_div = driver.wait_for_xpath(f'//div[text()="{comment_text}"]')
     comment_div = comment_text_div.find_element_by_xpath("..")
+    comment_id = comment_div.get_attribute("name").split("commentDiv")[-1]
     delete_button = comment_div.find_element_by_xpath(
-        "//*[starts-with(@name,'deleteCommentButton')]")
+        f"//*[@name='deleteCommentButton{comment_id}']")
     ActionChains(driver).move_to_element(comment_div).perform()
     time.sleep(0.2)
     driver.execute_script("arguments[0].click();", delete_button)
@@ -153,8 +148,9 @@ def test_regular_user_cannot_delete_unowned_comment(driver, super_admin_user,
     driver.get(f"/source/{public_source.id}")
     comment_text_div = driver.wait_for_xpath(f'//div[text()="{comment_text}"]')
     comment_div = comment_text_div.find_element_by_xpath("..")
+    comment_id = comment_div.get_attribute("name").split("commentDiv")[-1]
     delete_button = comment_div.find_element_by_xpath(
-        "//*[starts-with(@name,'deleteCommentButton')]")
+        f"//*[@name='deleteCommentButton{comment_id}']")
     driver.execute_script("arguments[0].scrollIntoView();", comment_div)
     ActionChains(driver).move_to_element(comment_div).perform()
     time.sleep(0.1)
@@ -176,8 +172,9 @@ def test_super_user_can_delete_unowned_comment(driver, super_admin_user,
     driver.refresh()
     comment_text_div = driver.wait_for_xpath(f'//div[text()="{comment_text}"]')
     comment_div = comment_text_div.find_element_by_xpath("..")
+    comment_id = comment_div.get_attribute("name").split("commentDiv")[-1]
     delete_button = comment_div.find_element_by_xpath(
-        "//*[starts-with(@name,'deleteCommentButton')]")
+        f"//*[@name='deleteCommentButton{comment_id}']")
     ActionChains(driver).move_to_element(comment_div).perform()
     time.sleep(0.2)
     driver.execute_script("arguments[0].click();", delete_button)

--- a/skyportal/tests/frontend/test_sources.py
+++ b/skyportal/tests/frontend/test_sources.py
@@ -23,9 +23,32 @@ def test_comments(driver, user, public_source):
     driver.get(f"/become_user/{user.id}")  # TODO decorator/context manager?
     driver.get(f"/source/{public_source.id}")
     driver.wait_for_xpath(f'//div[text()="{public_source.id}"]')
-    comment_box = driver.find_element_by_css_selector('[name=comment]')
+    comment_box = driver.wait_for_xpath("//input[@name='text']")
     comment_text = str(uuid.uuid4())
     comment_box.send_keys(comment_text)
+    driver.scroll_to_element_and_click(driver.find_element_by_css_selector('[type=submit]'))
+    driver.wait_for_xpath(f'//div[text()="{comment_text}"]')
+    driver.wait_for_xpath('//span[contains(@class,"commentTime")]')
+    timestamp_text = driver.find_element(By.XPATH,
+                                         '//span[contains(@class,"commentTime")]').text
+    assert timestamp_text == 'a few seconds ago'
+
+
+def test_comment_groups_validation(driver, user, public_source):
+    driver.get(f"/become_user/{user.id}")  # TODO decorator/context manager?
+    driver.get(f"/source/{public_source.id}")
+    driver.wait_for_xpath(f'//div[text()="{public_source.id}"]')
+    comment_box = driver.wait_for_xpath("//input[@name='text']")
+    comment_text = str(uuid.uuid4())
+    comment_box.send_keys(comment_text)
+    driver.wait_for_xpath("//div[text()='Customize Group Access']").click()
+    group_checkbox = driver.wait_for_xpath("//input[@name='group_ids[0]']")
+    assert group_checkbox.is_selected()
+    group_checkbox.click()
+    driver.scroll_to_element_and_click(driver.find_element_by_css_selector('[type=submit]'))
+    driver.wait_for_xpath('//div[contains(.,"Select at least one group")]')
+    group_checkbox.click()
+    driver.wait_for_xpath_to_disappear('//div[contains(.,"Select at least one group")]')
     driver.scroll_to_element_and_click(driver.find_element_by_css_selector('[type=submit]'))
     driver.wait_for_xpath(f'//div[text()="{comment_text}"]')
     driver.wait_for_xpath('//span[contains(@class,"commentTime")]')
@@ -38,7 +61,7 @@ def test_upload_comment_attachment(driver, user, public_source):
     driver.get(f"/become_user/{user.id}")  # TODO decorator/context manager?
     driver.get(f"/source/{public_source.id}")
     driver.wait_for_xpath(f'//div[text()="{public_source.id}"]')
-    comment_box = driver.find_element_by_css_selector('[name=comment]')
+    comment_box = driver.wait_for_xpath("//input[@name='text']")
     comment_text = str(uuid.uuid4())
     comment_box.send_keys(comment_text)
     attachment_file = driver.find_element_by_css_selector('input[type=file]')
@@ -53,7 +76,7 @@ def test_download_comment_attachment(driver, user, public_source):
     driver.get(f"/become_user/{user.id}")  # TODO decorator/context manager?
     driver.get(f"/source/{public_source.id}")
     driver.wait_for_xpath(f'//div[text()="{public_source.id}"]')
-    comment_box = driver.find_element_by_css_selector('[name=comment]')
+    comment_box = driver.wait_for_xpath("//input[@name='text']")
     comment_text = str(uuid.uuid4())
     comment_box.send_keys(comment_text)
     attachment_file = driver.find_element_by_css_selector('input[type=file]')
@@ -93,14 +116,14 @@ def test_view_only_user_cannot_comment(driver, view_only_user, public_source):
     driver.get(f"/become_user/{view_only_user.id}")
     driver.get(f"/source/{public_source.id}")
     driver.wait_for_xpath(f'//div[text()="{public_source.id}"]')
-    driver.wait_for_xpath_to_disappear('//input[@name="comment"]')
+    driver.wait_for_xpath_to_disappear('//input[@name="text"]')
 
 
 def test_delete_comment(driver, user, public_source):
     driver.get(f"/become_user/{user.id}")
     driver.get(f"/source/{public_source.id}")
     driver.wait_for_xpath(f'//div[text()="{public_source.id}"]')
-    comment_box = driver.find_element_by_css_selector('[name=comment]')
+    comment_box = driver.wait_for_xpath("//input[@name='text']")
     comment_text = str(uuid.uuid4())
     comment_box.send_keys(comment_text)
     driver.scroll_to_element_and_click(driver.find_element_by_css_selector('[type=submit]'))
@@ -120,7 +143,7 @@ def test_regular_user_cannot_delete_unowned_comment(driver, super_admin_user,
     driver.get(f"/become_user/{super_admin_user.id}")
     driver.get(f"/source/{public_source.id}")
     driver.wait_for_xpath(f'//div[text()="{public_source.id}"]')
-    comment_box = driver.find_element_by_css_selector('[name=comment]')
+    comment_box = driver.wait_for_xpath("//input[@name='text']")
     comment_text = str(uuid.uuid4())
     comment_box.send_keys(comment_text)
     submit_button = driver.find_element_by_css_selector('[type=submit]')
@@ -142,7 +165,7 @@ def test_super_user_can_delete_unowned_comment(driver, super_admin_user,
     driver.get(f"/become_user/{user.id}")
     driver.get(f"/source/{public_source.id}")
     driver.wait_for_xpath(f'//div[text()="{public_source.id}"]')
-    comment_box = driver.find_element_by_css_selector('[name=comment]')
+    comment_box = driver.wait_for_xpath("//input[@name='text']")
     comment_text = str(uuid.uuid4())
     comment_box.send_keys(comment_text)
     driver.scroll_to_element_and_click(driver.find_element_by_css_selector('[type=submit]'))

--- a/skyportal/tests/frontend/test_sources.py
+++ b/skyportal/tests/frontend/test_sources.py
@@ -134,7 +134,7 @@ def test_delete_comment(driver, user, public_source):
         "//*[starts-with(@name,'deleteCommentButton')]")
     ActionChains(driver).move_to_element(comment_div).perform()
     time.sleep(0.2)
-    driver.scroll_to_element_and_click(delete_button)
+    driver.execute_script("arguments[0].click();", delete_button)
     driver.wait_for_xpath_to_disappear(f'//div[text()="{comment_text}"]')
 
 
@@ -180,7 +180,7 @@ def test_super_user_can_delete_unowned_comment(driver, super_admin_user,
         "//*[starts-with(@name,'deleteCommentButton')]")
     ActionChains(driver).move_to_element(comment_div).perform()
     time.sleep(0.2)
-    driver.scroll_to_element_and_click(delete_button)
+    driver.execute_script("arguments[0].click();", delete_button)
     driver.wait_for_xpath_to_disappear(f'//div[text()="{comment_text}"]')
 
 

--- a/static/js/components/CommentEntry.css
+++ b/static/js/components/CommentEntry.css
@@ -2,3 +2,6 @@
     position: relative;
     z-index: 9999;
 }
+.inputDiv {
+    padding: 0.3rem;
+}

--- a/static/js/components/CommentEntry.jsx
+++ b/static/js/components/CommentEntry.jsx
@@ -1,67 +1,53 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import React, { useState } from "react";
+import PropTypes from "prop-types";
 
-import styles from './CommentEntry.css';
+import styles from "./CommentEntry.css";
 
-class CommentEntry extends React.Component {
-  constructor(props) {
-    super(props);
+const CommentEntry = ({ addComment }) => {
+  const [state, setState] = useState({ text: "", attachment: "" });
 
-    this.state = {
-      text: '',
-      attachment: ''
-    };
-    this._handleSubmit = this._handleSubmit.bind(this);
-    this._handleChange = this._handleChange.bind(this);
-  }
-
-  _handleSubmit(event) {
-    const { addComment } = this.props;
-
+  const handleSubmit = (event) => {
     event.preventDefault();
-    addComment(this.state);
+    addComment(state);
     this.fileInput.value = "";
-    this.setState({
+    setState({
       text: "",
       attachment: ""
     });
-  }
+  };
 
-  _handleChange(event) {
+  const handleChange = (event) => {
     if (event.target.files) {
-      this.setState({ attachment: event.target.files[0] });
+      setState({ ...state, attachment: event.target.files[0] });
     } else {
-      this.setState({ text: event.target.value });
+      setState({ ...state, text: event.target.value });
     }
-  }
+  };
 
-  render() {
-    const { text } = this.state;
-    return (
-      <form className={styles.commentEntry} onSubmit={this._handleSubmit}>
-        <div>
+  return (
+    <form className={styles.commentEntry} onSubmit={handleSubmit}>
+      <div>
+        <input
+          type="text"
+          name="comment"
+          value={state.text}
+          onChange={handleChange}
+        />
+      </div>
+      <div>
+        <label>
+          Attachment &nbsp;
           <input
-            type="text"
-            name="comment"
-            value={text}
-            onChange={this._handleChange}
+            ref={(el) => { this.fileInput = el; }}
+            type="file"
+            onChange={handleChange}
           />
-        </div>
-        <div>
-          <label>
-            Attachment &nbsp;
-            <input
-              ref={(el) => { this.fileInput = el; }}
-              type="file"
-              onChange={this._handleChange}
-            />
-          </label>
-        </div>
-        <input type="submit" value="↵" />
-      </form>
-    );
-  }
-}
+        </label>
+      </div>
+      <input type="submit" value="↵" />
+    </form>
+  );
+};
 
 CommentEntry.propTypes = {
   addComment: PropTypes.func.isRequired

--- a/static/js/components/CommentEntry.jsx
+++ b/static/js/components/CommentEntry.jsx
@@ -81,7 +81,7 @@ const CommentEntry = ({ addComment }) => {
           errors.group_ids &&
             <FormValidationError message="Select at least one group." />
         }
-        <Button onClick={toggleGroupSelectVisible} size="small">
+        <Button onClick={toggleGroupSelectVisible} size="small" style={{ textTransform: "none" }}>
           Customize Group Access
         </Button>
         <Box component="div" display={groupSelectVisible ? "block" : "none"}>

--- a/static/js/components/CommentEntry.jsx
+++ b/static/js/components/CommentEntry.jsx
@@ -1,26 +1,41 @@
 import React, { useEffect } from "react";
 import PropTypes from "prop-types";
-import { useForm } from "react-hook-form";
+import { useSelector } from "react-redux";
+import { useForm, Controller } from "react-hook-form";
+import Checkbox from "@material-ui/core/Checkbox";
+import TextField from "@material-ui/core/TextField";
+import FormControlLabel from "@material-ui/core/FormControlLabel";
+import ExpansionPanel from "@material-ui/core/ExpansionPanel";
+import ExpansionPanelSummary from "@material-ui/core/ExpansionPanelSummary";
+import ExpansionPanelDetails from "@material-ui/core/ExpansionPanelDetails";
+import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
+import Typography from "@material-ui/core/Typography";
 
+import FormValidationError from "./FormValidationError";
 import styles from "./CommentEntry.css";
 
 const CommentEntry = ({ addComment }) => {
-  const { handleSubmit, reset, register, getValues, setValue } = useForm({
-    text: "",
-    attachment: ""
-  });
+  const userGroups = useSelector((state) => state.groups.user);
+
+  const { handleSubmit, reset, register, getValues, setValue, control, errors } = useForm();
 
   // The file input needs to be registered here, not in the input tag below
   useEffect(() => {
     register({ name: "attachment" });
   }, [register]);
 
-  const onSubmit = () => {
-    addComment(getValues());
+  useEffect(() => {
     reset({
-      text: "",
-      attachment: ""
+      group_ids: Array(userGroups.length).fill(true)
     });
+  }, [reset, userGroups]);
+
+  const onSubmit = (data) => {
+    const groupIDs = userGroups.map((g) => g.id);
+    const selectedGroupIDs = groupIDs.filter((ID, idx) => data.group_ids[idx]);
+    data.group_ids = selectedGroupIDs;
+    addComment(data);
+    reset();
   };
 
   const handleFileInputChange = (event) => {
@@ -28,16 +43,26 @@ const CommentEntry = ({ addComment }) => {
     setValue("attachment", file);
   };
 
+  const validateGroups = () => {
+    const formState = getValues({ nest: true });
+    return formState.group_ids.filter((value) => Boolean(value)).length >= 1;
+  };
+
   return (
     <form className={styles.commentEntry} onSubmit={handleSubmit(onSubmit)}>
-      <div>
-        <input
-          type="text"
+      <Typography variant="h6">
+        Add comment
+      </Typography>
+      <div className={styles.inputDiv}>
+        <TextField
+          label="Comment text"
+          inputRef={register({ required: true })}
           name="text"
-          ref={register}
+          error={!!errors.text}
+          helperText={errors.text ? "Required" : ""}
         />
       </div>
-      <div>
+      <div className={styles.inputDiv}>
         <label>
           Attachment &nbsp;
           <input
@@ -47,7 +72,43 @@ const CommentEntry = ({ addComment }) => {
           />
         </label>
       </div>
-      <input type="submit" value="↵" />
+      <div className={styles.inputDiv}>
+        {
+          errors.group_ids &&
+            <FormValidationError message="Select at least one group." />
+        }
+        <ExpansionPanel>
+          <ExpansionPanelSummary
+            expandIcon={<ExpandMoreIcon />}
+            aria-controls="panel-content"
+            id="panel-header"
+          >
+            Customize Group Access
+          </ExpansionPanelSummary>
+          <ExpansionPanelDetails>
+            {
+              userGroups.map((userGroup, idx) => (
+                <FormControlLabel
+                  key={userGroup.id}
+                  control={(
+                    <Controller
+                      as={Checkbox}
+                      name={`group_ids[${idx}]`}
+                      control={control}
+                      rules={{ validate: validateGroups }}
+                      defaultValue
+                    />
+                  )}
+                  label={userGroup.name}
+                />
+              ))
+            }
+          </ExpansionPanelDetails>
+        </ExpansionPanel>
+      </div>
+      <div className={styles.inputDiv}>
+        <input type="submit" value="↵" />
+      </div>
     </form>
   );
 };

--- a/static/js/components/CommentEntry.jsx
+++ b/static/js/components/CommentEntry.jsx
@@ -1,46 +1,49 @@
-import React, { useState } from "react";
+import React, { useEffect } from "react";
 import PropTypes from "prop-types";
+import { useForm } from "react-hook-form";
 
 import styles from "./CommentEntry.css";
 
 const CommentEntry = ({ addComment }) => {
-  const [state, setState] = useState({ text: "", attachment: "" });
+  const { handleSubmit, reset, register, getValues, setValue } = useForm({
+    text: "",
+    attachment: ""
+  });
 
-  const handleSubmit = (event) => {
-    event.preventDefault();
-    addComment(state);
-    this.fileInput.value = "";
-    setState({
+  // The file input needs to be registered here, not in the input tag below
+  useEffect(() => {
+    register({ name: "attachment" });
+  }, [register]);
+
+  const onSubmit = () => {
+    addComment(getValues());
+    reset({
       text: "",
       attachment: ""
     });
   };
 
-  const handleChange = (event) => {
-    if (event.target.files) {
-      setState({ ...state, attachment: event.target.files[0] });
-    } else {
-      setState({ ...state, text: event.target.value });
-    }
+  const handleFileInputChange = (event) => {
+    const file = event.target.files[0];
+    setValue("attachment", file);
   };
 
   return (
-    <form className={styles.commentEntry} onSubmit={handleSubmit}>
+    <form className={styles.commentEntry} onSubmit={handleSubmit(onSubmit)}>
       <div>
         <input
           type="text"
-          name="comment"
-          value={state.text}
-          onChange={handleChange}
+          name="text"
+          ref={register}
         />
       </div>
       <div>
         <label>
           Attachment &nbsp;
           <input
-            ref={(el) => { this.fileInput = el; }}
             type="file"
-            onChange={handleChange}
+            name="attachment"
+            onChange={handleFileInputChange}
           />
         </label>
       </div>

--- a/static/js/components/CommentEntry.jsx
+++ b/static/js/components/CommentEntry.jsx
@@ -1,15 +1,13 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import { useSelector } from "react-redux";
 import { useForm, Controller } from "react-hook-form";
 import Checkbox from "@material-ui/core/Checkbox";
 import TextField from "@material-ui/core/TextField";
 import FormControlLabel from "@material-ui/core/FormControlLabel";
-import ExpansionPanel from "@material-ui/core/ExpansionPanel";
-import ExpansionPanelSummary from "@material-ui/core/ExpansionPanelSummary";
-import ExpansionPanelDetails from "@material-ui/core/ExpansionPanelDetails";
-import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 import Typography from "@material-ui/core/Typography";
+import Button from "@material-ui/core/Button";
+import Box from "@material-ui/core/Box";
 
 import FormValidationError from "./FormValidationError";
 import styles from "./CommentEntry.css";
@@ -30,12 +28,18 @@ const CommentEntry = ({ addComment }) => {
     });
   }, [reset, userGroups]);
 
+  const [groupSelectVisible, setGroupSelectVisible] = useState(false);
+  const toggleGroupSelectVisible = () => {
+    setGroupSelectVisible(!groupSelectVisible);
+  };
+
   const onSubmit = (data) => {
     const groupIDs = userGroups.map((g) => g.id);
     const selectedGroupIDs = groupIDs.filter((ID, idx) => data.group_ids[idx]);
     data.group_ids = selectedGroupIDs;
     addComment(data);
     reset();
+    setGroupSelectVisible(false);
   };
 
   const handleFileInputChange = (event) => {
@@ -77,34 +81,28 @@ const CommentEntry = ({ addComment }) => {
           errors.group_ids &&
             <FormValidationError message="Select at least one group." />
         }
-        <ExpansionPanel>
-          <ExpansionPanelSummary
-            expandIcon={<ExpandMoreIcon />}
-            aria-controls="panel-content"
-            id="panel-header"
-          >
-            Customize Group Access
-          </ExpansionPanelSummary>
-          <ExpansionPanelDetails>
-            {
-              userGroups.map((userGroup, idx) => (
-                <FormControlLabel
-                  key={userGroup.id}
-                  control={(
-                    <Controller
-                      as={Checkbox}
-                      name={`group_ids[${idx}]`}
-                      control={control}
-                      rules={{ validate: validateGroups }}
-                      defaultValue
-                    />
-                  )}
-                  label={userGroup.name}
-                />
-              ))
-            }
-          </ExpansionPanelDetails>
-        </ExpansionPanel>
+        <Button onClick={toggleGroupSelectVisible} size="small">
+          Customize Group Access
+        </Button>
+        <Box component="div" display={groupSelectVisible ? "block" : "none"}>
+          {
+            userGroups.map((userGroup, idx) => (
+              <FormControlLabel
+                key={userGroup.id}
+                control={(
+                  <Controller
+                    as={Checkbox}
+                    name={`group_ids[${idx}]`}
+                    control={control}
+                    rules={{ validate: validateGroups }}
+                    defaultValue
+                  />
+                )}
+                label={userGroup.name}
+              />
+            ))
+          }
+        </Box>
       </div>
       <div className={styles.inputDiv}>
         <input type="submit" value="↵" />

--- a/static/js/components/CommentList.jsx
+++ b/static/js/components/CommentList.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import { Button } from "@material-ui/core";
+import Tooltip from "@material-ui/core/Tooltip";
 
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
@@ -36,7 +37,7 @@ const CommentList = () => {
   comments = comments || [];
 
   const items = comments.map(
-    ({ id, author, created_at, text, attachment_name }) => (
+    ({ id, author, created_at, text, attachment_name, groups }) => (
       <span
         key={id}
         className={styles.comment}
@@ -55,6 +56,12 @@ const CommentList = () => {
           <span className={styles.commentTime}>
             {dayjs().to(dayjs(created_at))}
           </span>
+          &nbsp;|&nbsp;
+          <Tooltip title={groups.map((group) => group.name).join(", ")}>
+            <span className={styles.commentTime}>
+              Groups
+            </span>
+          </Tooltip>
         </div>
         <div className={styles.wrap} name={`commentDiv${id}`}>
           <div className={styles.commentMessage}>

--- a/static/js/components/CommentList.jsx
+++ b/static/js/components/CommentList.jsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import { Button } from "@material-ui/core";
 import Tooltip from "@material-ui/core/Tooltip";
+import GroupIcon from "@material-ui/icons/Group";
 
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
@@ -56,11 +57,9 @@ const CommentList = () => {
           <span className={styles.commentTime}>
             {dayjs().to(dayjs(created_at))}
           </span>
-          &nbsp;|&nbsp;
+          &nbsp;
           <Tooltip title={groups.map((group) => group.name).join(", ")}>
-            <span className={styles.commentTime}>
-              Groups
-            </span>
+            <GroupIcon fontSize="small" style={{ paddingTop: "6px", paddingBottom: "0px" }} />
           </Tooltip>
         </div>
         <div className={styles.wrap} name={`commentDiv${id}`}>

--- a/static/js/components/CommentList.jsx
+++ b/static/js/components/CommentList.jsx
@@ -56,7 +56,7 @@ const CommentList = () => {
             {dayjs().to(dayjs(created_at))}
           </span>
         </div>
-        <div className={styles.wrap}>
+        <div className={styles.wrap} name={`commentDiv${id}`}>
           <div className={styles.commentMessage}>
             {text}
           </div>

--- a/static/js/ducks/source.js
+++ b/static/js/ducks/source.js
@@ -38,7 +38,7 @@ export const uploadPhotometry = (data) => (
   API.POST("/api/photometry", UPLOAD_PHOTOMETRY, data)
 );
 
-export function addComment(form) {
+export function addComment(formData) {
   function fileReaderPromise(file) {
     return new Promise((resolve) => {
       const filereader = new FileReader();
@@ -48,16 +48,16 @@ export function addComment(form) {
       );
     });
   }
-  if (form.attachment) {
+  if (formData.attachment) {
     return (dispatch) => {
-      fileReaderPromise(form.attachment)
+      fileReaderPromise(formData.attachment)
         .then((fileData) => {
-          form.attachment = fileData;
-          dispatch(API.POST(`/api/comment`, ADD_COMMENT, form));
+          formData.attachment = fileData;
+          dispatch(API.POST(`/api/comment`, ADD_COMMENT, formData));
         });
     };
   } else {
-    return API.POST(`/api/comment`, ADD_COMMENT, form);
+    return API.POST(`/api/comment`, ADD_COMMENT, formData);
   }
 }
 


### PR DESCRIPTION
This PR introduces groups <--> comments relationships so that each comment has its own groups list. Users may now customize which of their groups should have access to a comment when commenting on the source page (by default, all groups are checked, and the checkbox area is not displayed). See screenshot below for front-end functionality demo.

![comments](https://user-images.githubusercontent.com/7230285/85636434-66a78d00-b635-11ea-9a08-951022e7105a.gif)
