### PR TITLE
Use PapaParse for parsing CSV strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "imports-loader": "0.8.0",
     "mui-datatables": "2.14.0",
     "npm-check": "5.9.2",
+    "papaparse": "5.2.0",
     "prop-types": "15.7.2",
     "raw-loader": "4.0.1",
     "react": "16.13.1",

--- a/skyportal/tests/frontend/test_upload_photometry.py
+++ b/skyportal/tests/frontend/test_upload_photometry.py
@@ -88,9 +88,9 @@ def test_upload_photometry_with_altdata(
     driver.get(f"/upload_photometry/{public_source.id}")
     csv_text_input = driver.wait_for_xpath('//textarea[@name="csvData"]')
     csv_text_input.send_keys(
-        "mjd,flux,fluxerr,zp,magsys,filter,altdata.meta1\n"
-        "58001,55,1,25,ab,ztfg,44.4\n"
-        "58002,53,1,25,ab,ztfg,44.2"
+        "mjd,flux,fluxerr,zp,magsys,filter,altdata.meta1,altdata.meta2\n"
+        "58001,55,1,25,ab,ztfg,44.4,\"abc,abc\"\n"
+        "58002,53,1,25,ab,ztfg,44.2,\"edf,edf\""
     )
     driver.wait_for_xpath('//*[@id="mui-component-select-instrumentID"]').click()
     driver.wait_for_xpath(f'//span[text()="P60 Camera (ID: {inst_id})"]').click()


### PR DESCRIPTION
This PR improves CSV parsing in the photometry upload front-end component. We use `PapaParse` for parsing CSV, which auto-detects the delimiter, simplifying our form by not requiring the delimiter to be specified. This also allows for escaped (quoted) values that contain the delimiter, as in the example screenshot below.

![Screenshot from 2020-07-01 15-48-12](https://user-images.githubusercontent.com/7230285/86298551-dd530600-bbb2-11ea-9085-e9cf501cfa48.png)
