### PR TITLE
Add individual user groups & public group that all users automatically belong to

### DIFF
--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -61,6 +61,7 @@ services:
 
 misc:
     days_to_keep_unsaved_candidates: 7
+    public_group_name: "Sitewide Group"
 
 cron:
   - interval: 1440

--- a/skyportal/handlers/api/group.py
+++ b/skyportal/handlers/api/group.py
@@ -98,7 +98,7 @@ class GroupHandler(BaseHandler):
                               and 'Super admin' in
                               [role.id for role in self.current_user.roles]
                               else None)
-        if not include_single_user_groups:
+        if (not include_single_user_groups) or (include_single_user_groups == "false"):
             info["user_groups"] = [g for g in info["user_groups"]
                                    if not g.single_user_group]
             if info["all_groups"]:

--- a/skyportal/handlers/api/group.py
+++ b/skyportal/handlers/api/group.py
@@ -90,14 +90,20 @@ class GroupHandler(BaseHandler):
                 return self.success(data=group)
             return self.error(f"Could not load group with ID {group_id}")
 
+        include_single_user_groups = self.get_query_argument("includeSingleUserGroups",
+                                                             False)
         info = {}
-        info['user_groups'] = [g for g in list(self.current_user.groups)
-                               if not g.single_user_group]
-        info['all_groups'] = ([g for g in list(Group.query) if not g.single_user_group]
-                              if hasattr(self.current_user, 'roles')
+        info['user_groups'] = list(self.current_user.groups)
+        info['all_groups'] = (list(Group.query) if hasattr(self.current_user, 'roles')
                               and 'Super admin' in
                               [role.id for role in self.current_user.roles]
                               else None)
+        if not include_single_user_groups:
+            info["user_groups"] = [g for g in info["user_groups"]
+                                   if not g.single_user_group]
+            if info["all_groups"]:
+                info["all_groups"] = [g for g in info["all_groups"]
+                                      if not g.single_user_group]
         return self.success(data=info)
 
     @permissions(['Manage groups'])

--- a/skyportal/handlers/api/group.py
+++ b/skyportal/handlers/api/group.py
@@ -91,8 +91,10 @@ class GroupHandler(BaseHandler):
             return self.error(f"Could not load group with ID {group_id}")
 
         info = {}
-        info['user_groups'] = list(self.current_user.groups)
-        info['all_groups'] = (list(Group.query) if hasattr(self.current_user, 'roles')
+        info['user_groups'] = [g for g in list(self.current_user.groups)
+                               if not g.single_user_group]
+        info['all_groups'] = ([g for g in list(Group.query) if not g.single_user_group]
+                              if hasattr(self.current_user, 'roles')
                               and 'Super admin' in
                               [role.id for role in self.current_user.roles]
                               else None)

--- a/skyportal/handlers/api/group.py
+++ b/skyportal/handlers/api/group.py
@@ -264,6 +264,9 @@ class GroupUserHandler(BaseHandler):
                               description: Boolean indicating whether user is group admin
         """
         data = self.get_json()
+        group = Group.query.get(group_id)
+        if group.single_user_group:
+            return self.error("Cannot add users to single user groups.")
         try:
             user_id = User.query.filter(User.username == username).first().id
         except AttributeError:
@@ -303,6 +306,9 @@ class GroupUserHandler(BaseHandler):
               application/json:
                 schema: Success
         """
+        group = Group.query.get(group_id)
+        if group.single_user_group:
+            return self.error("Cannot add users to single user groups.")
         user_id = User.query.filter(User.username == username).first().id
         (GroupUser.query.filter(GroupUser.group_id == group_id)
          .filter(GroupUser.user_id == user_id).delete())

--- a/skyportal/handlers/api/user.py
+++ b/skyportal/handlers/api/user.py
@@ -32,7 +32,9 @@ class UserHandler(BaseHandler):
         if user is None:
             return self.error(f'Invalid user ID ({user_id}).')
         else:
-            return self.success(data=user)
+            user_info = user.to_dict()
+            user_info['acls'] = user.acls
+            return self.success(data=user_info)
 
     @permissions(["Manage users"])
     def post(self):

--- a/skyportal/handlers/api/user.py
+++ b/skyportal/handlers/api/user.py
@@ -1,6 +1,7 @@
 from ..base import BaseHandler
 from baselayer.app.access import permissions
-from ...models import DBSession, User
+from ...models import DBSession, User, Group, GroupUser, cfg
+from ...model_util import role_acls
 
 from sqlalchemy.orm import joinedload
 
@@ -33,6 +34,80 @@ class UserHandler(BaseHandler):
         else:
             return self.success(data=user)
 
+    @permissions(["Manage users"])
+    def post(self):
+        """
+        ---
+        description: Add a new user
+        requestBody:
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  username:
+                    type: string
+                    description: User's email address
+                  roles:
+                    type: array
+                    items:
+                      type: string
+                    enum: {list(role_acls)}
+                    description: |
+                      List of user roles. Defaults to `[Full user]`. Will be overridden
+                      by `groupIDsAndAdmin` on a per-group basis.
+                  groupIDsAndAdmin:
+                    type: array
+                    items:
+                      type: array
+                    description: |
+                      Array of 2-element arrays `[groupID, admin]` where `groupID`
+                      is the ID of a group that the new user will be added to and
+                      `admin` is a boolean indicating whether they will be an admin in
+                      that group, e.g. `[[group_id_1, true], [group_id_2, false]]`
+                required:
+                  - username
+        responses:
+          200:
+            content:
+              application/json:
+                schema:
+                  allOf:
+                    - $ref: '#/components/schemas/Success'
+                    - type: object
+                      properties:
+                        data:
+                          type: object
+                          properties:
+                            id:
+                              type: integer
+                              description: New user ID
+        """
+        data = self.get_json()
+        roles = data.get("roles", ["Full user"])
+        group_ids_and_admin = data.get("groupIDsAndAdmin", [])
+
+        # Add user
+        user = User(username=data["username"], role_ids=roles)
+        DBSession().add(user)
+        DBSession().flush()
+
+        # Add user to specified groups
+        for group_id, admin in group_ids_and_admin:
+            DBSession.add(GroupUser(user_id=user.id, group_id=group_id, admin=admin))
+
+        # Create single-user group
+        DBSession().add(Group(name=user.username, users=[user], single_user_group=True))
+
+        # Add user to sitewide public group
+        public_group = Group.query.filter(
+            Group.name == cfg["misc"]["public_group_name"]
+        ).first()
+        if public_group is not None:
+            DBSession().add(GroupUser(group_id=public_group.id, user_id=user.id))
+        DBSession().commit()
+        return self.success(data={"id": user.id})
+
     @permissions(['Manage users'])
     def delete(self, user_id=None):
         """
@@ -54,7 +129,10 @@ class UserHandler(BaseHandler):
               application/json:
                 schema: Error
         """
-        user_id = int(user_id)
-        DBSession().query(User).filter(User.id == user_id).delete()
+        user = User.query.get(user_id)
+        DBSession().delete(user)
+        single_user_group = Group.query.filter(Group.name == user.username).first()
+        if single_user_group is not None:
+            DBSession().delete(single_user_group)
         DBSession().commit()
         return self.success()

--- a/skyportal/handlers/api/user.py
+++ b/skyportal/handlers/api/user.py
@@ -27,7 +27,7 @@ class UserHandler(BaseHandler):
               application/json:
                 schema: Error
         """
-        user = User.query.options(joinedload(User.acls)).get(int(user_id))
+        user = User.query.get(int(user_id))
         if user is None:
             return self.error(f'Invalid user ID ({user_id}).')
         else:

--- a/skyportal/handlers/api/user.py
+++ b/skyportal/handlers/api/user.py
@@ -90,7 +90,7 @@ class UserHandler(BaseHandler):
         group_ids_and_admin = data.get("groupIDsAndAdmin", [])
 
         # Add user
-        user = User(username=data["username"], role_ids=roles)
+        user = User(username=data["username"].lower(), role_ids=roles)
         DBSession().add(user)
         DBSession().flush()
 

--- a/skyportal/model_util.py
+++ b/skyportal/model_util.py
@@ -13,6 +13,18 @@ from skyportal.models import (init_db, Base, DBSession, ACL, Comment,
                               Source, Spectrum, Telescope, Thumbnail, User,
                               Token)
 
+all_acl_ids = ['Become user', 'Comment', 'Manage users', 'Manage sources',
+               'Manage groups', 'Upload data', 'System admin', 'Post taxonomy',
+               'Delete taxonomy']
+
+role_acls = {
+    'Super admin': all_acl_ids,
+    'Group admin': ['Comment', 'Manage sources', 'Upload data', 'Post taxonomy'],
+    'Full user': ['Comment', 'Upload data'],
+    'View only': []
+}
+
+
 def add_user(username, roles=[], auth=False):
     user = User.query.filter(User.username == username).first()
     if user is None:
@@ -66,19 +78,9 @@ def setup_permissions():
     """Create default ACLs/Roles needed by application.
 
     If a given ACL or Role already exists, it will be skipped."""
-    all_acl_ids = ['Become user', 'Comment', 'Manage users', 'Manage sources',
-                   'Manage groups', 'Upload data', 'System admin', 'Post taxonomy',
-                   'Delete taxonomy']
     all_acls = [ACL.create_or_get(a) for a in all_acl_ids]
     DBSession().add_all(all_acls)
     DBSession().commit()
-
-    role_acls = {
-        'Super admin': all_acl_ids,
-        'Group admin': ['Comment', 'Manage sources', 'Upload data', 'Post taxonomy'],
-        'Full user': ['Comment', 'Upload data'],
-        'View only': []
-    }
 
     for r, acl_ids in role_acls.items():
         role = Role.create_or_get(r)

--- a/skyportal/model_util.py
+++ b/skyportal/model_util.py
@@ -19,7 +19,8 @@ all_acl_ids = ['Become user', 'Comment', 'Manage users', 'Manage sources',
 
 role_acls = {
     'Super admin': all_acl_ids,
-    'Group admin': ['Comment', 'Manage sources', 'Upload data', 'Post taxonomy'],
+    'Group admin': ['Comment', 'Manage sources', 'Upload data', 'Post taxonomy',
+                    'Manage users'],
     'Full user': ['Comment', 'Upload data'],
     'View only': []
 }

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -67,17 +67,18 @@ class Group(Base):
     name = sa.Column(sa.String, unique=True, nullable=False)
 
     streams = relationship('Stream', secondary='stream_groups',
-                           back_populates='groups')
-    telescopes = relationship('Telescope', secondary='group_telescopes')
-    group_users = relationship('GroupUser', back_populates='group',
-                               cascade='save-update, merge, refresh-expire, expunge',
-                               passive_deletes=True)
+                           back_populates='groups',
+                           passive_deletes=True)
+    telescopes = relationship('Telescope', secondary='group_telescopes',
+                              passive_deletes=True)
     users = relationship('User', secondary='group_users',
-                         back_populates='groups')
+                         back_populates='groups',
+                         passive_deletes=True)
     filter = relationship("Filter", uselist=False, back_populates="group")
     photometry = relationship("Photometry", secondary="group_photometry",
                               back_populates="groups",
-                              cascade="save-update, merge, refresh-expire, expunge")
+                              cascade="save-update, merge, refresh-expire, expunge",
+                              passive_deletes=True)
     single_user_group = sa.Column(sa.Boolean, default=False)
 
 
@@ -114,17 +115,16 @@ class Stream(Base):
     password = sa.Column(sa.String)
 
     groups = relationship('Group', secondary='stream_groups',
-                          back_populates='streams')
+                          back_populates='streams',
+                          passive_deletes=True)
 
 
 StreamGroup = join_model('stream_groups', Stream, Group)
 
 
-User.group_users = relationship('GroupUser', back_populates='user',
-                                cascade='save-update, merge, refresh-expire, expunge',
-                                passive_deletes=True)
 User.groups = relationship('Group', secondary='group_users',
-                           back_populates='users')
+                           back_populates='users',
+                           passive_deletes=True)
 
 
 @property
@@ -184,7 +184,8 @@ class Obj(Base):
                            order_by="Spectrum.observed_at")
     thumbnails = relationship('Thumbnail', back_populates='obj',
                               secondary='photometry',
-                              cascade='save-update, merge, refresh-expire, expunge')
+                              cascade='save-update, merge, refresh-expire, expunge',
+                              passive_deletes=True)
 
     followup_requests = relationship('FollowupRequest', back_populates='obj')
 
@@ -340,7 +341,8 @@ Obj.get_photometry_owned_by_user = get_photometry_owned_by_user
 
 User.sources = relationship('Obj', backref='users',
                             secondary='join(Group, sources).join(group_users)',
-                            primaryjoin='group_users.c.user_id == users.c.id')
+                            primaryjoin='group_users.c.user_id == users.c.id',
+                            passive_deletes=True)
 
 
 class SourceView(Base):
@@ -362,7 +364,8 @@ class Telescope(Base):
     skycam_link = sa.Column(URLType, nullable=True,
                             doc="Link to the telescope's sky camera.")
 
-    groups = relationship('Group', secondary='group_telescopes')
+    groups = relationship('Group', secondary='group_telescopes',
+                          passive_deletes=True)
     instruments = relationship('Instrument', back_populates='telescope',
                                cascade='save-update, merge, refresh-expire, expunge',
                                passive_deletes=True)
@@ -435,7 +438,8 @@ class Taxonomy(Base):
                          )
     groups = relationship("Group", secondary="group_taxonomy",
                           cascade="save-update,"
-                                  "merge, refresh-expire, expunge"
+                                  "merge, refresh-expire, expunge",
+                          passive_deletes=True
                           )
 
 
@@ -470,7 +474,8 @@ class Comment(Base):
                        nullable=False, index=True)
     obj = relationship('Obj', back_populates='comments')
     groups = relationship("Group", secondary="group_comments",
-                          cascade="save-update, merge, refresh-expire, expunge")
+                          cascade="save-update, merge, refresh-expire, expunge",
+                          passive_deletes=True)
 
 
 GroupComment = join_model("group_comments", Group, Comment)
@@ -513,7 +518,8 @@ class Photometry(Base):
     obj = relationship('Obj', back_populates='photometry')
     groups = relationship("Group", secondary="group_photometry",
                           back_populates="photometry",
-                          cascade="save-update, merge, refresh-expire, expunge")
+                          cascade="save-update, merge, refresh-expire, expunge",
+                          passive_deletes=True)
     instrument_id = sa.Column(sa.ForeignKey('instruments.id'),
                               nullable=False, index=True)
     instrument = relationship('Instrument', back_populates='photometry')
@@ -627,7 +633,8 @@ class Thumbnail(Base):
                               nullable=False, index=True)
     photometry = relationship('Photometry', back_populates='thumbnails')
     obj = relationship('Obj', back_populates='thumbnails', uselist=False,
-                       secondary='photometry')
+                       secondary='photometry',
+                       passive_deletes=True)
 
 
 class FollowupRequest(Base):

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -94,6 +94,11 @@ def create_user_group_and_add_to_public_group(mapper, connection, target):
         )
 
 
+@event.listens_for(User, "after_delete")
+def delete_user_group(mapper, connection, target):
+    object_session(target).delete(Group.query.filter(Group.name == target.username))
+
+
 class Stream(Base):
     name = sa.Column(sa.String, unique=True, nullable=False)
     url = sa.Column(sa.String, unique=True, nullable=False)

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -87,7 +87,7 @@ def create_user_group_and_add_to_public_group(mapper, connection, target):
     object_session(target).add(
         Group(name=target.username, users=[target], single_user_group=True)
     )
-    public_group = Group.query.filter(Group.name == "public_group").first()
+    public_group = Group.query.filter(Group.name == "Public Group").first()
     if public_group is not None:
         object_session(target).add(
             GroupUser(group_id=public_group.id, user_id=target.id)

--- a/skyportal/schema.py
+++ b/skyportal/schema.py
@@ -141,7 +141,8 @@ def setup_schema():
             schema_class_name = class_.__name__
             add_schema(schema_class_name, exclude=['created_at', 'modified'],
                        add_to_model=True)
-            add_schema(f'{schema_class_name}NoID', exclude=['created_at', 'id', 'modified'])
+            add_schema(f'{schema_class_name}NoID',
+                       exclude=['created_at', 'id', 'modified', 'single_user_group'])
 
 
 class PhotBaseFlexible(object):
@@ -212,10 +213,8 @@ class PhotBaseFlexible(object):
                                         "points will be visible.",
                             required=True)
 
-
     altdata = fields.Field(description='Misc. alternative metadata.',
                            missing=None, default=None, required=False)
-
 
 
 class PhotFluxFlexible(_Schema, PhotBaseFlexible):

--- a/skyportal/tests/api/test_groups.py
+++ b/skyportal/tests/api/test_groups.py
@@ -6,88 +6,116 @@ from skyportal.model_util import create_token
 def test_token_user_create_new_group(manage_groups_token, super_admin_user):
     group_name = str(uuid.uuid4())
     status, data = api(
-        'POST',
-        'groups',
-        data={'name': group_name,
-              'group_admins': [super_admin_user.username]},
-        token=manage_groups_token)
+        "POST",
+        "groups",
+        data={"name": group_name, "group_admins": [super_admin_user.username]},
+        token=manage_groups_token,
+    )
     assert status == 200
-    assert data['status'] == 'success'
-    new_group_id = data['data']['id']
+    assert data["status"] == "success"
+    new_group_id = data["data"]["id"]
 
-    status, data = api('GET', f'groups/{new_group_id}',
-                       token=manage_groups_token)
-    assert data['status'] == 'success'
-    assert data['data']['name'] == group_name
+    status, data = api("GET", f"groups/{new_group_id}", token=manage_groups_token)
+    assert data["status"] == "success"
+    assert data["data"]["name"] == group_name
 
 
 def test_token_user_request_all_groups(manage_groups_token, super_admin_user):
     group_name = str(uuid.uuid4())
     status, data = api(
-        'POST',
-        'groups',
-        data={'name': group_name,
-              'group_admins': [super_admin_user.username]},
-        token=manage_groups_token)
+        "POST",
+        "groups",
+        data={"name": group_name, "group_admins": [super_admin_user.username]},
+        token=manage_groups_token,
+    )
     assert status == 200
-    assert data['status'] == 'success'
-    new_group_id = data['data']['id']
+    assert data["status"] == "success"
+    new_group_id = data["data"]["id"]
 
-    status, data = api('GET', 'groups',
-                       token=manage_groups_token)
-    assert data['status'] == 'success'
-    assert data['data']['user_groups'][-1]['name'] == group_name
-    assert data['data']['all_groups'] is None
+    status, data = api("GET", "groups", token=manage_groups_token)
+    assert data["status"] == "success"
+    assert data["data"]["user_groups"][-1]["name"] == group_name
+    assert data["data"]["all_groups"] is None
+    assert not any(
+        [
+            group["single_user_group"] == True
+            and group["name"] == super_admin_user.username
+            for group in data["data"]["user_groups"]
+        ]
+    )
+
+
+def test_token_user_request_all_groups_including_user(
+    manage_groups_token, super_admin_user
+):
+    group_name = str(uuid.uuid4())
+    status, data = api(
+        "POST",
+        "groups",
+        data={"name": group_name, "group_admins": [super_admin_user.username]},
+        token=manage_groups_token,
+    )
+    assert status == 200
+    assert data["status"] == "success"
+    new_group_id = data["data"]["id"]
+
+    status, data = api(
+        "GET", "groups?includeSingleUserGroups=true", token=manage_groups_token
+    )
+    assert data["status"] == "success"
+    assert any(
+        [
+            group["single_user_group"] == True
+            and group["name"] == super_admin_user.username
+            for group in data["data"]["user_groups"]
+        ]
+    )
 
 
 def test_token_user_update_group(manage_groups_token, public_group):
     new_name = str(uuid.uuid4())
     status, data = api(
-        'PUT',
-        f'groups/{public_group.id}',
-        data={'name': new_name},
-        token=manage_groups_token)
+        "PUT",
+        f"groups/{public_group.id}",
+        data={"name": new_name},
+        token=manage_groups_token,
+    )
     assert status == 200
-    assert data['status'] == 'success'
+    assert data["status"] == "success"
 
-    status, data = api('GET', f'groups/{public_group.id}',
-                       token=manage_groups_token)
-    assert data['status'] == 'success'
-    assert data['data']['name'] == new_name
+    status, data = api("GET", f"groups/{public_group.id}", token=manage_groups_token)
+    assert data["status"] == "success"
+    assert data["data"]["name"] == new_name
 
 
 def test_token_user_delete_group(manage_groups_token, public_group):
-    status, data = api(
-        'DELETE',
-        f'groups/{public_group.id}',
-        token=manage_groups_token)
+    status, data = api("DELETE", f"groups/{public_group.id}", token=manage_groups_token)
     assert status == 200
-    assert data['status'] == 'success'
+    assert data["status"] == "success"
 
-    status, data = api('GET', f'groups/{public_group.id}',
-                       token=manage_groups_token)
+    status, data = api("GET", f"groups/{public_group.id}", token=manage_groups_token)
     assert status == 400
 
 
-def test_manage_groups_token_get_unowned_group(manage_groups_token, user,
-                                               super_admin_user):
+def test_manage_groups_token_get_unowned_group(
+    manage_groups_token, user, super_admin_user
+):
     group_name = str(uuid.uuid4())
     status, data = api(
-        'POST',
-        'groups',
-        data={'name': group_name,
-              'group_admins': [user.username]},
-        token=manage_groups_token)
+        "POST",
+        "groups",
+        data={"name": group_name, "group_admins": [user.username]},
+        token=manage_groups_token,
+    )
     assert status == 200
-    assert data['status'] == 'success'
-    new_group_id = data['data']['id']
+    assert data["status"] == "success"
+    new_group_id = data["data"]["id"]
 
     token_name = str(uuid.uuid4())
     token_id = create_token(ACLs=['Manage groups'],
                             user_id=super_admin_user.id,
                             name=token_name)
 
-    status, data = api('GET', f'groups/{new_group_id}',
-                       token=token_id)
-    assert data['status'] == 'success'
-    assert data['data']['name'] == group_name
+    status, data = api("GET", f"groups/{new_group_id}", token=token_id)
+    assert data["status"] == "success"
+    assert data["data"]["name"] == group_name

--- a/skyportal/tests/api/test_groups.py
+++ b/skyportal/tests/api/test_groups.py
@@ -30,14 +30,13 @@ def test_token_user_request_all_groups(manage_groups_token, super_admin_user):
     )
     assert status == 200
     assert data["status"] == "success"
-    new_group_id = data["data"]["id"]
 
     status, data = api("GET", "groups", token=manage_groups_token)
     assert data["status"] == "success"
     assert data["data"]["user_groups"][-1]["name"] == group_name
-    assert data["data"]["all_groups"] is None
     assert not any(
         [
+<<<<<<< HEAD
             group["single_user_group"] == True
             and group["name"] == super_admin_user.username
             for group in data["data"]["user_groups"]
@@ -66,6 +65,9 @@ def test_token_user_request_all_groups_including_user(
     assert any(
         [
             group["single_user_group"] == True
+=======
+            group["single_user_group"] is True
+>>>>>>> Remove redundat, irrelenvant test
             and group["name"] == super_admin_user.username
             for group in data["data"]["user_groups"]
         ]

--- a/skyportal/tests/api/test_groups.py
+++ b/skyportal/tests/api/test_groups.py
@@ -36,38 +36,7 @@ def test_token_user_request_all_groups(manage_groups_token, super_admin_user):
     assert data["data"]["user_groups"][-1]["name"] == group_name
     assert not any(
         [
-<<<<<<< HEAD
-            group["single_user_group"] == True
-            and group["name"] == super_admin_user.username
-            for group in data["data"]["user_groups"]
-        ]
-    )
-
-
-def test_token_user_request_all_groups_including_user(
-    manage_groups_token, super_admin_user
-):
-    group_name = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "groups",
-        data={"name": group_name, "group_admins": [super_admin_user.username]},
-        token=manage_groups_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    new_group_id = data["data"]["id"]
-
-    status, data = api(
-        "GET", "groups?includeSingleUserGroups=true", token=manage_groups_token
-    )
-    assert data["status"] == "success"
-    assert any(
-        [
-            group["single_user_group"] == True
-=======
             group["single_user_group"] is True
->>>>>>> Remove redundat, irrelenvant test
             and group["name"] == super_admin_user.username
             for group in data["data"]["user_groups"]
         ]

--- a/static/js/components/GroupList.jsx
+++ b/static/js/components/GroupList.jsx
@@ -16,7 +16,7 @@ const GroupList = ({ title, groups }) => (
 
     <List dense>
       {
-        groups && groups.map((group) => (
+        groups && groups.filter((group) => !group.single_user_group).map((group) => (
           <Link to={`/group/${group.id}`} key={group.id}>
             <ListItem>
               <ListItemText primary={group.name} />

--- a/tools/data_loader.py
+++ b/tools/data_loader.py
@@ -15,7 +15,7 @@ from social_tornado.models import TornadoStorage
 
 from baselayer.app.env import load_env
 from baselayer.app.model_util import status, create_tables, drop_tables
-from skyportal.models import Base, init_db, Obj, DBSession, User
+from skyportal.models import Base, init_db, Obj, DBSession, User, Group
 from skyportal.model_util import setup_permissions, create_token
 from skyportal.tests import api
 from baselayer.tools.test_frontend import verify_server_availability
@@ -60,7 +60,9 @@ if __name__ == "__main__":
             setup_permissions()
 
     if src.get("users") is not None:
-        with status(f"Creating users"):
+        with status(f"Creating users & sitewide public group"):
+            DBSession().add(Group(name=cfg["misc"]["public_group_name"]))
+            DBSession().commit()
 
             users = []
             for user in src.get('users', []):


### PR DESCRIPTION
This PR adds individual user groups, which are automatically created whenever new users are added, to facilitate the sharing of data between individual users (PR forthcoming). This PR also adds a public group to which all users are automatically added (upon user creation).