### PR TITLE
Update Travis CI build to send test results to BuildPulse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ package-lock.json
 .jobs_timestamps.yaml
 skyportal_image_cache
 static/js/components/Main.jsx
+test-results/

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,3 +82,10 @@ after_success:
   # ESLint gets called when we try to commit the docs
   - rm .git/hooks/pre-commit
   - .travis/deploy_docs.sh
+
+after_script:
+  # Upload test results to BuildPulse for flaky test detection
+  - export BUILDPULSE_ACCOUNT_ID=25833053
+  - export BUILDPULSE_REPOSITORY_ID=82240075
+  - export BUILDPULSE_REPORT_PATH=test-results
+  - /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Workshop64/buildpulse-travis-ci/main/uploader-for-ubuntu.sh)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ matrix:
   include:
     - python: 3.7
       env:
-        - TEST_TARGET=test
+        - TEST_TARGET=test_xml
 
 before_install:
   - ccache -s

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+junit_family=xunit2


### PR DESCRIPTION
@dannygoldstein: Here's the starting point for the pull request we discussed.

To get everything wired up end-to-end, we'll need to do just a few things:

- [x] In your repository settings for https://travis-ci.org/github/skyportal/skyportal, set the `BUILDPULSE_ACCESS_KEY_ID` and `BUILDPULSE_SECRET_ACCESS_KEY` environment variables [[docs]](https://docs.travis-ci.com/user/environment-variables#defining-variables-in-repository-settings)

- [x] Configure pytest to generate an XML report for the test results. (You can see an example commit in https://github.com/Workshop64/buildpulse-example-pytest/commit/2ccd887723dcd48b44cbd18d9a9bb99de7a183f1.)

- [x] Add an `after_script` clause to `.travis.yml` to send the test results to BuildPulse for analysis

    This is done in 71c3b173bcb3a9a0698735b574d4928a8616bc75. It currently assumes that XML report(s) will reside in the `test-results` directory. If it would be helpful to use a different directory, that's totally fine. We'll just need to update the `BUILDPULSE_REPORT_PATH` in `.travis.yml` accordingly.

Please ping me when the first two items are done, and we can make sure that everything is flowing through nicely. And of course, if you run into any trouble with those items or if you have any questions at all, just let me know. :bow:
