### PR TITLE
Update Travis CI build to send test results to BuildPulse (#562)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ package-lock.json
 .jobs_timestamps.yaml
 skyportal_image_cache
 static/js/components/Main.jsx
+test-results/

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ matrix:
   include:
     - python: 3.7
       env:
-        - TEST_TARGET=test
+        - TEST_TARGET=test_xml
 
 before_install:
   - ccache -s
@@ -82,3 +82,10 @@ after_success:
   # ESLint gets called when we try to commit the docs
   - rm .git/hooks/pre-commit
   - .travis/deploy_docs.sh
+
+after_script:
+  # Upload test results to BuildPulse for flaky test detection
+  - export BUILDPULSE_ACCOUNT_ID=25833053
+  - export BUILDPULSE_REPOSITORY_ID=82240075
+  - export BUILDPULSE_REPORT_PATH=test-results
+  - /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Workshop64/buildpulse-travis-ci/main/uploader-for-ubuntu.sh)"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+junit_family=xunit2


### PR DESCRIPTION
This PR is a duplicate of #562, which updated the travis CI build to send test results to BuildPulse for flaky test detection. Since that PR was based on a Skyportal fork, it did not have access to the Travis CI secrets needed to send the results. This should solve that problem by moving the originating branch to the skyportal repository. 

* Update Travis CI build to send test results to BuildPulse

A couple notes:

- We'll need to push up another commit to instruct pytest to generate
  the test results as XML. You can see an example of this change in
  https://github.com/Workshop64/buildpulse-example-pytest/commit/2ccd887723dcd48b44cbd18d9a9bb99de7a183f1

  @dannygoldstein is going to look into configuring pytest to generate
  the test results as XML. pytest is currently invoked here:
  https://github.com/cesium-ml/baselayer/blob/8e4d0ec1f7/tools/test_frontend.py#L102

- This change assumes that the XML report will reside in the
  `test-results` directory. If it would be helpful to use a different
  directory, that's totally fine. We'll just need to update the
  BUILDPULSE_REPORT_PATH accordingly.

* Configure pytest to generate an XML report for the test results

Co-authored-by: Danny Goldstein <dgold@berkeley.edu>