### PR TITLE
Use `pytest-rerunfailures` to mark flaky front-end tests to be rerun up to 2 times

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ Pillow>=6
 sncosmo>=2.1.0
 tdtax>=0.1.1
 jsonschema
+pytest-rerunfailures>=9.0

--- a/skyportal/tests/frontend/test_followup_requests.py
+++ b/skyportal/tests/frontend/test_followup_requests.py
@@ -1,4 +1,5 @@
 import uuid
+import pytest
 from selenium.webdriver.support.ui import Select
 from selenium.common.exceptions import (ElementClickInterceptedException,
                                         TimeoutException)
@@ -43,6 +44,7 @@ def add_telescope_and_instrument(instrument_name, group_ids, token):
     return data
 
 
+@pytest.mark.flaky(reruns=2)
 def test_submit_new_followup_request(
     driver, user, public_source, public_group, super_admin_token
 ):
@@ -90,6 +92,7 @@ def test_submit_new_followup_request(
     driver.wait_for_xpath("//td[contains(.,'1')]")
 
 
+@pytest.mark.flaky(reruns=2)
 def test_edit_existing_followup_request(
     driver, user, public_source, public_group, super_admin_token
 ):
@@ -148,6 +151,7 @@ def test_edit_existing_followup_request(
         driver.wait_for_xpath("//td[contains(.,'5')]")
 
 
+@pytest.mark.flaky(reruns=2)
 def test_delete_followup_request(
     driver, user, public_source, public_group, super_admin_token
 ):
@@ -200,6 +204,7 @@ def test_delete_followup_request(
     driver.wait_for_xpath_to_disappear('//button[text()="Delete"]')
 
 
+@pytest.mark.flaky(reruns=2)
 def test_cannot_edit_uneditable_followup_request(
     driver, user, public_source, public_group, super_admin_token
 ):

--- a/skyportal/tests/frontend/test_scanning_page.py
+++ b/skyportal/tests/frontend/test_scanning_page.py
@@ -1,4 +1,5 @@
 import uuid
+import pytest
 from selenium.common.exceptions import TimeoutException
 
 from skyportal.tests import api
@@ -10,6 +11,7 @@ def test_candidates_page_render(driver, user, public_candidate):
     driver.wait_for_xpath(f'//a[text()="{public_candidate.id}"]')
 
 
+@pytest.mark.flaky(reruns=2)
 def test_candidate_group_filtering(
     driver,
     user,
@@ -63,6 +65,7 @@ def test_candidate_group_filtering(
         driver.wait_for_xpath(f'//a[text()="{candidate_id}_{i}"]')
 
 
+@pytest.mark.flaky(reruns=2)
 def test_candidate_unsaved_only_filtering(
     driver,
     user,
@@ -124,6 +127,7 @@ def test_candidate_unsaved_only_filtering(
         driver.wait_for_xpath(f'//a[text()="{candidate_id}_{i}"]')
 
 
+@pytest.mark.flaky(reruns=2)
 def test_candidate_date_filtering(
     driver,
     user,
@@ -193,6 +197,7 @@ def test_candidate_date_filtering(
         driver.wait_for_xpath(f'//a[text()="{candidate_id}_{i}"]', 10)
 
 
+@pytest.mark.flaky(reruns=2)
 def test_save_candidate_quick_save(
     driver, group_admin_user, public_group, public_candidate
 ):
@@ -216,6 +221,7 @@ def test_save_candidate_quick_save(
         driver.wait_for_xpath('//a[text()="Previously Saved"]')
 
 
+@pytest.mark.flaky(reruns=2)
 def test_save_candidate_select_groups(
     driver, group_admin_user, public_group, public_candidate
 ):
@@ -255,6 +261,7 @@ def test_save_candidate_select_groups(
         driver.wait_for_xpath('//a[text()="Previously Saved"]')
 
 
+@pytest.mark.flaky(reruns=2)
 def test_save_candidate_no_groups_error_message(
     driver, group_admin_user, public_group, public_candidate
 ):

--- a/skyportal/tests/frontend/test_sources.py
+++ b/skyportal/tests/frontend/test_sources.py
@@ -139,6 +139,7 @@ def test_delete_comment(driver, user, public_source):
     comment_id = comment_div.get_attribute("name").split("commentDiv")[-1]
     delete_button = comment_div.find_element_by_xpath(
         f"//*[@name='deleteCommentButton{comment_id}']")
+    driver.execute_script("arguments[0].scrollIntoView();", comment_div)
     ActionChains(driver).move_to_element(comment_div).perform()
     driver.execute_script("arguments[0].click();", delete_button)
     try:
@@ -154,6 +155,7 @@ def test_delete_comment(driver, user, public_source):
             comment_id = comment_div.get_attribute("name").split("commentDiv")[-1]
             delete_button = comment_div.find_element_by_xpath(
                 f"//*[@name='deleteCommentButton{comment_id}']")
+            driver.execute_script("arguments[0].scrollIntoView();", comment_div)
             ActionChains(driver).move_to_element(comment_div).perform()
             driver.execute_script("arguments[0].click();", delete_button)
             driver.wait_for_xpath_to_disappear(f'//div[text()="{comment_text}"]')
@@ -211,6 +213,7 @@ def test_super_user_can_delete_unowned_comment(driver, super_admin_user,
     comment_id = comment_div.get_attribute("name").split("commentDiv")[-1]
     delete_button = comment_div.find_element_by_xpath(
         f"//*[@name='deleteCommentButton{comment_id}']")
+    driver.execute_script("arguments[0].scrollIntoView();", comment_div)
     ActionChains(driver).move_to_element(comment_div).perform()
     driver.execute_script("arguments[0].click();", delete_button)
     try:

--- a/skyportal/tests/frontend/test_sources.py
+++ b/skyportal/tests/frontend/test_sources.py
@@ -19,7 +19,7 @@ def test_public_source_page(driver, user, public_source):
     driver.wait_for_xpath('//label[contains(text(), "Fe III")]')
 
 
-@pytest.mark.flaky(reruns=3)
+@pytest.mark.flaky(reruns=2)
 def test_comments(driver, user, public_source):
     driver.get(f"/become_user/{user.id}")  # TODO decorator/context manager?
     driver.get(f"/source/{public_source.id}")
@@ -70,7 +70,7 @@ def test_comment_groups_validation(driver, user, public_source):
         driver.wait_for_xpath('//span[text()="a few seconds ago"]')
 
 
-@pytest.mark.flaky(reruns=3)
+@pytest.mark.flaky(reruns=2)
 def test_upload_download_comment_attachment(driver, user, public_source):
     driver.get(f"/become_user/{user.id}")  # TODO decorator/context manager?
     driver.get(f"/source/{public_source.id}")
@@ -120,7 +120,7 @@ def test_view_only_user_cannot_comment(driver, view_only_user, public_source):
     driver.wait_for_xpath_to_disappear('//input[@name="text"]')
 
 
-@pytest.mark.flaky(reruns=3)
+@pytest.mark.flaky(reruns=2)
 def test_delete_comment(driver, user, public_source):
     driver.get(f"/become_user/{user.id}")
     driver.get(f"/source/{public_source.id}")
@@ -159,7 +159,7 @@ def test_delete_comment(driver, user, public_source):
             driver.wait_for_xpath_to_disappear(f'//div[text()="{comment_text}"]')
 
 
-@pytest.mark.flaky(reruns=3)
+@pytest.mark.flaky(reruns=2)
 def test_regular_user_cannot_delete_unowned_comment(driver, super_admin_user,
                                                     user, public_source):
     driver.get(f"/become_user/{super_admin_user.id}")
@@ -187,7 +187,7 @@ def test_regular_user_cannot_delete_unowned_comment(driver, super_admin_user,
     assert not delete_button.is_displayed()
 
 
-@pytest.mark.flaky(reruns=3)
+@pytest.mark.flaky(reruns=2)
 def test_super_user_can_delete_unowned_comment(driver, super_admin_user,
                                                user, public_source):
     driver.get(f"/become_user/{user.id}")

--- a/skyportal/tests/frontend/test_sources.py
+++ b/skyportal/tests/frontend/test_sources.py
@@ -1,6 +1,7 @@
 import os
 from os.path import join as pjoin
 import uuid
+import pytest
 from selenium.webdriver.common.action_chains import ActionChains
 from selenium.common.exceptions import TimeoutException
 
@@ -18,6 +19,7 @@ def test_public_source_page(driver, user, public_source):
     driver.wait_for_xpath('//label[contains(text(), "Fe III")]')
 
 
+@pytest.mark.flaky(reruns=3)
 def test_comments(driver, user, public_source):
     driver.get(f"/become_user/{user.id}")  # TODO decorator/context manager?
     driver.get(f"/source/{public_source.id}")
@@ -68,6 +70,7 @@ def test_comment_groups_validation(driver, user, public_source):
         driver.wait_for_xpath('//span[text()="a few seconds ago"]')
 
 
+@pytest.mark.flaky(reruns=3)
 def test_upload_download_comment_attachment(driver, user, public_source):
     driver.get(f"/become_user/{user.id}")  # TODO decorator/context manager?
     driver.get(f"/source/{public_source.id}")
@@ -117,6 +120,7 @@ def test_view_only_user_cannot_comment(driver, view_only_user, public_source):
     driver.wait_for_xpath_to_disappear('//input[@name="text"]')
 
 
+@pytest.mark.flaky(reruns=3)
 def test_delete_comment(driver, user, public_source):
     driver.get(f"/become_user/{user.id}")
     driver.get(f"/source/{public_source.id}")
@@ -155,6 +159,7 @@ def test_delete_comment(driver, user, public_source):
             driver.wait_for_xpath_to_disappear(f'//div[text()="{comment_text}"]')
 
 
+@pytest.mark.flaky(reruns=3)
 def test_regular_user_cannot_delete_unowned_comment(driver, super_admin_user,
                                                     user, public_source):
     driver.get(f"/become_user/{super_admin_user.id}")
@@ -182,6 +187,7 @@ def test_regular_user_cannot_delete_unowned_comment(driver, super_admin_user,
     assert not delete_button.is_displayed()
 
 
+@pytest.mark.flaky(reruns=3)
 def test_super_user_can_delete_unowned_comment(driver, super_admin_user,
                                                user, public_source):
     driver.get(f"/become_user/{user.id}")


### PR DESCRIPTION
This PR adds the `pytest-rerunfailures` dependency, using it to mark flaky tests to be rerun if they fail (up to two times, and this is easily configurable). This should greatly improve the overall reliability of the test suite.

A few small test bugs are also addressed.