### PR TITLE
Provisioned admin token now gets all ACLs

### DIFF
--- a/skyportal/model_util.py
+++ b/skyportal/model_util.py
@@ -67,9 +67,11 @@ def provision_token():
     ).first()
 
     if token is None:
-        token_id = create_token(['System admin'],
-                                admin.id,
-                                token_name)
+        token_id = create_token(
+            all_acl_ids,
+            user_id=admin.id,
+            name=token_name
+        )
         token = Token.query.get(token_id)
 
     return token


### PR DESCRIPTION
`System admin` should be enough, but we haven't yet allowed sysadmin to
do everything on the system.  So, this works around that for now.