### PR TITLE
Auto-complete usernames & create new users via group users form

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@date-io/dayjs": "1.3.13",
     "@material-ui/core": "4.10.1",
     "@material-ui/icons": "4.9.1",
+    "@material-ui/lab": "4.0.0-alpha.56",
     "@material-ui/pickers": "3.2.10",
     "bokehjs": "0.12.9",
     "check-dependencies": "1.1.0",

--- a/skyportal/handlers/api/group.py
+++ b/skyportal/handlers/api/group.py
@@ -1,7 +1,7 @@
-import tornado.web
 from sqlalchemy.orm import joinedload
 from marshmallow.exceptions import ValidationError
 from baselayer.app.access import permissions, auth_or_token
+from .user import add_user_and_setup_groups
 from ..base import BaseHandler
 from ...models import DBSession, Group, GroupUser, User, Token
 
@@ -272,24 +272,27 @@ class GroupUserHandler(BaseHandler):
         """
         data = self.get_json()
         admin = data.pop("admin", False)
+        group_id = int(group_id)
         group = Group.query.get(group_id)
         if group.single_user_group:
             return self.error("Cannot add users to single user groups.")
-        try:
-            user_id = User.query.filter(User.username == username).first().id
-        except AttributeError:
-            return self.error('Invalid username.')
-        gu = (GroupUser.query.filter(GroupUser.group_id == group_id)
-                       .filter(GroupUser.user_id == user_id).first())
-        if gu is None:
-            gu = GroupUser(group_id=group_id, user_id=user_id, admin=admin)
-        DBSession().add(gu)
+        user = User.query.filter(User.username == username.lower()).first()
+        if user is None:
+            user_id = add_user_and_setup_groups(
+                username=username,
+                roles=["Full user"],
+                group_ids_and_admin=[[group_id, admin]]
+            )
+        else:
+            user_id = user.id
+            # Just add new GroupUser
+            DBSession.add(GroupUser(group_id=group_id, user_id=user_id, admin=admin))
         DBSession().commit()
 
         self.push_all(action='skyportal/REFRESH_GROUP',
-                      payload={'group_id': gu.group_id})
-        return self.success(data={'group_id': gu.group_id, 'user_id': gu.user_id,
-                                  'admin': gu.admin})
+                      payload={'group_id': group_id})
+        return self.success(data={'group_id': group_id, 'user_id': user_id,
+                                  'admin': admin})
 
     @permissions(['Manage groups'])
     def delete(self, group_id, username):

--- a/skyportal/handlers/api/user.py
+++ b/skyportal/handlers/api/user.py
@@ -3,6 +3,28 @@ from baselayer.app.access import permissions
 from ...models import DBSession, User, Group, GroupUser, cfg
 
 
+def add_user_and_setup_groups(username, roles, group_ids_and_admin):
+    # Add user
+    user = User(username=username.lower(), role_ids=roles)
+    DBSession().add(user)
+    DBSession().flush()
+
+    # Add user to specified groups
+    for group_id, admin in group_ids_and_admin:
+        DBSession.add(GroupUser(user_id=user.id, group_id=group_id, admin=admin))
+
+    # Create single-user group
+    DBSession().add(Group(name=user.username, users=[user], single_user_group=True))
+
+    # Add user to sitewide public group
+    public_group = Group.query.filter(
+        Group.name == cfg["misc"]["public_group_name"]
+    ).first()
+    if public_group is not None:
+        DBSession().add(GroupUser(group_id=public_group.id, user_id=user.id))
+    return user.id
+
+
 class UserHandler(BaseHandler):
     @permissions(['Manage users'])
     def get(self, user_id=None):
@@ -109,26 +131,13 @@ class UserHandler(BaseHandler):
         roles = data.get("roles", ["Full user"])
         group_ids_and_admin = data.get("groupIDsAndAdmin", [])
 
-        # Add user
-        user = User(username=data["username"].lower(), role_ids=roles)
-        DBSession().add(user)
-        DBSession().flush()
-
-        # Add user to specified groups
-        for group_id, admin in group_ids_and_admin:
-            DBSession.add(GroupUser(user_id=user.id, group_id=group_id, admin=admin))
-
-        # Create single-user group
-        DBSession().add(Group(name=user.username, users=[user], single_user_group=True))
-
-        # Add user to sitewide public group
-        public_group = Group.query.filter(
-            Group.name == cfg["misc"]["public_group_name"]
-        ).first()
-        if public_group is not None:
-            DBSession().add(GroupUser(group_id=public_group.id, user_id=user.id))
+        user_id = add_user_and_setup_groups(
+            username=data["username"],
+            roles=roles,
+            group_ids_and_admin=group_ids_and_admin
+        )
         DBSession().commit()
-        return self.success(data={"id": user.id})
+        return self.success(data={"id": user_id})
 
     @permissions(['Manage users'])
     def delete(self, user_id=None):

--- a/skyportal/tests/frontend/test_groups.py
+++ b/skyportal/tests/frontend/test_groups.py
@@ -1,6 +1,7 @@
 import pytest
 from selenium import webdriver
 from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
 import uuid
 import requests
 
@@ -54,7 +55,8 @@ def test_add_new_group_user_admin(driver, super_admin_user, user, public_group):
     el = driver.wait_for_xpath(f'//a[contains(.,"{public_group.name}")]')
     driver.execute_script("arguments[0].click();", el)
     driver.wait_for_xpath(f'//a[contains(.,"{user.username}")]/../input').click()
-    driver.wait_for_xpath('//input[@id="newUserEmail"]').send_keys(user.username)
+    driver.wait_for_xpath('//input[@id="newUserEmail"]').send_keys(
+        user.username, Keys.ENTER)
     driver.wait_for_xpath('//input[@type="checkbox"]').click()
     driver.wait_for_xpath('//input[@value="Add user"]').click()
     driver.wait_for_xpath(f'//a[contains(.,"{user.username}")]')
@@ -69,7 +71,8 @@ def test_add_new_group_user_nonadmin(driver, super_admin_user, user, public_grou
     el = driver.wait_for_xpath(f'//a[contains(.,"{public_group.name}")]')
     driver.execute_script("arguments[0].click();", el)
     driver.wait_for_xpath(f'//a[contains(.,"{user.username}")]/../input').click()
-    driver.wait_for_xpath('//input[@id="newUserEmail"]').send_keys(user.username)
+    driver.wait_for_xpath('//input[@id="newUserEmail"]').send_keys(
+        user.username, Keys.ENTER)
     driver.wait_for_xpath('//input[@value="Add user"]').click()
     driver.wait_for_xpath(f'//a[contains(.,"{user.username}")]')
     assert len(driver.find_elements_by_xpath(

--- a/skyportal/tests/frontend/test_groups.py
+++ b/skyportal/tests/frontend/test_groups.py
@@ -79,6 +79,20 @@ def test_add_new_group_user_nonadmin(driver, super_admin_user, user, public_grou
         f'//a[contains(.,"{user.username}")]/..//span')) == 0
 
 
+def test_add_new_group_user_new_username(driver, super_admin_user, user, public_group):
+    new_username = str(uuid.uuid4())
+    driver.get(f'/become_user/{super_admin_user.id}')
+    driver.get('/groups')
+    driver.wait_for_xpath('//h6[text()="All Groups"]')
+    el = driver.wait_for_xpath(f'//a[contains(.,"{public_group.name}")]')
+    driver.execute_script("arguments[0].click();", el)
+    driver.wait_for_xpath(f'//a[contains(.,"{user.username}")]/../input').click()
+    driver.wait_for_xpath('//input[@id="newUserEmail"]').send_keys(
+        new_username, Keys.ENTER)
+    driver.wait_for_xpath('//input[@value="Add user"]').click()
+    driver.wait_for_xpath(f'//a[contains(.,"{new_username}")]')
+
+
 def test_delete_group_user(driver, super_admin_user, user, public_group):
     driver.get(f'/become_user/{super_admin_user.id}')
     driver.get('/groups')

--- a/static/js/actions.js
+++ b/static/js/actions.js
@@ -5,6 +5,8 @@ import * as dbInfoActions from './ducks/dbInfo';
 import * as newsFeedActions from './ducks/newsFeed';
 import * as topSourcesActions from './ducks/topSources';
 import * as instrumentsActions from './ducks/instruments';
+import * as usersActions from './ducks/users';
+
 
 export default function hydrate() {
   return (dispatch) => {
@@ -16,5 +18,6 @@ export default function hydrate() {
     dispatch(topSourcesActions.fetchTopSources());
     dispatch(instrumentsActions.fetchInstruments());
     dispatch(instrumentsActions.fetchInstrumentObsParams());
+    dispatch(usersActions.fetchUsers());
   };
 }

--- a/static/js/actions.js
+++ b/static/js/actions.js
@@ -5,7 +5,6 @@ import * as dbInfoActions from './ducks/dbInfo';
 import * as newsFeedActions from './ducks/newsFeed';
 import * as topSourcesActions from './ducks/topSources';
 import * as instrumentsActions from './ducks/instruments';
-import * as usersActions from './ducks/users';
 
 
 export default function hydrate() {
@@ -18,6 +17,5 @@ export default function hydrate() {
     dispatch(topSourcesActions.fetchTopSources());
     dispatch(instrumentsActions.fetchInstruments());
     dispatch(instrumentsActions.fetchInstrumentObsParams());
-    dispatch(usersActions.fetchUsers());
   };
 }

--- a/static/js/components/NewGroupUserForm.jsx
+++ b/static/js/components/NewGroupUserForm.jsx
@@ -1,22 +1,20 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
+import TextField from '@material-ui/core/TextField';
+import Autocomplete, { createFilterOptions } from '@material-ui/lab/Autocomplete';
 
 import * as Action from '../ducks/groups';
 
+const filter = createFilterOptions();
+
 const NewGroupUserForm = ({ group_id }) => {
   const dispatch = useDispatch();
-  const [formState, setState] = useState({
-    newUserEmail: "",
+  const { allUsers } = useSelector((state) => state.users);
+  const [formState, setFormState] = useState({
+    newUserEmail: null,
     admin: false
   });
-
-  const handleChange = (event) => {
-    setState({
-      ...formState,
-      newUserEmail: event.target.value
-    });
-  };
 
   const handleSubmit = (event) => {
     event.preventDefault();
@@ -25,14 +23,14 @@ const NewGroupUserForm = ({ group_id }) => {
       admin: formState.admin,
       group_id
     }));
-    setState({
-      newUserEmail: "",
+    setFormState({
+      newUserEmail: null,
       admin: false
     });
   };
 
   const toggleAdmin = (event) => {
-    setState({
+    setFormState({
       ...formState,
       admin: event.target.checked
     });
@@ -40,13 +38,60 @@ const NewGroupUserForm = ({ group_id }) => {
 
   return (
     <div>
-      <input
-        type="text"
+      <Autocomplete
         id="newUserEmail"
         value={formState.newUserEmail}
-        onChange={handleChange}
+        onChange={(event, newValue) => {
+          if (typeof newValue === 'string') {
+            setFormState({
+              newUserEmail: newValue,
+            });
+          } else if (newValue && newValue.inputValue) {
+            // Create a new value from the user input
+            setFormState({
+              newUserEmail: newValue.inputValue,
+            });
+          } else {
+            setFormState({ newUserEmail: newValue.username });
+          }
+        }}
+        filterOptions={(options, params) => {
+          const filtered = filter(options, params);
+
+          // Suggest the creation of a new value
+          if (params.inputValue !== '') {
+            filtered.push({
+              inputValue: params.inputValue,
+              username: `Add "${params.inputValue}"`,
+            });
+          }
+
+          return filtered;
+        }}
+        selectOnFocus
+        clearOnBlur
+        handleHomeEndKeys
+        options={allUsers}
+        getOptionLabel={(option) => {
+          // Value selected with enter, right from the input
+          if (typeof option === 'string') {
+            return option;
+          }
+          // Add "xxx" option created dynamically
+          if (option.inputValue) {
+            return option.inputValue;
+          }
+          // Regular option
+          return option.username;
+        }}
+        renderOption={(option) => option.username}
+        style={{ width: 300, paddingBottom: 10 }}
+        freeSolo
+        renderInput={(params) => (
+          // eslint-disable-next-line react/jsx-props-no-spreading
+          <TextField {...params} label="Enter user email" />
+        )}
       />
-      &nbsp;
       <input type="checkbox" checked={formState.admin} onChange={toggleAdmin} />
       Group Admin
       &nbsp;&nbsp;

--- a/static/js/components/NewGroupUserForm.jsx
+++ b/static/js/components/NewGroupUserForm.jsx
@@ -1,10 +1,12 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
 import TextField from '@material-ui/core/TextField';
 import Autocomplete, { createFilterOptions } from '@material-ui/lab/Autocomplete';
 
-import * as Action from '../ducks/groups';
+import * as groupsActions from '../ducks/groups';
+import * as usersActions from '../ducks/users';
+
 
 const filter = createFilterOptions();
 
@@ -16,9 +18,15 @@ const NewGroupUserForm = ({ group_id }) => {
     admin: false
   });
 
+  useEffect(() => {
+    if (allUsers.length === 0) {
+      dispatch(usersActions.fetchUsers());
+    }
+  }, [dispatch, allUsers]);
+
   const handleSubmit = (event) => {
     event.preventDefault();
-    dispatch(Action.addGroupUser({
+    dispatch(groupsActions.addGroupUser({
       username: formState.newUserEmail,
       admin: formState.admin,
       group_id

--- a/static/js/ducks/users.js
+++ b/static/js/ducks/users.js
@@ -4,17 +4,31 @@ import store from '../store';
 export const FETCH_USER = 'skyportal/FETCH_USER';
 export const FETCH_USER_OK = 'skyportal/FETCH_USER_OK';
 
+export const FETCH_USERS = 'skyportal/FETCH_USERS';
+export const FETCH_USERS_OK = 'skyportal/FETCH_USERS_OK';
+
 export function fetchUser(id) {
   return API.GET(`/api/user/${id}`, FETCH_USER);
 }
 
-const reducer = (state={}, action) => {
+export function fetchUsers() {
+  return API.GET("/api/user", FETCH_USERS);
+}
+
+const reducer = (state={ allUsers: [] }, action) => {
   switch (action.type) {
     case FETCH_USER_OK: {
       const { id, ...user_info } = action.data;
       return {
         ...state,
         [id]: user_info
+      };
+    }
+    case FETCH_USERS_OK: {
+      const users = action.data;
+      return {
+        ...state,
+        allUsers: users
       };
     }
     default:


### PR DESCRIPTION
This PR adds auto-complete functionality to the group users front-end form. If a _new_ username is provided, that user is created, along with the associated individual user group and associated `GroupUser` row for the site-wide public group. Tests are updated.