### PR TITLE
Observing Planning & Follow-up PR #1: Classical Targets API

### DIFF
--- a/data/db_demo.yaml
+++ b/data/db_demo.yaml
@@ -42,6 +42,7 @@ telescope:
     lon: -116.8361345
     elevation: 1870
     diameter: 1.5
+    robotic: true
     skycam_link: http://bianca.palomar.caltech.edu/images/allsky/AllSkyCurrentImage.JPG
     group_ids:
       - =public_group_id
@@ -51,6 +52,7 @@ telescope:
     nickname: NOT
     lat: 28.75
     lon: 17.88
+    robotic: true
     elevation: 2000
     diameter: 2.56
     skycam_link: http://catserver.ing.iac.es/weather/archive/concam/concam_labels.png
@@ -58,18 +60,51 @@ telescope:
       - =public_group_id
       - =program_A
     =id: NOT
+  - diameter: 10.0
+    elevation: 4160.0
+    lat: 19.8283
+    lon: -155.478
+    name: Keck II 10m
+    nickname: Keck2
+    skycam_link: http://kree.ifa.hawaii.edu/allsky/allsky_last.png
+    robotic: false
+    group_ids:
+      - =program_A
+    =id: Keck2
+  - name: Keck I Telescope
+    nickname: Keck1
+    lat: 19.8283
+    lon: -155.478
+    elevation: 2000
+    diameter: 2.56
+    skycam_link: http://catserver.ing.iac.es/weather/archive/concam/concam_labels.png
+    robotic: false
+    group_ids:
+      - =program_A
+    =id: Keck1
 
 instrument:
   - name: P60 Camera
-    type: phot
+    type: imager
     band: V
     telescope_id: =P60
     filters: ["ztfg", "ztfr", "ztfi"]
   - name: ALFOSC
-    type: both
+    type: imaging spectrograph
     band: V
     telescope_id: =NOT
     =id: ALFOSC
+  - name: ESI
+    type: spectrograph
+    band: optical
+    =id: ESI
+    telescope_id: =Keck2
+  - name: LRIS
+    type: spectrograph
+    band: optical
+    =id: LRIS
+    telescope_id: =Keck1
+    
 
 candidates:
   - id: 14gqr_unsaved_copy
@@ -253,3 +288,35 @@ spectrum:
 
 taxonomy:
   file: taxonomy_demo.yaml
+
+observing_run:
+  - pi: Danny Goldstein
+    instrument_id: =ESI
+    calendar_date: "2021-02-16"
+    group_id: =program_A
+    observers: "Danny Goldstein, Peter Nugent"
+    =id: esi_run
+  - pi: Danny Goldstein
+    instrument_id: =LRIS
+    calendar_date: "2021-06-17"
+    group_id: =program_A
+    observers: "Danny Goldstein, Peter Nugent"
+    =id: lris_run
+
+assignment:
+  - obj_id: 14gqr
+    run_id: =lris_run
+    priority: "4"
+    comment: Please get 2x625s
+  - obj_id: 16fil
+    run_id: =lris_run
+    priority: "3"
+    comment: Please do i-band imaging to 24th mag
+  - obj_id: 14gqr
+    run_id: =esi_run
+    priority: "2"
+    comment: Please integrate for 1200s
+  - obj_id: 16fil
+    run_id: =esi_run
+    priority: "2"
+    comment: Please take only when seeing is less than 1.5"

--- a/data/instruments.yaml
+++ b/data/instruments.yaml
@@ -77,7 +77,7 @@
 - band: optical
   name: GMOS
   telescope_id: =GS
-  type: both
+  type: imaging spectrograph
   filters: ['sdssu', 'sdssg', 'sdssr', 'sdssi', 'sdssz', 'desy']
 - band: ir
   name: FLAMINGOS-2
@@ -91,7 +91,7 @@
 - band: optical
   name: GMOS
   telescope_id: =Gemini N
-  type: both
+  type: imaging spectrograph
   filters: ['sdssu', 'sdssg', 'sdssr', 'sdssi', 'sdssz', 'desy']
 - band: optical
   name: SNIFS

--- a/data/telescopes.yaml
+++ b/data/telescopes.yaml
@@ -16,6 +16,7 @@
   skycam_link: null
   group_ids: [=public_group_id]
   =id: PTEL
+  robotic: true
 - diameter: 8.0
   elevation: 2722.0
   lat: -30.24075
@@ -74,9 +75,10 @@
   elevation: 875.0
   lat: 34.763333
   lon: 30.595833
-  nickname: Wise 18\"
-  name: C18
+  name: Wise 18\"
+  nickname: C18
   skycam_link: null
+  robotic: true
   group_ids: [=public_group_id]
   =id: C18
 - diameter: 2.5
@@ -97,6 +99,7 @@
   skycam_link: null
   group_ids: [=public_group_id]
   =id: LT
+  robotic: true
 - diameter: 10.4
   elevation: 2275.0
   lat: 28.756611
@@ -186,6 +189,7 @@
   name: LCOGT1m
   skycam_link: null
   group_ids: [=public_group_id]
+  robotic: true
   =id: LCOGT1m
 - diameter: 2.5
   elevation: 2282.0
@@ -286,6 +290,7 @@
   skycam_link: http://bianca.palomar.caltech.edu/images/allsky/AllSkyCurrentImage.JPG
   group_ids: [=public_group_id]
   =id: P48
+  robotic: true
 - diameter: 10.0
   elevation: 4160.0
   lat: 19.8283
@@ -331,6 +336,7 @@
   skycam_link: http://bianca.palomar.caltech.edu/images/allsky/AllSkyCurrentImage.JPG
   group_ids: [=public_group_id]
   =id: P60
+  robotic: true
 - diameter: 5.0999999
   elevation: 1870.0
   lat: 33.3633675
@@ -403,6 +409,7 @@
   skycam_link: http://catserver.ing.iac.es/weather/archive/concam/concam_labels.png
   group_ids: [=public_group_id]
   =id: NOT
+  robotic: true
 - diameter: 4.0
   elevation: 2207.0
   lat: -30.169661
@@ -484,6 +491,7 @@
   skycam_link: null
   group_ids: [=public_group_id]
   =id: MASTER-SAAO
+  robotic: true
 - diameter: 0.41
   elevation: 2286.0
   lat: -30.168
@@ -497,7 +505,7 @@
   elevation: 1165.0
   lat: -31.273333
   lon: 149.064444
-  nickname: Snameing Spring Observatory
+  nickname: Siding Spring Observatory
   name: SSO
   skycam_link: null
   group_ids: [=public_group_id]

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,7 @@ healpix-alchemy>=0.1.2
 jsonschema
 jsonpath_ng>=1.5.1
 pytest-rerunfailures>=9.0
+timezonefinder>=4.4.0
 astroplan>=0.6
 phonenumbers>=8.12.7
 py3-validate-email>=0.2.9

--- a/skyportal/app_server.py
+++ b/skyportal/app_server.py
@@ -5,6 +5,7 @@ from baselayer.app import model_util as baselayer_model_util
 
 from skyportal.handlers import (BecomeUserHandler, LogoutHandler)
 from skyportal.handlers.api import (
+    AssignmentHandler,
     CandidateHandler,
     ClassificationHandler,
     CommentHandler, CommentAttachmentHandler,
@@ -14,6 +15,7 @@ from skyportal.handlers.api import (
     InstrumentHandler,
     InvalidEndpointHandler,
     NewsFeedHandler,
+    ObservingRunHandler,
     PhotometryHandler, BulkDeletePhotometryHandler, ObjPhotometryHandler,
     SharingHandler,
     SourceHandler, SourceOffsetsHandler,
@@ -56,6 +58,7 @@ def make_app(cfg, baselayer_handlers, baselayer_settings):
 
     handlers = baselayer_handlers + [
         # API endpoints
+        (r'/api/assignment(/.*)?', AssignmentHandler),
         (r'/api/candidates(/.*)?', CandidateHandler),
         (r'/api/classification(/[0-9]+)?', ClassificationHandler),
         (r'/api/comment(/[0-9]+)?', CommentHandler),
@@ -67,6 +70,7 @@ def make_app(cfg, baselayer_handlers, baselayer_settings):
         (r'/api/groups(/.*)?', GroupHandler),
         (r'/api/instrument(/[0-9]+)?', InstrumentHandler),
         (r'/api/newsfeed', NewsFeedHandler),
+        (r'/api/observing_run(/[0-9]+)?', ObservingRunHandler),
         (r'/api/photometry(/[0-9]+)?', PhotometryHandler),
         (r'/api/sharing', SharingHandler),
         (r'/api/photometry/bulk_delete/(.*)', BulkDeletePhotometryHandler),

--- a/skyportal/enum_types.py
+++ b/skyportal/enum_types.py
@@ -7,14 +7,25 @@ from sncosmo.magsystems import _MAGSYSTEMS
 def force_render_enum_markdown(values):
     return ', '.join(list(map(lambda v: f'`{v}`', values)))
 
+
 ALLOWED_MAGSYSTEMS = tuple(l['name'] for l in _MAGSYSTEMS.get_loaders_metadata())
 ALLOWED_BANDPASSES = tuple(l['name'] for l in _BANDPASSES.get_loaders_metadata())
 THUMBNAIL_TYPES = ('new', 'ref', 'sub', 'sdss', 'dr8', "new_gz", 'ref_gz', 'sub_gz')
+INSTRUMENT_TYPES = ('imager', 'spectrograph', 'imaging spectrograph')
+FOLLOWUP_REQUEST_TYPES = ('imaging', 'spectroscopy')
+FOLLOWUP_PRIORITIES = ('1', '2', '3', '4', '5')
 
 allowed_magsystems = sa.Enum(*ALLOWED_MAGSYSTEMS, name="magsystems", validate_strings=True)
 allowed_bandpasses = sa.Enum(*ALLOWED_BANDPASSES, name="bandpasses", validate_strings=True)
 thumbnail_types = sa.Enum(*THUMBNAIL_TYPES, name='thumbnail_types', validate_strings=True)
+instrument_types = sa.Enum(*INSTRUMENT_TYPES, name='instrument_types', validate_strings=True)
+followup_request_types = sa.Enum(*FOLLOWUP_REQUEST_TYPES, name='followup_request_types',
+                                 validate_strings=True)
+followup_priorities = sa.Enum(*FOLLOWUP_PRIORITIES, name='followup_priorities',
+                              validate_strings=True)
 
 py_allowed_magsystems = Enum('magsystems', ALLOWED_MAGSYSTEMS)
 py_allowed_bandpasses = Enum('bandpasses', ALLOWED_BANDPASSES)
 py_thumbnail_types = Enum('thumbnail_types', THUMBNAIL_TYPES)
+py_followup_request_types = Enum('followup_request_types', FOLLOWUP_REQUEST_TYPES)
+py_followup_priorities = Enum('priority', FOLLOWUP_PRIORITIES)

--- a/skyportal/handlers/api/__init__.py
+++ b/skyportal/handlers/api/__init__.py
@@ -2,11 +2,12 @@ from .candidate import CandidateHandler
 from .classification import ClassificationHandler
 from .comment import CommentHandler, CommentAttachmentHandler
 from .filter import FilterHandler
-from .followup_request import FollowupRequestHandler
+from .followup_request import FollowupRequestHandler, AssignmentHandler
 from .group import GroupHandler, GroupUserHandler
 from .instrument import InstrumentHandler
 from .invalid import InvalidEndpointHandler
 from .news_feed import NewsFeedHandler
+from .observingrun import ObservingRunHandler
 from .photometry import (PhotometryHandler, ObjPhotometryHandler,
                          BulkDeletePhotometryHandler)
 from .public_group import PublicGroupHandler

--- a/skyportal/handlers/api/followup_request.py
+++ b/skyportal/handlers/api/followup_request.py
@@ -3,7 +3,242 @@ from marshmallow.exceptions import ValidationError
 
 from baselayer.app.access import auth_or_token
 from ..base import BaseHandler
-from ...models import DBSession, Instrument, Source, FollowupRequest, Token
+from ...models import (DBSession, Source, FollowupRequest, Token,
+                       ClassicalAssignment, ObservingRun, Source,
+                       Obj, Group, Thumbnail)
+
+from sqlalchemy.orm import joinedload
+
+from ...schema import AssignmentSchema
+
+
+class AssignmentHandler(BaseHandler):
+
+    @auth_or_token
+    def get(self, assignment_id=None):
+        """
+        ---
+        single:
+          description: Retrieve an observing run assignment
+          parameters:
+            - in: path
+              name: assignment_id
+              required: true
+              schema:
+                type: integer
+          responses:
+            200:
+               content:
+                application/json:
+                  schema: SingleClassicalAssignment
+            400:
+              content:
+                application/json:
+                  schema: Error
+        multiple:
+          description: Retrieve all observing run assignments
+          responses:
+            200:
+              content:
+                application/json:
+                  schema: ArrayOfClassicalAssignments
+            400:
+              content:
+                application/json:
+                  schema: Error
+        """
+
+        # get owned assignments
+        assignments = DBSession().query(ClassicalAssignment)
+        acls = [a.id for a in self.current_user.acls]
+        if 'System admin' not in acls:
+            assignments = assignments.join(Obj).join(Source).join(Group).filter(
+                Group.id.in_([g.id for g in self.current_user.groups])
+            )
+
+        if assignment_id is not None:
+            assignments = assignments.filter(
+                ClassicalAssignment.id == assignment_id
+            ).options(
+                joinedload(ClassicalAssignment.obj)
+                .joinedload(Obj.thumbnails),
+                joinedload(ClassicalAssignment.requester),
+                joinedload(ClassicalAssignment.obj)
+            )
+
+        assignments = assignments.all()
+        screened = []
+
+        for assignment in assignments:
+            obj = Source.get_obj_if_owned_by(assignment.obj.id, self.current_user)
+            if obj is not None:
+                screened.append(assignment)
+
+        if len(screened) == 0 and assignment_id is not None:
+            return self.error("Could not retrieve assignment.")
+
+        out_json = ClassicalAssignment.__schema__().dump(screened, many=True)
+
+        # calculate when the targets rise and set
+        for json_obj, assignment_obj in zip(out_json, screened):
+            json_obj['rise_time_utc'] = assignment_obj.rise_time.isot
+            json_obj['set_time_utc'] = assignment_obj.set_time.isot
+            json_obj['obj'] = assignment_obj.obj
+            json_obj['requester'] = assignment_obj.requester
+
+        if assignment_id is not None:
+            out_json = out_json[0]
+
+        return self.success(data=out_json)
+
+    @auth_or_token
+    def post(self):
+        """
+        ---
+        description: Post new target assignment to observing run
+        requestBody:
+          content:
+            application/json:
+              schema: AssignmentSchema
+        responses:
+          200:
+            content:
+              application/json:
+                schema:
+                  allOf:
+                    - $ref: '#/components/schemas/Success'
+                    - type: object
+                      properties:
+                        data:
+                          type: object
+                          properties:
+                            id:
+                              type: integer
+                              description: New assignment ID
+        """
+
+        data = self.get_json()
+        try:
+            assignment = ClassicalAssignment(**AssignmentSchema.load(data=data))
+        except ValidationError as e:
+            return self.error('Error parsing followup request: '
+                              f'"{e.normalized_messages()}"')
+
+        run_id = assignment.run_id
+        data['priority'] = assignment.priority.name
+        run = ObservingRun.query.get(run_id)
+        if run is None:
+            return self.error(f'Invalid observing run: "{run_id}"')
+
+        predecessor = ClassicalAssignment.query.filter(
+            ClassicalAssignment.obj_id == assignment.obj_id,
+            ClassicalAssignment.run_id == run_id
+        ).first()
+
+        if predecessor is not None:
+            return self.error('Object is already assigned to this run.')
+
+        assignment = ClassicalAssignment(**data)
+        source = Source.get_obj_if_owned_by(assignment.obj_id, self.current_user)
+        obj = Obj.query.get(assignment.obj_id)
+        acls = [a.id for a in self.current_user.acls]
+        if (obj is None) or (source is None and 'System admin' not in acls):
+            return self.error(f'Invalid obj_id: "{assignment.obj_id}"')
+
+        assignment.requester_id = self.associated_user_object.id
+        DBSession().add(assignment)
+        DBSession().commit()
+        self.push_all(
+            action="skyportal/REFRESH_SOURCE",
+            payload={"obj_id": assignment.obj_id},
+        )
+        return self.success(data={"id": assignment.id})
+
+    @auth_or_token
+    def put(self, assignment_id):
+        """
+        ---
+        description: Update an assignment
+        parameters:
+          - in: path
+            name: assignment_id
+            required: true
+            schema:
+              type: integer
+        requestBody:
+          content:
+            application/json:
+              schema: ClassicalAssignmentNoID
+        responses:
+          200:
+            content:
+              application/json:
+                schema: Success
+          400:
+            content:
+              application/json:
+                schema: Error
+        """
+        followup_request = ClassicalAssignment.query.get(assignment_id)
+        source = Source.get_obj_if_owned_by(
+            followup_request.obj_id, self.current_user
+        )
+
+        if followup_request is None or source is None:
+            return self.error('No such assignment')
+
+        data = self.get_json()
+        data['id'] = assignment_id
+        data["requester_id"] = self.associated_user_object.id
+
+        schema = ClassicalAssignment.__schema__()
+        try:
+            schema.load(data, partial=True)
+        except ValidationError as e:
+            return self.error('Invalid/missing parameters: '
+                              f'{e.normalized_messages()}')
+        DBSession().commit()
+
+        self.push_all(
+            action="skyportal/REFRESH_SOURCE",
+            payload={"obj_id": followup_request.obj_id},
+        )
+
+        return self.success()
+
+    @auth_or_token
+    def delete(self, assignment_id):
+        """
+        ---
+        description: Delete assignment.
+        parameters:
+          - in: path
+            name: assignment_id
+            required: true
+            schema:
+              type: string
+        responses:
+          200:
+            content:
+              application/json:
+                schema: Success
+        """
+        assignment = ClassicalAssignment.query.get(int(assignment_id))
+        user = self.associated_user_object
+        delok = "Super admin" in [role.id for role in user.roles] \
+                or "Group admin" in [role.id for role in user.roles] \
+                or assignment.requester.username == user.username
+        if not delok:
+            return self.error("Insufficient permissions.")
+
+        DBSession().delete(assignment)
+        DBSession().commit()
+
+        self.push_all(
+            action="skyportal/REFRESH_SOURCE",
+            payload={"obj_id": assignment.obj_id},
+        )
+        return self.success()
 
 
 class FollowupRequestHandler(BaseHandler):

--- a/skyportal/handlers/api/instrument.py
+++ b/skyportal/handlers/api/instrument.py
@@ -2,7 +2,7 @@ from marshmallow.exceptions import ValidationError
 from baselayer.app.access import permissions, auth_or_token
 from ..base import BaseHandler
 from ...models import DBSession, Instrument, Telescope, GroupTelescope
-from ...phot_enum import ALLOWED_BANDPASSES
+from ...enum_types import ALLOWED_BANDPASSES
 
 
 class InstrumentHandler(BaseHandler):

--- a/skyportal/handlers/api/observingrun.py
+++ b/skyportal/handlers/api/observingrun.py
@@ -1,0 +1,234 @@
+from sqlalchemy.orm import joinedload
+from marshmallow.exceptions import ValidationError
+from baselayer.app.access import permissions, auth_or_token
+from ..base import BaseHandler
+from ...models import(DBSession, ObservingRun, ClassicalAssignment, Obj,
+                      Thumbnail)
+from ...schema import (ObservingRunPost, ObservingRunGet,
+                       ObservingRunGetWithAssignments)
+
+
+class ObservingRunHandler(BaseHandler):
+
+    @permissions(['Upload data'])
+    def post(self):
+        """
+        ---
+        description: Add a new observing run
+        requestBody:
+          content:
+            application/json:
+              schema: ObservingRunPost
+        responses:
+          200:
+            content:
+              application/json:
+                schema:
+                  allOf:
+                    - $ref: '#/components/schemas/Success'
+                    - type: object
+                      properties:
+                        data:
+                          type: object
+                          properties:
+                            id:
+                              type: integer
+                              description: New Observing Run ID
+          400:
+            content:
+              application/json:
+                schema: Error
+        """
+
+        # See bottom of this file for redoc docstring -- moved it there so that
+        # it could be made an f-string.
+
+        data = self.get_json()
+
+        try:
+            rund = ObservingRunPost.load(data)
+        except ValidationError as exc:
+            return self.error('Invalid/missing parameters: '
+                              f'{exc.normalized_messages()}')
+
+        run = ObservingRun(**rund)
+
+        current_user_id = self.current_user.id if \
+            hasattr(self.current_user, 'username') else self.current_user.created_by_id
+        run.owner_id = current_user_id
+
+        DBSession().add(run)
+        DBSession().commit()
+
+        return self.success(data={"id": run.id})
+
+    @auth_or_token
+    def get(self, run_id=None):
+        """
+        ---
+        single:
+          description: Retrieve an observing run
+          parameters:
+            - in: path
+              name: run_id
+              required: true
+              schema:
+                type: integer
+          responses:
+            200:
+              content:
+                application/json:
+                  schema: SingleObservingRunGetWithAssignments
+            400:
+              content:
+                application/json:
+                  schema: Error
+        multiple:
+          description: Retrieve all observing runs
+          responses:
+            200:
+              content:
+                application/json:
+                  schema: ArrayOfObservingRunGets
+            400:
+              content:
+                application/json:
+                  schema: Error
+        """
+        if run_id is not None:
+            run = DBSession().query(ObservingRun).options(
+                joinedload(ObservingRun.assignments)
+                .joinedload(ClassicalAssignment.obj)
+                .joinedload(Obj.thumbnails)
+                .joinedload(Thumbnail.photometry),
+                joinedload(ObservingRun.assignments)
+                .joinedload(ClassicalAssignment.requester),
+                joinedload(ObservingRun.assignments)
+                .joinedload(ClassicalAssignment.obj)
+                .joinedload(Obj.comments),
+            ).filter(ObservingRun.id == run_id).first()
+
+            if run is None:
+                return self.error(f"Could not load observing run {run_id}",
+                                  data={"run_id": run_id})
+            # order the assignments by ra
+            run.assignments = sorted(
+                run.assignments, key=lambda a: a.obj.ra
+            )
+
+            # filter out the assignments of objects that are not visible to
+            # the user
+            run.assignments = list(filter(
+                lambda a: a.obj.is_owned_by(self.current_user),
+                run.assignments
+            ))
+
+            for assignment in run.assignments:
+                assignment.obj.comments = sorted(assignment.obj.comments,
+                                                 key=lambda c: c.modified,
+                                                 reverse=True)
+
+            data = ObservingRunGetWithAssignments.dump(run)
+            data['assignments'] = [a.to_dict() for a in data['assignments']]
+
+            # calculate when the targets rise and set
+            for d, a in zip(data['assignments'], run.assignments):
+                d['rise_time_utc'] = a.rise_time.isot
+                d['set_time_utc'] = a.set_time.isot
+
+            return self.success(data=data)
+        runs = ObservingRun.query.all()
+        data = ObservingRunGet.dump(runs, many=True)
+        out = sorted(data, key=lambda d: d['ephemeris']['sunrise_utc'])
+        return self.success(data=out)
+
+    @permissions(['Upload data'])
+    def put(self, run_id):
+        """
+        ---
+        description: Update observing run
+        parameters:
+          - in: path
+            name: run_id
+            required: true
+            schema:
+              type: integer
+        requestBody:
+          content:
+            application/json:
+              schema: ObservingRunPost
+        responses:
+          200:
+            content:
+              application/json:
+                schema: Success
+          400:
+            content:
+              application/json:
+                schema: Error
+        """
+
+        data = self.get_json()
+        run_id = int(run_id)
+        is_superadmin = 'System admin' in [a.id for a in self.current_user.acls]
+
+        orun = ObservingRun.query.get(run_id)
+
+        current_user_id = self.current_user.id if \
+            hasattr(self.current_user, 'username') else self.current_user.created_by_id
+
+        if orun.owner_id != current_user_id and not is_superadmin:
+            return self.error('Only the owner of an observing run can modify '
+                              'the run.')
+        try:
+            new_params = ObservingRunPost.load(data, partial=True)
+        except ValidationError as exc:
+            return self.error('Invalid/missing parameters: '
+                              f'{exc.normalized_messages()}')
+
+        for param in new_params:
+            setattr(orun, param, new_params[param])
+
+        DBSession().add(orun)
+        DBSession().commit()
+        return self.success()
+
+    @permissions(['Upload data'])
+    def delete(self, run_id):
+        """
+        ---
+        description: Delete an observing run
+        parameters:
+          - in: path
+            name: run_id
+            required: true
+            schema:
+              type: integer
+        responses:
+          200:
+            content:
+              application/json:
+                schema: Success
+          400:
+            content:
+              application/json:
+                schema: Error
+        """
+        run_id = int(run_id)
+        is_superadmin = 'System admin' in [a.id for a in self.current_user.acls]
+
+        run = ObservingRun.query.get(run_id)
+
+        current_user_id = self.current_user.id if \
+            hasattr(self.current_user, 'username') else self.current_user.created_by_id
+
+        if run.owner_id != current_user_id and not is_superadmin:
+            return self.error('Only the owner of an observing run can modify '
+                              'the run.')
+
+        DBSession().query(ObservingRun).filter(
+            ObservingRun.id == run_id
+        ).delete()
+        DBSession().commit()
+
+        return self.success()

--- a/skyportal/handlers/api/observingrun.py
+++ b/skyportal/handlers/api/observingrun.py
@@ -9,7 +9,6 @@ from ...schema import (ObservingRunPost, ObservingRunGet,
 
 
 class ObservingRunHandler(BaseHandler):
-
     @permissions(['Upload data'])
     def post(self):
         """
@@ -39,10 +38,6 @@ class ObservingRunHandler(BaseHandler):
               application/json:
                 schema: Error
         """
-
-        # See bottom of this file for redoc docstring -- moved it there so that
-        # it could be made an f-string.
-
         data = self.get_json()
 
         try:
@@ -52,10 +47,7 @@ class ObservingRunHandler(BaseHandler):
                               f'{exc.normalized_messages()}')
 
         run = ObservingRun(**rund)
-
-        current_user_id = self.current_user.id if \
-            hasattr(self.current_user, 'username') else self.current_user.created_by_id
-        run.owner_id = current_user_id
+        run.owner_id = self.associated_user_object.id
 
         DBSession().add(run)
         DBSession().commit()

--- a/skyportal/handlers/api/observingrun.py
+++ b/skyportal/handlers/api/observingrun.py
@@ -166,8 +166,7 @@ class ObservingRunHandler(BaseHandler):
 
         orun = ObservingRun.query.get(run_id)
 
-        current_user_id = self.current_user.id if \
-            hasattr(self.current_user, 'username') else self.current_user.created_by_id
+        current_user_id = self.associated_user_object.id
 
         if orun.owner_id != current_user_id and not is_superadmin:
             return self.error('Only the owner of an observing run can modify '
@@ -211,8 +210,7 @@ class ObservingRunHandler(BaseHandler):
 
         run = ObservingRun.query.get(run_id)
 
-        current_user_id = self.current_user.id if \
-            hasattr(self.current_user, 'username') else self.current_user.created_by_id
+        current_user_id = self.associated_user_object.id
 
         if run.owner_id != current_user_id and not is_superadmin:
             return self.error('Only the owner of an observing run can modify '

--- a/skyportal/handlers/api/photometry.py
+++ b/skyportal/handlers/api/photometry.py
@@ -15,7 +15,7 @@ from ...models import (
 
 
 from ...schema import (PhotometryMag, PhotometryFlux, PhotFluxFlexible, PhotMagFlexible)
-from ...phot_enum import ALLOWED_MAGSYSTEMS
+from ...enum_types import ALLOWED_MAGSYSTEMS
 
 
 def nan_to_none(value):

--- a/skyportal/schema.py
+++ b/skyportal/schema.py
@@ -171,10 +171,10 @@ class PhotBaseFlexible(object):
                           required=True)
 
     instrument_id = fields.Field(description='ID of the `Instrument`(s) with which the '
-                                      'photometry was acquired. '
-                                      'Can be given as a scalar or a 1D list. '
-                                      'If a scalar, will be broadcast to all values '
-                                      'given as lists. Null values are not allowed.',
+                                             'photometry was acquired. '
+                                             'Can be given as a scalar or a 1D list. '
+                                             'If a scalar, will be broadcast to all values '
+                                             'given as lists. Null values are not allowed.',
                                  required=True)
 
     ra = fields.Field(description='ICRS Right Ascension of the centroid '

--- a/skyportal/tests/api/test_assignments.py
+++ b/skyportal/tests/api/test_assignments.py
@@ -1,0 +1,110 @@
+from skyportal.tests import api
+
+
+def test_token_user_post_classical_followup_request(red_transients_run,
+                                                    public_source,
+                                                    upload_data_token):
+    request_data = {'run_id': red_transients_run.id,
+                    'obj_id': public_source.id,
+                    'priority': '5',
+                    'comment': 'Please take spectrum only below airmass 1.5'}
+
+    status, data = api('POST', 'assignment',
+                       data=request_data,
+                       token=upload_data_token)
+    assert status == 200
+    assert data['status'] == 'success'
+    id = data['data']['id']
+
+    status, data = api('GET', f'assignment/{id}',
+                       token=upload_data_token)
+    assert status == 200
+    assert data['status'] == 'success'
+
+    for key in request_data:
+        assert data['data'][key] == request_data[key]
+
+
+def test_token_user_delete_owned_assignment(red_transients_run,
+                                            public_source,
+                                            upload_data_token):
+
+    request_data = {'run_id': red_transients_run.id,
+                    'obj_id': public_source.id,
+                    'priority': '5',
+                    'comment': 'Please take spectrum only below airmass 1.5'}
+
+    status, data = api('POST', 'assignment',
+                       data=request_data,
+                       token=upload_data_token)
+    assert status == 200
+    assert data['status'] == 'success'
+    id = data['data']['id']
+
+    status, data = api('DELETE', f'assignment/{id}',
+                       token=upload_data_token)
+    assert status == 200
+    assert data['status'] == 'success'
+
+
+def test_regular_user_delete_super_admin_assignment(red_transients_run,
+                                                    public_source,
+                                                    upload_data_token,
+                                                    super_admin_token):
+
+    request_data = {'run_id': red_transients_run.id,
+                    'obj_id': public_source.id,
+                    'priority': '5',
+                    'comment': 'Please take spectrum only below airmass 1.5'}
+
+    status, data = api('POST', 'assignment',
+                       data=request_data,
+                       token=super_admin_token)
+    assert status == 200
+    assert data['status'] == 'success'
+    id = data['data']['id']
+
+    status, data = api('DELETE', f'assignment/{id}',
+                       token=upload_data_token)
+    assert status == 400
+    assert data['status'] == 'error'
+
+
+def test_group1_user_cannot_see_group2_assignment(red_transients_run,
+                                                  private_source,
+                                                  public_source,
+                                                  super_admin_token,
+                                                  view_only_token):
+
+    request_data = {'run_id': red_transients_run.id,
+                    'obj_id': private_source.id,
+                    'priority': '5',
+                    'comment': 'Please take spectrum only below airmass 1.5'}
+
+    status, data = api('POST', 'assignment',
+                       data=request_data,
+                       token=super_admin_token)
+    assert status == 200
+    assert data['status'] == 'success'
+    id = data['data']['id']
+
+    request_data = {'run_id': red_transients_run.id,
+                    'obj_id': public_source.id,
+                    'priority': '5',
+                    'comment': 'Please take spectrum only below airmass 1.5'}
+
+    status, data = api('POST', 'assignment',
+                       data=request_data,
+                       token=super_admin_token)
+    assert status == 200
+    assert data['status'] == 'success'
+
+    status, data = api('GET', f'assignment/{id}',
+                       token=view_only_token)
+    assert status == 400
+    assert data['status'] == 'error'
+
+    status, data = api('GET', f'assignment/',
+                       token=view_only_token)
+    assert status == 200
+    assert private_source.id not in [a['id'] for a in data['data']]

--- a/skyportal/tests/api/test_assignments.py
+++ b/skyportal/tests/api/test_assignments.py
@@ -71,13 +71,13 @@ def test_regular_user_delete_super_admin_assignment(red_transients_run,
 
 
 def test_group1_user_cannot_see_group2_assignment(red_transients_run,
-                                                  private_source,
+                                                  public_source_group2,
                                                   public_source,
                                                   super_admin_token,
                                                   view_only_token):
 
     request_data = {'run_id': red_transients_run.id,
-                    'obj_id': private_source.id,
+                    'obj_id': public_source_group2.id,
                     'priority': '5',
                     'comment': 'Please take spectrum only below airmass 1.5'}
 
@@ -107,4 +107,4 @@ def test_group1_user_cannot_see_group2_assignment(red_transients_run,
     status, data = api('GET', f'assignment/',
                        token=view_only_token)
     assert status == 200
-    assert private_source.id not in [a['id'] for a in data['data']]
+    assert public_source_group2.id not in [a['id'] for a in data['data']]

--- a/skyportal/tests/api/test_instrument.py
+++ b/skyportal/tests/api/test_instrument.py
@@ -22,8 +22,9 @@ def test_token_user_post_get_instrument(super_admin_token, public_group):
     instrument_name = str(uuid.uuid4())
     status, data = api('POST', 'instrument',
                        data={'name': instrument_name,
-                             'type': 'type',
-                             'band': 'V',
+                             'type': 'imager',
+                             'band': 'NIR',
+                             'filters': ['f110w'],
                              'telescope_id': telescope_id
                              },
                        token=super_admin_token)
@@ -37,7 +38,7 @@ def test_token_user_post_get_instrument(super_admin_token, public_group):
         token=super_admin_token)
     assert status == 200
     assert data['status'] == 'success'
-    assert data['data']['band'] == 'V'
+    assert data['data']['band'] == 'NIR'
 
 
 def test_fetch_instrument_by_name(super_admin_token, public_group):
@@ -59,7 +60,7 @@ def test_fetch_instrument_by_name(super_admin_token, public_group):
     instrument_name = str(uuid.uuid4())
     status, data = api('POST', 'instrument',
                        data={'name': instrument_name,
-                             'type': 'type',
+                             'type': 'imager',
                              'band': 'V',
                              'telescope_id': telescope_id
                              },
@@ -100,8 +101,9 @@ def test_token_user_update_instrument(super_admin_token, manage_sources_token,
     instrument_name = str(uuid.uuid4())
     status, data = api('POST', 'instrument',
                        data={'name': instrument_name,
-                             'type': 'type',
-                             'band': 'V',
+                             'type': 'imager',
+                             'band': 'NIR',
+                             'filters': ['f110w'],
                              'telescope_id': telescope_id
                              },
                        token=super_admin_token)
@@ -115,14 +117,18 @@ def test_token_user_update_instrument(super_admin_token, manage_sources_token,
         token=super_admin_token)
     assert status == 200
     assert data['status'] == 'success'
-    assert data['data']['band'] == 'V'
+    assert data['data']['band'] == 'NIR'
+
+    new_name =  f'Gattini2_{uuid.uuid4()}'
 
     status, data = api(
         'PUT',
         f'instrument/{instrument_id}',
-        data={'name': 'new_name',
-              'band': 'V',
-              'type': 'type'
+        data={'name': new_name,
+              'type': 'imager',
+              'band': 'NIR',
+              'filters': ['f110w'],
+              'telescope_id': telescope_id
               },
         token=manage_sources_token)
     assert status == 400
@@ -131,9 +137,11 @@ def test_token_user_update_instrument(super_admin_token, manage_sources_token,
     status, data = api(
         'PUT',
         f'instrument/{instrument_id}',
-        data={'name': 'new_name',
-              'band': 'V',
-              'type': 'type'
+        data={'name': new_name,
+              'type': 'imager',
+              'band': 'NIR',
+              'filters': ['f110w'],
+              'telescope_id': telescope_id
               },
         token=super_admin_token)
     assert status == 200
@@ -145,7 +153,7 @@ def test_token_user_update_instrument(super_admin_token, manage_sources_token,
         token=view_only_token)
     assert status == 200
     assert data['status'] == 'success'
-    assert data['data']['name'] == 'new_name'
+    assert data['data']['name'] == new_name
 
 
 def test_token_user_delete_instrument(super_admin_token, view_only_token,
@@ -168,11 +176,13 @@ def test_token_user_delete_instrument(super_admin_token, view_only_token,
     instrument_name = str(uuid.uuid4())
     status, data = api('POST', 'instrument',
                        data={'name': instrument_name,
-                             'type': 'type',
-                             'band': 'V',
+                             'type': 'imager',
+                             'band': 'NIR',
+                             'filters': ['f110w'],
                              'telescope_id': telescope_id
                              },
                        token=super_admin_token)
+
     assert status == 200
     assert data['status'] == 'success'
     instrument_id = data['data']['id']

--- a/skyportal/tests/api/test_observing_runs.py
+++ b/skyportal/tests/api/test_observing_runs.py
@@ -1,0 +1,133 @@
+from skyportal.tests import api
+
+
+def test_token_user_add_new_observing_run(lris, upload_data_token,
+                                          red_transients_group):
+    run_details = {'instrument_id': lris.id,
+                   'pi': 'Danny Goldstein',
+                   'observers': 'D. Goldstein, P. Nugent',
+                   'group_id': red_transients_group.id,
+                   'calendar_date': '2020-02-16'}
+
+    status, data = api('POST', 'observing_run',
+                       data=run_details,
+                       token=upload_data_token)
+    assert status == 200
+    assert data['status'] == 'success'
+    run_id = data['data']['id']
+
+    status, data = api('GET', f'observing_run/{run_id}',
+                       token=upload_data_token)
+
+    assert status == 200
+    assert data['status'] == 'success'
+    for key in run_details:
+        assert data['data'][key] == run_details[key]
+
+
+def test_super_admin_user_delete_nonowned_observing_run(lris, upload_data_token,
+                                                        super_admin_token,
+                                                        red_transients_group):
+    run_details = {'instrument_id': lris.id,
+                   'pi': 'Danny Goldstein',
+                   'observers': 'D. Goldstein, P. Nugent',
+                   'group_id': red_transients_group.id,
+                   'calendar_date': '2020-02-16'}
+
+    status, data = api('POST', 'observing_run',
+                       data=run_details,
+                       token=upload_data_token)
+    assert status == 200
+    assert data['status'] == 'success'
+    run_id = data['data']['id']
+
+    status, data = api('DELETE', f'observing_run/{run_id}',
+                       token=super_admin_token)
+
+    assert status == 200
+    assert data['status'] == 'success'
+
+
+def test_unauthorized_user_delete_nonowned_observing_run(lris, upload_data_token,
+                                                         manage_sources_token,
+                                                         red_transients_group):
+    run_details = {'instrument_id': lris.id,
+                   'pi': 'Danny Goldstein',
+                   'observers': 'D. Goldstein, P. Nugent',
+                   'group_id': red_transients_group.id,
+                   'calendar_date': '2020-02-16'}
+
+    status, data = api('POST', 'observing_run',
+                       data=run_details,
+                       token=upload_data_token)
+    assert status == 200
+    assert data['status'] == 'success'
+    run_id = data['data']['id']
+
+    status, data = api('DELETE', f'observing_run/{run_id}',
+                       token=manage_sources_token)
+
+    assert status == 400
+    assert data['status'] == 'error'
+
+
+def test_authorized_user_modify_owned_observing_run(lris, upload_data_token,
+                                                    red_transients_group):
+    run_details = {'instrument_id': lris.id,
+                   'pi': 'Danny Goldstein',
+                   'observers': 'D. Goldstein, P. Nugent',
+                   'group_id': red_transients_group.id,
+                   'calendar_date': '2020-02-16'}
+
+    status, data = api('POST', 'observing_run',
+                       data=run_details,
+                       token=upload_data_token)
+    assert status == 200
+    assert data['status'] == 'success'
+    run_id = data['data']['id']
+
+    new_date = {'calendar_date': '2020-02-17'}
+    run_details.update(new_date)
+
+    status, data = api('PUT', f'observing_run/{run_id}',
+                       data=new_date,
+                       token=upload_data_token)
+
+    assert status == 200
+    assert data['status'] == 'success'
+
+    status, data = api('GET', f'observing_run/{run_id}',
+                       token=upload_data_token)
+
+    assert status == 200
+    assert data['status'] == 'success'
+    for key in run_details:
+        assert data['data'][key] == run_details[key]
+
+
+def test_unauthorized_user_modify_unowned_observing_run(lris, upload_data_token,
+                                                        manage_sources_token,
+                                                        red_transients_group):
+    run_details = {'instrument_id': lris.id,
+                   'pi': 'Danny Goldstein',
+                   'observers': 'D. Goldstein, P. Nugent',
+                   'group_id': red_transients_group.id,
+                   'calendar_date': '2020-02-16'}
+
+    status, data = api('POST', 'observing_run',
+                       data=run_details,
+                       token=upload_data_token)
+    assert status == 200
+    assert data['status'] == 'success'
+    run_id = data['data']['id']
+
+    new_date = {'calendar_date': '2020-02-17'}
+    run_details.update(new_date)
+
+    status, data = api('PUT', f'observing_run/{run_id}',
+                       data=new_date,
+                       token=manage_sources_token)
+
+    assert status == 400
+    assert data['status'] == 'error'
+

--- a/skyportal/tests/api/test_telescope.py
+++ b/skyportal/tests/api/test_telescope.py
@@ -12,7 +12,8 @@ def test_token_user_post_get_telescope(upload_data_token, public_group):
                  'elevation': 0.0,
                  'diameter': 10.0,
                  'group_ids': [public_group.id],
-                 'skycam_link': 'http://www.lulin.ncu.edu.tw/wea/cur_sky.jpg'
+                 'skycam_link': 'http://www.lulin.ncu.edu.tw/wea/cur_sky.jpg',
+                 'robotic': True
                  }
 
     status, data = api('POST', 'telescope',
@@ -74,7 +75,8 @@ def test_token_user_update_telescope(upload_data_token, manage_sources_token,
                              'lon': 0.0,
                              'elevation': 0.0,
                              'diameter': 10.0,
-                             'group_ids': [public_group.id]
+                             'group_ids': [public_group.id],
+                             'robotic': True
                              },
                        token=upload_data_token)
     assert status == 200
@@ -122,7 +124,8 @@ def test_token_user_delete_telescope(upload_data_token, manage_sources_token,
                              'lon': 0.0,
                              'elevation': 0.0,
                              'diameter': 10.0,
-                             'group_ids': [public_group.id]
+                             'group_ids': [public_group.id],
+                             'robotic': False
                              },
                        token=upload_data_token)
     assert status == 200

--- a/skyportal/tests/conftest.py
+++ b/skyportal/tests/conftest.py
@@ -75,6 +75,14 @@ def public_source_two_groups(public_group, public_group2):
 
 
 @pytest.fixture()
+def public_source_group2(public_group2):
+    obj = ObjFactory(groups=[public_group2])
+    DBSession.add(Source(obj_id=obj.id, group_id=public_group2.id))
+    DBSession.commit()
+    return obj
+
+
+@pytest.fixture()
 def public_candidate(public_filter):
     obj = ObjFactory(groups=[public_filter.group])
     DBSession.add(Candidate(obj=obj, filter=public_filter))

--- a/skyportal/tests/conftest.py
+++ b/skyportal/tests/conftest.py
@@ -20,6 +20,8 @@ from skyportal.tests.fixtures import (
     UserFactory,
     FilterFactory,
     InstrumentFactory,
+    ObservingRunFactory,
+    TelescopeFactory
 )
 from skyportal.model_util import create_token
 from skyportal.models import DBSession, Source, Candidate, Role
@@ -33,8 +35,11 @@ set_server_url(f'http://localhost:{cfg["ports.app"]}')
 print("Setting test database to:", cfg["database"])
 models.init_db(**cfg["database"])
 
-# grab the latest earth orientation data for observatory calculations
-astroplan.download_IERS_A()
+
+@pytest.fixture(scope='session')
+def iers_data():
+    # grab the latest earth orientation data for observatory calculations
+    astroplan.download_IERS_A()
 
 
 @pytest.fixture()
@@ -80,6 +85,66 @@ def public_candidate(public_filter):
 @pytest.fixture()
 def ztf_camera():
     return InstrumentFactory()
+
+
+@pytest.fixture()
+def red_transients_group(group_admin_user, view_only_user):
+    return GroupFactory(name=f'red transients-{uuid.uuid4().hex}',
+                        users=[group_admin_user,
+                               view_only_user])
+
+
+@pytest.fixture()
+def ztf_camera():
+    return InstrumentFactory()
+
+
+@pytest.fixture()
+def keck1_telescope():
+    observer = astroplan.Observer.at_site('Keck')
+    return TelescopeFactory(name=f'Keck I Telescope_{uuid.uuid4()}',
+                            nickname='Keck1_{uuid.uuid4()}',
+                            lat=observer.location.lat.to('deg').value,
+                            lon=observer.location.lon.to('deg').value,
+                            elevation=observer.location.height.to('m').value,
+                            diameter=10.)
+
+
+@pytest.fixture()
+def p60_telescope():
+    observer = astroplan.Observer.at_site('Palomar')
+    return TelescopeFactory(name=f'Palomar 60-inch telescope_{uuid.uuid4()}',
+                            nickname='p60_{uuid.uuid4()}',
+                            lat=observer.location.lat.to('deg').value,
+                            lon=observer.location.lon.to('deg').value,
+                            elevation=observer.location.height.to('m').value,
+                            diameter=1.6)
+
+
+@pytest.fixture()
+def lris(keck1_telescope):
+    return InstrumentFactory(name=f'LRIS_{uuid.uuid4()}',
+                             type='imaging spectrograph',
+                             telescope=keck1_telescope,
+                             band='Optical', filters=['sdssu', 'sdssg',
+                                                      'sdssr', 'sdssi',
+                                                      'sdssz', 'bessellux',
+                                                      'bessellv', 'bessellb',
+                                                      'bessellr', 'besselli'])
+
+
+@pytest.fixture()
+def sedm(p60_telescope):
+    return InstrumentFactory(name=f'SEDM_{uuid.uuid4()}',
+                             type='imaging spectrograph',
+                             telescope=p60_telescope,
+                             band='Optical', filters=['sdssu', 'sdssg', 'sdssr',
+                                                      'sdssi'])
+
+
+@pytest.fixture()
+def red_transients_run():
+    return ObservingRunFactory()
 
 
 @pytest.fixture()

--- a/skyportal/tests/fixtures.py
+++ b/skyportal/tests/fixtures.py
@@ -6,7 +6,7 @@ import numpy as np
 import factory
 from skyportal.models import (DBSession, User, Group, Photometry,
                               Spectrum, Instrument, Telescope, Obj,
-                              Comment, Thumbnail, Filter)
+                              Comment, Thumbnail, Filter, ObservingRun)
 
 TMP_DIR = mkdtemp()
 
@@ -26,6 +26,7 @@ class TelescopeFactory(factory.alchemy.SQLAlchemyModelFactory):
     lon = -116.8650
     elevation = 1712.
     diameter = 1.2
+    robotic = True
 
 
 class CommentFactory(factory.alchemy.SQLAlchemyModelFactory):
@@ -42,7 +43,7 @@ class InstrumentFactory(factory.alchemy.SQLAlchemyModelFactory):
         model = Instrument
 
     name = factory.LazyFunction(lambda: f'ZTF_{str(uuid.uuid4())}')
-    type = 'Imager'
+    type = 'imager'
     band = 'Optical'
     telescope = factory.SubFactory(TelescopeFactory)
     filters = ['ztfg', 'ztfr', 'ztfi']
@@ -152,3 +153,30 @@ class UserFactory(factory.alchemy.SQLAlchemyModelFactory):
                 obj.groups.append(group)
                 DBSession().add(obj)
                 DBSession().commit()
+
+
+class ObservingRunFactory(factory.alchemy.SQLAlchemyModelFactory):
+    class Meta(BaseMeta):
+        model = ObservingRun
+
+    instrument = factory.SubFactory(
+        InstrumentFactory,
+        name=factory.LazyFunction(lambda: f'DBSP_{uuid.uuid4()}'),
+        type='spectrograph',
+        band='Optical', filters=[],
+        telescope=factory.SubFactory(
+            TelescopeFactory,
+            name=factory.LazyFunction(
+                lambda: f'Palomar 200-inch Telescope_{uuid.uuid4()}'
+            ),
+            nickname=factory.LazyFunction(
+                lambda: f'P200_{uuid.uuid4()}'
+            ), robotic=False
+        )
+    )
+
+    group = factory.SubFactory(GroupFactory)
+    pi = 'Danny Goldstein'
+    observers = 'D. Goldstein, S. Dhawan'
+    calendar_date = '3021-02-27'
+    owner = factory.SubFactory(UserFactory)

--- a/skyportal/tests/frontend/test_followup_requests.py
+++ b/skyportal/tests/frontend/test_followup_requests.py
@@ -24,6 +24,7 @@ def add_telescope_and_instrument(instrument_name, group_ids, token):
             "elevation": 0.0,
             "diameter": 10.0,
             "group_ids": group_ids,
+            "robotic": True
         },
         token=token,
     )
@@ -36,7 +37,7 @@ def add_telescope_and_instrument(instrument_name, group_ids, token):
         "instrument",
         data={
             "name": instrument_name,
-            "type": "type",
+            "type": "imager",
             "band": "Optical",
             "telescope_id": telescope_id,
             "filters": ["ztfg"],

--- a/skyportal/tests/tools/test_sky.py
+++ b/skyportal/tests/tools/test_sky.py
@@ -32,7 +32,7 @@ star_dict = {
 
 
 @pytest.mark.parametrize('star', ['polaris', 'skat'])
-def test_airmass(ztf_camera, star):
+def test_airmass(ztf_camera, star, iers_data):
     star_obj = star_dict[star]['target']
     star_obj = Obj(ra=star_obj.ra.deg, dec=star_obj.dec.deg)
     telescope = ztf_camera.telescope
@@ -54,7 +54,7 @@ def test_airmass(ztf_camera, star):
     )
 
 
-def test_airmass_single(ztf_camera, public_source):
+def test_airmass_single(ztf_camera, public_source, iers_data):
     telescope = ztf_camera.telescope
     time = night_times[-1]
     airmass_calc = public_source.airmass(telescope, time)


### PR DESCRIPTION
This PR is the first of several in the Observing Planning & Follow-up epic. Here we introduce the `ObservingRun` and `ClassicalAssignment` infrastructure (Table, API Handlers, Tests) which allow programmatic access to add, retrieve, and delete observing runs and add, retrieve and delete targets associated with those runs.

Some features:

- Observing Runs are associated with an instrument, a PI, names of observers, and a calendar date
- Observing run ORM objects provide convenience methods for calculating the run ephemerides, which will be used by the frontend to prevent users from assigning targets to runs that the Sun has already risen on
- Run owners and superusers can delete observing runs, which cascade to assignments
- Observing runs can optionally be associated with a group, for bookkeeping purposes
- astroplan is used for the calculation of ephemerides 
- Telescope elev, longitude, and latitude is used to determine the local time zone on the date of the run, using the `timezonefinder` package, which in turn is used to calculate the sunrise and sunset times in UTC 

The next PR will tackle the Frontend, allowing users to 

-  Create new observing runs 
-  Add sources to observing runs from the Obj pages

Future frontend PRs will:

Allow user interaction (add, delete) of Classifications at the Obj level
Visualization of the Classification for the Obj/Source that adhere to group-level permissions
Search facility based on Classification
([ch825] [ch824] [ch823])