### PR TITLE
Configure sidebar entries in `config.yaml.defaults`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,8 @@ static/thumbnails
 package-lock.json
 .jobs_timestamps.yaml
 skyportal_image_cache
-static/js/components/Main.jsx
 .tokens.yaml
+
+# Templated files
+static/js/components/Main.jsx
+static/js/components/SidebarAndHeader.jsx

--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -1,16 +1,16 @@
 app:
-    secret_key: abc01234  # This secret key can be any random string of
-                          # characters.
-                          #
-                          # You should re-generate this for your application
-                          # using:
-                          #
-                          # base64.b64encode(os.urandom(50)).decode('ascii')
-    factory: skyportal.app_server.make_app
+  secret_key: abc01234  # This secret key can be any random string of
+                        # characters.
+                        #
+                        # You should re-generate this for your application
+                        # using:
+                        #
+                        # base64.b64encode(os.urandom(50)).decode('ascii')
+  factory: skyportal.app_server.make_app
 
-    # See https://stackoverflow.com/a/35604855 for syntax
-    # These are Javascript component routes
-    routes:
+  # See https://stackoverflow.com/a/35604855 for syntax
+  # These are Javascript component routes
+  routes:
     - path: "/"
       component: HomePage
       exact: True
@@ -36,32 +36,32 @@ app:
       component: About
 
 database:
-    database: skyportal
-    host: localhost
-    port: 5432
-    user: skyportal
-    password:
+  database: skyportal
+  host: localhost
+  port: 5432
+  user: skyportal
+  password:
 
 server:
-    # From https://console.developers.google.com/
-    #
-    # - Create Client ID
-    # - Javascript origins: https://localhost:5000
-    # - Authorized redirect URLs: http://localhost:5000/complete/google-oauth2/
-    #
-    # You need to have Google+ API enabled; it takes a few minutes to activate.
+  # From https://console.developers.google.com/
+  #
+  # - Create Client ID
+  # - Javascript origins: https://localhost:5000
+  # - Authorized redirect URLs: http://localhost:5000/complete/google-oauth2/
+  #
+  # You need to have Google+ API enabled; it takes a few minutes to activate.
 
-    auth:
-        debug_login: True
-        google_oauth2_key:
-        google_oauth2_secret:
+  auth:
+    debug_login: True
+    google_oauth2_key:
+    google_oauth2_secret:
 
 services:
-    dask: False
+  dask: False
 
 misc:
-    days_to_keep_unsaved_candidates: 7
-    public_group_name: "Sitewide Group"
+  days_to_keep_unsaved_candidates: 7
+  public_group_name: "Sitewide Group"
 
 cron:
   - interval: 1440

--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -35,6 +35,21 @@ app:
     - path: "/about"
       component: About
 
+  sidebar:
+    # See https://material-ui.com/components/material-icons/
+
+    - name: Dashboard
+      icon: Home
+      url: /
+
+    - name: Candidates
+      icon: Search
+      url: /candidates
+
+    - name: About
+      icon: Info
+      url: /about
+
 database:
   database: skyportal
   host: localhost

--- a/static/js/components/Main.jsx.template
+++ b/static/js/components/Main.jsx.template
@@ -95,7 +95,7 @@ const MainContent = ({ root }) => {
 
       <MuiPickersUtilsProvider utils={DayJSUtils}>
 
-        <SidebarAndHeader root={root} open={open} />
+        <SidebarAndHeader open={open} />
 
         <Responsive mobileElement={ProfileDropdown} />
 

--- a/static/js/components/SidebarAndHeader.jsx
+++ b/static/js/components/SidebarAndHeader.jsx
@@ -84,7 +84,7 @@ const useStyles = makeStyles((theme) => ({
   }
 }));
 
-const SidebarAndHeader = ({ open, root }) => {
+const SidebarAndHeader = ({ open }) => {
   const dispatch = useDispatch();
   const classes = useStyles();
 
@@ -107,7 +107,7 @@ const SidebarAndHeader = ({ open, root }) => {
           >
             <MenuIcon />
           </IconButton>
-          <HeaderContent root={root} />
+          <HeaderContent />
         </Toolbar>
       </AppBar>
       <Drawer
@@ -152,8 +152,7 @@ const SidebarAndHeader = ({ open, root }) => {
 };
 
 SidebarAndHeader.propTypes = {
-  open: PropTypes.bool.isRequired,
-  root: PropTypes.string.isRequired
+  open: PropTypes.bool.isRequired
 };
 
 export default SidebarAndHeader;

--- a/static/js/components/SidebarAndHeader.jsx.template
+++ b/static/js/components/SidebarAndHeader.jsx.template
@@ -120,28 +120,26 @@ const SidebarAndHeader = ({ open }) => {
       >
         <div className={classes.drawerHeader} />
         <List>
-          {% for item in app.sidebar %}
+          {%- for item in app.sidebar -%}
 
-            {% if item.url.startswith('http') %}
-              <a href="{{ item.url }}" className={classes.link}>
-            {% else %}
-              <Link to="{{ item.url }}" className={classes.link}>
-            {% endif %}
+          {%- if item.url.startswith('http') %}
+          <a href="{{ item.url }}" className={classes.link}>
+          {% else %}
+          <Link to="{{ item.url }}" className={classes.link}>
+          {%- endif %}
+            <ListItem button name="sidebar{{ item.name }}Button">
+              <ListItemIcon>
+                <{{ item.icon }}Icon style={{ "{{ color: blue[200] }}" }} />
+              </ListItemIcon>
+              <ListItemText primary="{{ item.name }}" />
+            </ListItem>
+          {%- if item.url.startswith('http') %}
+          </a>
+          {% else %}
+          </Link>
+          {%- endif -%}
 
-              <ListItem button name="sidebar{{ item.name }}Button">
-                <ListItemIcon>
-                  <{{ item.icon }}Icon style={{ "{{ color: blue[200] }}" }} />
-                </ListItemIcon>
-                <ListItemText primary="{{ item.name }}" />
-              </ListItem>
-
-            {% if item.url.startswith('http') %}
-              </a>
-            {% else %}
-              </Link>
-            {% endif %}
-
-          {% endfor %}
+          {%- endfor %}
         </List>
       </Drawer>
     </>
@@ -149,8 +147,7 @@ const SidebarAndHeader = ({ open }) => {
 };
 
 SidebarAndHeader.propTypes = {
-  open: PropTypes.bool.isRequired,
-  sideItems: PropTypes.object.isRequired
+  open: PropTypes.bool.isRequired
 };
 
 export default SidebarAndHeader;

--- a/static/js/components/SidebarAndHeader.jsx.template
+++ b/static/js/components/SidebarAndHeader.jsx.template
@@ -11,12 +11,13 @@ import ListItem from "@material-ui/core/ListItem";
 import ListItemIcon from "@material-ui/core/ListItemIcon";
 import ListItemText from "@material-ui/core/ListItemText";
 import { blue } from "@material-ui/core/colors";
-import HomeIcon from "@material-ui/icons/Home";
-import SearchIcon from "@material-ui/icons/Search";
-import InfoIcon from "@material-ui/icons/Info";
-import MenuIcon from "@material-ui/icons/Menu";
 import IconButton from "@material-ui/core/IconButton";
 import { makeStyles } from "@material-ui/core/styles";
+
+{% for item in app.sidebar %}
+import {{ item.icon }}Icon from "@material-ui/icons/{{ item.icon }}";
+{% endfor %}
+import MenuIcon from "@material-ui/icons/Menu";
 
 import HeaderContent from "./HeaderContent";
 import * as Actions from "../ducks/sidebar";
@@ -115,36 +116,32 @@ const SidebarAndHeader = ({ open }) => {
         variant="persistent"
         anchor="left"
         open={open}
-        classes={{
-          paper: classes.drawerPaper,
-        }}
+        classes={{ "{{ paper: classes.drawerPaper }}" }}
       >
         <div className={classes.drawerHeader} />
         <List>
-          <Link to="/" className={classes.link}>
-            <ListItem button name="sidebarDashboardButton">
-              <ListItemIcon>
-                <HomeIcon style={{ color: blue[200] }} />
-              </ListItemIcon>
-              <ListItemText primary="Dashboard" />
-            </ListItem>
-          </Link>
-          <Link to="/candidates" className={classes.link}>
-            <ListItem button name="sidebarCandidatesButton">
-              <ListItemIcon>
-                <SearchIcon style={{ color: blue[200] }} />
-              </ListItemIcon>
-              <ListItemText primary="Candidates" />
-            </ListItem>
-          </Link>
-          <Link to="/about" className={classes.link}>
-            <ListItem button name="sidebarAboutButton">
-              <ListItemIcon>
-                <InfoIcon style={{ color: blue[200] }} />
-              </ListItemIcon>
-              <ListItemText primary="About" />
-            </ListItem>
-          </Link>
+          {% for item in app.sidebar %}
+
+            {% if item.url.startswith('http') %}
+              <a href="{{ item.url }}" className={classes.link}>
+            {% else %}
+              <Link to="{{ item.url }}" className={classes.link}>
+            {% endif %}
+
+              <ListItem button name="sidebar{{ item.name }}Button">
+                <ListItemIcon>
+                  <{{ item.icon }}Icon style={{ "{{ color: blue[200] }}" }} />
+                </ListItemIcon>
+                <ListItemText primary="{{ item.name }}" />
+              </ListItem>
+
+            {% if item.url.startswith('http') %}
+              </a>
+            {% else %}
+              </Link>
+            {% endif %}
+
+          {% endfor %}
         </List>
       </Drawer>
     </>
@@ -152,7 +149,8 @@ const SidebarAndHeader = ({ open }) => {
 };
 
 SidebarAndHeader.propTypes = {
-  open: PropTypes.bool.isRequired
+  open: PropTypes.bool.isRequired,
+  sideItems: PropTypes.object.isRequired
 };
 
 export default SidebarAndHeader;


### PR DESCRIPTION
Sidebar entries can now be specified in `config.yaml.defaults` under `app.sidebar`.
    
Links can either be internal (`/profile`) or can point to the outside world (those must start with `http` to be recognized).
