### PR TITLE
Robustify group user management

### DIFF
--- a/skyportal/handlers/api/group.py
+++ b/skyportal/handlers/api/group.py
@@ -286,7 +286,19 @@ class GroupUserHandler(BaseHandler):
         else:
             user_id = user.id
             # Just add new GroupUser
-            DBSession.add(GroupUser(group_id=group_id, user_id=user_id, admin=admin))
+            gu = GroupUser.query.filter(
+                GroupUser.group_id == group_id
+            ).filter(
+                GroupUser.user_id == user_id
+            ).first()
+            if gu is None:
+                DBSession.add(
+                    GroupUser(group_id=group_id, user_id=user_id, admin=admin)
+                )
+            else:
+                return self.error(
+                    "Specified user is already associated with this group."
+                )
         DBSession().commit()
 
         self.push_all(action='skyportal/REFRESH_GROUP',

--- a/skyportal/tests/frontend/test_groups.py
+++ b/skyportal/tests/frontend/test_groups.py
@@ -54,7 +54,7 @@ def test_add_new_group_user_admin(driver, super_admin_user, user, public_group):
     driver.wait_for_xpath('//h6[text()="All Groups"]')
     el = driver.wait_for_xpath(f'//a[contains(.,"{public_group.name}")]')
     driver.execute_script("arguments[0].click();", el)
-    driver.wait_for_xpath(f'//a[contains(.,"{user.username}")]/../input').click()
+    driver.wait_for_xpath(f'//a[contains(.,"{user.username}")]/../button').click()
     driver.wait_for_xpath('//input[@id="newUserEmail"]').send_keys(
         user.username, Keys.ENTER)
     driver.wait_for_xpath('//input[@type="checkbox"]').click()
@@ -70,7 +70,7 @@ def test_add_new_group_user_nonadmin(driver, super_admin_user, user, public_grou
     driver.wait_for_xpath('//h6[text()="All Groups"]')
     el = driver.wait_for_xpath(f'//a[contains(.,"{public_group.name}")]')
     driver.execute_script("arguments[0].click();", el)
-    driver.wait_for_xpath(f'//a[contains(.,"{user.username}")]/../input').click()
+    driver.wait_for_xpath(f'//a[contains(.,"{user.username}")]/../button').click()
     driver.wait_for_xpath('//input[@id="newUserEmail"]').send_keys(
         user.username, Keys.ENTER)
     driver.wait_for_xpath('//input[@value="Add user"]').click()
@@ -86,7 +86,7 @@ def test_add_new_group_user_new_username(driver, super_admin_user, user, public_
     driver.wait_for_xpath('//h6[text()="All Groups"]')
     el = driver.wait_for_xpath(f'//a[contains(.,"{public_group.name}")]')
     driver.execute_script("arguments[0].click();", el)
-    driver.wait_for_xpath(f'//a[contains(.,"{user.username}")]/../input').click()
+    driver.wait_for_xpath(f'//a[contains(.,"{user.username}")]/../button').click()
     driver.wait_for_xpath('//input[@id="newUserEmail"]').send_keys(
         new_username, Keys.ENTER)
     driver.wait_for_xpath('//input[@value="Add user"]').click()
@@ -99,7 +99,7 @@ def test_delete_group_user(driver, super_admin_user, user, public_group):
     driver.wait_for_xpath('//h6[text()="All Groups"]')
     el = driver.wait_for_xpath(f'//a[contains(.,"{public_group.name}")]')
     driver.execute_script("arguments[0].click();", el)
-    driver.wait_for_xpath(f'//a[contains(.,"{user.username}")]/../input').click()
+    driver.wait_for_xpath(f'//a[contains(.,"{user.username}")]/../button').click()
     assert len(driver.find_elements_by_xpath(
         f'//a[contains(.,"{user.username}")]')) == 0
 

--- a/static/js/components/Group.jsx
+++ b/static/js/components/Group.jsx
@@ -44,6 +44,13 @@ const Group = () => {
       )[0].admin
     );
 
+    let numAdmins = 0;
+    group.group_users.forEach((groupUser) => {
+      if (groupUser.admin) {
+        numAdmins += 1;
+      }
+    });
+
     return (
       <div>
         <b>
@@ -74,16 +81,18 @@ const Group = () => {
                   (currentUser.roles.includes('Super admin') ||
                    currentUser.roles.includes('Group admin')) &&
                   (
-                    <input
-                      type="submit"
+                    <button
+                      type="button"
+                      disabled={isAdmin(user, group) && (numAdmins <= 1)}
                       onClick={() => dispatch(
                         groupsActions.deleteGroupUser(
                           { username: user.username,
                             group_id: group.id }
                         )
                       )}
-                      value="Remove from group"
-                    />
+                    >
+                      Remove from group
+                    </button>
                   )
                 }
               </li>


### PR DESCRIPTION
This PR fixes a few group user management bugs. 

If a group only has a single admin, its associated delete button is disabled (another user must be made admin before they can be deleted so that no group has zero admins). See screen capture below for demo:

![cannot_delete_only_group_admin](https://user-images.githubusercontent.com/7230285/87840190-31b4e180-c853-11ea-9a3a-938e6e72e6b0.gif)

If a user is selected to be added that already exists, a simple, informative error message is displayed.

Closes #579 
Closes #577 