### PR TITLE
Mobile profile link

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "redux-thunk": "2.3.0",
     "semver": "7.3.2",
     "style-loader": "1.2.1",
+    "styled-components": "^5.1.1",
     "vega": "5.13.0",
     "vega-embed": "6.8.0",
     "vega-lite": "4.13.1",

--- a/static/js/components/ProfileDropdown.jsx
+++ b/static/js/components/ProfileDropdown.jsx
@@ -4,7 +4,22 @@ import { Link } from 'react-router-dom';
 import Dropdown, { DropdownTrigger, DropdownContent } from 'react-simple-dropdown';
 
 import styles from "./ProfileDropdown.css";
-import Responsive from "./Responsive";
+import styled from 'styled-components';
+
+const Container = styled.div`
+  padding: 1em;
+  color: white;
+  font-weight: normal;
+  float: right;
+  vertical-align: middle;
+
+  @media only screen and (max-width: 768px) {
+    position: absolute;
+    right: 15px;
+    top: 20px;
+    z-index: 200;
+  }
+`
 
 const ProfileDropdown = () => {
   const profile = useSelector((state) => state.profile);
@@ -15,21 +30,15 @@ const ProfileDropdown = () => {
   };
 
   return (
-    <Responsive
-      desktopStyle={styles.profileDesktop}
-      mobileStyle={styles.profileMobile}
-    >
-
+    <Container>
       <Dropdown ref={dropdown}>
-
         <DropdownTrigger>
           { profile.username }
           {' '}
           &nbsp;▾
         </DropdownTrigger>
-
+        
         <DropdownContent>
-
           <Link to="/profile" role="link">
             <div role="menuitem" tabIndex="0" className={styles.entry} onClick={collapseDropdown}>
               Profile
@@ -51,12 +60,10 @@ const ProfileDropdown = () => {
               Sign out
             </div>
           </a>
-
         </DropdownContent>
 
       </Dropdown>
-
-    </Responsive>
+    </Container>
   );
 };
 

--- a/static/js/components/ProfileDropdown.jsx
+++ b/static/js/components/ProfileDropdown.jsx
@@ -2,9 +2,9 @@ import React, { useRef } from 'react';
 import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 import Dropdown, { DropdownTrigger, DropdownContent } from 'react-simple-dropdown';
+import styled from 'styled-components';
 
 import styles from "./ProfileDropdown.css";
-import styled from 'styled-components';
 
 const Container = styled.div`
   padding: 1em;
@@ -19,7 +19,7 @@ const Container = styled.div`
     top: 20px;
     z-index: 200;
   }
-`
+`;
 
 const ProfileDropdown = () => {
   const profile = useSelector((state) => state.profile);
@@ -37,7 +37,7 @@ const ProfileDropdown = () => {
           {' '}
           &nbsp;▾
         </DropdownTrigger>
-        
+
         <DropdownContent>
           <Link to="/profile" role="link">
             <div role="menuitem" tabIndex="0" className={styles.entry} onClick={collapseDropdown}>


### PR DESCRIPTION
A very simple example of using styled-components. This replaces the Responsive component, and hopefully everyone finds its more explicit, easier to read, and a bit simpler.

We can continue down this path if people like this example.

This will keep the ProfileDropdown link on the right side of the header instead of positioned over the header on widths < 768px. 

<img width="552" alt="Screen Shot 2020-07-19 at 10 19 44 PM" src="https://user-images.githubusercontent.com/3891660/87896481-fad6fb00-ca0d-11ea-84db-1a2f2ec7c99d.png">