### PR TITLE
Add facility selector to starlist component

### DIFF
--- a/skyportal/tests/frontend/test_sources.py
+++ b/skyportal/tests/frontend/test_sources.py
@@ -410,12 +410,11 @@ def test_dropdown_facility_change(driver, user, public_source):
         driver.wait_for_xpath('//span[text()="Show Starlist"]')
     )
     driver.wait_for_xpath("//code/div[text()[contains(., 'raoffset')]]", timeout=20)
-    driver.scroll_to_element_and_click(
-        driver.wait_for_xpath(
-            '//div[@id="mui-component-select-StarListSelectFacility"]'
-        )
-    )
-    driver.scroll_to_element_and_click(
-        driver.wait_for_xpath('//li[@data-value="P200"]')
-    )
+
+    xpath = '//*[@id="mui-component-select-StarListSelectElement"]'
+    element = driver.wait_for_xpath(xpath)
+    ActionChains(driver).move_to_element(element).click_and_hold().perform()
+    xpath = '//li[@data-value="P200"]'
+    element = driver.wait_for_xpath(xpath)
+    ActionChains(driver).move_to_element(element).click_and_hold().perform()
     driver.wait_for_xpath("//code/div[text()[contains(., 'dist')]]", timeout=20)

--- a/skyportal/tests/frontend/test_sources.py
+++ b/skyportal/tests/frontend/test_sources.py
@@ -329,7 +329,7 @@ def test_show_starlist(driver, user, public_source):
     driver.get(f"/source/{public_source.id}")
     button = driver.wait_for_xpath(f'//span[text()="Show Starlist"]')
     button.click()
-    driver.wait_for_xpath(f'//code[contains(text(), _off1)]')
+    driver.wait_for_xpath(f"//code/div[text()[contains(., '_off1')]]", timeout=20)
 
 
 @pytest.mark.flaky(reruns=2)
@@ -401,3 +401,21 @@ def test_centroid_plot(
 
         difference = ImageChops.difference(generated_plot, expected_plot)
         assert difference.getbbox() is None
+
+
+def test_dropdown_facility_change(driver, user, public_source):
+    driver.get(f"/become_user/{user.id}")  # TODO decorator/context manager?
+    driver.get(f"/source/{public_source.id}")
+    driver.scroll_to_element_and_click(
+        driver.wait_for_xpath('//span[text()="Show Starlist"]')
+    )
+    driver.wait_for_xpath("//code/div[text()[contains(., 'raoffset')]]", timeout=20)
+    driver.scroll_to_element_and_click(
+        driver.wait_for_xpath(
+            '//div[@id="mui-component-select-StarListSelectFacility"]'
+        )
+    )
+    driver.scroll_to_element_and_click(
+        driver.wait_for_xpath('//li[@data-value="P200"]')
+    )
+    driver.wait_for_xpath("//code/div[text()[contains(., 'dist')]]", timeout=20)

--- a/static/js/components/StarList.css
+++ b/static/js/components/StarList.css
@@ -3,8 +3,22 @@
   padding: 1rem;
   margin: 1rem;
   line-height: 0.8rem;
+  position: relative;
+  min-height: 10rem;
+  min-width: 20rem;
 }
 
 .starList {
   font-size: 0.5rem;
+}
+
+.codeText {
+  max-width: 80%;
+}
+
+.dropDown {
+  position: absolute;
+  top: 0;
+  right: 0;
+  margin: 1.5rem;
 }

--- a/static/js/components/StarList.css
+++ b/static/js/components/StarList.css
@@ -4,8 +4,8 @@
   margin: 1rem;
   line-height: 0.8rem;
   position: relative;
-  min-height: 10rem;
-  min-width: 20rem;
+  min-height: 7rem;
+  min-width: 15rem;
 }
 
 .starList {

--- a/static/js/components/StarList.jsx
+++ b/static/js/components/StarList.jsx
@@ -2,34 +2,59 @@ import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import PropTypes from "prop-types";
 
-import { GET } from "../API";
+import Select from "@material-ui/core/Select";
+import MenuItem from "@material-ui/core/MenuItem";
+import InputLabel from "@material-ui/core/InputLabel";
 
+import { GET } from "../API";
 import styles from "./StarList.css";
 
-const StarListBody = ({ starList }) => (
-  <div className={styles.starListDiv}>
-    <code className={styles.starList}>
-      {starList &&
-        starList.map((item, idx) => (
-          // eslint-disable-next-line react/no-array-index-key
-          <React.Fragment key={idx}>
-            {item.str}
-            <br />
-          </React.Fragment>
-        ))}
-    </code>
-  </div>
-);
+const StarListBody = ({ starList, facility, setFacility, setStarList }) => {
+  const handleChange = (event) => {
+    setFacility(event.target.value);
+    setStarList([{ str: "Loading starlist..." }]);
+  };
+
+  return (
+    <div className={styles.starListDiv}>
+      <code className={styles.starList}>
+        <div className={styles.codeText}>
+          {starList &&
+            starList.map((item, idx) => (
+              // eslint-disable-next-line react/no-array-index-key
+              <React.Fragment key={idx}>
+                {item.str}
+                <br />
+              </React.Fragment>
+            ))}
+        </div>
+      </code>
+      <div className={styles.dropDown}>
+        <InputLabel id="StarListSelect">Facility</InputLabel>
+        <Select
+          labelId="StarListSelect"
+          value={facility}
+          onChange={handleChange}
+        >
+          <MenuItem value="Keck">Keck</MenuItem>
+          <MenuItem value="P200">P200</MenuItem>
+          <MenuItem value="Shane">Shane</MenuItem>
+        </Select>
+      </div>
+    </div>
+  );
+};
 
 const StarList = ({ sourceId }) => {
   const [starList, setStarList] = useState([{ str: "Loading starlist..." }]);
   const dispatch = useDispatch();
+  const [fac, setFacility] = useState("Keck");
 
   useEffect(() => {
     const fetchStarList = async () => {
       const response = await dispatch(
         GET(
-          `/api/sources/${sourceId}/offsets?facility=Keck`,
+          `/api/sources/${sourceId}/offsets?facility=${fac}`,
           "skyportal/FETCH_STARLIST"
         )
       );
@@ -37,22 +62,30 @@ const StarList = ({ sourceId }) => {
     };
 
     fetchStarList();
-  }, [sourceId, dispatch]);
+  }, [sourceId, dispatch, fac]);
 
-  return <StarListBody starList={starList} />;
+  return (
+    <StarListBody
+      starList={starList}
+      fac={fac}
+      setFacility={setFacility}
+      setStarList={setStarList}
+    />
+  );
 };
 
 export const ObservingRunStarList = () => {
+  const dispatch = useDispatch();
   const [starList, setStarList] = useState([{ str: "Loading starlist..." }]);
   const { assignments } = useSelector((state) => state.observingRun);
-  const dispatch = useDispatch();
+  const [facility, setFacility] = useState("Keck");
 
   useEffect(() => {
     const fetchStarList = async () => {
       const promises = assignments.map((assignment) =>
         dispatch(
           GET(
-            `/api/sources/${assignment.obj_id}/offsets?facility=Keck`,
+            `/api/sources/${assignment.obj_id}/offsets?facility=${facility}`,
             "skyportal/FETCH_STARLIST"
           )
         )
@@ -69,8 +102,15 @@ export const ObservingRunStarList = () => {
     };
     fetchStarList();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [assignments, dispatch]);
-  return <StarListBody starList={starList} />;
+  }, [assignments, dispatch, facility]);
+  return (
+    <StarListBody
+      starList={starList}
+      facility={facility}
+      setStarList={setStarList}
+      setFacility={setFacility}
+    />
+  );
 };
 
 StarList.propTypes = {
@@ -83,6 +123,9 @@ StarListBody.propTypes = {
       str: PropTypes.string,
     })
   ).isRequired,
+  setStarList: PropTypes.func.isRequired,
+  setFacility: PropTypes.func.isRequired,
+  facility: PropTypes.string.isRequired,
 };
 
 export default StarList;

--- a/static/js/components/StarList.jsx
+++ b/static/js/components/StarList.jsx
@@ -35,6 +35,7 @@ const StarListBody = ({ starList, facility, setFacility, setStarList }) => {
           labelId="StarListSelect"
           value={facility}
           onChange={handleChange}
+          name="StarListSelectElement"
         >
           <MenuItem value="Keck">Keck</MenuItem>
           <MenuItem value="P200">P200</MenuItem>
@@ -48,13 +49,13 @@ const StarListBody = ({ starList, facility, setFacility, setStarList }) => {
 const StarList = ({ sourceId }) => {
   const [starList, setStarList] = useState([{ str: "Loading starlist..." }]);
   const dispatch = useDispatch();
-  const [fac, setFacility] = useState("Keck");
+  const [facility, setFacility] = useState("Keck");
 
   useEffect(() => {
     const fetchStarList = async () => {
       const response = await dispatch(
         GET(
-          `/api/sources/${sourceId}/offsets?facility=${fac}`,
+          `/api/sources/${sourceId}/offsets?facility=${facility}`,
           "skyportal/FETCH_STARLIST"
         )
       );
@@ -62,12 +63,12 @@ const StarList = ({ sourceId }) => {
     };
 
     fetchStarList();
-  }, [sourceId, dispatch, fac]);
+  }, [sourceId, dispatch, facility]);
 
   return (
     <StarListBody
       starList={starList}
-      fac={fac}
+      facility={facility}
       setFacility={setFacility}
       setStarList={setStarList}
     />


### PR DESCRIPTION
![Jul-29-2020 21-30-32](https://user-images.githubusercontent.com/2769632/88880912-d08df600-d1e2-11ea-8117-70040cfd8a5d.gif)



This PR adds a dropdown menu to the StarList and ObservingRunStarList components  that allows you to choose the facility formatting guidelines that you would like applied to your starlist. 

This PR is an extension of #711 . It changes the `ObservingRunStarList` API (to have it take an `observingRun` object as opposed to an `observingRunId`) as defined in that PR, but does not alter the single-object `StarList` API that renders on the source page, which was written by others. 

This PR also fixes a bug in `skyportal/tests/frontend/test_sources.py::test_show_starlist` that caused the test to pass without the expected text being present. 

[ch1095]