### PR TITLE
System admin permissions

### DIFF
--- a/skyportal/handlers/api/filter.py
+++ b/skyportal/handlers/api/filter.py
@@ -49,7 +49,9 @@ class FilterHandler(BaseHandler):
             return self.success(data=f)
         filters = (
             DBSession().query(Filter)
-            .filter(Filter.group_id.in_([g.id for g in self.current_user.groups]))
+            .filter(Filter.group_id.in_(
+                [g.id for g in self.current_user.accessible_groups]
+            ))
             .all()
         )
         return self.success(data=filters)

--- a/skyportal/handlers/api/instrument.py
+++ b/skyportal/handlers/api/instrument.py
@@ -74,7 +74,7 @@ class InstrumentHandler(BaseHandler):
             return self.success(data=instrument)
         query = Instrument.query.filter(Instrument.telescope_id.in_(
             DBSession().query(GroupTelescope.telescope_id).filter(GroupTelescope.group_id.in_(
-                [g.id for g in self.current_user.groups]
+                [g.id for g in self.current_user.accessible_groups]
             ))))
         return self.success(data=query.all())
 
@@ -155,7 +155,7 @@ InstrumentHandler.post.__doc__ = f"""
         requestBody:
           content:
             application/json:
-              schema: 
+              schema:
                 allOf:
                 - $ref: "#/components/schemas/InstrumentNoID"
                 - type: object
@@ -168,7 +168,7 @@ InstrumentHandler.post.__doc__ = f"""
                       description: >-
                         List of filters on the instrument. If the instrument
                         has no filters (e.g., because it is a spectrograph),
-                        leave blank or pass the empty list. 
+                        leave blank or pass the empty list.
                       default: []
         responses:
           200:

--- a/skyportal/handlers/api/internal/source_views.py
+++ b/skyportal/handlers/api/internal/source_views.py
@@ -29,7 +29,7 @@ class SourceViewsHandler(BaseHandler):
                              SourceView.obj_id).group_by(SourceView.obj_id)
              .filter(SourceView.obj_id.in_(DBSession.query(
                  Source.obj_id).filter(Source.group_id.in_(
-                     [g.id for g in self.current_user.groups]))))
+                     [g.id for g in self.current_user.accessible_groups]))))
              .filter(SourceView.created_at >= cutoff_day)
              .order_by(desc('views')).limit(max_num_sources))
         return self.success(data=q.all())

--- a/skyportal/handlers/api/news_feed.py
+++ b/skyportal/handlers/api/news_feed.py
@@ -44,7 +44,7 @@ class NewsFeedHandler(BaseHandler):
         def fetch_newest(model):
             return model.query.filter(model.obj_id.in_(
                 DBSession().query(Source.obj_id).filter(
-                    Source.group_id.in_([g.id for g in self.current_user.groups])
+                    Source.group_id.in_([g.id for g in self.current_user.accessible_groups])
                 ))).order_by(desc(model.created_at or model.saved_at)).limit(n_items).all()
 
         sources = fetch_newest(Source)

--- a/skyportal/handlers/api/photometry.py
+++ b/skyportal/handlers/api/photometry.py
@@ -166,10 +166,9 @@ class PhotometryHandler(BaseHandler):
         if not groups:
             return self.error("Invalid group_ids field. "
                               "Specify at least one valid group ID.")
-        if "Super admin" not in [r.id for r in self.associated_user_object.roles]:
-            if not all([group in self.current_user.groups for group in groups]):
-                return self.error("Cannot upload photometry to groups that you "
-                                  "are not a member of.")
+        if not all([group in self.current_user.accessible_groups for group in groups]):
+            return self.error("Cannot upload photometry to groups that you "
+                              "are not a member of.")
         if "alert_id" in data:
             phot = Photometry.query.filter(
                 Photometry.alert_id == data["alert_id"]
@@ -221,7 +220,7 @@ class PhotometryHandler(BaseHandler):
 
             # https://en.wikipedia.org/wiki/Bitwise_operation#XOR
             bad = magerrnull ^ magnull  # bitwise exclusive or -- returns true
-                                        #  if A and not B or B and not A
+            #  if A and not B or B and not A
 
             if any(bad):
                 # find the first offending packet
@@ -437,10 +436,9 @@ class PhotometryHandler(BaseHandler):
             if not groups:
                 return self.error("Invalid group_ids field. "
                                   "Specify at least one valid group ID.")
-            if "Super admin" not in [r.id for r in self.associated_user_object.roles]:
-                if not all([group in self.current_user.groups for group in groups]):
-                    return self.error("Cannot upload photometry to groups you "
-                                      "are not a member of.")
+            if not all([group in self.current_user.accessible_groups for group in groups]):
+                return self.error("Cannot upload photometry to groups you "
+                                  "are not a member of.")
             photometry.groups = groups
         DBSession().commit()
         return self.success()

--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -283,13 +283,14 @@ class SourceHandler(BaseHandler):
         """
         data = self.get_json()
         schema = Obj.__schema__()
-        user_group_ids = [int(g.id) for g in self.current_user.groups]
+        user_group_ids = [g.id for g in self.current_user.groups]
+        user_accessible_group_ids = [g.id for g in self.current_user.accessible_groups]
         if not user_group_ids:
             return self.error("You must belong to one or more groups before "
                               "you can add sources.")
         try:
             group_ids = [int(id) for id in data.pop('group_ids')
-                         if int(id) in user_group_ids]
+                         if int(id) in user_accessible_group_ids]
         except KeyError:
             group_ids = user_group_ids
         if not group_ids:
@@ -373,7 +374,7 @@ class SourceHandler(BaseHandler):
               application/json:
                 schema: Success
         """
-        if group_id not in [g.id for g in self.current_user.groups]:
+        if group_id not in [g.id for g in self.current_user.accessible_groups]:
             return self.error("Inadequate permissions.")
         s = (DBSession().query(Source).filter(Source.obj_id == obj_id)
              .filter(Source.group_id == group_id).first())

--- a/skyportal/handlers/api/taxonomy.py
+++ b/skyportal/handlers/api/taxonomy.py
@@ -32,8 +32,8 @@ class TaxonomyHandler(BaseHandler):
         """
         taxonomy = Taxonomy. \
             get_taxonomy_usable_by_user(
-                        taxonomy_id,
-                        self.current_user
+                taxonomy_id,
+                self.current_user
             )
         if taxonomy is None:
             return self.error(
@@ -149,10 +149,11 @@ class TaxonomyHandler(BaseHandler):
 
         # establish the groups to use
         user_group_ids = [g.id for g in self.current_user.groups]
+        user_accessible_group_ids = [g.id for g in self.current_user.accessible_groups]
         group_ids = data.pop("group_ids", user_group_ids)
         if group_ids == []:
             group_ids = user_group_ids
-        group_ids = [gid for gid in group_ids if gid in user_group_ids]
+        group_ids = [gid for gid in group_ids if gid in user_accessible_group_ids]
         if not group_ids:
             return self.error(f"Invalid group IDs field ({group_ids}): "
                               "You must provide one or more valid group IDs.")

--- a/skyportal/handlers/api/telescope.py
+++ b/skyportal/handlers/api/telescope.py
@@ -48,7 +48,7 @@ class TelescopeHandler(BaseHandler):
         data = self.get_json()
         group_ids = data.pop('group_ids')
         groups = [g for g in Group.query.filter(Group.id.in_(group_ids)).all()
-                  if g in self.current_user.groups]
+                  if g in self.current_user.accessible_groups]
         if not groups:
             return self.error('You must specify at least one group of which you '
                               'are a member.')

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -45,9 +45,9 @@ def is_owned_by(self, user_or_token):
     if hasattr(self, 'tokens'):
         return user_or_token in self.tokens
     if hasattr(self, 'groups'):
-        return bool(set(self.groups) & set(user_or_token.groups))
+        return bool(set(self.groups) & set(user_or_token.accessible_groups))
     if hasattr(self, 'group'):
-        return self.group in user_or_token.groups
+        return self.group in user_or_token.accessible_groups
     if hasattr(self, 'users'):
         if hasattr(user_or_token, 'created_by'):
             if user_or_token.created_by in self.users:
@@ -111,6 +111,17 @@ StreamGroup = join_model('stream_groups', Stream, Group)
 User.groups = relationship('Group', secondary='group_users',
                            back_populates='users',
                            passive_deletes=True)
+
+
+@property
+def user_or_token_accessible_groups(self):
+    if "System admin" in [acl.id for acl in self.acls]:
+        return Group.query.all()
+    return self.groups
+
+
+User.accessible_groups = user_or_token_accessible_groups
+Token.accessible_groups = user_or_token_accessible_groups
 
 
 @property
@@ -299,7 +310,7 @@ Candidate.passing_alert_id = sa.Column(sa.BigInteger)
 def get_candidate_if_owned_by(obj_id, user_or_token, options=[]):
     if Candidate.query.filter(Candidate.obj_id == obj_id).first() is None:
         return None
-    user_group_ids = [g.id for g in user_or_token.groups]
+    user_group_ids = [g.id for g in user_or_token.accessible_groups]
     c = (
         Candidate.query.filter(Candidate.obj_id == obj_id)
         .filter(
@@ -316,7 +327,7 @@ def get_candidate_if_owned_by(obj_id, user_or_token, options=[]):
 
 
 def candidate_is_owned_by(self, user_or_token):
-    return self.filter.group in user_or_token.groups
+    return self.filter.group in user_or_token.accessible_groups
 
 
 Candidate.get_obj_if_owned_by = get_candidate_if_owned_by
@@ -341,13 +352,13 @@ Source.unsaved_by = relationship("User", foreign_keys=[Source.unsaved_by_id])
 def source_is_owned_by(self, user_or_token):
     source_group_ids = [row[0] for row in DBSession.query(
         Source.group_id).filter(Source.obj_id == self.obj_id).all()]
-    return bool(set(source_group_ids) & {g.id for g in user_or_token.groups})
+    return bool(set(source_group_ids) & {g.id for g in user_or_token.accessible_groups})
 
 
 def get_source_if_owned_by(obj_id, user_or_token, options=[]):
     if Source.query.filter(Source.obj_id == obj_id).first() is None:
         return None
-    user_group_ids = [g.id for g in user_or_token.groups]
+    user_group_ids = [g.id for g in user_or_token.accessible_groups]
     s = (Source.query.filter(Source.obj_id == obj_id)
          .filter(Source.group_id.in_(user_group_ids)).options(options).first())
     if s is None:
@@ -390,7 +401,9 @@ def get_photometry_owned_by_user(obj_id, user_or_token):
     return (
         Photometry.query.filter(Photometry.obj_id == obj_id)
         .filter(
-            Photometry.groups.any(Group.id.in_([g.id for g in user_or_token.groups]))
+            Photometry.groups.any(Group.id.in_(
+                [g.id for g in user_or_token.accessible_groups]
+            ))
         )
         .all()
     )


### PR DESCRIPTION
This PR improves permissions checking by introducing a new `User.accessible_groups` attribute, which returns either the normal user's group list (`User.groups`) in the case of non-system admin users, or, in the case of system admin users, returns all groups. This new attribute is used in place of `User.groups` for checking whether a user has access to the specified record(s). Some security lapses are also addressed.

Closes #619 