### PR TITLE
Add images to ``Top sources'' widget

### DIFF
--- a/static/js/components/TopSources.css
+++ b/static/js/components/TopSources.css
@@ -22,12 +22,12 @@
   padding-left: 10px;
 }
 
-.ul {
-  display: block;
-  align-items: center;
-  list-style-type: none;
+.topSourceList {
+   display: block;
+   align-items: center;
+   list-style-type: none;
 }
 
 .topSource {
-  margin: 10px;
+   margin: 10px;
 }

--- a/static/js/components/TopSources.css
+++ b/static/js/components/TopSources.css
@@ -1,0 +1,29 @@
+.stamp {
+    transition: transform 0.1s;
+    width: 20%;
+    height: 20%;
+    margin: 0 auto;
+    vertical-align: middle;
+}
+
+.stamp:hover {
+  transform: scale(2.0);
+}
+
+.div {
+  display: flex;
+  border-style: solid;
+  border-width: 1px;
+  border-color: #DDD;
+  padding-top: 10px;
+  padding-right: 10px;
+  padding-bottom: 10px;
+  padding-left: 10px;
+}
+
+.ul {
+   display: flex;
+   align-items: center;
+   list-style-type: none;
+}
+

--- a/static/js/components/TopSources.css
+++ b/static/js/components/TopSources.css
@@ -1,3 +1,4 @@
+
 .stamp {
     transition: transform 0.1s;
     width: 20%;
@@ -10,8 +11,8 @@
   transform: scale(2.0);
 }
 
-.div {
-  display: flex;
+.topSourcesContainer {
+  display: block;
   border-style: solid;
   border-width: 1px;
   border-color: #DDD;
@@ -22,8 +23,11 @@
 }
 
 .ul {
-   display: flex;
-   align-items: center;
-   list-style-type: none;
+  display: block;
+  align-items: center;
+  list-style-type: none;
 }
 
+.topSource {
+  margin: 10px;
+}

--- a/static/js/components/TopSources.jsx
+++ b/static/js/components/TopSources.jsx
@@ -19,7 +19,7 @@ const TopSources = () => {
   ) || defaultPrefs;
 
   return (
-      <div className={styles.topSourcesContainer}>
+    <div className={styles.topSourcesContainer}>
       <h2 style={{ display: "inline-block" }}>
         Top Sources
       </h2>
@@ -34,28 +34,28 @@ const TopSources = () => {
       <p>
         Displaying most-viewed sources
       </p>
-      <ul className={styles.ul}>
+      <ul className={styles.topSourceList}>
         {
           sourceViews.map(({ obj_id, views, public_url }) => (
             <li key={`topSources_${obj_id}_${views}`} className={styles.topSource}>
               <Link to={`/source/${obj_id}`}>
                 <img className={styles.stamp} src={public_url} alt={obj_id} />
               </Link>
-              <span>
+              <div>
+                &nbsp;
+                -&nbsp;
                 <Link to={`/source/${obj_id}`}>
-                  &nbsp;
-                  -&nbsp;
                   {obj_id}
                 </Link>
-              </span>
-              <span>
+              </div>
+              <div>
                 <em>
                   &nbsp;
                   -&nbsp;
                   {views}
                   &nbsp;view(s)
                 </em>
-              </span>
+              </div>
             </li>
           ))
         }

--- a/static/js/components/TopSources.jsx
+++ b/static/js/components/TopSources.jsx
@@ -32,10 +32,13 @@ const TopSources = () => {
       <p>
         Displaying most-viewed sources
       </p>
-      <ul>
+      <ul style={{ listStyleType: "none" }}>
         {
           sourceViews.map(({ obj_id, views, public_url }) => (
             <li key={`topSources_${obj_id}_${views}`}>
+              <span>
+                <img src={public_url} alt={obj_id} width="50%" height="50%" />
+              </span>
               <span>
                 <Link to={`/source/${obj_id}`}>
                   {obj_id}
@@ -48,9 +51,6 @@ const TopSources = () => {
                   {views}
                   &nbsp;view(s)
                 </em>
-              </span>
-              <span>
-                <img src={public_url} alt="" />
               </span>
             </li>
           ))

--- a/static/js/components/TopSources.jsx
+++ b/static/js/components/TopSources.jsx
@@ -5,6 +5,8 @@ import { Link } from 'react-router-dom';
 import * as profileActions from '../ducks/profile';
 import WidgetPrefsDialog from './WidgetPrefsDialog';
 
+import styles from "./TopSources.css";
+
 const defaultPrefs = {
   maxNumSources: "",
   sinceDaysAgo: ""
@@ -17,7 +19,7 @@ const TopSources = () => {
   ) || defaultPrefs;
 
   return (
-    <div style={{ border: "1px solid #DDD", padding: "10px" }}>
+    <div className={styles.div}>
       <h2 style={{ display: "inline-block" }}>
         Top Sources
       </h2>
@@ -32,15 +34,17 @@ const TopSources = () => {
       <p>
         Displaying most-viewed sources
       </p>
-      <ul style={{ listStyleType: "none" }}>
+      <ul className={styles.ul}>
         {
           sourceViews.map(({ obj_id, views, public_url }) => (
             <li key={`topSources_${obj_id}_${views}`}>
-              <span>
-                <img src={public_url} alt={obj_id} width="50%" height="50%" />
-              </span>
+              <Link to={`/source/${obj_id}`}>
+                <img className={styles.stamp} src={public_url} alt={obj_id} />
+              </Link>
               <span>
                 <Link to={`/source/${obj_id}`}>
+                  &nbsp;
+                  -&nbsp;
                   {obj_id}
                 </Link>
               </span>

--- a/static/js/components/TopSources.jsx
+++ b/static/js/components/TopSources.jsx
@@ -50,7 +50,7 @@ const TopSources = () => {
                 </em>
               </span>
               <span>
-                <img src={public_url} /> 
+                <img src={public_url} alt="" />
               </span>
             </li>
           ))

--- a/static/js/components/TopSources.jsx
+++ b/static/js/components/TopSources.jsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 
 import * as profileActions from '../ducks/profile';
 import WidgetPrefsDialog from './WidgetPrefsDialog';
+import ThumbnailList from './ThumbnailList';
 
 const defaultPrefs = {
   maxNumSources: "",
@@ -15,6 +16,8 @@ const TopSources = () => {
   const topSourcesPrefs = useSelector(
     (state) => state.profile.preferences.topSources
   ) || defaultPrefs;
+
+  console.log(sourceViews)
 
   return (
     <div style={{ border: "1px solid #DDD", padding: "10px" }}>
@@ -34,7 +37,7 @@ const TopSources = () => {
       </p>
       <ul>
         {
-          sourceViews.map(({ obj_id, views }) => (
+          sourceViews.map(({ obj_id, views, public_url }) => (
             <li key={`topSources_${obj_id}_${views}`}>
               <span>
                 <Link to={`/source/${obj_id}`}>
@@ -48,6 +51,13 @@ const TopSources = () => {
                   {views}
                   &nbsp;view(s)
                 </em>
+              </span>
+              <span>
+                &nbsp;
+                -&nbsp;
+                <img src={public_url} /> 
+                &nbsp;
+                -&nbsp;
               </span>
             </li>
           ))

--- a/static/js/components/TopSources.jsx
+++ b/static/js/components/TopSources.jsx
@@ -19,7 +19,7 @@ const TopSources = () => {
   ) || defaultPrefs;
 
   return (
-    <div className={styles.div}>
+      <div className={styles.topSourcesContainer}>
       <h2 style={{ display: "inline-block" }}>
         Top Sources
       </h2>
@@ -37,7 +37,7 @@ const TopSources = () => {
       <ul className={styles.ul}>
         {
           sourceViews.map(({ obj_id, views, public_url }) => (
-            <li key={`topSources_${obj_id}_${views}`}>
+            <li key={`topSources_${obj_id}_${views}`} className={styles.topSource}>
               <Link to={`/source/${obj_id}`}>
                 <img className={styles.stamp} src={public_url} alt={obj_id} />
               </Link>

--- a/static/js/components/TopSources.jsx
+++ b/static/js/components/TopSources.jsx
@@ -4,7 +4,6 @@ import { Link } from 'react-router-dom';
 
 import * as profileActions from '../ducks/profile';
 import WidgetPrefsDialog from './WidgetPrefsDialog';
-import ThumbnailList from './ThumbnailList';
 
 const defaultPrefs = {
   maxNumSources: "",
@@ -16,8 +15,6 @@ const TopSources = () => {
   const topSourcesPrefs = useSelector(
     (state) => state.profile.preferences.topSources
   ) || defaultPrefs;
-
-  console.log(sourceViews)
 
   return (
     <div style={{ border: "1px solid #DDD", padding: "10px" }}>
@@ -53,11 +50,7 @@ const TopSources = () => {
                 </em>
               </span>
               <span>
-                &nbsp;
-                -&nbsp;
                 <img src={public_url} /> 
-                &nbsp;
-                -&nbsp;
               </span>
             </li>
           ))


### PR DESCRIPTION
This PR adds detection images to the top sources widget.

![image](https://user-images.githubusercontent.com/2291947/89359239-f4da4e80-d68a-11ea-8d4f-8f6f3902f1c4.png)
