### PR TITLE
remove GroupTelescopes in preparation for Allocations model

### DIFF
--- a/data/db_demo.yaml
+++ b/data/db_demo.yaml
@@ -44,9 +44,6 @@ telescope:
     diameter: 1.5
     robotic: true
     skycam_link: http://bianca.palomar.caltech.edu/images/allsky/AllSkyCurrentImage.JPG
-    group_ids:
-      - =public_group_id
-      - =program_A
     =id: P60
   - name: Nordic Optical Telescope
     nickname: NOT
@@ -56,9 +53,6 @@ telescope:
     elevation: 2000
     diameter: 2.56
     skycam_link: http://catserver.ing.iac.es/weather/archive/concam/concam_labels.png
-    group_ids:
-      - =public_group_id
-      - =program_A
     =id: NOT
   - diameter: 10.0
     elevation: 4160.0
@@ -68,8 +62,6 @@ telescope:
     nickname: Keck2
     skycam_link: http://kree.ifa.hawaii.edu/allsky/allsky_last.png
     robotic: false
-    group_ids:
-      - =program_A
     =id: Keck2
   - name: Keck I Telescope
     nickname: Keck1
@@ -79,8 +71,6 @@ telescope:
     diameter: 2.56
     skycam_link: http://catserver.ing.iac.es/weather/archive/concam/concam_labels.png
     robotic: false
-    group_ids:
-      - =program_A
     =id: Keck1
 
 instrument:

--- a/data/telescopes.yaml
+++ b/data/telescopes.yaml
@@ -5,7 +5,6 @@
   nickname: Hobby-Eberly Telescope
   name: HET
   skycam_link: null
-  group_ids: [=public_group_id]
   =id: HET
 - diameter: 1.3
   elevation: 2340.0
@@ -14,7 +13,6 @@
   nickname: Peters Automated Infrared Imaging Telescope
   name: PTEL
   skycam_link: null
-  group_ids: [=public_group_id]
   =id: PTEL
   robotic: true
 - diameter: 8.0
@@ -24,7 +22,6 @@
   nickname: Gemini South
   name: GS
   skycam_link: null
-  group_ids: [=public_group_id]
   =id: GS
 - diameter: 3.5799999
   elevation: 2396.0
@@ -33,7 +30,6 @@
   nickname: Telescopio Nazionale Galileo
   name: TNG
   skycam_link: null
-  group_ids: [=public_group_id]
   =id: TNG
 - diameter: 4.0
   elevation: 7079.0
@@ -42,7 +38,6 @@
   nickname: Kitt Peak 4m
   name: KPNO4m
   skycam_link: null
-  group_ids: [=public_group_id]
   =id: KPNO4m
 - diameter: 3.0
   elevation: 1283.0
@@ -51,7 +46,6 @@
   nickname: Lick 3-m
   name: Lick 3-m
   skycam_link: null
-  group_ids: [=public_group_id]
   =id: Lick 3-m
 - diameter: 4.1999998
   elevation: 2332.0
@@ -60,7 +54,6 @@
   nickname: WHT 4.2m
   name: WHT
   skycam_link: null
-  group_ids: [=public_group_id]
   =id: WHT
 - diameter: 2.1600001
   elevation: 950.0
@@ -69,7 +62,6 @@
   nickname: Xinglong 2.16m
   name: XL216
   skycam_link: null
-  group_ids: [=public_group_id]
   =id: XL216
 - diameter: 0.46000001
   elevation: 875.0
@@ -79,7 +71,6 @@
   nickname: C18
   skycam_link: null
   robotic: true
-  group_ids: [=public_group_id]
   =id: C18
 - diameter: 2.5
   elevation: 2336.0
@@ -88,7 +79,6 @@
   nickname: INT
   name: INT
   skycam_link: null
-  group_ids: [=public_group_id]
   =id: INT
 - diameter: 2.0
   elevation: 2363.0
@@ -97,7 +87,6 @@
   nickname: Liverpool Telescope
   name: LT
   skycam_link: null
-  group_ids: [=public_group_id]
   =id: LT
   robotic: true
 - diameter: 10.4
@@ -107,7 +96,6 @@
   nickname: Gran Telescopio Canarias 10.4 m
   name: GTC
   skycam_link: null
-  group_ids: [=public_group_id]
   =id: GTC
 - diameter: 2.0
   elevation: 3055.0
@@ -116,7 +104,6 @@
   nickname: Faulkes Telescope North
   name: FTN
   skycam_link: null
-  group_ids: [=public_group_id]
   =id: FTN
 - diameter: 2.0
   elevation: 1116.0
@@ -125,7 +112,6 @@
   nickname: Faulkes Telescope South
   name: FTS
   skycam_link: null
-  group_ids: [=public_group_id]
   =id: FTS
 - diameter: 1.0
   elevation: 1859.0
@@ -134,7 +120,6 @@
   nickname: MLO 1m
   name: MLO
   skycam_link: null
-  group_ids: [=public_group_id]
   =id: MLO
 - diameter: 2.0
   elevation: 1000.0
@@ -143,7 +128,6 @@
   nickname: IUCAA Girawali Observatory
   name: IGO
   skycam_link: null
-  group_ids: [=public_group_id]
   =id: IGO
 - diameter: 2.0
   elevation: 4500.0
@@ -152,7 +136,6 @@
   nickname: Himalyan Chandra Telescope
   name: HCT
   skycam_link: null
-  group_ids: [=public_group_id]
   =id: HCT
 - diameter: 1.5
   elevation: 2790.0
@@ -161,7 +144,6 @@
   nickname: San Pedro Martir 1.5m
   name: SPM15
   skycam_link: null
-  group_ids: [=public_group_id]
   =id: SPM15
 - diameter: 2.4000001
   elevation: 1938.5
@@ -170,7 +152,6 @@
   nickname: MDM 2.4m Hiltner
   name: MDM24
   skycam_link: null
-  group_ids: [=public_group_id]
   =id: MDM24
 - diameter: 9.8000002
   elevation: 1798.0
@@ -179,7 +160,6 @@
   nickname: South African Large Telescope
   name: SALT
   skycam_link: null
-  group_ids: [=public_group_id]
   =id: SALT
 - diameter: 1.0
   elevation: 2070.0
@@ -188,7 +168,6 @@
   nickname: LCOGT 1m Network
   name: LCOGT1m
   skycam_link: null
-  group_ids: [=public_group_id]
   robotic: true
   =id: LCOGT1m
 - diameter: 2.5
@@ -198,7 +177,6 @@
   nickname: du Pont 2.5m
   name: DUP
   skycam_link: null
-  group_ids: [=public_group_id]
   =id: DUP
 - diameter: 1.0
   elevation: 2282.0
@@ -207,7 +185,6 @@
   nickname: Swope 1m
   name: Swope
   skycam_link: null
-  group_ids: [=public_group_id]
   =id: Swope
 - diameter: 1.0
   elevation: 2080.0
@@ -216,7 +193,6 @@
   nickname: Nanshan 1m
   name: Nanshan 1m
   skycam_link: null
-  group_ids: [=public_group_id]
   =id: Nanshan 1m
 - diameter: 4.3000002
   elevation: 2337.0
@@ -225,7 +201,6 @@
   nickname: Discovery Channel Telescope
   name: DCT
   skycam_link: null
-  group_ids: [=public_group_id]
   =id: DCT
 - diameter: 1.23
   elevation: 2168.0
@@ -234,7 +209,6 @@
   nickname: Calar Alto 1.2m
   name: CAHA 1.2m
   skycam_link: null
-  group_ids: [=public_group_id]
   =id: CAHA 1.2m
 - diameter: 1.8200001
   elevation: 1366.0
@@ -243,7 +217,6 @@
   nickname: Ekar 1.82m
   name: Ekar
   skycam_link: null
-  group_ids: [=public_group_id]
   =id: Ekar
 - diameter: 1.8
   elevation: 4215.0
@@ -252,7 +225,6 @@
   nickname: PAN-STARRS 1.8m
   name: PS1
   skycam_link: null
-  group_ids: [=public_group_id]
   =id: PS1
 - diameter: 1.3
   elevation: 2450.0
@@ -261,7 +233,6 @@
   nickname: ARIES 1.3m Devasthal Fast Optical Telescope
   name: DFOT
   skycam_link: null
-  group_ids: [=public_group_id]
   =id: DFOT
 - diameter: 2.5
   elevation: 2788.0
@@ -270,7 +241,6 @@
   nickname: SDSS 2.5-M
   name: SDSS2.5m
   skycam_link: null
-  group_ids: [=public_group_id]
   =id: SDSS2.5m
 - diameter: 3.5799999
   elevation: 2375.0
@@ -279,7 +249,6 @@
   nickname: New Technology Telescope
   name: NTT
   skycam_link: null
-  group_ids: [=public_group_id]
   =id: NTT
 - diameter: 1.2
   elevation: 1870.0
@@ -288,7 +257,6 @@
   nickname: Palomar 1.2m Oschin
   name: P48
   skycam_link: http://bianca.palomar.caltech.edu/images/allsky/AllSkyCurrentImage.JPG
-  group_ids: [=public_group_id]
   =id: P48
   robotic: true
 - diameter: 10.0
@@ -298,7 +266,6 @@
   nickname: Keck II 10m
   name: Keck2
   skycam_link: http://kree.ifa.hawaii.edu/allsky/allsky_last.png
-  group_ids: [=public_group_id]
   =id: Keck2
 - diameter: 8.1999998
   elevation: 4139.0
@@ -307,7 +274,6 @@
   nickname: Subaru FOCAS
   name: Subaru FOCAS
   skycam_link: http://kree.ifa.hawaii.edu/allsky/allsky_last.png
-  group_ids: [=public_group_id]
   =id: Subaru FOCAS
 - diameter: 8.1000004
   elevation: 4213.0
@@ -316,7 +282,6 @@
   nickname: Gemini North
   name: Gemini N
   skycam_link: http://kree.ifa.hawaii.edu/allsky/allsky_last.png
-  group_ids: [=public_group_id]
   =id: Gemini N
 - diameter: 2.2
   elevation: 4123.0
@@ -325,7 +290,6 @@
   nickname: UH 2.2-m
   name: SNIFS
   skycam_link: http://kree.ifa.hawaii.edu/allsky/allsky_last.png
-  group_ids: [=public_group_id]
   =id: SNIFS
 - diameter: 1.5
   elevation: 1870.0
@@ -334,7 +298,6 @@
   nickname: Palomar 1.5m
   name: P60
   skycam_link: http://bianca.palomar.caltech.edu/images/allsky/AllSkyCurrentImage.JPG
-  group_ids: [=public_group_id]
   =id: P60
   robotic: true
 - diameter: 5.0999999
@@ -344,7 +307,6 @@
   nickname: Palomar 5.1m Hale
   name: P200
   skycam_link: http://bianca.palomar.caltech.edu/images/allsky/AllSkyCurrentImage.JPG
-  group_ids: [=public_group_id]
   =id: P200
 - diameter: 0.5
   elevation: 900.0
@@ -353,7 +315,6 @@
   nickname: Akeno MITSuME
   name: Akeno
   skycam_link: http://sncwall.hp.phys.titech.ac.jp:2388/monitor/skymon_s.jpg
-  group_ids: [=public_group_id]
   =id: Akeno
 - diameter: 1.0
   elevation: 2862.0
@@ -362,7 +323,6 @@
   nickname: Lulin
   name: LOT
   skycam_link: http://www.lulin.ncu.edu.tw/wea/cur_sky.jpg
-  group_ids: [=public_group_id]
   =id: LOT
 - diameter: 2.2
   elevation: 4213.5601
@@ -371,7 +331,6 @@
   nickname: UH 88inch
   name: UH88
   skycam_link: null
-  group_ids: [=public_group_id]
   =id: UH88
 - diameter: 10.0
   elevation: 4160.0
@@ -380,7 +339,6 @@
   nickname: Keck I 10m
   name: Keck1
   skycam_link: http://kree.ifa.hawaii.edu/allsky/allsky_last.png
-  group_ids: [=public_group_id]
   =id: Keck1
 - diameter: 1.0
   elevation: 1.0
@@ -389,7 +347,6 @@
   nickname: Swift
   name: Swift
   skycam_link: null
-  group_ids: [=public_group_id]
   =id: Swift
 - diameter: 3.5
   elevation: 2788.0
@@ -398,7 +355,6 @@
   nickname: Apache Point 3.5m
   name: APO
   skycam_link: null
-  group_ids: [=public_group_id]
   =id: APO
 - diameter: 2.5599999
   elevation: 2327.0
@@ -407,7 +363,6 @@
   nickname: Nordic Optical Telescope
   name: NOT
   skycam_link: http://catserver.ing.iac.es/weather/archive/concam/concam_labels.png
-  group_ids: [=public_group_id]
   =id: NOT
   robotic: true
 - diameter: 4.0
@@ -417,7 +372,6 @@
   nickname: CTIO Victor M. Blanco 4-meter Telescope
   name: CTIO-4m
   skycam_link: null
-  group_ids: [=public_group_id]
   =id: CTIO-4m
 - diameter: 8.0
   elevation: 2648.0
@@ -426,7 +380,6 @@
   nickname: VLT
   name: VLT
   skycam_link: null
-  group_ids: [=public_group_id]
   =id: VLT
 - diameter: 6.5
   elevation: 2282.0
@@ -435,7 +388,6 @@
   nickname: Magellan_Baade
   name: Magellan_Baade
   skycam_link: null
-  group_ids: [=public_group_id]
   =id: Magellan_Baade
 - diameter: 4.0999999
   elevation: 2518.0
@@ -444,7 +396,6 @@
   nickname: VISTA
   name: VISTA
   skycam_link: null
-  group_ids: [=public_group_id]
   =id: VISTA
 - diameter: 6.5
   elevation: 2282.0
@@ -453,7 +404,6 @@
   nickname: Magellan_Clay
   name: Magellan_Clay
   skycam_link: null
-  group_ids: [=public_group_id]
   =id: Magellan_Clay
 - diameter: 2.4000001
   elevation: null
@@ -462,7 +412,6 @@
   nickname: Hubble Space Telescope
   name: HST
   skycam_link: null
-  group_ids: [=public_group_id]
   =id: HST
 - diameter: 1.4
   elevation: 1798.0
@@ -471,7 +420,6 @@
   nickname: Infrared Survey Facility
   name: IRSF
   skycam_link: null
-  group_ids: [=public_group_id]
   =id: IRSF
 - diameter: 1.6
   elevation: 0.0
@@ -480,7 +428,6 @@
   nickname: Korea Microlensing Telescope Network
   name: KMTNet
   skycam_link: null
-  group_ids: [=public_group_id]
   =id: KMTNet
 - diameter: 0.40000001
   elevation: 1760.0
@@ -489,7 +436,6 @@
   nickname: MASTER-SAAO
   name: MASTER-SAAO
   skycam_link: null
-  group_ids: [=public_group_id]
   =id: MASTER-SAAO
   robotic: true
 - diameter: 0.41
@@ -499,7 +445,6 @@
   nickname: PROMPT5
   name: PROMPT5
   skycam_link: null
-  group_ids: [=public_group_id]
   =id: PROMPT5
 - diameter: 2.3
   elevation: 1165.0
@@ -508,7 +453,6 @@
   nickname: Siding Spring Observatory
   name: SSO
   skycam_link: null
-  group_ids: [=public_group_id]
   =id: SSO
 - diameter: 1.35
   elevation: 1163.0
@@ -517,7 +461,6 @@
   nickname: Skymapper
   name: Skymapper
   skycam_link: null
-  group_ids: [=public_group_id]
   =id: Skymapper
 - diameter: 6.6999998
   elevation: 50.0
@@ -526,7 +469,6 @@
   nickname: Zadko
   name: Zadko
   skycam_link: null
-  group_ids: [=public_group_id]
   =id: Zadko
 - diameter: 1.3
   elevation: 2207.0
@@ -535,7 +477,6 @@
   nickname: CTIO 1.3m
   name: CTIO-1.3m
   skycam_link: null
-  group_ids: [=public_group_id]
   =id: CTIO-1.3m
 - diameter: 2.2
   elevation: 2375.0
@@ -544,7 +485,6 @@
   nickname: MPI_ESO-2.2m
   name: MPI_ESO-2.2m
   skycam_link: null
-  group_ids: [=public_group_id]
   =id: MPI_ESO-2.2m
 - diameter: 1.5
   elevation: 267.0
@@ -553,5 +493,4 @@
   nickname: China Near Earth Object Survey Telescope
   name: CNEOST
   skycam_link: null
-  group_ids: [=public_group_id]
   =id: CNEOST

--- a/skyportal/handlers/api/instrument.py
+++ b/skyportal/handlers/api/instrument.py
@@ -1,7 +1,7 @@
 from marshmallow.exceptions import ValidationError
 from baselayer.app.access import permissions, auth_or_token
 from ..base import BaseHandler
-from ...models import DBSession, Instrument, Telescope, GroupTelescope
+from ...models import DBSession, Instrument, Telescope
 from ...enum_types import ALLOWED_BANDPASSES
 
 
@@ -13,7 +13,7 @@ class InstrumentHandler(BaseHandler):
 
         data = self.get_json()
         telescope_id = data.get('telescope_id')
-        telescope = Telescope.get_if_owned_by(telescope_id, self.current_user)
+        telescope = Telescope.query.get(telescope_id)
         if not telescope:
             return self.error('Invalid telescope ID.')
 
@@ -74,16 +74,10 @@ class InstrumentHandler(BaseHandler):
             if instrument is None:
                 return self.error(f"Could not load instrument {instrument_id}",
                                   data={"instrument_id": instrument_id})
-            # Ensure permissions to parent telescope
-            _ = Telescope.get_if_owned_by(instrument.telescope_id,
-                                          self.current_user)
             return self.success(data=instrument)
 
         inst_name = self.get_query_argument("name", None)
-        query = Instrument.query.filter(Instrument.telescope_id.in_(
-            DBSession().query(GroupTelescope.telescope_id).filter(GroupTelescope.group_id.in_(
-                [g.id for g in self.current_user.accessible_groups]
-            ))))
+        query = Instrument.query
         if inst_name is not None:
             query = query.filter(Instrument.name == inst_name)
         return self.success(data=query.all())
@@ -113,9 +107,6 @@ class InstrumentHandler(BaseHandler):
               application/json:
                 schema: Error
         """
-        instrument = Instrument.query.get(int(instrument_id))
-        _ = Telescope.get_if_owned_by(instrument.telescope_id,
-                                      self.current_user)
         data = self.get_json()
         data['id'] = int(instrument_id)
 
@@ -150,9 +141,6 @@ class InstrumentHandler(BaseHandler):
               application/json:
                 schema: Error
         """
-        instrument = Instrument.query.get(int(instrument_id))
-        _ = Telescope.get_if_owned_by(instrument.telescope_id,
-                                      self.current_user)
         DBSession().query(Instrument).filter(Instrument.id == int(instrument_id)).delete()
         DBSession().commit()
 

--- a/skyportal/handlers/api/telescope.py
+++ b/skyportal/handlers/api/telescope.py
@@ -1,7 +1,7 @@
 from marshmallow.exceptions import ValidationError
 from baselayer.app.access import permissions, auth_or_token
 from ..base import BaseHandler
-from ...models import DBSession, Telescope, Group, GroupTelescope
+from ...models import DBSession, Telescope
 
 
 class TelescopeHandler(BaseHandler):
@@ -13,18 +13,7 @@ class TelescopeHandler(BaseHandler):
         requestBody:
           content:
             application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/TelescopeNoID'
-                  - type: object
-                    properties:
-                      group_ids:
-                        type: array
-                        items:
-                          type: integer
-                        description: List of group IDs to associate the telescope with
-                    required:
-                      - group_ids
+              schema: TelescopeNoID
         responses:
           200:
             content:
@@ -46,12 +35,6 @@ class TelescopeHandler(BaseHandler):
                 schema: Error
         """
         data = self.get_json()
-        group_ids = data.pop('group_ids')
-        groups = [g for g in Group.query.filter(Group.id.in_(group_ids)).all()
-                  if g in self.current_user.accessible_groups]
-        if not groups:
-            return self.error('You must specify at least one group of which you '
-                              'are a member.')
         schema = Telescope.__schema__()
 
         try:
@@ -59,7 +42,6 @@ class TelescopeHandler(BaseHandler):
         except ValidationError as e:
             return self.error('Invalid/missing parameters: '
                               f'{e.normalized_messages()}')
-        telescope.groups = groups
         DBSession().add(telescope)
         DBSession().commit()
 
@@ -105,15 +87,12 @@ class TelescopeHandler(BaseHandler):
                   schema: Error
         """
         if telescope_id is not None:
-            t = Telescope.get_if_owned_by(int(telescope_id), self.current_user)
+            t = Telescope.query.get(int(telescope_id))
             if t is None:
                 return self.error(f"Could not load telescope with ID {telescope_id}")
             return self.success(data=t)
         tel_name = self.get_query_argument("name", None)
-        query = Telescope.query.filter(Telescope.id.in_(
-            DBSession().query(GroupTelescope.telescope_id).filter(GroupTelescope.group_id.in_(
-                [g.id for g in self.current_user.accessible_groups]
-            ))))
+        query = Telescope.query
         if tel_name is not None:
             query = query.filter(Telescope.name == tel_name)
         return self.success(data=query.all())
@@ -143,7 +122,9 @@ class TelescopeHandler(BaseHandler):
               application/json:
                 schema: Error
         """
-        _ = Telescope.get_if_owned_by(int(telescope_id), self.current_user)
+        t = Telescope.query.get(int(telescope_id))
+        if t is None:
+            return self.error('Invalid telescope ID.')
         data = self.get_json()
         data['id'] = int(telescope_id)
 
@@ -178,7 +159,10 @@ class TelescopeHandler(BaseHandler):
               application/json:
                 schema: Error
         """
-        t = Telescope.get_if_owned_by(int(telescope_id), self.current_user)
+        t = Telescope.query.get(int(telescope_id))
+        if t is None:
+            return self.error('Invalid telescope ID.')
+
         DBSession().query(Telescope).filter(Telescope.id == int(telescope_id)).delete()
         DBSession().commit()
 

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -75,8 +75,6 @@ class Group(Base):
     streams = relationship('Stream', secondary='stream_groups',
                            back_populates='groups',
                            passive_deletes=True)
-    telescopes = relationship('Telescope', secondary='group_telescopes',
-                              passive_deletes=True)
     users = relationship('User', secondary='group_users',
                          back_populates='groups',
                          passive_deletes=True)
@@ -474,8 +472,6 @@ class Telescope(Base):
     robotic = sa.Column(sa.Boolean, default=False, nullable=False,
                         doc="Is this telescope robotic?")
 
-    groups = relationship('Group', secondary='group_telescopes',
-                          passive_deletes=True)
     instruments = relationship('Instrument', back_populates='telescope',
                                cascade='save-update, merge, refresh-expire, expunge',
                                passive_deletes=True)
@@ -488,10 +484,6 @@ class Telescope(Base):
                                   latitude=self.lat * u.deg,
                                   elevation=self.elevation * u.m,
                                   timezone=local_tz)
-
-
-
-GroupTelescope = join_model('group_telescopes', Group, Telescope)
 
 
 class ArrayOfEnum(ARRAY):

--- a/skyportal/tests/api/test_instrument.py
+++ b/skyportal/tests/api/test_instrument.py
@@ -3,7 +3,7 @@ from skyportal.tests import api
 from skyportal.models import Telescope, Instrument, DBSession
 
 
-def test_token_user_post_get_instrument(super_admin_token, public_group):
+def test_token_user_post_get_instrument(super_admin_token):
     name = str(uuid.uuid4())
     status, data = api('POST', 'telescope',
                        data={'name': name,
@@ -12,7 +12,6 @@ def test_token_user_post_get_instrument(super_admin_token, public_group):
                              'lon': 0.0,
                              'elevation': 0.0,
                              'diameter': 10.0,
-                             'group_ids': [public_group.id]
                              },
                        token=super_admin_token)
     assert status == 200
@@ -41,7 +40,7 @@ def test_token_user_post_get_instrument(super_admin_token, public_group):
     assert data['data']['band'] == 'NIR'
 
 
-def test_fetch_instrument_by_name(super_admin_token, public_group):
+def test_fetch_instrument_by_name(super_admin_token):
     tel_name = str(uuid.uuid4())
     status, data = api('POST', 'telescope',
                        data={'name': tel_name,
@@ -50,7 +49,6 @@ def test_fetch_instrument_by_name(super_admin_token, public_group):
                              'lon': 0.0,
                              'elevation': 0.0,
                              'diameter': 10.0,
-                             'group_ids': [public_group.id]
                              },
                        token=super_admin_token)
     assert status == 200
@@ -82,7 +80,7 @@ def test_fetch_instrument_by_name(super_admin_token, public_group):
 
 
 def test_token_user_update_instrument(super_admin_token, manage_sources_token,
-                                      view_only_token, public_group):
+                                      view_only_token):
     name = str(uuid.uuid4())
     status, data = api('POST', 'telescope',
                        data={'name': name,
@@ -91,7 +89,6 @@ def test_token_user_update_instrument(super_admin_token, manage_sources_token,
                              'lon': 0.0,
                              'elevation': 0.0,
                              'diameter': 10.0,
-                             'group_ids': [public_group.id]
                              },
                        token=super_admin_token)
     assert status == 200
@@ -156,8 +153,7 @@ def test_token_user_update_instrument(super_admin_token, manage_sources_token,
     assert data['data']['name'] == new_name
 
 
-def test_token_user_delete_instrument(super_admin_token, view_only_token,
-                                      public_group):
+def test_token_user_delete_instrument(super_admin_token, view_only_token):
     name = str(uuid.uuid4())
     status, data = api('POST', 'telescope',
                        data={'name': name,
@@ -166,7 +162,6 @@ def test_token_user_delete_instrument(super_admin_token, view_only_token,
                              'lon': 0.0,
                              'elevation': 0.0,
                              'diameter': 10.0,
-                             'group_ids': [public_group.id]
                              },
                        token=super_admin_token)
     assert status == 200

--- a/skyportal/tests/api/test_telescope.py
+++ b/skyportal/tests/api/test_telescope.py
@@ -3,7 +3,7 @@ from skyportal.tests import api
 from skyportal.models import Telescope, DBSession
 
 
-def test_token_user_post_get_telescope(upload_data_token, public_group):
+def test_token_user_post_get_telescope(upload_data_token):
     name = str(uuid.uuid4())
     post_data = {'name': name,
                  'nickname': name,
@@ -11,7 +11,6 @@ def test_token_user_post_get_telescope(upload_data_token, public_group):
                  'lon': 0.0,
                  'elevation': 0.0,
                  'diameter': 10.0,
-                 'group_ids': [public_group.id],
                  'skycam_link': 'http://www.lulin.ncu.edu.tw/wea/cur_sky.jpg',
                  'robotic': True
                  }
@@ -30,11 +29,10 @@ def test_token_user_post_get_telescope(upload_data_token, public_group):
     assert status == 200
     assert data['status'] == 'success'
     for key in post_data:
-        if key != 'group_ids':
-            assert data['data'][key] == post_data[key]
+        assert data['data'][key] == post_data[key]
 
 
-def test_fetch_telescope_by_name(upload_data_token, public_group):
+def test_fetch_telescope_by_name(upload_data_token):
     name = str(uuid.uuid4())
     post_data = {'name': name,
                  'nickname': name,
@@ -42,7 +40,6 @@ def test_fetch_telescope_by_name(upload_data_token, public_group):
                  'lon': 0.0,
                  'elevation': 0.0,
                  'diameter': 10.0,
-                 'group_ids': [public_group.id],
                  'skycam_link': 'http://www.lulin.ncu.edu.tw/wea/cur_sky.jpg'
                  }
 
@@ -52,7 +49,6 @@ def test_fetch_telescope_by_name(upload_data_token, public_group):
     assert status == 200
     assert data['status'] == 'success'
 
-    telescope_id = data['data']['id']
     status, data = api(
         'GET',
         f'telescope?name={name}',
@@ -61,12 +57,10 @@ def test_fetch_telescope_by_name(upload_data_token, public_group):
     assert data['status'] == 'success'
     assert len(data['data']) == 1
     for key in post_data:
-        if key != 'group_ids':
-            assert data['data'][0][key] == post_data[key]
+        assert data['data'][0][key] == post_data[key]
 
 
-def test_token_user_update_telescope(upload_data_token, manage_sources_token,
-                                     public_group):
+def test_token_user_update_telescope(upload_data_token, manage_sources_token):
     name = str(uuid.uuid4())
     status, data = api('POST', 'telescope',
                        data={'name': name,
@@ -75,7 +69,6 @@ def test_token_user_update_telescope(upload_data_token, manage_sources_token,
                              'lon': 0.0,
                              'elevation': 0.0,
                              'diameter': 10.0,
-                             'group_ids': [public_group.id],
                              'robotic': True
                              },
                        token=upload_data_token)
@@ -114,8 +107,7 @@ def test_token_user_update_telescope(upload_data_token, manage_sources_token,
     assert data['data']['diameter'] == 12.0
 
 
-def test_token_user_delete_telescope(upload_data_token, manage_sources_token,
-                                     public_group):
+def test_token_user_delete_telescope(upload_data_token, manage_sources_token):
     name = str(uuid.uuid4())
     status, data = api('POST', 'telescope',
                        data={'name': name,
@@ -124,7 +116,6 @@ def test_token_user_delete_telescope(upload_data_token, manage_sources_token,
                              'lon': 0.0,
                              'elevation': 0.0,
                              'diameter': 10.0,
-                             'group_ids': [public_group.id],
                              'robotic': False
                              },
                        token=upload_data_token)

--- a/skyportal/tests/frontend/test_followup_requests.py
+++ b/skyportal/tests/frontend/test_followup_requests.py
@@ -7,7 +7,7 @@ from selenium.common.exceptions import (ElementClickInterceptedException,
 from skyportal.tests import api
 
 
-def add_telescope_and_instrument(instrument_name, group_ids, token):
+def add_telescope_and_instrument(instrument_name, token):
     status, data = api("GET", f"instrument?name={instrument_name}", token=token)
     if len(data["data"]) == 1:
         return data["data"][0]
@@ -23,7 +23,6 @@ def add_telescope_and_instrument(instrument_name, group_ids, token):
             "lon": 0.0,
             "elevation": 0.0,
             "diameter": 10.0,
-            "group_ids": group_ids,
             "robotic": True
         },
         token=token,
@@ -51,9 +50,9 @@ def add_telescope_and_instrument(instrument_name, group_ids, token):
 
 @pytest.mark.flaky(reruns=2)
 def test_submit_new_followup_request(
-    driver, super_admin_user, public_source, public_group, super_admin_token
+    driver, super_admin_user, public_source, super_admin_token
 ):
-    add_telescope_and_instrument("P60 Camera", [public_group.id], super_admin_token)
+    add_telescope_and_instrument("P60 Camera", super_admin_token)
     driver.get(f"/become_user/{super_admin_user.id}")
     driver.get(f"/source/{public_source.id}")
     instrument_select = driver.wait_for_xpath(
@@ -99,9 +98,9 @@ def test_submit_new_followup_request(
 
 @pytest.mark.flaky(reruns=2)
 def test_edit_existing_followup_request(
-    driver, super_admin_user, public_source, public_group, super_admin_token
+    driver, super_admin_user, public_source, super_admin_token
 ):
-    add_telescope_and_instrument("P60 Camera", [public_group.id], super_admin_token)
+    add_telescope_and_instrument("P60 Camera", super_admin_token)
 
     driver.get(f"/become_user/{super_admin_user.id}")
     driver.get(f"/source/{public_source.id}")
@@ -158,9 +157,9 @@ def test_edit_existing_followup_request(
 
 @pytest.mark.flaky(reruns=2)
 def test_delete_followup_request(
-    driver, super_admin_user, public_source, public_group, super_admin_token
+    driver, super_admin_user, public_source, super_admin_token
 ):
-    add_telescope_and_instrument("P60 Camera", [public_group.id], super_admin_token)
+    add_telescope_and_instrument("P60 Camera", super_admin_token)
 
     driver.get(f"/become_user/{super_admin_user.id}")
     driver.get(f"/source/{public_source.id}")
@@ -211,9 +210,9 @@ def test_delete_followup_request(
 
 @pytest.mark.flaky(reruns=2)
 def test_cannot_edit_uneditable_followup_request(
-    driver, super_admin_user, public_source, public_group, super_admin_token
+    driver, super_admin_user, public_source, super_admin_token
 ):
-    add_telescope_and_instrument("ALFOSC", [public_group.id], super_admin_token)
+    add_telescope_and_instrument("ALFOSC", super_admin_token)
 
     driver.get(f"/become_user/{super_admin_user.id}")
     driver.get(f"/source/{public_source.id}")

--- a/skyportal/tests/frontend/test_upload_photometry.py
+++ b/skyportal/tests/frontend/test_upload_photometry.py
@@ -1,5 +1,6 @@
 import pytest
 from selenium.common.exceptions import ElementClickInterceptedException
+import time
 
 from skyportal.tests import api
 
@@ -8,10 +9,10 @@ from .test_followup_requests import add_telescope_and_instrument
 
 @pytest.mark.flaky(reruns=2)
 def test_upload_photometry(
-    driver, super_admin_user, public_group, public_source, super_admin_token
+    driver, super_admin_user, public_source, super_admin_token, public_group
 ):
     data = add_telescope_and_instrument(
-        "P60 Camera", [public_group.id], super_admin_token
+        "P60 Camera", super_admin_token
     )
     inst_id = data["id"]
     driver.get(f"/become_user/{super_admin_user.id}")
@@ -26,9 +27,11 @@ def test_upload_photometry(
     driver.wait_for_xpath_to_be_clickable(
         f'//span[text()="P60 Camera (ID: {inst_id})"]'
     ).click()
+    driver.wait_for_xpath_to_be_clickable('//body').click()
     try:
         driver.wait_for_xpath_to_be_clickable('//div[@id="selectGroups"]').click()
     except ElementClickInterceptedException:
+        # time.sleep(3)
         try:
             driver.wait_for_xpath_to_be_clickable('//div[@id="selectGroups"]').click()
         except ElementClickInterceptedException:
@@ -59,7 +62,7 @@ def test_upload_photometry_multiple_groups(
     user = super_admin_user_two_groups
     public_source = public_source_two_groups
     data = add_telescope_and_instrument(
-        "P60 Camera", [public_group.id], super_admin_token
+        "P60 Camera", super_admin_token
     )
     inst_id = data["id"]
     driver.get(f"/become_user/{user.id}")
@@ -72,9 +75,11 @@ def test_upload_photometry_multiple_groups(
     )
     driver.wait_for_xpath('//*[@id="mui-component-select-instrumentID"]').click()
     driver.wait_for_xpath(f'//span[text()="P60 Camera (ID: {inst_id})"]').click()
+    driver.wait_for_xpath_to_be_clickable('//body').click()
     try:
         driver.wait_for_xpath_to_be_clickable('//div[@id="selectGroups"]').click()
     except ElementClickInterceptedException:
+        # time.sleep(3)
         try:
             driver.wait_for_xpath_to_be_clickable('//div[@id="selectGroups"]').click()
         except ElementClickInterceptedException:
@@ -98,10 +103,10 @@ def test_upload_photometry_multiple_groups(
 
 @pytest.mark.flaky(reruns=2)
 def test_upload_photometry_with_altdata(
-    driver, super_admin_user, public_group, public_source, super_admin_token
+    driver, super_admin_user, public_source, super_admin_token, public_group
 ):
     data = add_telescope_and_instrument(
-        "P60 Camera", [public_group.id], super_admin_token
+        "P60 Camera", super_admin_token
     )
     inst_id = data["id"]
     driver.get(f"/become_user/{super_admin_user.id}")
@@ -114,9 +119,11 @@ def test_upload_photometry_with_altdata(
     )
     driver.wait_for_xpath('//*[@id="mui-component-select-instrumentID"]').click()
     driver.wait_for_xpath(f'//span[text()="P60 Camera (ID: {inst_id})"]').click()
+    driver.wait_for_xpath_to_be_clickable('//body').click()
     try:
         driver.wait_for_xpath_to_be_clickable('//div[@id="selectGroups"]').click()
     except ElementClickInterceptedException:
+        # time.sleep(3)
         try:
             driver.wait_for_xpath_to_be_clickable('//div[@id="selectGroups"]').click()
         except ElementClickInterceptedException:
@@ -137,10 +144,10 @@ def test_upload_photometry_with_altdata(
 
 @pytest.mark.flaky(reruns=2)
 def test_upload_photometry_form_validation(
-    driver, super_admin_user, public_group, public_source, super_admin_token
+    driver, super_admin_user, public_source, super_admin_token, public_group
 ):
     data = add_telescope_and_instrument(
-        "P60 Camera", [public_group.id], super_admin_token
+        "P60 Camera", super_admin_token
     )
     inst_id = data["id"]
     driver.get(f"/become_user/{super_admin_user.id}")
@@ -179,9 +186,11 @@ def test_upload_photometry_form_validation(
     driver.wait_for_xpath('//*[@id="mui-component-select-instrumentID"]').click()
     driver.wait_for_xpath(f'//span[text()="P60 Camera (ID: {inst_id})"]').click()
     driver.wait_for_xpath('//div[contains(.,"Select at least one group")]')
+    driver.wait_for_xpath_to_be_clickable('//body').click()
     try:
         driver.wait_for_xpath_to_be_clickable('//div[@id="selectGroups"]').click()
     except ElementClickInterceptedException:
+        # time.sleep(3)
         try:
             driver.wait_for_xpath_to_be_clickable('//div[@id="selectGroups"]').click()
         except ElementClickInterceptedException:


### PR DESCRIPTION
In our current data model, `GroupTelescope`s are used to determine a user's access to instruments and telescopes. After a discussion on how access to instruments and telescopes is implemented, @acrellin and I decided that a better model would be to mediate facility access at the instrument level. Such a model more closely mirrors the astronomical proposal writing process: people apply for time on specific instruments and are granted time on them, as opposed to time on telescopes. In ch1158, @acrellin requested that the GroupTelescope model be removed and replaced with an Allocation model, which tracks InstrumentID, GroupID, and some other columns (PI, Proposal ID, Allocation ID [PK])

This PR facilitates the removal of `GroupTelescope`. A future PR will implement `Allocation`.


[ch1158]