### PR TITLE
Afix ProfileDropdown to the top of page

### DIFF
--- a/skyportal/tests/frontend/test_frontpage.py
+++ b/skyportal/tests/frontend/test_frontpage.py
@@ -1,6 +1,8 @@
 import uuid
 import time
 
+import pytest
+
 from skyportal.tests import api
 
 
@@ -129,7 +131,7 @@ def test_source_filtering_and_pagination(driver, user, public_group, upload_data
         time.sleep(1)
         assert not next_button.is_enabled()
 
-
+@pytest.mark.flaky(reruns=2)
 def test_jump_to_page_invalid_values(driver):
     driver.get('/')
     jump_to_page_input = driver.wait_for_xpath("//input[@name='jumpToPageInputField']")

--- a/static/js/components/HeaderContent.jsx
+++ b/static/js/components/HeaderContent.jsx
@@ -15,7 +15,7 @@ const HeaderContent = () => (
         SkyPortal ∝
       </Link>
     </div>
-    <div style={{ position: "fixed", right: "1em" }}>
+    <div style={{ position: "fixed", right: "1em", top: "1em" }}>
       <Responsive desktopElement={ProfileDropdown} />
     </div>
   </div>

--- a/static/js/components/HeaderContent.jsx
+++ b/static/js/components/HeaderContent.jsx
@@ -15,7 +15,7 @@ const HeaderContent = () => (
         SkyPortal ∝
       </Link>
     </div>
-    <div style={{ position: "fixed", right: "1em", top: "1em" }}>
+    <div style={{ position: "fixed", right: "1rem", top: "1rem" }}>
       <Responsive desktopElement={ProfileDropdown} />
     </div>
   </div>


### PR DESCRIPTION
This PR adds `top: "1rem"` to the styling of the `ProfileDropdown` component to afix it to the top of the page. Before this PR, it was only `position: fixed` to the right of the page. When adding a new component to the header (quick searchbar, coming soon!) I found that we needed both the top and right glue for proper formatting.

Note: the styling is added inline in `HeaderContent`, consistent with how it is currently done. It, like many other inline styling commands, ought to be moved using the makeStyles paradigm (or into css files).

Also: found a flaky test `test_frontpage.py::test_jump_to_page_invalid_values` which has been marked accordingly.
