### PR TITLE
allow ClassificationForm Autocomplete options to be an empty array as page loads

### DIFF
--- a/static/js/components/ClassificationForm.jsx
+++ b/static/js/components/ClassificationForm.jsx
@@ -153,7 +153,7 @@ const ClassificationForm = ({ obj_id, taxonomyList }) => {
           </Select>
           <div style={{ display: state.class_select_enabled ? "block" : "none" }}>
             <Autocomplete
-              options={state.allowed_classes}
+              options={state.allowed_classes || []}
               id="classification"
               getOptionSelected={(option) => {
                 if ((state.classification === null) || (state.classification === '')) {


### PR DESCRIPTION
Since `state.allowed_classes` is now computed, rather than loaded from the source api, we need to allow the options to be an empty array. I believe that this obviates the need for PR #662 but the small fix there could also go in without effecting this PR.