### PR TITLE
Quick Search Bar for Sources

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@material-ui/icons": "4.9.1",
     "@material-ui/lab": "4.0.0-alpha.56",
     "@material-ui/pickers": "3.2.10",
+    "autosuggest-highlight": "3.1.1",
     "bokehjs": "0.12.9",
     "check-dependencies": "1.1.0",
     "clsx": "1.1.1",

--- a/skyportal/tests/frontend/test_data_sharing.py
+++ b/skyportal/tests/frontend/test_data_sharing.py
@@ -14,7 +14,7 @@ def test_share_data(
     driver.click_xpath('//*[text()="Share data"]')
     driver.wait_for_xpath(f"//div[text()='{public_group.name}']", 15)
     driver.click_xpath('//*[@id="MUIDataTableSelectCell-0"]', wait_clickable=False)
-    driver.click_xpath('//input[contains(@class, "MuiAutocomplete-input")]')
+    driver.click_xpath('//*[@id="dataSharingFormGroupsSelect"]')
     driver.click_xpath(f'//li[text()="{public_group2.name}"]')
     driver.click_xpath('//*[text()="Submit"]')
     driver.wait_for_xpath('//*[text()="Data successfully shared"]', 15)

--- a/skyportal/tests/frontend/test_quick_search.py
+++ b/skyportal/tests/frontend/test_quick_search.py
@@ -1,0 +1,20 @@
+# Adding a comment here to make flake8 and black play nicely together (spacing below)
+
+
+def test_quick_search(
+    driver, super_admin_user, public_source, public_group,
+):
+    driver.get(f"/become_user/{super_admin_user.id}")
+    driver.get("/")
+    driver.wait_for_xpath('//*[@id="quick-search-bar"]').send_keys(public_source.id)
+    driver.click_xpath(f'//*[@id="quickSearchLinkTo{public_source.id}"]')
+    # Should be redirected to source page; check for elements that should render
+    driver.wait_for_xpath(f'//div[text()="{public_source.id}"]')
+    driver.wait_for_xpath(
+        '//label[contains(text(), "band")]', 10
+    )  # TODO how to check plot?
+    driver.wait_for_xpath('//label[contains(text(), "Fe III")]')
+    driver.wait_for_xpath(f'//span[text()="{public_group.name}"]')
+
+    driver.wait_for_xpath('//*[@id="quick-search-bar"]').send_keys("invalid_source_id")
+    driver.wait_for_xpath('//*[text()="No matching sources."]')

--- a/static/js/components/HeaderContent.jsx
+++ b/static/js/components/HeaderContent.jsx
@@ -1,19 +1,23 @@
 import React from "react";
 import { Link } from "react-router-dom";
 
+import Box from "@material-ui/core/Box";
 import Responsive from "./Responsive";
 import ProfileDropdown from "./ProfileDropdown";
 import Logo from "./Logo";
+import QuickSearchBar from "./QuickSearchBar";
 
 import styles from "./Main.css";
 
 const HeaderContent = () => (
   <div className={styles.topBannerContent}>
-    <div style={{ display: "inline-block", float: "left" }}>
+    <div style={{ display: "inline-flex", flexDirection: "row" }}>
       <Logo className={styles.logo} />
       <Link className={styles.title} to="/">
-        SkyPortal ∝
+        SkyPortal
       </Link>
+      <Box p={2} />
+      <QuickSearchBar id="search" />
     </div>
     <div style={{ position: "fixed", right: "1rem", top: "1rem" }}>
       <Responsive desktopElement={ProfileDropdown} />

--- a/static/js/components/QuickSearchBar.jsx
+++ b/static/js/components/QuickSearchBar.jsx
@@ -34,7 +34,7 @@ function useDebouncer(value, delay) {
 
 const QuickSearchBar = () => {
   const dispatch = useDispatch();
-  const [options, setOptions] = React.useState([]);
+  const [options, setOptions] = useState([]);
   const [value, setValue] = useState(null);
   const [inputValue, setInputValue] = useState("");
   const [loading, setLoading] = useState(false);
@@ -121,6 +121,7 @@ const QuickSearchBar = () => {
       selectOnFocus
       limitTags={15}
       value={value}
+      popupIcon={null}
       renderOption={(option) => {
         const v = `/source/${option}`;
         return (
@@ -135,6 +136,7 @@ const QuickSearchBar = () => {
           {...params}
           className={classes.root}
           variant="outlined"
+          label="Source ID Search"
           InputProps={{
             ...params.InputProps,
             startAdornment: (

--- a/static/js/components/QuickSearchBar.jsx
+++ b/static/js/components/QuickSearchBar.jsx
@@ -1,0 +1,160 @@
+import React, { useEffect, useState, useRef } from "react";
+import { useDispatch } from "react-redux";
+import { useHistory } from "react-router-dom";
+import { makeStyles } from "@material-ui/core/styles";
+
+import Link from "@material-ui/core/Link";
+import TextField from "@material-ui/core/TextField";
+import Autocomplete from "@material-ui/lab/Autocomplete";
+import SearchIcon from "@material-ui/icons/Search";
+import InputAdornment from "@material-ui/core/InputAdornment";
+import CircularProgress from "@material-ui/core/CircularProgress";
+
+import { GET } from "../API";
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    background: "#6EB5DC",
+    marginRight: theme.spacing(1),
+  },
+}));
+
+function useDebouncer(value, delay) {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+  return debouncedValue;
+}
+
+const QuickSearchBar = () => {
+  const dispatch = useDispatch();
+  const [options, setOptions] = React.useState([]);
+  const [value, setValue] = useState(null);
+  const [inputValue, setInputValue] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [open, setOpen] = useState(false);
+  const history = useHistory();
+
+  const classes = useStyles();
+
+  const debouncedInputValue = useDebouncer(inputValue, 500);
+  const cache = useRef({});
+
+  useEffect(() => {
+    const get = (val) =>
+      dispatch(
+        GET(
+          `/api/sources?sourceID=${val}&pageNumber=1&totalMatches=25`,
+          "skyportal/FETCH_SOURCES"
+        )
+      );
+    (async () => {
+      if (debouncedInputValue === "") {
+        setOptions([]);
+        setOpen(false);
+        return undefined;
+      }
+
+      let newOptions = [];
+
+      if (cache.current[debouncedInputValue]) {
+        setLoading(true);
+        newOptions = cache.current[debouncedInputValue];
+        setLoading(false);
+      } else {
+        setLoading(true);
+        const response = await get(debouncedInputValue);
+        setLoading(false);
+
+        const matchingSources = await response.data.sources;
+
+        if (matchingSources) {
+          const rez = Object.keys(matchingSources).map(
+            (key) => matchingSources[key].id
+          );
+          newOptions = [...newOptions, ...rez];
+        }
+        cache.current[debouncedInputValue] = newOptions;
+      }
+      setOpen(true);
+      setOptions(newOptions);
+      return undefined;
+    })();
+  }, [dispatch, debouncedInputValue]);
+
+  return (
+    <Autocomplete
+      id="quick-search-bar"
+      style={{ width: 200 }}
+      getOptionSelected={(option, val) => option.name === val.name}
+      getOptionLabel={(option) => option}
+      onInputChange={(e, val) => {
+        if (e.constructor.name === "SyntheticEvent") {
+          setInputValue(val);
+        }
+      }}
+      onChange={(event, newValue, reason) => {
+        setValue(newValue);
+        if (reason === "select-option") {
+          history.push(`/source/${newValue}`);
+        }
+        if (reason === "clear") {
+          setOpen(false);
+        }
+      }}
+      onClose={() => {
+        setOpen(false);
+      }}
+      size="small"
+      noOptionsText="No matching sources."
+      options={options}
+      open={open}
+      loading={loading}
+      clearOnEscape
+      clearOnBlur
+      selectOnFocus
+      limitTags={15}
+      value={value}
+      renderOption={(option) => {
+        const v = `/source/${option}`;
+        return (
+          <Link href={v} color="inherit">
+            {option}
+          </Link>
+        );
+      }}
+      renderInput={(params) => (
+        <TextField
+          // eslint-disable-next-line react/jsx-props-no-spreading
+          {...params}
+          className={classes.root}
+          variant="outlined"
+          InputProps={{
+            ...params.InputProps,
+            startAdornment: (
+              <InputAdornment position="start">
+                <SearchIcon fontSize="small" color="inherit" />
+              </InputAdornment>
+            ),
+            endAdornment: (
+              <>
+                {loading ? (
+                  <CircularProgress color="inherit" size={15} />
+                ) : null}
+                {params.InputProps.endAdornment}
+              </>
+            ),
+          }}
+        />
+      )}
+    />
+  );
+};
+
+export default QuickSearchBar;

--- a/static/js/components/QuickSearchBar.jsx
+++ b/static/js/components/QuickSearchBar.jsx
@@ -124,7 +124,7 @@ const QuickSearchBar = () => {
       renderOption={(option) => {
         const v = `/source/${option}`;
         return (
-          <Link href={v} color="inherit">
+          <Link href={v} id={`quickSearchLinkTo${option}`} color="inherit">
             {option}
           </Link>
         );

--- a/static/js/components/ShareDataForm.jsx
+++ b/static/js/components/ShareDataForm.jsx
@@ -233,6 +233,7 @@ const ShareDataForm = ({ route }) => {
           )}
           <Controller
             name="groups"
+            id="dataSharingFormGroupsSelect"
             as={
               <Autocomplete
                 multiple


### PR DESCRIPTION
![Kapture 2020-08-08 at 11 08 35](https://user-images.githubusercontent.com/480799/89717093-f005eb00-d967-11ea-91dd-df27655318a6.gif)

This PR adds a quick search bar for sources. Rather than having endusers type in the full source name to an address bar to jump to a source, this quick search bar will allow them to find and navigate to that source more quickly, from within the UI. Searches are debounced to 250ms to avoid making unnecessarily too many calls rapidly to the backend. This debouncing can be seen in the screenshot above, as the network does not get called when a long string is entered quickly. 

A maximum of 25 results are returned to avoid large data transfers from the backend to the frontend.

Future:
  - allow searches for richer content, like comment strings or classification
  - memoize the searches so that we do not rely on the browser to cache results