### PR TITLE
mark all frontend tests flaky

### DIFF
--- a/skyportal/tests/frontend/test_about_page.py
+++ b/skyportal/tests/frontend/test_about_page.py
@@ -1,6 +1,7 @@
 import skyportal
+import pytest
 
-
+@pytest.mark.flaky(reruns=2)
 def test_skyportal_version_displayed(driver):
     driver.get('/about')
     driver.wait_for_xpath(f"//*[contains(.,'{skyportal.__version__}')]")

--- a/skyportal/tests/frontend/test_candidate_page.py
+++ b/skyportal/tests/frontend/test_candidate_page.py
@@ -1,3 +1,7 @@
+import pytest
+
+
+@pytest.mark.flaky(reruns=2)
 def test_public_candidate_page_render(driver, user, public_candidate):
     driver.get(f"/become_user/{user.id}")
     driver.get(f"/candidate/{public_candidate.id}")

--- a/skyportal/tests/frontend/test_data_sharing.py
+++ b/skyportal/tests/frontend/test_data_sharing.py
@@ -1,8 +1,10 @@
+import pytest
 from selenium.webdriver.common.keys import Keys
 
 from skyportal.tests import api
 
 
+@pytest.mark.flaky(reruns=2)
 def test_share_data(
     driver,
     super_admin_user,

--- a/skyportal/tests/frontend/test_frontpage.py
+++ b/skyportal/tests/frontend/test_frontpage.py
@@ -1,10 +1,10 @@
 import uuid
 import time
 import pytest
-
 from skyportal.tests import api
 
 
+@pytest.mark.flaky(reruns=2)
 def test_foldable_sidebar(driver):
     driver.get('/')
     sidebar_text = driver.wait_for_xpath('//span[contains(text(),"Dashboard")]')
@@ -18,6 +18,7 @@ def test_foldable_sidebar(driver):
     assert sidebar_text.is_displayed()
 
 
+@pytest.mark.flaky(reruns=2)
 def test_source_list(driver, user, public_source, private_source):
     driver.get(f"/become_user/{user.id}")  # TODO decorator/context manager?
     assert 'localhost' in driver.current_url
@@ -35,7 +36,7 @@ def test_source_list(driver, user, public_source, private_source):
     assert not el.is_enabled()
 
 
-@pytest.mark.flaky(reruns=3)
+@pytest.mark.flaky(reruns=2)
 def test_source_filtering_and_pagination(driver, user, public_group, upload_data_token):
     obj_id = str(uuid.uuid4())
     for i in range(205):
@@ -132,6 +133,7 @@ def test_source_filtering_and_pagination(driver, user, public_group, upload_data
         assert not next_button.is_enabled()
 
 
+@pytest.mark.flaky(reruns=2)
 def test_jump_to_page_invalid_values(driver):
     driver.get('/')
     jump_to_page_input = driver.wait_for_xpath("//input[@name='jumpToPageInputField']")

--- a/skyportal/tests/frontend/test_groups.py
+++ b/skyportal/tests/frontend/test_groups.py
@@ -6,6 +6,7 @@ import uuid
 import requests
 
 
+@pytest.mark.flaky(reruns=2)
 def test_public_groups_list(driver, user, public_group):
     driver.get(f'/become_user/{user.id}')  # TODO decorator/context manager?
     driver.get('/groups')
@@ -13,6 +14,7 @@ def test_public_groups_list(driver, user, public_group):
     driver.wait_for_xpath(f'//a[contains(.,"{public_group.name}")]')
 
 
+@pytest.mark.flaky(reruns=2)
 def test_super_admin_groups_list(driver, super_admin_user, public_group):
     driver.get(f'/become_user/{super_admin_user.id}')  # TODO decorator/context manager?
     driver.get('/groups')
@@ -22,6 +24,7 @@ def test_super_admin_groups_list(driver, super_admin_user, public_group):
     # get list of names of previously created groups here
 
 
+@pytest.mark.flaky(reruns=2)
 def test_add_new_group(driver, super_admin_user, user):
     test_proj_name = str(uuid.uuid4())
     driver.get(f'/become_user/{super_admin_user.id}')  # TODO decorator/context manager?
@@ -35,6 +38,7 @@ def test_add_new_group(driver, super_admin_user, user):
     driver.wait_for_xpath(f'//a[contains(.,"{test_proj_name}")]')
 
 
+@pytest.mark.flaky(reruns=2)
 def test_add_new_group_explicit_self_admin(driver, super_admin_user, user):
     test_proj_name = str(uuid.uuid4())
     driver.get(f'/become_user/{super_admin_user.id}')  # TODO decorator/context manager?
@@ -48,6 +52,7 @@ def test_add_new_group_explicit_self_admin(driver, super_admin_user, user):
     driver.wait_for_xpath(f'//a[contains(.,"{test_proj_name}")]')
 
 
+@pytest.mark.flaky(reruns=2)
 def test_add_new_group_user_admin(driver, super_admin_user, user, public_group):
     driver.get(f'/become_user/{super_admin_user.id}')
     driver.get('/groups')
@@ -64,6 +69,7 @@ def test_add_new_group_user_admin(driver, super_admin_user, user, public_group):
         f'//a[contains(.,"{user.username}")]/..//span')) == 1
 
 
+@pytest.mark.flaky(reruns=2)
 def test_add_new_group_user_nonadmin(driver, super_admin_user, user, public_group):
     driver.get(f'/become_user/{super_admin_user.id}')
     driver.get('/groups')
@@ -79,6 +85,7 @@ def test_add_new_group_user_nonadmin(driver, super_admin_user, user, public_grou
         f'//a[contains(.,"{user.username}")]/..//span')) == 0
 
 
+@pytest.mark.flaky(reruns=2)
 def test_add_new_group_user_new_username(driver, super_admin_user, user, public_group):
     new_username = str(uuid.uuid4())
     driver.get(f'/become_user/{super_admin_user.id}')
@@ -93,6 +100,7 @@ def test_add_new_group_user_new_username(driver, super_admin_user, user, public_
     driver.wait_for_xpath(f'//a[contains(.,"{new_username}")]')
 
 
+@pytest.mark.flaky(reruns=2)
 def test_delete_group_user(driver, super_admin_user, user, public_group):
     driver.get(f'/become_user/{super_admin_user.id}')
     driver.get('/groups')
@@ -104,6 +112,7 @@ def test_delete_group_user(driver, super_admin_user, user, public_group):
         f'//a[contains(.,"{user.username}")]')) == 0
 
 
+@pytest.mark.flaky(reruns=2)
 def test_delete_group(driver, super_admin_user, user, public_group):
     driver.get(f'/become_user/{super_admin_user.id}')
     driver.get('/groups')

--- a/skyportal/tests/frontend/test_newsfeed.py
+++ b/skyportal/tests/frontend/test_newsfeed.py
@@ -1,8 +1,9 @@
 import uuid
-
+import pytest
 from skyportal.tests import api
 
 
+@pytest.mark.flaky(reruns=2)
 def test_news_feed(driver, user, public_source, public_group, upload_data_token, comment_token):
     obj_id_base = str(uuid.uuid4())
     for i in range(2):
@@ -31,6 +32,7 @@ def test_news_feed(driver, user, public_source, public_group, upload_data_token,
         driver.wait_for_xpath(f'//span[contains(text(),"comment_text_{i} ({obj_id_base}_{i})")]')
 
 
+@pytest.mark.flaky(reruns=2)
 def test_news_feed_prefs_widget(driver, user, public_source, public_group, upload_data_token, comment_token):
     obj_id_base = str(uuid.uuid4())
     for i in range(2):

--- a/skyportal/tests/frontend/test_profile.py
+++ b/skyportal/tests/frontend/test_profile.py
@@ -5,6 +5,7 @@ import pytest
 from selenium.webdriver.support.ui import Select
 
 
+@pytest.mark.flaky(reruns=2)
 def test_token_acls_options_rendering1(driver, user):
     driver.get(f"/become_user/{user.id}")
     driver.get("/profile")
@@ -14,6 +15,7 @@ def test_token_acls_options_rendering1(driver, user):
     driver.wait_for_xpath_to_disappear('//input[@name="acls[3]"]')
 
 
+@pytest.mark.flaky(reruns=2)
 def test_token_acls_options_rendering2(driver, super_admin_user):
     driver.get(f"/become_user/{super_admin_user.id}")
     driver.get("/profile")
@@ -43,6 +45,7 @@ def test_add_and_see_realname_in_user_profile(driver, user):
     assert name_display == f"{first_name} {last_name}"
 
 
+@pytest.mark.flaky(reruns=2)
 def test_add_data_to_user_profile(driver, user):
     driver.get(f"/become_user/{user.id}")
     driver.get("/profile")
@@ -66,6 +69,7 @@ def test_add_data_to_user_profile(driver, user):
     )
 
 
+@pytest.mark.flaky(reruns=2)
 def test_insufficient_name_entry_in_profile(driver, user):
     driver.get(f"/become_user/{user.id}")
     driver.get("/profile")

--- a/skyportal/tests/frontend/test_remote.py
+++ b/skyportal/tests/frontend/test_remote.py
@@ -3,9 +3,11 @@
 # fixture data directly into the database). Used for testing broadly that a
 # server or Docker image was started successfully.
 
+import pytest
 from skyportal.models import Source, DBSession
 
 
+@pytest.mark.flaky(reruns=2)
 def test_remote(driver):
     # TODO expand to cover the basics of all site functionality
     # (c.f. `test_pipeline_sequentially` from `cesium_web`)

--- a/skyportal/tests/frontend/test_scanning_page.py
+++ b/skyportal/tests/frontend/test_scanning_page.py
@@ -5,6 +5,7 @@ from selenium.common.exceptions import TimeoutException
 from skyportal.tests import api
 
 
+@pytest.mark.flaky(reruns=2)
 def test_candidates_page_render(driver, user, public_candidate):
     driver.get(f"/become_user/{user.id}")
     driver.get("/candidates")

--- a/skyportal/tests/frontend/test_sources.py
+++ b/skyportal/tests/frontend/test_sources.py
@@ -12,6 +12,7 @@ import time
 cfg = load_config()
 
 
+@pytest.mark.flaky(reruns=2)
 def test_public_source_page(driver, user, public_source, public_group):
     driver.get(f"/become_user/{user.id}")  # TODO decorator/context manager?
     driver.get(f"/source/{public_source.id}")
@@ -85,6 +86,7 @@ def test_comments(driver, user, public_source):
         driver.wait_for_xpath('//span[text()="a few seconds ago"]')
 
 
+@pytest.mark.flaky(reruns=2)
 def test_comment_groups_validation(driver, user, public_source):
     driver.get(f"/become_user/{user.id}")  # TODO decorator/context manager?
     driver.get(f"/source/{public_source.id}")
@@ -155,6 +157,7 @@ def test_upload_download_comment_attachment(driver, user, public_source):
         os.remove(fpath)
 
 
+@pytest.mark.flaky(reruns=2)
 def test_view_only_user_cannot_comment(driver, view_only_user, public_source):
     driver.get(f"/become_user/{view_only_user.id}")
     driver.get(f"/source/{public_source.id}")
@@ -265,6 +268,7 @@ def test_super_user_can_delete_unowned_comment(driver, super_admin_user,
         driver.wait_for_xpath_to_disappear(f'//div[text()="{comment_text}"]')
 
 
+@pytest.mark.flaky(reruns=2)
 def test_show_starlist(driver, user, public_source):
     driver.get(f"/become_user/{user.id}")
     driver.get(f"/source/{public_source.id}")

--- a/skyportal/tests/frontend/test_top_sources.py
+++ b/skyportal/tests/frontend/test_top_sources.py
@@ -1,10 +1,12 @@
 import uuid
+import pytest
 from selenium import webdriver
 from selenium.webdriver.common.by import By
 
 from skyportal.tests import api
 
 
+@pytest.mark.flaky(reruns=2)
 def test_top_sources(driver, user, public_source, public_group, upload_data_token):
     obj_id = str(uuid.uuid4())
     status, data = api('POST', 'sources',

--- a/skyportal/tests/frontend/test_user.py
+++ b/skyportal/tests/frontend/test_user.py
@@ -5,6 +5,7 @@ import uuid
 import time
 
 
+@pytest.mark.flaky(reruns=2)
 def test_user_info(driver, super_admin_user):
     user = super_admin_user
     driver.get(f'/become_user/{user.id}')
@@ -16,6 +17,7 @@ def test_user_info(driver, super_admin_user):
         assert acl.id in pg_src
 
 
+@pytest.mark.flaky(reruns=2)
 def test_user_info_forbidden(driver, user):
     driver.get(f'/become_user/{user.id}')
     driver.get(f'/user/{user.id}')


### PR DESCRIPTION
As the number of tests in the repository has grown (we are hovering around 170 at this point) and the time for a single CI build has reached ~20 mins, flakiness has had an increasingly derailing effect on the on the stability and reliability of our CI, leading to a situation where several builds of a single commit are often needed to get a green check mark (oftentimes the better part of an hour to build a single commit).

All of the flaky tests are related to selenium, and occur on the frontend. Using pytest-rerunfailures has helped mitigate the effect of flakiness on frontend tests that we have identified as flaky, however, we continually discover new flaky frontend tests. As only a single failure is needed to derail a build, this leads to a situation where our builds are constantly derailed by newly discovered flakiness.

This PR marks all selenium frontend tests flaky and reruns them up to 2 times until they pass. This should add minimal overhead to the build (since, in a given test session, usually only one or two tests flake out) but prevent flakiness from derailing our builds by automatically rerunning failures. If a test should indeed fail, it will fail in this solution, with minimal overhead, but if a test should not fail, this solution may cut the build time for CI by a factor of several and effect a corresponding improvement in CI stability.

As a corollary to this PR, I also request that in future, we automatically mark frontend tests as flaky to keep our CI builds stable.