### PR TITLE
fix topsources rendering

### DIFF
--- a/static/js/components/TopSources.jsx
+++ b/static/js/components/TopSources.jsx
@@ -41,21 +41,21 @@ const TopSources = () => {
               <Link to={`/source/${obj_id}`}>
                 <img className={styles.stamp} src={public_url} alt={obj_id} />
               </Link>
-              <div>
+              <span>
                 &nbsp;
                 -&nbsp;
                 <Link to={`/source/${obj_id}`}>
                   {obj_id}
                 </Link>
-              </div>
-              <div>
+              </span>
+              <span>
                 <em>
                   &nbsp;
                   -&nbsp;
                   {views}
                   &nbsp;view(s)
                 </em>
-              </div>
+              </span>
             </li>
           ))
         }


### PR DESCRIPTION
@mcoughlin 

Fixes #679.

<img width="447" alt="Screen Shot 2020-08-08 at 5 10 36 PM" src="https://user-images.githubusercontent.com/2769632/89722095-23fa0400-d99a-11ea-87c1-228f367f91ae.png">
