### PR TITLE
do not run `test_get_ztfref_url` if irsa server is down

### DIFF
--- a/skyportal/tests/tools/test_offset_util.py
+++ b/skyportal/tests/tools/test_offset_util.py
@@ -8,7 +8,20 @@ from skyportal.utils import (
     get_finding_chart, get_ztfref_url
 )
 
+from skyportal.utils.offset import irsa
 
+
+ztfref_url = irsa['url_search']
+run_ztfref_test = True
+try:
+    r = requests.get(ztfref_url)
+    r.raise_for_status()
+except (HTTPError, TimeoutError, ConnectionError) as e:
+    run_ztfref_test = False
+    print(e)
+
+
+@pytest.mark.skipif(not run_ztfref_test, reason='IRSA server down')
 def test_get_ztfref_url():
     url = get_ztfref_url(123.0, 33.3, 2)
 


### PR DESCRIPTION
This PR skips the test `test_get_ztfref_url` if the IRSA server it depends on is down. 

```
(skyportal2) Dannys-MBP:skyportal danny$ py.test skyportal/tests/tools/test_offset_util.py::test_get_ztfref_url
===================== test session starts =====================
platform darwin -- Python 3.7.6, pytest-5.4.3, py-1.9.0, pluggy-0.13.1
Using --randomly-seed=1597018957
benchmark: 3.2.3 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /Users/danny
plugins: Faker-4.1.1, postgresql-2.4.0, rerunfailures-9.0, randomly-3.4.0, factoryboy-2.0.3, benchmark-3.2.3
collected 1 item

skyportal/tests/tools/test_offset_util.py s             [100%]

===================== 1 skipped in 3.19s ======================
(skyportal2) Dannys-MBP:skyportal danny$
```