### PR TITLE
Fix user handler bug

### DIFF
--- a/skyportal/handlers/api/user.py
+++ b/skyportal/handlers/api/user.py
@@ -99,7 +99,7 @@ class UserHandler(BaseHandler):
 
             user_info["acls"] = sorted(user.acls, key=lambda a: a.id)
             return self.success(data=user_info)
-        users = User.query.all()
+        users = [user.to_dict() for user in User.query.all()]
         for user in users:
             if user.get("contact_phone"):
                 user["contact_phone"] = user["contact_phone"].e164


### PR DESCRIPTION
The logs have been full of this error: 
```
[34mTraceback (most recent call last):
[34m  File "/home/travis/virtualenv/python3.7.6/lib/python3.7/site-packages/tornado/web.py", line 1697, in _execute
[34m    result = method(*self.path_args, **self.path_kwargs)
[34m  File "/home/travis/build/skyportal/skyportal/baselayer/app/access.py", line 31, in wrapper
[34m    return tornado.web.authenticated(method)(self, *args, **kwargs)
[34m  File "/home/travis/virtualenv/python3.7.6/lib/python3.7/site-packages/tornado/web.py", line 3174, in wrapper
[34m    return method(self, *args, **kwargs)
[34m  File "/home/travis/build/skyportal/skyportal/baselayer/app/access.py", line 46, in wrapper
[34m    return method(self, *args, **kwargs)
[34m  File "/home/travis/build/skyportal/skyportal/skyportal/handlers/api/user.py", line 104, in get
[34m    if user.get("contact_phone"):
[34mAttributeError: 'User' object has no attribute 'get'
[34m[!] Error in `/api/user`: 'User' object has no attribute 'get'
```