### PR TITLE
patch photometry handler to trip more informative errors @acrellin

### DIFF
--- a/skyportal/handlers/api/photometry.py
+++ b/skyportal/handlers/api/photometry.py
@@ -225,6 +225,9 @@ class PhotometryHandler(BaseHandler):
             bad = magerrnull ^ magnull  # bitwise exclusive or -- returns true
             #  if A and not B or B and not A
 
+            # coerce to numpy array
+            bad = bad.values
+
             if any(bad):
                 # find the first offending packet
                 first_offender = np.argwhere(bad)[0, 0]
@@ -273,7 +276,7 @@ class PhotometryHandler(BaseHandler):
 
         else:
             for field in PhotFluxFlexible.required_keys:
-                missing = df[field].isna()
+                missing = df[field].isna().values
                 if any(missing):
                     first_offender = np.argwhere(missing)[0, 0]
                     packet = df.iloc[first_offender].to_dict()


### PR DESCRIPTION
From @acrellin  in slack:

> @dannygoldstein  is this an exception we're tripping intentionally in the tests? If so, we should explicitly catch it in the handler and return an error so the logs don't show the whole TB

> ```
> ERROR:tornado.application:Uncaught exception POST /api/photometry (127.0.0.1)
> HTTPServerRequest(protocol='http', host='localhost:5000', method='POST', uri='/api/photometry', version='HTTP/1.0', remote_ip='127.0.0.1')
> Traceback (most recent call last):
>   File "/home/travis/virtualenv/python3.7.6/lib/python3.7/site-packages/tornado/web.py", line 1697, in _execute
>     result = method(*self.path_args, **self.path_kwargs)
>   File "/home/travis/build/skyportal/skyportal/baselayer/app/access.py", line 29, in wrapper
>     return method(self, *args, **kwargs)
>   File "/home/travis/build/skyportal/skyportal/baselayer/app/access.py", line 46, in wrapper
>     return method(self, *args, **kwargs)
>   File "/home/travis/build/skyportal/skyportal/skyportal/handlers/api/photometry.py", line 230, in post
>     first_offender = np.argwhere(bad)[0, 0]
>   File "<__array_function__ internals>", line 6, in argwhere
>   File "/home/travis/virtualenv/python3.7.6/lib/python3.7/site-packages/numpy/core/numeric.py", line 583, in argwhere
>     return transpose(nonzero(a))
>   File "<__array_function__ internals>", line 6, in nonzero
>   File "/home/travis/virtualenv/python3.7.6/lib/python3.7/site-packages/numpy/core/fromnumeric.py", line 1849, in nonzero
>     return _wrapfunc(a, 'nonzero')
>   File "/home/travis/virtualenv/python3.7.6/lib/python3.7/site-packages/numpy/core/fromnumeric.py", line 58, in _wrapfunc
>     return _wrapit(obj, method, *args, **kwds)
>   File "/home/travis/virtualenv/python3.7.6/lib/python3.7/site-packages/numpy/core/fromnumeric.py", line 51, in _wrapit
>     result = wrap(result)
>   File "/home/travis/virtualenv/python3.7.6/lib/python3.7/site-packages/pandas/core/generic.py", line 1787, in __array_wrap__
>     return self._constructor(result, **d).__finalize__(
>   File "/home/travis/virtualenv/python3.7.6/lib/python3.7/site-packages/pandas/core/series.py", line 314, in __init__
>     f"Length of passed values is {len(data)}, "
> ValueError: Length of passed values is 1, index implies 2.
> [!] Error in `/api/photometry`: Length of passed values is 1, index implies 2.
> ```

This PR attempts to trigger a more informative error message in those situations. 