### PR TITLE
Update Material UI color theme when user preferences are updated

### DIFF
--- a/static/js/components/UIPreferences.jsx
+++ b/static/js/components/UIPreferences.jsx
@@ -8,6 +8,7 @@ import Switch from "@material-ui/core/Switch";
 // import { useTheme } from '@material-ui/core/styles';
 
 import * as profileActions from "../ducks/profile";
+import * as themeActions from "../ducks/theme";
 
 const UIPreferences = () => {
   const currentTheme = useSelector((state) => state.profile.preferences.theme);
@@ -18,6 +19,7 @@ const UIPreferences = () => {
       theme: event.target.checked ? "dark" : "light",
     };
 
+    dispatch(themeActions.updateMaterialTheme(prefs.theme));
     dispatch(profileActions.updateUserPreferences(prefs));
   };
 

--- a/static/js/ducks/theme.js
+++ b/static/js/ducks/theme.js
@@ -1,0 +1,40 @@
+import store from "../store";
+
+export const UPDATE_MATERIAL_THEME = "skyportal/UPDATE_MATERIAL_THEME";
+
+export function updateMaterialTheme(theme) {
+  return {
+    type: UPDATE_MATERIAL_THEME,
+    theme,
+  };
+}
+
+const initialState = {
+  profile: {
+    preferences: {
+      theme: "light",
+    },
+  },
+};
+
+const reducer = (state = initialState, action) => {
+  switch (action.type) {
+    case UPDATE_MATERIAL_THEME: {
+      const { theme } = action;
+      return {
+        ...state,
+        profile: {
+          ...state.profile,
+          preferences: {
+            ...state.profile.preferences,
+            theme,
+          },
+        },
+      };
+    }
+    default:
+      return state;
+  }
+};
+
+store.injectReducer("theme", reducer);


### PR DESCRIPTION
Noticed that the Material UI CSS colors weren't matching the user preferred theme (light or dark) - added a reducer to reflect changes in the user preference to the theme state as well.