### PR TITLE
fix bug in Photometry.mag.expression

### DIFF
--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -831,8 +831,10 @@ class Photometry(Base, ha.Point):
     def mag(cls):
         return sa.case(
             [
-                sa.and_(cls.flux != None, cls.flux > 0),  # noqa
-                -2.5 * sa.func.log(cls.flux) + PHOT_ZP,
+                (
+                    sa.and_(cls.flux != None, cls.flux > 0),  # noqa
+                    -2.5 * sa.func.log(cls.flux) + PHOT_ZP,
+                )
             ],
             else_=None,
         )


### PR DESCRIPTION
This fixes a bug in `Photometry.mag.expression` that caused usages of SQL hybrid of this property to error with `NotImplementedError: Operator 'getitem' is not supported on this expression`.