### PR TITLE
New user on-boarding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ geckodriver.log
 __pycache__/
 node_modules/
 *.pyc
-./config.yaml
+config.yaml
 static/thumbnails
 *.lock
 *.dirlock

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ static/index.html
 data/taxonomy_sitewide.yaml
 data/taxonomy_demo.yaml
 .idea
+sendgrid.env

--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,3 @@ static/index.html
 data/taxonomy_sitewide.yaml
 data/taxonomy_demo.yaml
 .idea
-sendgrid.env

--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -102,3 +102,11 @@ cron:
   - interval: 1440
     script: jobs/delete_unsaved_candidates.py
     limit: ["01:00", "02:00"]
+
+invitations:
+  # Note that in order for invitations to be sent, a valid Sendgrid API key must be
+  # stored in sendgrid.env as per their setup docs
+  n_days_til_expiry: 3
+  email_subject: You\'ve been invited to collaborate on SkyPortal
+  email_body_preamble: Welcome to SkyPortal!
+  from_email: # This needs to be set to a valid, Sendgrid-registered address in config.yaml

--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -106,9 +106,12 @@ cron:
     limit: ["01:00", "02:00"]
 
 invitations:
-  # Note that in order for invitations to be sent, a valid Sendgrid API key must be
-  # available as an environment variable as per their setup docs
+  enabled: False
   days_until_expiry: 3
   email_subject: "You've been invited to collaborate on SkyPortal"
-  email_body_preamble: "Welcome to SkyPortal!"
+  email_body_preamble: |
+    Welcome to SkyPortal!
+
+    Some other text here.
   from_email: # This needs to be set to a valid, Sendgrid-registered address in config.yaml
+  sendgrid_api_key: # This needs to be obtained via Sendgrid setup on their site

--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -107,7 +107,7 @@ cron:
 
 invitations:
   # Note that in order for invitations to be sent, a valid Sendgrid API key must be
-  # stored in sendgrid.env as per their setup docs
+  # available as an environment variable as per their setup docs
   days_until_expiry: 3
   email_subject: "You've been invited to collaborate on SkyPortal"
   email_body_preamble: "Welcome to SkyPortal!"

--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -110,7 +110,7 @@ invitations:
   days_until_expiry: 3
   email_subject: "You've been invited to collaborate on SkyPortal"
   email_body_preamble: |
-    Welcome to SkyPortal!
+    Welcome to <b>SkyPortal</b>!
 
     Some other text here.
   from_email: # This needs to be set to a valid, Sendgrid-registered address in config.yaml

--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -85,6 +85,8 @@ server:
   # - Authorized redirect URLs: http://localhost:5000/complete/google-oauth2/
   #
   # You need to have Google+ API enabled; it takes a few minutes to activate.
+  host: localhost
+  ssl: False
 
   auth:
     debug_login: True
@@ -106,7 +108,7 @@ cron:
 invitations:
   # Note that in order for invitations to be sent, a valid Sendgrid API key must be
   # stored in sendgrid.env as per their setup docs
-  days_til_expiry: 3
+  days_until_expiry: 3
   email_subject: You\'ve been invited to collaborate on SkyPortal
   email_body_preamble: Welcome to SkyPortal!
   from_email: # This needs to be set to a valid, Sendgrid-registered address in config.yaml

--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -106,7 +106,7 @@ cron:
     limit: ["01:00", "02:00"]
 
 invitations:
-  enabled: False
+  enabled: False  # If debug_login=True above, invite tokens won't be used during auth
   days_until_expiry: 3
   email_subject: "You've been invited to collaborate on SkyPortal"
   email_body_preamble: | # This can include HTML tags

--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -109,9 +109,9 @@ invitations:
   enabled: False
   days_until_expiry: 3
   email_subject: "You've been invited to collaborate on SkyPortal"
-  email_body_preamble: |
+  email_body_preamble: | # This can include HTML tags
     Welcome to <b>SkyPortal</b>!
-
+    <br />
     Some other text here.
   from_email: # This needs to be set to a valid, Sendgrid-registered address in config.yaml
   sendgrid_api_key: # This needs to be obtained via Sendgrid setup on their site

--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -109,6 +109,6 @@ invitations:
   # Note that in order for invitations to be sent, a valid Sendgrid API key must be
   # stored in sendgrid.env as per their setup docs
   days_until_expiry: 3
-  email_subject: You\'ve been invited to collaborate on SkyPortal
-  email_body_preamble: Welcome to SkyPortal!
+  email_subject: "You've been invited to collaborate on SkyPortal"
+  email_body_preamble: "Welcome to SkyPortal!"
   from_email: # This needs to be set to a valid, Sendgrid-registered address in config.yaml

--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -106,7 +106,7 @@ cron:
 invitations:
   # Note that in order for invitations to be sent, a valid Sendgrid API key must be
   # stored in sendgrid.env as per their setup docs
-  n_days_til_expiry: 3
+  days_til_expiry: 3
   email_subject: You\'ve been invited to collaborate on SkyPortal
   email_body_preamble: Welcome to SkyPortal!
   from_email: # This needs to be set to a valid, Sendgrid-registered address in config.yaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,3 +32,4 @@ timezonefinder>=4.4.0
 astroplan>=0.6
 phonenumbers>=8.12.7
 py3-validate-email>=0.2.9
+sendgrid>=6.4.6

--- a/skyportal/app_server.py
+++ b/skyportal/app_server.py
@@ -125,42 +125,43 @@ def make_app(cfg, baselayer_handlers, baselayer_settings):
     ]
 
     settings = baselayer_settings
-    settings.update(
-        {
-            'SOCIAL_AUTH_PIPELINE': (
-                # Get the information we can about the user and return it in a simple
-                # format to create the user instance later. In some cases the details are
-                # already part of the auth response from the provider, but sometimes this
-                # could hit a provider API.
-                'social_core.pipeline.social_auth.social_details',
-                # Get the social uid from whichever service we're authing thru. The uid is
-                # the unique identifier of the given user in the provider.
-                'social_core.pipeline.social_auth.social_uid',
-                # Verify that the current auth process is valid within the current
-                # project, this is where emails and domains whitelists are applied (if
-                # defined).
-                'social_core.pipeline.social_auth.auth_allowed',
-                # Checks if the current social-account is already associated in the site.
-                'social_core.pipeline.social_auth.social_user',
-                # Make up a username for this person, appends a random string at the end if
-                # there's any collision.
-                'social_core.pipeline.user.get_username',
-                'skyportal.onboarding.create_user',
-                # Create a user account if we haven't found one yet.
-                # 'social_core.pipeline.user.create_user',
-                # Create the record that associates the social account with the user.
-                'social_core.pipeline.social_auth.associate_user',
-                # Populate the extra_data field in the social record with the values
-                # specified by settings (and the default ones like access_token, etc).
-                'social_core.pipeline.social_auth.load_extra_data',
-                # Update the user record with any changed info from the auth service.
-                'social_core.pipeline.user.user_details',
-                'skyportal.onboarding.setup_invited_user_permissions',
-            ),
-            'SOCIAL_AUTH_NEW_USER_REDIRECT_URL': '/profile?newUser=true',
-            'SOCIAL_AUTH_FIELDS_STORED_IN_SESSION': ['invite_token'],
-        }
-    )
+    if not cfg["server.auth.debug_login"]:
+        settings.update(
+            {
+                'SOCIAL_AUTH_PIPELINE': (
+                    # Get the information we can about the user and return it in a simple
+                    # format to create the user instance later. In some cases the details are
+                    # already part of the auth response from the provider, but sometimes this
+                    # could hit a provider API.
+                    'social_core.pipeline.social_auth.social_details',
+                    # Get the social uid from whichever service we're authing thru. The uid is
+                    # the unique identifier of the given user in the provider.
+                    'social_core.pipeline.social_auth.social_uid',
+                    # Verify that the current auth process is valid within the current
+                    # project, this is where emails and domains whitelists are applied (if
+                    # defined).
+                    'social_core.pipeline.social_auth.auth_allowed',
+                    # Checks if the current social-account is already associated in the site.
+                    'social_core.pipeline.social_auth.social_user',
+                    # Make up a username for this person, appends a random string at the end if
+                    # there's any collision.
+                    'social_core.pipeline.user.get_username',
+                    'skyportal.onboarding.create_user',
+                    # Create a user account if we haven't found one yet.
+                    # 'social_core.pipeline.user.create_user',
+                    # Create the record that associates the social account with the user.
+                    'social_core.pipeline.social_auth.associate_user',
+                    # Populate the extra_data field in the social record with the values
+                    # specified by settings (and the default ones like access_token, etc).
+                    'social_core.pipeline.social_auth.load_extra_data',
+                    # Update the user record with any changed info from the auth service.
+                    'social_core.pipeline.user.user_details',
+                    'skyportal.onboarding.setup_invited_user_permissions',
+                ),
+                'SOCIAL_AUTH_NEW_USER_REDIRECT_URL': '/profile?newUser=true',
+                'SOCIAL_AUTH_FIELDS_STORED_IN_SESSION': ['invite_token'],
+            }
+        )
 
     app = tornado.web.Application(handlers, **settings)
     models.init_db(**cfg['database'])

--- a/skyportal/app_server.py
+++ b/skyportal/app_server.py
@@ -125,7 +125,42 @@ def make_app(cfg, baselayer_handlers, baselayer_settings):
     ]
 
     settings = baselayer_settings
-    settings.update({})  # Specify any additional settings here
+    settings.update(
+        {
+            'SOCIAL_AUTH_PIPELINE': (
+                # Get the information we can about the user and return it in a simple
+                # format to create the user instance later. In some cases the details are
+                # already part of the auth response from the provider, but sometimes this
+                # could hit a provider API.
+                'social_core.pipeline.social_auth.social_details',
+                # Get the social uid from whichever service we're authing thru. The uid is
+                # the unique identifier of the given user in the provider.
+                'social_core.pipeline.social_auth.social_uid',
+                # Verify that the current auth process is valid within the current
+                # project, this is where emails and domains whitelists are applied (if
+                # defined).
+                'social_core.pipeline.social_auth.auth_allowed',
+                # Checks if the current social-account is already associated in the site.
+                'social_core.pipeline.social_auth.social_user',
+                # Make up a username for this person, appends a random string at the end if
+                # there's any collision.
+                'social_core.pipeline.user.get_username',
+                'skyportal.utils.onboarding.create_user',
+                # Create a user account if we haven't found one yet.
+                # 'social_core.pipeline.user.create_user',
+                # Create the record that associates the social account with the user.
+                'social_core.pipeline.social_auth.associate_user',
+                # Populate the extra_data field in the social record with the values
+                # specified by settings (and the default ones like access_token, etc).
+                'social_core.pipeline.social_auth.load_extra_data',
+                # Update the user record with any changed info from the auth service.
+                'social_core.pipeline.user.user_details',
+                'skyportal.utils.onboarding.setup_invited_user_permissions',
+            ),
+            'SOCIAL_AUTH_NEW_USER_REDIRECT_URL': '/profile',  # first-time login
+            'SOCIAL_AUTH_FIELDS_STORED_IN_SESSION': ['invite_token'],
+        }
+    )
 
     app = tornado.web.Application(handlers, **settings)
     models.init_db(**cfg['database'])

--- a/skyportal/app_server.py
+++ b/skyportal/app_server.py
@@ -157,7 +157,7 @@ def make_app(cfg, baselayer_handlers, baselayer_settings):
                 'social_core.pipeline.user.user_details',
                 'skyportal.utils.onboarding.setup_invited_user_permissions',
             ),
-            'SOCIAL_AUTH_NEW_USER_REDIRECT_URL': '/profile',  # first-time login
+            'SOCIAL_AUTH_NEW_USER_REDIRECT_URL': '/profile?newUser=true',
             'SOCIAL_AUTH_FIELDS_STORED_IN_SESSION': ['invite_token'],
         }
     )

--- a/skyportal/app_server.py
+++ b/skyportal/app_server.py
@@ -145,7 +145,7 @@ def make_app(cfg, baselayer_handlers, baselayer_settings):
                 # Make up a username for this person, appends a random string at the end if
                 # there's any collision.
                 'social_core.pipeline.user.get_username',
-                'skyportal.utils.onboarding.create_user',
+                'skyportal.onboarding.create_user',
                 # Create a user account if we haven't found one yet.
                 # 'social_core.pipeline.user.create_user',
                 # Create the record that associates the social account with the user.
@@ -155,7 +155,7 @@ def make_app(cfg, baselayer_handlers, baselayer_settings):
                 'social_core.pipeline.social_auth.load_extra_data',
                 # Update the user record with any changed info from the auth service.
                 'social_core.pipeline.user.user_details',
-                'skyportal.utils.onboarding.setup_invited_user_permissions',
+                'skyportal.onboarding.setup_invited_user_permissions',
             ),
             'SOCIAL_AUTH_NEW_USER_REDIRECT_URL': '/profile?newUser=true',
             'SOCIAL_AUTH_FIELDS_STORED_IN_SESSION': ['invite_token'],

--- a/skyportal/handlers/api/group.py
+++ b/skyportal/handlers/api/group.py
@@ -1,7 +1,7 @@
+import uuid
 from sqlalchemy.orm import joinedload
 from marshmallow.exceptions import ValidationError
 from baselayer.app.access import permissions, auth_or_token
-from .user import add_user_and_setup_groups
 from ..base import BaseHandler
 from ...models import (
     DBSession,
@@ -9,6 +9,7 @@ from ...models import (
     Group,
     GroupStream,
     GroupUser,
+    Invitation,
     Stream,
     User,
     Token,
@@ -349,11 +350,18 @@ class GroupUserHandler(BaseHandler):
             return self.error("Cannot add users to single-user groups.")
         user = User.query.filter(User.username == username.lower()).first()
         if user is None:
-            user_id = add_user_and_setup_groups(
-                username=username,
-                roles=["Full user"],
-                group_ids_and_admin=[[group_id, admin]],
+            groups = Group.query.filter(Group.id == group_id).all()
+            invite_token = str(uuid.uuid4())
+            DBSession.add(
+                Invitation(
+                    token=invite_token,
+                    groups=groups,
+                    admin_for_groups=[admin],
+                    user_email=username,
+                    invited_by=self.associated_user_object,
+                )
             )
+            user_id = None
         else:
             user_id = user.id
             # Just add new GroupUser

--- a/skyportal/handlers/api/group.py
+++ b/skyportal/handlers/api/group.py
@@ -1,4 +1,5 @@
 import uuid
+import python_http_client.exceptions
 from sqlalchemy.orm import joinedload
 from marshmallow.exceptions import ValidationError
 from baselayer.app.access import permissions, auth_or_token
@@ -378,7 +379,14 @@ class GroupUserHandler(BaseHandler):
                 return self.error(
                     "Specified user is already associated with this group."
                 )
-        DBSession().commit()
+        try:
+            DBSession().commit()
+        except python_http_client.exceptions.UnauthorizedError:
+            return self.error(
+                "Twilio Sendgrid authorization error. Please ensure "
+                "valid Sendgrid API key is set in server environment as "
+                "per their setup docs."
+            )
 
         self.push_all(action='skyportal/REFRESH_GROUP', payload={'group_id': group_id})
         return self.success(

--- a/skyportal/handlers/api/group.py
+++ b/skyportal/handlers/api/group.py
@@ -362,10 +362,6 @@ class GroupUserHandler(BaseHandler):
                 )
             )
             user_id = None
-            self.push(
-                action='baselayer/SHOW_NOTIFICATION',
-                payload={'note': f'Invitation sent to {username}.', 'type': 'info'},
-            )
         else:
             user_id = user.id
             # Just add new GroupUser

--- a/skyportal/handlers/api/group.py
+++ b/skyportal/handlers/api/group.py
@@ -362,6 +362,10 @@ class GroupUserHandler(BaseHandler):
                 )
             )
             user_id = None
+            self.push(
+                action='baselayer/SHOW_NOTIFICATION',
+                payload={'note': f'Invitation sent to {username}.', 'type': 'info'},
+            )
         else:
             user_id = user.id
             # Just add new GroupUser

--- a/skyportal/handlers/api/group.py
+++ b/skyportal/handlers/api/group.py
@@ -3,7 +3,9 @@ import python_http_client.exceptions
 from sqlalchemy.orm import joinedload
 from marshmallow.exceptions import ValidationError
 from baselayer.app.access import permissions, auth_or_token
+from baselayer.app.env import load_env
 from ..base import BaseHandler
+from .user import add_user_and_setup_groups
 from ...models import (
     DBSession,
     Filter,
@@ -343,6 +345,7 @@ class GroupUserHandler(BaseHandler):
         username = data.pop("username", None)
         if username is None:
             return self.error("Username must be specified")
+        _, cfg = load_env()
 
         admin = data.pop("admin", False)
         group_id = int(group_id)
@@ -352,17 +355,24 @@ class GroupUserHandler(BaseHandler):
         user = User.query.filter(User.username == username.lower()).first()
         if user is None:
             groups = Group.query.filter(Group.id == group_id).all()
-            invite_token = str(uuid.uuid4())
-            DBSession.add(
-                Invitation(
-                    token=invite_token,
-                    groups=groups,
-                    admin_for_groups=[admin],
-                    user_email=username,
-                    invited_by=self.associated_user_object,
+            if cfg["invitations.enabled"]:
+                invite_token = str(uuid.uuid4())
+                DBSession.add(
+                    Invitation(
+                        token=invite_token,
+                        groups=groups,
+                        admin_for_groups=[admin],
+                        user_email=username,
+                        invited_by=self.associated_user_object,
+                    )
                 )
-            )
-            user_id = None
+                user_id = None
+            else:
+                user_id = add_user_and_setup_groups(
+                    username=username,
+                    roles=["Full user"],
+                    group_ids_and_admin=[[group_id, admin]],
+                )
         else:
             user_id = user.id
             # Just add new GroupUser

--- a/skyportal/handlers/api/internal/profile.py
+++ b/skyportal/handlers/api/internal/profile.py
@@ -147,6 +147,8 @@ class ProfileHandler(BaseHandler):
             username = data.pop("username").strip()
             if username == "":
                 return self.error("Invalid username.")
+            if len(username) < 5:
+                return self.error("Username must be at least five characters long.")
             user.username = username
 
         if data.get("first_name") is not None:

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -1297,7 +1297,10 @@ def send_user_invite_email(mapper, connection, target):
     _, cfg = load_env()
     app_base_url = (
         f"{'https' if cfg['server.ssl'] else 'http'}:"
-        "//{cfg['server.host']}:{cfg['ports.app']}"
+        f"//{cfg['server.host']}:{cfg['ports.app']}"
+    )
+    link_location = (
+        f'{app_base_url}/login/google-oauth2/' f'?invite_token={target.token}'
     )
     message = Mail(
         from_email=cfg["invitations.from_email"],
@@ -1305,8 +1308,7 @@ def send_user_invite_email(mapper, connection, target):
         subject=cfg["invitations.email_subject"],
         html_content=(
             f'{cfg["invitations.email_body_preamble"]}<br /><br />'
-            f'Please click <a href="{app_base_url}/login/google-oauth2/'
-            f'?invite_token={target.token}">here</a> to join.'
+            f'Please click <a href="{link_location}">here</a> to join.'
         ),
     )
     sg = SendGridAPIClient(os.environ.get('SENDGRID_API_KEY'))

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -1285,6 +1285,7 @@ class Invitation(Base):
         passive_deletes=True,
         uselist=False,
     )
+    used = sa.Column(sa.Boolean, nullable=False, default=False)
 
 
 GroupInvitation = join_model('group_invitations', Group, Invitation)

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -1294,13 +1294,17 @@ UserInvitation = join_model("user_invitations", User, Invitation)
 @event.listens_for(Invitation, 'after_insert')
 def send_user_invite_email(mapper, connection, target):
     _, cfg = load_env()
+    app_base_url = (
+        f"{'https' if cfg['server.ssl'] else 'http'}:"
+        "//{cfg['server.host']}:{cfg['ports.app']}"
+    )
     message = Mail(
         from_email=cfg["invitations.from_email"],
         to_emails=target.user_email,
         subject=cfg["invitations.email_subject"],
         html_content=(
             f'{cfg["invitations.email_body_preamble"]}<br /><br />'
-            'Please click <a href="http://localhost:5000/login/google-oauth2/'
+            f'Please click <a href="{app_base_url}/login/google-oauth2/'
             f'?invite_token={target.token}">here</a> to join.'
         ),
     )

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -1,4 +1,3 @@
-import os
 import uuid
 import re
 from datetime import datetime, timezone
@@ -1309,7 +1308,7 @@ def send_user_invite_email(mapper, connection, target):
             f'Please click <a href="{link_location}">here</a> to join.'
         ),
     )
-    sg = SendGridAPIClient(os.environ.get('SENDGRID_API_KEY'))
+    sg = SendGridAPIClient(cfg["invitations.sendgrid_api_key"])
     sg.send(message)
 
 

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -1299,9 +1299,7 @@ def send_user_invite_email(mapper, connection, target):
         f"{'https' if cfg['server.ssl'] else 'http'}:"
         f"//{cfg['server.host']}:{cfg['ports.app']}"
     )
-    link_location = (
-        f'{app_base_url}/login/google-oauth2/' f'?invite_token={target.token}'
-    )
+    link_location = f'{app_base_url}/login/google-oauth2/?invite_token={target.token}'
     message = Mail(
         from_email=cfg["invitations.from_email"],
         to_emails=target.user_email,

--- a/skyportal/onboarding.py
+++ b/skyportal/onboarding.py
@@ -6,7 +6,7 @@ from baselayer.app.env import load_env
 
 env, cfg = load_env()
 
-USER_FIELDS = ['username', 'email']
+USER_FIELDS = ["username", "email"]
 
 
 def create_user(strategy, details, backend, user=None, *args, **kwargs):
@@ -38,16 +38,17 @@ def create_user(strategy, details, backend, user=None, *args, **kwargs):
         DBSession().add(user)
         invitation.used = True
         DBSession().commit()
-        return {'is_new': True, 'user': user}
-
-    if cfg["server.auth.debug_login"] and user is None:  # Allow uninvited new auths
+        return {"is_new": True, "user": user}
+    elif not cfg["invitations.enabled"] and not cfg["server.auth.debug_login"]:
+        if user is not None:  # Matching user already exists
+            return {"is_new": False, "user": user}
+        # No matching user exists; create a new user
         fields = dict(
             (name, kwargs.get(name, details.get(name)))
-            for name in backend.setting('USER_FIELDS', USER_FIELDS)
+            for name in backend.setting("USER_FIELDS", USER_FIELDS)
         )
         user = strategy.create_user(**fields)
-
-        return {'is_new': True, 'user': user}
+        return {"is_new": True, "user": user}
     elif user is not None:
         return {"is_new": False, "user": user}
 

--- a/skyportal/onboarding.py
+++ b/skyportal/onboarding.py
@@ -60,7 +60,7 @@ def setup_invited_user_permissions(strategy, uid, details, user, *args, **kwargs
 
     invitation = Invitation.query.filter(Invitation.token == invite_token).first()
     if invitation is None:
-        return
+        raise AuthTokenError("Invalid invite token.")
 
     group_ids = [g.id for g in invitation.groups]
 

--- a/skyportal/onboarding.py
+++ b/skyportal/onboarding.py
@@ -12,7 +12,7 @@ USER_FIELDS = ['username', 'email']
 def create_user(strategy, details, backend, user=None, *args, **kwargs):
     invite_token = strategy.session_get("invite_token")
 
-    if invite_token is not None:
+    if cfg["invitations.enabled"] and invite_token is not None:
         try:
             n_days = int(cfg["invitations.days_until_expiry"])
         except ValueError:
@@ -53,6 +53,9 @@ def create_user(strategy, details, backend, user=None, *args, **kwargs):
 
 
 def setup_invited_user_permissions(strategy, uid, details, user, *args, **kwargs):
+    if not cfg["invitations.enabled"]:
+        return
+
     invite_token = strategy.session_get("invite_token")
 
     invitation = Invitation.query.filter(Invitation.token == invite_token).first()

--- a/skyportal/onboarding.py
+++ b/skyportal/onboarding.py
@@ -1,6 +1,6 @@
 import datetime
 from social_core.exceptions import AuthTokenError
-from ..models import DBSession, User, Group, GroupUser, Invitation
+from .models import DBSession, User, Group, GroupUser, Invitation
 from baselayer.app.env import load_env
 
 

--- a/skyportal/onboarding.py
+++ b/skyportal/onboarding.py
@@ -22,7 +22,7 @@ def create_user(strategy, details, backend, user=None, *args, **kwargs):
             )
         invitation = Invitation.query.filter(Invitation.token == invite_token).first()
         if invitation is None:
-            return
+            raise AuthTokenError("Invalid invite token.")
 
         cutoff_datetime = datetime.datetime.now() - datetime.timedelta(days=n_days)
         if invitation.created_at < cutoff_datetime:

--- a/skyportal/tests/frontend/test_groups.py
+++ b/skyportal/tests/frontend/test_groups.py
@@ -118,6 +118,9 @@ def test_add_new_group_user_new_username(driver, super_admin_user, user, public_
     driver.click_xpath('//span[text()="Confirm"]')
     if cfg["invitations.enabled"]:  # If invites are disabled, we won't see this notif.
         driver.wait_for_xpath('//*[contains(., "Invitation successfully sent to")]')
+    else:
+        # If invitations are disabled, the user will be added and will appear
+        driver.wait_for_xpath(f'//a[contains(.,"{new_username}")]')
 
 
 @pytest.mark.flaky(reruns=2)

--- a/skyportal/tests/frontend/test_groups.py
+++ b/skyportal/tests/frontend/test_groups.py
@@ -1,6 +1,10 @@
 import uuid
 import pytest
 from selenium.webdriver.common.keys import Keys
+from baselayer.app.env import load_env
+
+
+_, cfg = load_env()
 
 
 def test_public_groups_list(driver, user, public_group):
@@ -99,9 +103,7 @@ def test_add_new_group_user_nonadmin(
     )
 
 
-@pytest.mark.xfail(
-    strict=False
-)  # This will now fail without valid Twilio Sendgrid config files
+@pytest.mark.flaky(reruns=2)
 def test_add_new_group_user_new_username(driver, super_admin_user, user, public_group):
     new_username = str(uuid.uuid4())
     driver.get(f'/become_user/{super_admin_user.id}')
@@ -114,7 +116,8 @@ def test_add_new_group_user_new_username(driver, super_admin_user, user, public_
     )
     driver.click_xpath('//input[@value="Add user"]')
     driver.click_xpath('//span[text()="Confirm"]')
-    driver.wait_for_xpath('//*[contains(., "Invitation successfully sent to")]')
+    if cfg["invitations.enabled"]:  # If invites are disabled, we won't see this notif.
+        driver.wait_for_xpath('//*[contains(., "Invitation successfully sent to")]')
 
 
 @pytest.mark.flaky(reruns=2)

--- a/skyportal/tests/frontend/test_groups.py
+++ b/skyportal/tests/frontend/test_groups.py
@@ -99,7 +99,9 @@ def test_add_new_group_user_nonadmin(
     )
 
 
-@pytest.mark.flaky(reruns=2)
+@pytest.mark.xfail(
+    strict=False
+)  # This will now fail without valid Twilio Sendgrid config files
 def test_add_new_group_user_new_username(driver, super_admin_user, user, public_group):
     new_username = str(uuid.uuid4())
     driver.get(f'/become_user/{super_admin_user.id}')
@@ -111,7 +113,8 @@ def test_add_new_group_user_new_username(driver, super_admin_user, user, public_
         new_username, Keys.ENTER
     )
     driver.click_xpath('//input[@value="Add user"]')
-    driver.wait_for_xpath(f'//a[contains(.,"{new_username}")]')
+    driver.click_xpath('//span[text()="Confirm"]')
+    driver.wait_for_xpath('//*[contains(., "Invitation successfully sent to")]')
 
 
 @pytest.mark.flaky(reruns=2)

--- a/skyportal/utils/onboarding.py
+++ b/skyportal/utils/onboarding.py
@@ -1,0 +1,55 @@
+from ..models import DBSession, User, Group, GroupUser, Invitation
+from baselayer.app.env import load_env
+
+
+env, cfg = load_env()
+
+USER_FIELDS = ['username', 'email']
+
+
+def create_user(strategy, details, backend, user=None, *args, **kwargs):
+    invite_token = strategy.session_get("invite_token")
+
+    if invite_token is not None:
+        user = User(
+            username=details["username"],
+            contact_email=details["email"],
+            first_name=details["first_name"],
+            last_name=details["last_name"],
+        )
+        DBSession().add(user)
+        DBSession().commit()
+    if cfg["server.auth.debug_login"] and user is None:  # Allow uninvited new auths
+        fields = dict(
+            (name, kwargs.get(name, details.get(name)))
+            for name in backend.setting('USER_FIELDS', USER_FIELDS)
+        )
+        user = strategy.create_user(**fields)
+
+    return {'is_new': True, 'user': user}
+
+
+def setup_invited_user_permissions(strategy, uid, details, user, *args, **kwargs):
+    invite_token = strategy.session_get("invite_token")
+
+    invitation = Invitation.query.filter(Invitation.token == invite_token).first()
+    if invitation is None:
+        return
+
+    group_ids = [g.id for g in invitation.groups]
+
+    # Add user to specified groups
+    for group_id, admin in zip(group_ids, invitation.admin_for_groups):
+        DBSession.add(GroupUser(user_id=user.id, group_id=group_id, admin=admin))
+
+    # Create single-user group
+    DBSession().add(Group(name=user.username, users=[user], single_user_group=True))
+
+    # Add user to sitewide public group
+    public_group = Group.query.filter(
+        Group.name == cfg["misc"]["public_group_name"]
+    ).first()
+    if public_group is not None:
+        DBSession().add(GroupUser(group_id=public_group.id, user_id=user.id))
+
+    DBSession().commit()

--- a/skyportal/utils/onboarding.py
+++ b/skyportal/utils/onboarding.py
@@ -14,11 +14,11 @@ def create_user(strategy, details, backend, user=None, *args, **kwargs):
 
     if invite_token is not None:
         try:
-            n_days = int(cfg["invitations.days_til_expiry"])
+            n_days = int(cfg["invitations.days_until_expiry"])
         except ValueError:
             raise ValueError(
                 "Invalid (non-integer) value provided for "
-                "invitations.days_til_expiry in config file."
+                "invitations.days_until_expiry in config file."
             )
         invitation = Invitation.query.filter(Invitation.token == invite_token).first()
         if invitation is None:

--- a/skyportal/utils/onboarding.py
+++ b/skyportal/utils/onboarding.py
@@ -27,6 +27,8 @@ def create_user(strategy, details, backend, user=None, *args, **kwargs):
         cutoff_datetime = datetime.datetime.now() - datetime.timedelta(days=n_days)
         if invitation.created_at < cutoff_datetime:
             raise AuthTokenError("Invite token has expired.")
+        if invitation.used:
+            raise AuthTokenError("Invite token has already been used.")
         user = User(
             username=details["username"],
             contact_email=details["email"],
@@ -34,6 +36,7 @@ def create_user(strategy, details, backend, user=None, *args, **kwargs):
             last_name=details["last_name"],
         )
         DBSession().add(user)
+        invitation.used = True
         DBSession().commit()
     if cfg["server.auth.debug_login"] and user is None:  # Allow uninvited new auths
         fields = dict(

--- a/skyportal/utils/onboarding.py
+++ b/skyportal/utils/onboarding.py
@@ -38,6 +38,8 @@ def create_user(strategy, details, backend, user=None, *args, **kwargs):
         DBSession().add(user)
         invitation.used = True
         DBSession().commit()
+        return {'is_new': True, 'user': user}
+
     if cfg["server.auth.debug_login"] and user is None:  # Allow uninvited new auths
         fields = dict(
             (name, kwargs.get(name, details.get(name)))
@@ -45,7 +47,9 @@ def create_user(strategy, details, backend, user=None, *args, **kwargs):
         )
         user = strategy.create_user(**fields)
 
-    return {'is_new': True, 'user': user}
+        return {'is_new': True, 'user': user}
+    elif user is not None:
+        return {"is_new": False, "user": user}
 
 
 def setup_invited_user_permissions(strategy, uid, details, user, *args, **kwargs):

--- a/static/js/components/NewGroupUserForm.jsx
+++ b/static/js/components/NewGroupUserForm.jsx
@@ -12,6 +12,7 @@ import DialogContent from "@material-ui/core/DialogContent";
 import DialogContentText from "@material-ui/core/DialogContentText";
 import DialogTitle from "@material-ui/core/DialogTitle";
 
+import { showNotification } from "baselayer/components/Notifications";
 import * as groupsActions from "../ducks/groups";
 import * as usersActions from "../ducks/users";
 
@@ -33,14 +34,21 @@ const NewGroupUserForm = ({ group_id }) => {
     }
   }, [dispatch, allUsers]);
 
-  const submitAndResetForm = () => {
-    dispatch(
+  const submitAndResetForm = async () => {
+    const result = await dispatch(
       groupsActions.addGroupUser({
         username: formState.newUserEmail,
         admin: formState.admin,
         group_id,
       })
     );
+    if (formState.invitingNewUser && result.status === "success") {
+      dispatch(
+        showNotification(
+          `Invitation successfully sent to ${formState.newUserEmail}`
+        )
+      );
+    }
     setFormState({
       newUserEmail: null,
       admin: false,

--- a/static/js/components/NewGroupUserForm.jsx
+++ b/static/js/components/NewGroupUserForm.jsx
@@ -42,7 +42,11 @@ const NewGroupUserForm = ({ group_id }) => {
         group_id,
       })
     );
-    if (formState.invitingNewUser && result.status === "success") {
+    if (
+      formState.invitingNewUser &&
+      result.status === "success" &&
+      result.data.user_id === null
+    ) {
       dispatch(
         showNotification(
           `Invitation successfully sent to ${formState.newUserEmail}`

--- a/static/js/components/NewGroupUserForm.jsx
+++ b/static/js/components/NewGroupUserForm.jsx
@@ -5,6 +5,12 @@ import TextField from "@material-ui/core/TextField";
 import Autocomplete, {
   createFilterOptions,
 } from "@material-ui/lab/Autocomplete";
+import Button from "@material-ui/core/Button";
+import Dialog from "@material-ui/core/Dialog";
+import DialogActions from "@material-ui/core/DialogActions";
+import DialogContent from "@material-ui/core/DialogContent";
+import DialogContentText from "@material-ui/core/DialogContentText";
+import DialogTitle from "@material-ui/core/DialogTitle";
 
 import * as groupsActions from "../ducks/groups";
 import * as usersActions from "../ducks/users";
@@ -17,7 +23,9 @@ const NewGroupUserForm = ({ group_id }) => {
   const [formState, setFormState] = useState({
     newUserEmail: null,
     admin: false,
+    invitingNewUser: false,
   });
+  const [confirmDialogOpen, setConfirmDialogOpen] = React.useState(false);
 
   useEffect(() => {
     if (allUsers.length === 0) {
@@ -25,8 +33,7 @@ const NewGroupUserForm = ({ group_id }) => {
     }
   }, [dispatch, allUsers]);
 
-  const handleSubmit = (event) => {
-    event.preventDefault();
+  const submitAndResetForm = () => {
     dispatch(
       groupsActions.addGroupUser({
         username: formState.newUserEmail,
@@ -37,7 +44,18 @@ const NewGroupUserForm = ({ group_id }) => {
     setFormState({
       newUserEmail: null,
       admin: false,
+      invitingNewUser: false,
     });
+  };
+
+  const handleClickSubmit = (event) => {
+    event.preventDefault();
+    if (formState.invitingNewUser) {
+      // If user clicks confirm, `submitAndResetForm` will be called
+      setConfirmDialogOpen(true);
+    } else {
+      submitAndResetForm();
+    }
   };
 
   const toggleAdmin = (event) => {
@@ -61,6 +79,7 @@ const NewGroupUserForm = ({ group_id }) => {
             // Create a new value from the user input
             setFormState({
               newUserEmail: newValue.inputValue,
+              invitingNewUser: true,
             });
           } else {
             setFormState({ newUserEmail: newValue.username });
@@ -105,7 +124,44 @@ const NewGroupUserForm = ({ group_id }) => {
       />
       <input type="checkbox" checked={formState.admin} onChange={toggleAdmin} />
       Group Admin &nbsp;&nbsp;
-      <input type="submit" onClick={handleSubmit} value="Add user" />
+      <input type="submit" onClick={handleClickSubmit} value="Add user" />
+      <Dialog
+        open={confirmDialogOpen}
+        onClose={() => {
+          setConfirmDialogOpen(false);
+        }}
+        aria-labelledby="alert-dialog-title"
+        aria-describedby="alert-dialog-description"
+      >
+        <DialogTitle id="alert-dialog-title">
+          Invite new user to this group?
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText id="alert-dialog-description">
+            Click Confirm to invite specified user and grant them access to this
+            group.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            onClick={() => {
+              setConfirmDialogOpen(false);
+            }}
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={() => {
+              setConfirmDialogOpen(false);
+              submitAndResetForm();
+            }}
+            color="primary"
+            autoFocus
+          >
+            Confirm
+          </Button>
+        </DialogActions>
+      </Dialog>
     </div>
   );
 };

--- a/static/js/components/NewGroupUserForm.jsx
+++ b/static/js/components/NewGroupUserForm.jsx
@@ -76,6 +76,7 @@ const NewGroupUserForm = ({ group_id }) => {
       admin: event.target.checked,
     });
   };
+  const allUserNames = allUsers.map((user) => user.username);
 
   return (
     <div>
@@ -84,11 +85,13 @@ const NewGroupUserForm = ({ group_id }) => {
         value={formState.newUserEmail}
         onChange={(event, newValue) => {
           if (typeof newValue === "string") {
+            // The user has entered a username and hit the Enter/Return key
             setFormState({
               newUserEmail: newValue,
+              invitingNewUser: !allUserNames.includes(newValue),
             });
           } else if (newValue && newValue.inputValue) {
-            // Create a new value from the user input
+            // The user has entered a new username and clicked the "Add" option
             setFormState({
               newUserEmail: newValue.inputValue,
               invitingNewUser: true,

--- a/static/js/components/UpdateProfileForm.jsx
+++ b/static/js/components/UpdateProfileForm.jsx
@@ -27,6 +27,7 @@ const UpdateProfileForm = () => {
 
   useEffect(() => {
     reset({
+      username: profile.username,
       firstName: profile.first_name,
       lastName: profile.last_name,
       email: profile.contact_email ? profile.contact_email : profile.username,
@@ -34,13 +35,14 @@ const UpdateProfileForm = () => {
     });
   }, [reset, profile]);
 
-  const onSubmit = async (value) => {
+  const onSubmit = async (formValues) => {
     setIsSubmitting(true);
     const basicinfo = {
-      first_name: value.firstName,
-      last_name: value.lastName,
-      contact_email: value.email,
-      contact_phone: value.phone,
+      username: formValues.username,
+      first_name: formValues.firstName,
+      last_name: formValues.lastName,
+      contact_email: formValues.email,
+      contact_phone: formValues.phone,
     };
     const result = await dispatch(
       ProfileActions.updateBasicUserInfo(basicinfo)
@@ -53,12 +55,20 @@ const UpdateProfileForm = () => {
 
   return (
     <div>
-      <Typography variant="h5">Change User Profile</Typography>
-
+      <Typography variant="h5">Update User Profile</Typography>
       <Card>
         <CardContent>
-          <h2>Contact Information</h2>
+          <h2>Username</h2>
           <form onSubmit={handleSubmit(onSubmit)}>
+            <InputLabel htmlFor="usernameInput">Username</InputLabel>
+            <TextField
+              inputRef={register({ required: true })}
+              name="username"
+              id="usernameInput"
+              error={!!errors.username}
+              helperText={errors.username ? "Required" : ""}
+            />
+            <h2>Contact Information</h2>
             <Grid
               container
               direction="row"

--- a/static/js/components/UpdateProfileForm.jsx
+++ b/static/js/components/UpdateProfileForm.jsx
@@ -6,6 +6,11 @@ import Button from "@material-ui/core/Button";
 import Card from "@material-ui/core/Card";
 import CardContent from "@material-ui/core/CardContent";
 import Typography from "@material-ui/core/Typography";
+import Dialog from "@material-ui/core/Dialog";
+import DialogActions from "@material-ui/core/DialogActions";
+import DialogContent from "@material-ui/core/DialogContent";
+import DialogContentText from "@material-ui/core/DialogContentText";
+import DialogTitle from "@material-ui/core/DialogTitle";
 
 import { showNotification } from "baselayer/components/Notifications";
 
@@ -24,6 +29,11 @@ const UpdateProfileForm = () => {
 
   const dispatch = useDispatch();
   const { handleSubmit, register, reset, errors } = useForm();
+
+  const isNewUser =
+    new URL(window.location).searchParams.get("newUser") === "true";
+
+  const [welcomeDialogOpen, setWelcomeDialogOpen] = useState(isNewUser);
 
   useEffect(() => {
     reset({
@@ -151,6 +161,36 @@ const UpdateProfileForm = () => {
           <UIPreferences />
         </CardContent>
       </Card>
+      <Dialog
+        open={welcomeDialogOpen}
+        onClose={() => {
+          setWelcomeDialogOpen(false);
+        }}
+        aria-labelledby="alert-dialog-title"
+        aria-describedby="alert-dialog-description"
+      >
+        <DialogTitle id="alert-dialog-title">Welcome!</DialogTitle>
+        <DialogContent>
+          <DialogContentText id="alert-dialog-description">
+            First, please change your username as you see fit. You can also
+            change your contact email address to something other than the one
+            you used to authenticate. If you have a gravatar (
+            <a href="https://en.gravatar.com/">https://en.gravatar.com/</a>)
+            account set up for your contact email address then we&apos;ll use
+            that gravatar picture throughout. Once you&apos;re done setting up
+            your profile info, click Dashboard to get started.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            onClick={() => {
+              setWelcomeDialogOpen(false);
+            }}
+          >
+            Got it. Let&apos;s go!
+          </Button>
+        </DialogActions>
+      </Dialog>
     </div>
   );
 };

--- a/static/js/components/UserProfileInfo.jsx
+++ b/static/js/components/UserProfileInfo.jsx
@@ -44,12 +44,6 @@ const UserProfileInfo = () => {
         &nbsp;
         <br />
         <Typography component="div">
-          <Box fontWeight="fontWeightBold" component="span" mr={1}>
-            Username:
-          </Box>
-          {profile.username}
-        </Typography>
-        <Typography component="div">
           <Box pb={1}>
             <Box fontWeight="fontWeightBold" component="span" mr={1}>
               User roles:

--- a/static/js/ducks/profile.js
+++ b/static/js/ducks/profile.js
@@ -25,14 +25,8 @@ export function updateUserPreferences(preferences) {
   });
 }
 
-export function updateBasicUserInfo(basicinfo) {
-  const { first_name, last_name, contact_email, contact_phone } = basicinfo;
-  return API.PATCH("/api/internal/profile", UPDATE_BASIC_USER_INFO, {
-    first_name,
-    last_name,
-    contact_email,
-    contact_phone,
-  });
+export function updateBasicUserInfo(formData) {
+  return API.PATCH("/api/internal/profile", UPDATE_BASIC_USER_INFO, formData);
 }
 
 export function fetchUserProfile() {

--- a/test_config.yaml
+++ b/test_config.yaml
@@ -10,3 +10,14 @@ server:
     debug_login: True
     google_oauth2_key:
     google_oauth2_secret:
+
+invitations:
+  enabled: False
+  days_until_expiry: 3
+  email_subject: "You've been invited to collaborate on SkyPortal"
+  email_body_preamble: | # This can include HTML tags
+    Welcome to <b>SkyPortal</b>!
+    <br />
+    Some other text here.
+  from_email: # This needs to be set to a valid, Sendgrid-registered address in config.yaml
+  sendgrid_api_key: # This needs to be obtained via Sendgrid setup on their site


### PR DESCRIPTION
This PR introduces a new pipeline for inviting new users to collaborate on SkyPortal. A new user can be invited to join SP from the group page (admin must click "Confirm" in a dialog in this case, see screen capture below), and an `Invitation` instance will be created (this new table is added in this PR). When the row is inserted, an event listener is triggered, sending the user an email via Twilio Sendgrid containing a login link with a unique invite token. When they authenticate (only Google OAuth is currently supported), the matching `Invitation` record is fetched, which contains the group(s) and admin status(es) that should be granted to the user after they've authenticated and a new user instance is created. Upon initial authentication, they're directed to the profile page, where they can change their username, contact email, etc (this front-end form/handler has been updated here to allow for this, as well). Subsequent logins direct the user to the homepage. The invite email subject and body preamble are set in config.yaml.defaults, as well as the expiry period; an expired invitation will result in an Auth error being raised during the authentication process. 

![invite_new_user_notification](https://user-images.githubusercontent.com/7230285/91626314-f97ce480-e962-11ea-901d-145382db917d.gif)

![invite_new_user_and_login_with_link](https://user-images.githubusercontent.com/7230285/91621083-abf27e80-e946-11ea-970e-569b9490e351.gif)

![auth_redirect_profile_username](https://user-images.githubusercontent.com/7230285/91621112-c75d8980-e946-11ea-9d7c-58591413403c.gif)
