### PR TITLE
update gitignore to ignore file with secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ geckodriver.log
 __pycache__/
 node_modules/
 *.pyc
-./config.yaml
+config.yaml
 static/thumbnails
 *.lock
 *.dirlock


### PR DESCRIPTION
the previous `.gitignore` did not ignore config.yaml, with this PR it is ignored. now it can be used to store secrets.