### PR TITLE
Fix share page component error

### DIFF
--- a/static/js/components/SharePage.jsx
+++ b/static/js/components/SharePage.jsx
@@ -36,7 +36,7 @@ const SharePage = () => {
         aria-label="share page"
         onClick={handleOpen}
         edge="start"
-        disableRipple="true"
+        disableRipple
       >
         <MobileScreenShareIcon color="action" />
       </IconButton>


### PR DESCRIPTION
Fixing incorrect MUI IconButton parameter for SharePage.jsx

![Screenshot 2020-09-01 133855](https://user-images.githubusercontent.com/17696889/91904023-119d7e00-ec59-11ea-9d4b-f459888d1606.png)
