### PR TITLE
React sends null as a ref on component unmount; do not expect otherwise.

### DIFF
--- a/static/js/components/AirmassPlot.jsx
+++ b/static/js/components/AirmassPlot.jsx
@@ -46,9 +46,11 @@ const AirmassPlot = React.memo((props) => {
   return (
     <div
       ref={(node) => {
-        embed(node, airmass_spec(dataUrl, ephemeris), {
-          actions: false,
-        });
+        if (node) {
+          embed(node, airmass_spec(dataUrl, ephemeris), {
+            actions: false,
+          });
+        }
       }}
     />
   );

--- a/static/js/components/CentroidPlot.jsx
+++ b/static/js/components/CentroidPlot.jsx
@@ -322,9 +322,11 @@ const CentroidPlot = ({ sourceId }) => {
         <div
           className="centroid-plot-div"
           ref={(node) => {
-            embed(node, spec(plotData), {
-              actions: false,
-            });
+            if (node) {
+              embed(node, spec(plotData), {
+                actions: false,
+              });
+            }
           }}
         />
       );

--- a/static/js/components/VegaPlot.jsx
+++ b/static/js/components/VegaPlot.jsx
@@ -171,9 +171,11 @@ const VegaPlot = React.memo((props) => {
   return (
     <div
       ref={(node) => {
-        embed(node, spec(dataUrl), {
-          actions: false,
-        });
+        if (node) {
+          embed(node, spec(dataUrl), {
+            actions: false,
+          });
+        }
       }}
     />
   );


### PR DESCRIPTION
Edited by acrellin: does not close 793, as it's two separate issues

@acrellin There seems to be another issue, though, which is that clicking "search" as provisioned admin returns no results.  Any idea why that would be?  The initial page load produces results.