### PR TITLE
Ensure state.groups.all includes single user groups upon ShareDataForm render

### DIFF
--- a/static/js/actions.js
+++ b/static/js/actions.js
@@ -17,7 +17,7 @@ export default function hydrate() {
     dispatch(sysInfoActions.fetchSystemInfo());
     dispatch(dbInfoActions.fetchDBInfo());
     dispatch(profileActions.fetchUserProfile());
-    dispatch(groupsActions.fetchGroups());
+    dispatch(groupsActions.fetchGroups(true));
     dispatch(newsFeedActions.fetchNewsFeed());
     dispatch(topSourcesActions.fetchTopSources());
     dispatch(instrumentsActions.fetchInstruments());

--- a/static/js/components/GroupManagement.jsx
+++ b/static/js/components/GroupManagement.jsx
@@ -25,7 +25,9 @@ const useStyles = makeStyles(() => ({
 
 const GroupManagement = () => {
   const classes = useStyles();
-  const allGroups = useSelector((state) => state.groups.all);
+  const allGroups = useSelector((state) => state.groups.all).filter(
+    (group) => !group.single_user_group
+  );
 
   return (
     <Paper variant="outlined">

--- a/static/js/components/ShareDataForm.jsx
+++ b/static/js/components/ShareDataForm.jsx
@@ -87,8 +87,16 @@ const ShareDataForm = ({ route }) => {
   useEffect(() => {
     dispatch(photometryActions.fetchSourcePhotometry(route.id));
     dispatch(spectraActions.fetchSourceSpectra(route.id));
-    dispatch(groupsActions.fetchGroups(true));
   }, [route.id, dispatch]);
+
+  useEffect(() => {
+    const fetchGroups = () => {
+      dispatch(groupsActions.fetchGroups(true));
+    };
+    if (!groups || !groups.filter((g) => g.single_user_group).length) {
+      fetchGroups();
+    }
+  }, [route.id, dispatch, groups]);
 
   const validateGroups = () => {
     const formState = getValues({ nest: true });

--- a/static/js/components/ShareDataForm.jsx
+++ b/static/js/components/ShareDataForm.jsx
@@ -18,7 +18,6 @@ import Plot from "./Plot";
 import * as photometryActions from "../ducks/photometry";
 import * as spectraActions from "../ducks/spectra";
 import * as sourceActions from "../ducks/source";
-import * as groupsActions from "../ducks/groups";
 import styles from "./Source.css";
 
 const createPhotRow = (
@@ -88,15 +87,6 @@ const ShareDataForm = ({ route }) => {
     dispatch(photometryActions.fetchSourcePhotometry(route.id));
     dispatch(spectraActions.fetchSourceSpectra(route.id));
   }, [route.id, dispatch]);
-
-  useEffect(() => {
-    const fetchGroups = () => {
-      dispatch(groupsActions.fetchGroups(true));
-    };
-    if (!groups || !groups.filter((g) => g.single_user_group).length) {
-      fetchGroups();
-    }
-  }, [route.id, dispatch, groups]);
 
   const validateGroups = () => {
     const formState = getValues({ nest: true });


### PR DESCRIPTION
The issue was that sometimes the `fetchGroups()` call in `hydrate` (which does not fetch single user groups) was returning after the `fetchGroups(includeSingleUserGroups=true)` call in `ShareDataForm`. Now, when the component initially renders and when the groups list is updated, the groups list is checked, and if no single user groups are present, `fetchGroups(includeSingleUserGroups=true)` is called.

Closes https://github.com/skyportal/skyportal/issues/787