### PR TITLE
use & to separate parameters in URL

### DIFF
--- a/static/js/components/UserAvatar.jsx
+++ b/static/js/components/UserAvatar.jsx
@@ -29,7 +29,7 @@ const UserAvatar = ({ size, firstName, lastName, username, gravatarUrl }) => {
   return (
     <Avatar
       alt={backUpLetters}
-      src={`${gravatarUrl}s=${size}`}
+      src={`${gravatarUrl}&s=${size}`}
       size={size}
       style={{
         width: size,


### PR DESCRIPTION
A user without a gravatar will not cause an insecure URL call.