### PR TITLE
Revert react-dnd and @date-io/dayjs version upgrades

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "test": "eslint --ext .jsx,.js static/js && make test"
   },
   "dependencies": {
-    "@date-io/dayjs": "2.9.0",
+    "@date-io/dayjs": "1.3.13",
     "@material-ui/core": "4.11.0",
     "@material-ui/icons": "4.9.1",
     "@material-ui/lab": "4.0.0-alpha.56",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "raw-loader": "4.0.1",
     "react": "16.13.1",
     "react-datepicker": "3.1.3",
-    "react-dnd": "11.1.3",
     "react-dom": "16.13.1",
     "react-grid-layout": "1.0.0",
     "react-hook-form": "5.7.2",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "react": "16.13.1",
     "react-datepicker": "3.1.3",
     "react-dom": "16.13.1",
+    "react-dnd": "7.7.0",
     "react-grid-layout": "1.0.0",
     "react-hook-form": "5.7.2",
     "react-redux": "7.2.1",


### PR DESCRIPTION
test PR to see if removing react dnd as a dependency fixes GA