### PR TITLE
fix admin label positioning

### DIFF
--- a/static/js/components/Group.jsx
+++ b/static/js/components/Group.jsx
@@ -261,7 +261,6 @@ const Group = () => {
                     id={`${user.id}-admin-chip`}
                   >
                     <Chip label="Admin" size="small" color="secondary" />
-                    &nbsp;&nbsp;
                   </div>
                 )}
                 {isAdmin(currentUser) &&


### PR DESCRIPTION
Not fixed in the top label:
![image](https://user-images.githubusercontent.com/7557205/92445329-11c1e000-f169-11ea-9d19-b0981d55becb.png)
