### PR TITLE
Show spinner on initial scanning page load

### DIFF
--- a/static/js/components/CandidateList.jsx
+++ b/static/js/components/CandidateList.jsx
@@ -65,7 +65,10 @@ const CandidateList = () => {
 
   useEffect(() => {
     if (candidates === null) {
+      setQueryInProgress(true);
       dispatch(candidatesActions.fetchCandidates());
+    } else {
+      setQueryInProgress(false);
     }
   }, [candidates, dispatch]);
 


### PR DESCRIPTION
Closes https://github.com/skyportal/skyportal/issues/861

![spinner_scanning_page_initial_load](https://user-images.githubusercontent.com/7230285/92510899-685b0880-f1c1-11ea-8530-02e97faee5a8.gif)
