### PR TITLE
fix rendering of observing run titles

### DIFF
--- a/static/js/components/AssignmentForm.jsx
+++ b/static/js/components/AssignmentForm.jsx
@@ -31,19 +31,24 @@ export function observingRunTitle(
 
   const group = groups?.filter((g) => g.id === observingRun.group_id)[0];
 
-  if (
-    !(
-      observingRun?.calendar_date &&
-      instrument?.name &&
-      telescope?.name &&
-      observingRun?.pi &&
-      group?.name
-    )
-  ) {
+  if (!(observingRun?.calendar_date && instrument?.name && telescope?.name)) {
     return "Loading ...";
   }
 
-  return `${observingRun?.calendar_date} ${instrument?.name}/${telescope?.nickname} (PI: ${observingRun?.pi} / Group: ${group?.name})`;
+  let result = `${observingRun?.calendar_date} ${instrument?.name}/${telescope?.nickname}`;
+
+  if (observingRun?.pi || group?.name) {
+    result += " (";
+    if (observingRun?.pi) {
+      result += `PI: ${observingRun.pi}`;
+    }
+    if (group?.name) {
+      result += ` / Group: ${group?.name}`;
+    }
+    result += ")";
+  }
+
+  return result;
 }
 
 const AssignmentForm = ({ obj_id, observingRunList }) => {


### PR DESCRIPTION
Currently, on the observing run page, the titles of observing runs that are not associated with any group render as "Loading...". This is because the render only completes successfully if a group ID is defined. 

This PR fixes this bug by defining render behavior when group ID is not defined for a run.

Before:

<img width="412" alt="Screen Shot 2020-09-08 at 10 11 19 PM" src="https://user-images.githubusercontent.com/2769632/92557504-34173480-f221-11ea-968d-e7f55d5091ba.png">

After:

<img width="375" alt="Screen Shot 2020-09-08 at 10 11 13 PM" src="https://user-images.githubusercontent.com/2769632/92557511-37aabb80-f221-11ea-87b5-dcde0bacde93.png">

