### PR TITLE
Render login error page with informative error message upon auth failure

### DIFF
--- a/skyportal/app_server.py
+++ b/skyportal/app_server.py
@@ -3,7 +3,7 @@ import tornado.web
 from baselayer.app.app_server import MainPageHandler
 from baselayer.app import model_util as baselayer_model_util
 
-from skyportal.handlers import BecomeUserHandler, LogoutHandler
+from skyportal.handlers import BecomeUserHandler, LogoutHandler, LoginErrorPageHandler
 from skyportal.handlers.api import (
     AllocationHandler,
     AssignmentHandler,
@@ -122,7 +122,8 @@ def make_app(cfg, baselayer_handlers, baselayer_settings):
         (r'/become_user(/.*)?', BecomeUserHandler),
         (r'/logout', LogoutHandler),
         # User-facing pages
-        (r'/.*', MainPageHandler)  # Route all frontend pages, such as
+        (r'/login-error/', LoginErrorPageHandler),
+        (r'/.*', MainPageHandler),  # Route all frontend pages, such as
         # `/source/g647ba`, through the main page.
         #
         # Refer to Main.jsx for routing info.
@@ -162,6 +163,7 @@ def make_app(cfg, baselayer_handlers, baselayer_settings):
                 ),
                 'SOCIAL_AUTH_NEW_USER_REDIRECT_URL': '/profile?newUser=true',
                 'SOCIAL_AUTH_FIELDS_STORED_IN_SESSION': ['invite_token'],
+                'SOCIAL_AUTH_LOGIN_ERROR_URL': '/login-error/',
             }
         )
 

--- a/skyportal/handlers/__init__.py
+++ b/skyportal/handlers/__init__.py
@@ -9,4 +9,5 @@ from baselayer.app.custom_exceptions import AccessError
 from .base import BaseHandler
 
 from .become_user import BecomeUserHandler
+from .loginerror import LoginErrorPageHandler
 from .logout import LogoutHandler

--- a/skyportal/handlers/loginerror.py
+++ b/skyportal/handlers/loginerror.py
@@ -1,0 +1,16 @@
+import os
+from baselayer.app.handlers.base import BaseHandler
+from baselayer.app.env import load_env
+
+
+env, cfg = load_env()
+
+
+class LoginErrorPageHandler(BaseHandler):
+    def get(self):
+        if os.environ.get("PSA_ERROR_MSG"):
+            error_message = str(os.environ.get("PSA_ERROR_MSG"))
+            os.environ["PSA_ERROR_MSG"] = ""
+        else:
+            error_message = "Unable to retrieve authentication error message."
+        self.render("loginerror.html", app=cfg["app"], error_message=error_message)

--- a/skyportal/onboarding.py
+++ b/skyportal/onboarding.py
@@ -1,5 +1,5 @@
+import os
 import datetime
-from social_core.exceptions import AuthTokenError
 from .models import (
     DBSession,
     User,
@@ -27,27 +27,34 @@ def create_user(strategy, details, backend, uid, user=None, *args, **kwargs):
     if cfg["invitations.enabled"]:
 
         if existing_user is None and invite_token is None:
-            raise AuthTokenError("No invite token provided.")
+            os.environ[
+                "PSA_ERROR_MSG"
+            ] = "No invite token provided, and no previously-authenticated matching Google OAuth account found."
+            return
         elif existing_user is not None:
             return {"is_new": False, "user": existing_user}
 
         try:
             n_days = int(cfg["invitations.days_until_expiry"])
         except ValueError:
-            raise ValueError(
+            os.environ["PSA_ERROR_MSG"] = (
                 "Invalid (non-integer) value provided for "
                 "invitations.days_until_expiry in config file."
             )
+            return
 
         invitation = Invitation.query.filter(Invitation.token == invite_token).first()
         if invitation is None:
-            raise AuthTokenError("Invalid invite token.")
+            os.environ["PSA_ERROR_MSG"] = "Invalid invite token."
+            return
 
         cutoff_datetime = datetime.datetime.now() - datetime.timedelta(days=n_days)
         if invitation.created_at < cutoff_datetime:
-            raise AuthTokenError("Invite token has expired.")
+            os.environ["PSA_ERROR_MSG"] = "Invite token has expired."
+            return
         if invitation.used:
-            raise AuthTokenError("Invite token has already been used.")
+            os.environ["PSA_ERROR_MSG"] = "Invite token has already been used."
+            return
 
         user = User(
             username=details["username"],
@@ -108,19 +115,28 @@ def get_username(strategy, details, backend, uid, user=None, *args, **kwargs):
 
 def setup_invited_user_permissions(strategy, uid, details, user, *args, **kwargs):
     if not cfg["invitations.enabled"]:
+        os.environ["PSA_ERROR_MSG"] = ""
         return
 
     existing_user = DBSession().query(User).filter(User.oauth_uid == uid).first()
 
     invite_token = strategy.session_get("invite_token")
     if invite_token is None:
+        if existing_user is None:
+            os.environ[
+                "PSA_ERROR_MSG"
+            ] = "No invite token provided, and no previously-authenticated matching Google OAuth account found."
+        else:
+            os.environ["PSA_ERROR_MSG"] = ""
         return
     invitation = Invitation.query.filter(Invitation.token == invite_token).first()
     if invitation is None:
-        raise AuthTokenError("Invalid invite token.")
+        os.environ["PSA_ERROR_MSG"] = "Invalid invite token."
+        return
 
     if invitation.used:
-        raise AuthTokenError("Invite token has already been used.")
+        os.environ["PSA_ERROR_MSG"] = "Invite token has already been used."
+        return
 
     group_ids = [g.id for g in invitation.groups]
 
@@ -164,3 +180,4 @@ def setup_invited_user_permissions(strategy, uid, details, user, *args, **kwargs
 
     invitation.used = True
     DBSession().commit()
+    os.environ["PSA_ERROR_MSG"] = ""

--- a/static/loginerror.html
+++ b/static/loginerror.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>{{ app["title"] }}</title>
+    <link rel="stylesheet" type="text/css" href="/static/login.css" />
+  </head>
+  <body>
+    <div class="loginBox">
+      <img src="{{ app['logo'] }}" class="logo" />
+      <span class="title">Welcome to {{ app["title"] }}</span>
+      <p>
+        Your authentication attempt has failed with the following error message:
+        <em>{{ error_message }}</em>
+      </p>
+      <p>
+        Please ensure that you are either logging in via a valid invitation link
+        or are attempting to login with the same OAuth account that you
+        previously used to login via an invite link. If you believe you are
+        seeing this in error, delete your cookies and try logging in again; if
+        the problem persists, please contact a site administrator.
+      </p>
+      <div class="loginButton">
+        <a href="/login/google-oauth2">
+          <img
+            src="/static/images/btn_google_signin_dark_normal_web.png"
+            alt="Click this image to log in"
+          />
+        </a>
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
This PR is one of two possible implementations (second option in forthcoming PR) for rendering a login error page upon unsuccessful authentication attempts. This PR utilizes `os.environ` variables and therefore will not be appropriate if a user's initial auth request might processed on a different node than the subsequent redirect request. The following PR will have a more general login error page that won't have the specific auth error message, but will not need to use environment variables.

![login_error_page_specific_message](https://user-images.githubusercontent.com/7230285/92664825-e1d62200-f2b9-11ea-97e1-b960b2fd15cc.png)
