### PR TITLE
Align rows in recent sources widget

### DIFF
--- a/static/js/components/RecentSources.jsx
+++ b/static/js/components/RecentSources.jsx
@@ -56,6 +56,7 @@ const useStyles = makeStyles(() => ({
     display: "flex",
     flexFlow: "column wrap",
     margin: "1rem 2rem",
+    flex: "0 1 50%",
   },
   recentSourceName: {
     fontSize: "1rem",
@@ -65,6 +66,7 @@ const useStyles = makeStyles(() => ({
   },
   quickViewButton: {
     visibility: "hidden",
+    textAlign: "center",
     display: "none",
   },
   recentSourceItemWithButton: {
@@ -73,7 +75,6 @@ const useStyles = makeStyles(() => ({
     justifyContent: "center",
     marginBottom: "1rem",
     marginLeft: "0.625rem",
-    alignItems: "center",
     transition: "all 0.3s ease",
     "&:hover": {
       backgroundColor: "#ddd",

--- a/static/js/components/RecentSources.jsx
+++ b/static/js/components/RecentSources.jsx
@@ -30,7 +30,8 @@ const useStyles = makeStyles(() => ({
     height: "auto",
     display: "block",
     "&:hover": {
-      transform: "scale(1.25)",
+      color: "rgba(255, 255, 255, 1)",
+      boxShadow: "0 5px 15px rgba(51, 52, 92, 0.6)",
     },
   },
   recentSourceListContainer: {


### PR DESCRIPTION
Also switch to using the warm glow on thumbnail hovers like the top sources

![Screenshot 2020-09-09 192313](https://user-images.githubusercontent.com/17696889/92675103-831da200-f2d3-11ea-8294-766cdca67df3.png)
