### PR TITLE
Fix 404s generated by invalid fetches to Gravatar

### DIFF
--- a/static/js/components/UserAvatar.jsx
+++ b/static/js/components/UserAvatar.jsx
@@ -1,10 +1,26 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { createMuiTheme } from "@material-ui/core/styles";
+import { makeStyles } from "@material-ui/core/styles";
 
 import Avatar from "@material-ui/core/Avatar";
 
-const theme = createMuiTheme({});
+const useStyles = makeStyles((theme) => ({
+  avatar: (props) => ({
+    width: props.size,
+    height: props.size,
+    backgroundColor: props.usercolor,
+    "&:after": {
+      content: `"${props.backUpLetters}"`,
+      color: theme.palette.getContrastText(props.usercolor),
+      fontWeight: "bold",
+      fontSize: `${Math.max(parseInt(parseFloat(props.size) / 3, 10), 10)}px`,
+      position: "absolute",
+    },
+  }),
+  avatarImg: {
+    zIndex: 5,
+  },
+}));
 
 const UserAvatar = ({ size, firstName, lastName, username, gravatarUrl }) => {
   // use the hash of the username (which is in the gravatarUrl) to
@@ -26,21 +42,19 @@ const UserAvatar = ({ size, firstName, lastName, username, gravatarUrl }) => {
       ? username.slice(0, 2)
       : `${firstName?.charAt(0)}${lastName?.charAt(0)}`;
 
+  const props = { size, usercolor, backUpLetters };
+  const classes = useStyles(props);
+
   return (
     <Avatar
       alt={backUpLetters}
       src={`${gravatarUrl}&s=${size}`}
       size={size}
-      style={{
-        width: size,
-        height: size,
-        backgroundColor: usercolor,
-        color: theme.palette.getContrastText(usercolor),
-        fontSize: `${Math.max(parseInt(parseFloat(size) / 3, 10), 10)}px`,
+      classes={{
+        root: classes.avatar,
+        img: classes.avatarImg,
       }}
-    >
-      {backUpLetters}
-    </Avatar>
+    />
   );
 };
 

--- a/static/js/ducks/profile.js
+++ b/static/js/ducks/profile.js
@@ -54,7 +54,7 @@ const initialState = {
   last_name: null,
   contact_email: null,
   contact_phone: null,
-  gravatar_url: "https://www.gravatar.com/avatar/0000000?d=404",
+  gravatar_url: "",
   roles: [],
   acls: [],
   tokens: [],


### PR DESCRIPTION
Now, fall back to a transparent image.

Use CSS to add user initials underneath the image.  If a non-blank image is
fetched, it covers the user initials.