### PR TITLE
Use @id instead of @class to select elements in followup request tests

### DIFF
--- a/skyportal/tests/frontend/test_followup_requests.py
+++ b/skyportal/tests/frontend/test_followup_requests.py
@@ -113,16 +113,16 @@ def add_followup_request_using_frontend_and_verify(
     driver.scroll_to_element_and_click(submit_button)
 
     driver.wait_for_xpath(
-        f'//table[@id="followupRequestTable_{idata["id"]}"]//td[contains(., "Mix \'n Match")]'
+        f'//table[contains(@id, "followupRequestTable")]//td[contains(., "Mix \'n Match")]'
     )
     driver.wait_for_xpath(
-        f'''//table[@id="followupRequestTable_{idata["id"]}"]//td[contains(., "u,IFU")]'''
+        f'''//table[contains(@id, "followupRequestTable")]//td[contains(., "u,IFU")]'''
     )
     driver.wait_for_xpath(
-        f'''//table[@id="followupRequestTable_{idata["id"]}"]//td[contains(., "1")]'''
+        f'''//table[contains(@id, "followupRequestTable")]//td[contains(., "1")]'''
     )
     driver.wait_for_xpath(
-        f'''//table[@id="followupRequestTable_{idata["id"]}"]//td[contains(., "submitted")]'''
+        f'''//table[contains(@id, "followupRequestTable")]//td[contains(., "submitted")]'''
     )
 
 

--- a/skyportal/tests/frontend/test_followup_requests.py
+++ b/skyportal/tests/frontend/test_followup_requests.py
@@ -113,16 +113,16 @@ def add_followup_request_using_frontend_and_verify(
     driver.scroll_to_element_and_click(submit_button)
 
     driver.wait_for_xpath(
-        f'//table[contains(@id, "followupRequestTable")]//td[contains(., "Mix \'n Match")]'
+        f'//table[contains(@data-testid, "followupRequestTable")]//td[contains(., "Mix \'n Match")]'
     )
     driver.wait_for_xpath(
-        f'''//table[contains(@id, "followupRequestTable")]//td[contains(., "u,IFU")]'''
+        f'''//table[contains(@data-testid, "followupRequestTable")]//td[contains(., "u,IFU")]'''
     )
     driver.wait_for_xpath(
-        f'''//table[contains(@id, "followupRequestTable")]//td[contains(., "1")]'''
+        f'''//table[contains(@data-testid, "followupRequestTable")]//td[contains(., "1")]'''
     )
     driver.wait_for_xpath(
-        f'''//table[contains(@id, "followupRequestTable")]//td[contains(., "submitted")]'''
+        f'''//table[contains(@data-testid, "followupRequestTable")]//td[contains(., "submitted")]'''
     )
 
 
@@ -162,13 +162,13 @@ def test_edit_existing_followup_request(
     driver.scroll_to_element_and_click(submit_button)
 
     driver.wait_for_xpath(
-        '//table[contains(@id, "followupRequestTable")]//td[contains(., "IFU")]'
+        '//table[contains(@data-testid, "followupRequestTable")]//td[contains(., "IFU")]'
     )
     driver.wait_for_xpath(
-        '''//table[contains(@id, "followupRequestTable")]//td[contains(., "1")]'''
+        '''//table[contains(@data-testid, "followupRequestTable")]//td[contains(., "1")]'''
     )
     driver.wait_for_xpath(
-        '''//table[contains(@id, "followupRequestTable")]//td[contains(., "submitted")]'''
+        '''//table[contains(@data-testid, "followupRequestTable")]//td[contains(., "submitted")]'''
     )
 
 
@@ -184,11 +184,11 @@ def test_delete_followup_request(
     driver.scroll_to_element_and_click(delete_button)
 
     driver.wait_for_xpath_to_disappear(
-        '''//table[contains(@id, "followupRequestTable")]//td[contains(., "u,IFU")]'''
+        '''//table[contains(@data-testid, "followupRequestTable")]//td[contains(., "u,IFU")]'''
     )
     driver.wait_for_xpath_to_disappear(
-        '''//table[contains(@id, "followupRequestTable")]//td[contains(., "1")]'''
+        '''//table[contains(@data-testid, "followupRequestTable")]//td[contains(., "1")]'''
     )
     driver.wait_for_xpath_to_disappear(
-        '''//table[contains(@id, "followupRequestTable")]//td[contains(., "submitted")]'''
+        '''//table[contains(@data-testid, "followupRequestTable")]//td[contains(., "submitted")]'''
     )

--- a/skyportal/tests/frontend/test_followup_requests.py
+++ b/skyportal/tests/frontend/test_followup_requests.py
@@ -116,7 +116,7 @@ def add_followup_request_using_frontend_and_verify(
         f'//table[@id="followupRequestTable_{idata["id"]}"]//td[contains(., "Mix \'n Match")]'
     )
     driver.wait_for_xpath(
-        f'''//table[@id="followupRequestTable_{idata["id"]}")]//td[contains(., "u,IFU")]'''
+        f'''//table[@id="followupRequestTable_{idata["id"]}"]//td[contains(., "u,IFU")]'''
     )
     driver.wait_for_xpath(
         f'''//table[@id="followupRequestTable_{idata["id"]}"]//td[contains(., "1")]'''
@@ -162,13 +162,13 @@ def test_edit_existing_followup_request(
     driver.scroll_to_element_and_click(submit_button)
 
     driver.wait_for_xpath(
-        '//table[contains(@class, "followupRequestTable")]//td[contains(., "IFU")]'
+        '//table[contains(@id, "followupRequestTable")]//td[contains(., "IFU")]'
     )
     driver.wait_for_xpath(
-        '''//table[contains(@class, "followupRequestTable")]//td[contains(., "1")]'''
+        '''//table[contains(@id, "followupRequestTable")]//td[contains(., "1")]'''
     )
     driver.wait_for_xpath(
-        '''//table[contains(@class, "followupRequestTable")]//td[contains(., "submitted")]'''
+        '''//table[contains(@id, "followupRequestTable")]//td[contains(., "submitted")]'''
     )
 
 
@@ -184,11 +184,11 @@ def test_delete_followup_request(
     driver.scroll_to_element_and_click(delete_button)
 
     driver.wait_for_xpath_to_disappear(
-        '''//table[contains(@class, "followupRequestTable")]//td[contains(., "u,IFU")]'''
+        '''//table[contains(@id, "followupRequestTable")]//td[contains(., "u,IFU")]'''
     )
     driver.wait_for_xpath_to_disappear(
-        '''//table[contains(@class, "followupRequestTable")]//td[contains(., "1")]'''
+        '''//table[contains(@id, "followupRequestTable")]//td[contains(., "1")]'''
     )
     driver.wait_for_xpath_to_disappear(
-        '''//table[contains(@class, "followupRequestTable")]//td[contains(., "submitted")]'''
+        '''//table[contains(@id, "followupRequestTable")]//td[contains(., "submitted")]'''
     )

--- a/skyportal/tests/frontend/test_followup_requests.py
+++ b/skyportal/tests/frontend/test_followup_requests.py
@@ -113,16 +113,16 @@ def add_followup_request_using_frontend_and_verify(
     driver.scroll_to_element_and_click(submit_button)
 
     driver.wait_for_xpath(
-        '//table[contains(@class, "followupRequestTable")]//td[contains(., "Mix \'n Match")]'
+        f'//table[@id="followupRequestTable_{idata["id"]}"]//td[contains(., "Mix \'n Match")]'
     )
     driver.wait_for_xpath(
-        '''//table[contains(@class, "followupRequestTable")]//td[contains(., "u,IFU")]'''
+        f'''//table[@id="followupRequestTable_{idata["id"]}")]//td[contains(., "u,IFU")]'''
     )
     driver.wait_for_xpath(
-        '''//table[contains(@class, "followupRequestTable")]//td[contains(., "1")]'''
+        f'''//table[@id="followupRequestTable_{idata["id"]}"]//td[contains(., "1")]'''
     )
     driver.wait_for_xpath(
-        '''//table[contains(@class, "followupRequestTable")]//td[contains(., "submitted")]'''
+        f'''//table[@id="followupRequestTable_{idata["id"]}"]//td[contains(., "submitted")]'''
     )
 
 

--- a/static/js/components/FollowupRequestLists.jsx
+++ b/static/js/components/FollowupRequestLists.jsx
@@ -70,7 +70,10 @@ const FollowupRequestLists = ({
         return (
           <div key={`instrument_${instrument_id}_table_div`}>
             <h3>{instLookUp[instrument_id].name} Requests</h3>
-            <table className={classes.followupRequestTable}>
+            <table
+              className={classes.followupRequestTable}
+              id={`followupRequestTable_${instrument_id}`}
+            >
               <thead>
                 <td>Requester</td>
                 <td>Allocation</td>

--- a/static/js/components/FollowupRequestLists.jsx
+++ b/static/js/components/FollowupRequestLists.jsx
@@ -72,7 +72,7 @@ const FollowupRequestLists = ({
             <h3>{instLookUp[instrument_id].name} Requests</h3>
             <table
               className={classes.followupRequestTable}
-              id={`followupRequestTable_${instrument_id}`}
+              data-testid={`followupRequestTable_${instrument_id}`}
             >
               <thead>
                 <td>Requester</td>


### PR DESCRIPTION
Fixes followup request failures in #888 