### PR TITLE
fix overfetching of users in AssigmentList

### DIFF
--- a/static/js/components/AssignmentList.jsx
+++ b/static/js/components/AssignmentList.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import { useSelector, useDispatch } from "react-redux";
 import * as Actions from "../ducks/source";
@@ -15,20 +15,21 @@ const AssignmentList = ({ assignments }) => {
   const { users } = useSelector((state) => state);
   const { observingRunList } = useSelector((state) => state.observingRuns);
   const { instrumentList } = useSelector((state) => state.instruments);
+  const [loadingUsers, setLoadingUsers] = useState([]);
 
   // fetch all the requester ids before rendering the component
   const requesterIDs = assignments.map((assignment) => assignment.requester_id);
-  const uniqueRequesterIDs = [...new Set(requesterIDs)];
-  uniqueRequesterIDs.sort((a, b) => a - b);
 
   // use useEffect to only send 1 fetchUser per User
   useEffect(() => {
-    uniqueRequesterIDs.forEach((id) => {
-      if (!users[id]) {
+    requesterIDs.forEach((id) => {
+      if (!users[id] && !loadingUsers.includes(id)) {
         dispatch(UserActions.fetchUser(id));
+        loadingUsers.push(id);
+        setLoadingUsers(loadingUsers);
       }
     });
-  }, [...uniqueRequesterIDs, users, dispatch]);
+  }, [requesterIDs, users, dispatch]);
 
   if (assignments.length === 0) {
     return <b>No assignments to show for this object...</b>;

--- a/static/js/components/AssignmentList.jsx
+++ b/static/js/components/AssignmentList.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import PropTypes from "prop-types";
 import { useSelector, useDispatch } from "react-redux";
 import * as Actions from "../ducks/source";
@@ -12,24 +12,20 @@ const AssignmentList = ({ assignments }) => {
     dispatch(Actions.deleteAssignment(id));
   };
 
-  const { users } = useSelector((state) => state);
+  const { allUsers } = useSelector((state) => state.users);
   const { observingRunList } = useSelector((state) => state.observingRuns);
   const { instrumentList } = useSelector((state) => state.instruments);
-  const [loadingUsers, setLoadingUsers] = useState([]);
-
-  // fetch all the requester ids before rendering the component
-  const requesterIDs = assignments.map((assignment) => assignment.requester_id);
 
   // use useEffect to only send 1 fetchUser per User
   useEffect(() => {
-    requesterIDs.forEach((id) => {
-      if (!users[id] && !loadingUsers.includes(id)) {
-        dispatch(UserActions.fetchUser(id));
-        loadingUsers.push(id);
-        setLoadingUsers(loadingUsers);
-      }
-    });
-  }, [requesterIDs, users, dispatch]);
+    if (allUsers.length === 0) {
+      dispatch(UserActions.fetchUsers());
+    }
+  }, [allUsers, dispatch]);
+
+  if (allUsers.length === 0) {
+    return <b>Loading users...</b>;
+  }
 
   if (assignments.length === 0) {
     return <b>No assignments to show for this object...</b>;
@@ -69,7 +65,7 @@ const AssignmentList = ({ assignments }) => {
         <tbody>
           {assignments.map((assignment) => {
             const { requester_id } = assignment;
-            const requester = users[requester_id];
+            const requester = allUsers.find((user) => user.id === requester_id);
 
             const { run_id } = assignment;
             const run = observingRunList.filter((r) => r.id === run_id)[0];


### PR DESCRIPTION
Fixes #699 .

The currently merged solution to this issue (#759 ) is flawed in that it provides a dependency list with a length that can change (spread syntax). This can cause React errors.

The solution here avoids the spread syntax and passes a fixed dependency list to `useEffect` each time the component is rerendered. A useState hook is used to prevent redundant `fetchUser` calls between renders. 