### PR TITLE
Refactor NewGroupForm to use MUI and update API to use user IDs instead of user emails

### DIFF
--- a/data/db_demo.yaml
+++ b/data/db_demo.yaml
@@ -36,13 +36,13 @@ streams:
 groups:
   - name: Program A
     group_admins:
-      - testadmin@cesium-ml.org
-      - groupadmin@cesium-ml.org
+      - =testadmin
+      - =groupadmin
     =id: program_A
   - name: Program B
     group_admins:
-      - testadmin@cesium-ml.org
-      - groupadmin@cesium-ml.org
+      - =testadmin
+      - =groupadmin
     =id: program_B
 
 groups/=program_A/users:

--- a/skyportal/handlers/api/group.py
+++ b/skyportal/handlers/api/group.py
@@ -206,9 +206,9 @@ class GroupHandler(BaseHandler):
                       group_admins:
                         type: array
                         items:
-                          type: string
+                          type: integer
                         description: |
-                          List of emails of users to be group admins. Current user will
+                          List of IDs of users to be group admins. Current user will
                           automatically be added as a group admin.
         responses:
           200:
@@ -228,10 +228,13 @@ class GroupHandler(BaseHandler):
         """
         data = self.get_json()
 
-        group_admin_emails = [
-            e.strip() for e in data.get('group_admins', []) if e.strip()
-        ]
-        group_admins = list(User.query.filter(User.username.in_(group_admin_emails)))
+        try:
+            group_admin_ids = [int(e) for e in data.get('group_admins', [])]
+        except ValueError:
+            return self.error(
+                "Invalid group_admins field; unable to parse all items to int"
+            )
+        group_admins = User.query.filter(User.id.in_(group_admin_ids)).all()
         if self.current_user not in group_admins and not isinstance(
             self.current_user, Token
         ):

--- a/skyportal/tests/api/test_groups.py
+++ b/skyportal/tests/api/test_groups.py
@@ -11,7 +11,7 @@ def test_token_user_create_new_group(manage_groups_token, super_admin_user):
     status, data = api(
         "POST",
         "groups",
-        data={"name": group_name, "group_admins": [super_admin_user.username]},
+        data={"name": group_name, "group_admins": [super_admin_user.id]},
         token=manage_groups_token,
     )
     assert status == 200
@@ -28,7 +28,7 @@ def test_fetch_group_by_name(manage_groups_token, super_admin_user):
     status, data = api(
         "POST",
         "groups",
-        data={"name": group_name, "group_admins": [super_admin_user.username]},
+        data={"name": group_name, "group_admins": [super_admin_user.id]},
         token=manage_groups_token,
     )
     assert status == 200
@@ -47,7 +47,7 @@ def test_token_user_request_all_groups(manage_groups_token, super_admin_user):
     status, data = api(
         "POST",
         "groups",
-        data={"name": group_name, "group_admins": [super_admin_user.username]},
+        data={"name": group_name, "group_admins": [super_admin_user.id]},
         token=manage_groups_token,
     )
     assert status == 200
@@ -112,7 +112,7 @@ def test_manage_groups_token_get_unowned_group(
     status, data = api(
         "POST",
         "groups",
-        data={"name": group_name, "group_admins": [user.username]},
+        data={"name": group_name, "group_admins": [user.id]},
         token=manage_groups_token,
     )
     assert status == 200

--- a/skyportal/tests/frontend/test_groups.py
+++ b/skyportal/tests/frontend/test_groups.py
@@ -33,7 +33,9 @@ def test_add_new_group(driver, super_admin_user, user):
     driver.get('/groups')
     driver.wait_for_xpath('//input[@name="name"]').send_keys(test_proj_name)
     driver.click_xpath('//div[@id="groupAdminsSelect"]')
-    driver.wait_for_xpath_to_be_clickable(f'//li[text()="{user.username}"]').click()
+    driver.wait_for_xpath_to_be_clickable(
+        f'//li[contains(text(),"{user.username}")]'
+    ).click()
     driver.click_xpath('//button[contains(.,"Create Group")]', wait_clickable=False)
     driver.wait_for_xpath(f'//a[contains(.,"{test_proj_name}")]')
 
@@ -48,7 +50,7 @@ def test_add_new_group_explicit_self_admin(driver, super_admin_user, user):
     driver.wait_for_xpath('//input[@name="name"]').send_keys(test_proj_name)
     driver.click_xpath('//div[@id="groupAdminsSelect"]')
     driver.wait_for_xpath_to_be_clickable(
-        f'//li[text()="{super_admin_user.username}"]'
+        f'//li[contains(text(),"{user.username}")]'
     ).click()
     driver.click_xpath('//button[contains(.,"Create Group")]', wait_clickable=False)
     driver.wait_for_xpath(f'//a[contains(.,"{test_proj_name}")]')

--- a/skyportal/tests/frontend/test_groups.py
+++ b/skyportal/tests/frontend/test_groups.py
@@ -32,10 +32,8 @@ def test_add_new_group(driver, super_admin_user, user):
     driver.refresh()
     driver.get('/groups')
     driver.wait_for_xpath('//input[@name="name"]').send_keys(test_proj_name)
-    driver.click_xpath('//div[@id="groupAdminsSelect"]')
-    driver.wait_for_xpath_to_be_clickable(
-        f'//li[contains(text(),"{user.username}")]'
-    ).click()
+    driver.wait_for_xpath('//div[@id="groupAdminsSelect"]').click()
+    driver.wait_for_xpath(f'//li[contains(text(),"{user.username}")]').click()
     driver.click_xpath('//button[contains(.,"Create Group")]', wait_clickable=False)
     driver.wait_for_xpath(f'//a[contains(.,"{test_proj_name}")]')
 
@@ -48,10 +46,8 @@ def test_add_new_group_explicit_self_admin(driver, super_admin_user, user):
     driver.refresh()
     driver.get('/groups')
     driver.wait_for_xpath('//input[@name="name"]').send_keys(test_proj_name)
-    driver.click_xpath('//div[@id="groupAdminsSelect"]')
-    driver.wait_for_xpath_to_be_clickable(
-        f'//li[contains(text(),"{user.username}")]'
-    ).click()
+    driver.wait_for_xpath('//div[@id="groupAdminsSelect"]').click()
+    driver.wait_for_xpath(f'//li[contains(text(),"{user.username}")]').click()
     driver.click_xpath('//button[contains(.,"Create Group")]', wait_clickable=False)
     driver.wait_for_xpath(f'//a[contains(.,"{test_proj_name}")]')
 

--- a/skyportal/tests/frontend/test_groups.py
+++ b/skyportal/tests/frontend/test_groups.py
@@ -32,9 +32,9 @@ def test_add_new_group(driver, super_admin_user, user):
     driver.refresh()
     driver.get('/groups')
     driver.wait_for_xpath('//input[@name="name"]').send_keys(test_proj_name)
-    driver.wait_for_xpath('//input[@name="groupAdmins"]').send_keys(user.username)
-    driver.save_screenshot('/tmp/screenshot1.png')
-    driver.click_xpath('//button[contains(.,"Create Group")]')
+    driver.click_xpath('//div[@id="groupAdminsSelect"]')
+    driver.wait_for_xpath_to_be_clickable(f'//li[text()="{user.username}"]').click()
+    driver.click_xpath('//button[contains(.,"Create Group")]', wait_clickable=False)
     driver.wait_for_xpath(f'//a[contains(.,"{test_proj_name}")]')
 
 
@@ -46,10 +46,11 @@ def test_add_new_group_explicit_self_admin(driver, super_admin_user, user):
     driver.refresh()
     driver.get('/groups')
     driver.wait_for_xpath('//input[@name="name"]').send_keys(test_proj_name)
-    driver.wait_for_xpath('//input[@name="groupAdmins"]').send_keys(
-        super_admin_user.username
-    )
-    driver.click_xpath('//button[contains(.,"Create Group")]')
+    driver.click_xpath('//div[@id="groupAdminsSelect"]')
+    driver.wait_for_xpath_to_be_clickable(
+        f'//li[text()="{super_admin_user.username}"]'
+    ).click()
+    driver.click_xpath('//button[contains(.,"Create Group")]', wait_clickable=False)
     driver.wait_for_xpath(f'//a[contains(.,"{test_proj_name}")]')
 
 

--- a/skyportal/tests/frontend/test_scanning_page.py
+++ b/skyportal/tests/frontend/test_scanning_page.py
@@ -44,7 +44,7 @@ def test_candidate_group_filtering(
     status, data = api(
         "POST",
         "groups",
-        data={"name": str(uuid.uuid4()), "group_admins": [user.username]},
+        data={"name": str(uuid.uuid4()), "group_admins": [user.id]},
         token=manage_groups_token,
     )
     assert status == 200

--- a/static/js/components/NewGroupForm.jsx
+++ b/static/js/components/NewGroupForm.jsx
@@ -65,7 +65,7 @@ const NewGroupForm = () => {
 
   const useStyles = makeStyles((theme) => ({
     formControl: {
-      margin: theme.spacing(1),
+      margin: `${theme.spacing(1)}px 0`,
       minWidth: 130,
     },
     chips: {


### PR DESCRIPTION
This PR updates the new group form component to use Material UI and uses a multi-select instead of a comma-separated text input for specifying new group admins. The API is also updated to use group admin user IDs instead of (outdated, error-prone) user email.

![new_group_form](https://user-images.githubusercontent.com/7230285/93392680-10a64800-f826-11ea-8889-9c7735973ba5.gif)
