### PR TITLE
Refactor Transaction Logging in Remote Facility Framework

### DIFF
--- a/skyportal/facility_apis/sedm.py
+++ b/skyportal/facility_apis/sedm.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 import json
 import requests
 
+from ..utils import http
 
 env, cfg = load_env()
 
@@ -26,11 +27,19 @@ class SEDMListener(Listener):
            The instance of the handler that received the request.
         """
 
-        from ..models import FollowupRequest
+        from ..models import FollowupRequest, FacilityTransaction, DBSession
 
         data = handler_instance.get_json()
         request = FollowupRequest.query.get(int(data['followup_request_id']))
         request.status = data['new_status']
+
+        transaction_record = FacilityTransaction(
+            request=http.serialize_tornado_request(handler_instance),
+            followup_request=request,
+            initiator=handler_instance.associated_user_object,
+        )
+
+        DBSession().add(transaction_record)
 
 
 def convert_request_to_sedm(request, method_value='new'):
@@ -117,6 +126,8 @@ class SEDMAPI(FollowUpAPI):
             The request to submit.
         """
 
+        from ..models import FacilityTransaction, DBSession
+
         payload = convert_request_to_sedm(request, method_value='new')
         content = json.dumps(payload)
         r = requests.post(
@@ -128,7 +139,14 @@ class SEDMAPI(FollowUpAPI):
         else:
             request.status = f'rejected: {r.content}'
 
-        return r
+        transaction = FacilityTransaction(
+            request=http.serialize_requests_request(r.request),
+            response=http.serialize_requests_response(r),
+            followup_request=request,
+            initiator_id=request.last_modified_by_id,
+        )
+
+        DBSession().add(transaction)
 
     @staticmethod
     def delete(request):
@@ -140,6 +158,8 @@ class SEDMAPI(FollowUpAPI):
             The request to delete from the queue and the SkyPortal database.
         """
 
+        from ..models import FacilityTransaction, DBSession
+
         payload = convert_request_to_sedm(request, method_value='delete')
         content = json.dumps(payload)
         r = requests.post(
@@ -149,7 +169,14 @@ class SEDMAPI(FollowUpAPI):
         r.raise_for_status()
         request.status = "deleted"
 
-        return r
+        transaction = FacilityTransaction(
+            request=http.serialize_requests_request(r.request),
+            response=http.serialize_requests_response(r),
+            followup_request=request,
+            initiator_id=request.last_modified_by_id,
+        )
+
+        DBSession().add(transaction)
 
     @staticmethod
     def update(request):
@@ -160,6 +187,8 @@ class SEDMAPI(FollowUpAPI):
         request: skyportal.models.FollowupRequest
             The updated request.
         """
+
+        from ..models import FacilityTransaction, DBSession
 
         payload = convert_request_to_sedm(request, method_value='edit')
         content = json.dumps(payload)
@@ -172,7 +201,14 @@ class SEDMAPI(FollowUpAPI):
         else:
             request.status = f'rejected: {r.content}'
 
-        return r
+        transaction = FacilityTransaction(
+            request=http.serialize_requests_request(r.request),
+            response=http.serialize_requests_response(r),
+            followup_request=request,
+            initiator_id=request.last_modified_by_id,
+        )
+
+        DBSession().add(transaction)
 
     _observation_types = [
         '3-shot (gri)',

--- a/skyportal/handlers/api/facility_listener.py
+++ b/skyportal/handlers/api/facility_listener.py
@@ -2,8 +2,7 @@ from skyportal.handlers import BaseHandler
 from baselayer.app.access import auth_or_token
 import jsonschema
 
-from ...utils import http
-from ...models import FollowupRequest, DBSession, FacilityTransaction
+from ...models import FollowupRequest, DBSession
 from ... import facility_apis, enum_types
 
 
@@ -37,14 +36,6 @@ class FacilityMessageHandler(BaseHandler):
 
         jsonschema.validate(data, instrument.listener_class.complete_schema())
         instrument.listener_class.process_message(self)
-
-        transaction_record = FacilityTransaction(
-            request=http.serialize_tornado_request(self),
-            followup_request=request,
-            initiator=self.associated_user_object,
-        )
-
-        DBSession().add(transaction_record)
         DBSession().commit()
 
         self.push_all(

--- a/skyportal/handlers/api/followup_request.py
+++ b/skyportal/handlers/api/followup_request.py
@@ -360,6 +360,7 @@ class FollowupRequestHandler(BaseHandler):
         data = self.get_json()
         _ = Source.get_obj_if_owned_by(data["obj_id"], self.current_user)
         data["requester_id"] = self.associated_user_object.id
+        data["last_modified_by_id"] = self.associated_user_object.id
         data['allocation_id'] = int(data['allocation_id'])
 
         allocation = Allocation.query.get(data['allocation_id'])
@@ -445,7 +446,7 @@ class FollowupRequestHandler(BaseHandler):
 
         data = self.get_json()
         data['id'] = request_id
-        data["requester_id"] = self.associated_user_object.id
+        data["last_modified_by_id"] = self.associated_user_object.id
 
         api = followup_request.instrument.api_class
 
@@ -513,6 +514,7 @@ class FollowupRequestHandler(BaseHandler):
         if not api.implements()['delete']:
             return self.error('Cannot delete requests on this instrument.')
 
+        followup_request.last_modified_by_id = self.associated_user_object.id
         response = api.delete(followup_request)
 
         transaction = FacilityTransaction(

--- a/skyportal/handlers/api/followup_request.py
+++ b/skyportal/handlers/api/followup_request.py
@@ -12,13 +12,11 @@ from ...models import (
     Obj,
     Group,
     Allocation,
-    FacilityTransaction,
 )
 
 from sqlalchemy.orm import joinedload
 
 from ...schema import AssignmentSchema
-from ...utils import http
 
 
 class AssignmentHandler(BaseHandler):
@@ -391,26 +389,16 @@ class FollowupRequestHandler(BaseHandler):
         )
 
         try:
-            response = instrument.api_class.submit(followup_request)
+            instrument.api_class.submit(followup_request)
         except Exception:
             followup_request.status = 'failed to submit'
             raise
         finally:
-            DBSession().add(followup_request)
             DBSession().commit()
             self.push_all(
                 action="skyportal/REFRESH_SOURCE",
                 payload={"obj_id": followup_request.obj_id},
             )
-
-        transaction = FacilityTransaction(
-            request=http.serialize_requests_request(response.request),
-            response=http.serialize_requests_response(response),
-            followup_request=followup_request,
-            initiator=self.associated_user_object,
-        )
-        DBSession().add(transaction)
-        DBSession().commit()
 
         return self.success(data={"id": followup_request.id})
 
@@ -464,16 +452,7 @@ class FollowupRequestHandler(BaseHandler):
         for k in data:
             setattr(followup_request, k, data[k])
 
-        response = followup_request.instrument.api_class.update(followup_request)
-
-        transaction = FacilityTransaction(
-            request=http.serialize_requests_request(response.request),
-            response=http.serialize_requests_response(response),
-            followup_request=followup_request,
-            initiator=self.associated_user_object,
-        )
-
-        DBSession().add(transaction)
+        followup_request.instrument.api_class.update(followup_request)
         DBSession().commit()
 
         self.push_all(
@@ -515,16 +494,7 @@ class FollowupRequestHandler(BaseHandler):
             return self.error('Cannot delete requests on this instrument.')
 
         followup_request.last_modified_by_id = self.associated_user_object.id
-        response = api.delete(followup_request)
-
-        transaction = FacilityTransaction(
-            request=http.serialize_requests_request(response.request),
-            response=http.serialize_requests_response(response),
-            followup_request=followup_request,
-            initiator=self.associated_user_object,
-        )
-
-        DBSession().add(transaction)
+        api.delete(followup_request)
         DBSession().commit()
 
         self.push_all(

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -1649,7 +1649,7 @@ class FollowupRequest(Base):
     )
 
     last_modified_by_id = sa.Column(
-        sa.ForeignKey('users.id', ondelete='SET_NULL'),
+        sa.ForeignKey('users.id', ondelete='SET NULL'),
         nullable=False,
         doc="The ID of the User who last modified the request.",
     )
@@ -1760,6 +1760,7 @@ User.followup_requests = relationship(
     'FollowupRequest',
     back_populates='requester',
     doc="The follow-up requests this User has made.",
+    foreign_keys=[FollowupRequest.requester_id],
 )
 
 User.transactions = relationship(

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -1669,8 +1669,9 @@ class FollowupRequest(Base):
     )
 
     payload = sa.Column(
-        psql.JSONB, nullable=True, doc="Content of the followup request."
+        psql.JSONB, nullable=False, doc="Content of the followup request."
     )
+
     status = sa.Column(
         sa.String(),
         nullable=False,

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -1634,17 +1634,32 @@ class FollowupRequest(Base):
     """A request for follow-up data (spectroscopy, photometry, or both) using a
     robotic instrument."""
 
-    requester = relationship(
-        User,
-        back_populates='followup_requests',
-        doc="The User who requested the follow-up.",
-    )
     requester_id = sa.Column(
         sa.ForeignKey('users.id', ondelete='CASCADE'),
         nullable=False,
         index=True,
         doc="ID of the User who requested the follow-up.",
     )
+
+    requester = relationship(
+        User,
+        back_populates='followup_requests',
+        doc="The User who requested the follow-up.",
+        foreign_keys=[requester_id],
+    )
+
+    last_modified_by_id = sa.Column(
+        sa.ForeignKey('users.id', ondelete='SET_NULL'),
+        nullable=False,
+        doc="The ID of the User who last modified the request.",
+    )
+
+    last_modified_by = relationship(
+        User,
+        doc="The user who last modified the request.",
+        foreign_keys=[last_modified_by_id],
+    )
+
     obj = relationship('Obj', back_populates='followup_requests', doc="The target Obj.")
     obj_id = sa.Column(
         sa.ForeignKey('objs.id', ondelete='CASCADE'),

--- a/skyportal/tests/conftest.py
+++ b/skyportal/tests/conftest.py
@@ -458,6 +458,7 @@ def public_source_followup_request(public_group_sedm_allocation, public_source, 
             'observation_type': 'IFU',
         },
         requester_id=user.id,
+        last_modified_by_id=user.id,
     )
 
     DBSession().add(fr)
@@ -479,6 +480,7 @@ def public_source_group2_followup_request(
             'observation_type': 'IFU',
         },
         requester_id=user_two_groups.id,
+        last_modified_by_id=user_two_groups.id,
     )
 
     DBSession().add(fr)


### PR DESCRIPTION
This PR moves the logging of remote facility transactions to the `staticmethod`s within the Listener and API classes for individual facilities. The previous implementation legislated a universal method for serializing these transactions based on `requests`. This didn't work, for example, for LT, which uses an XML/urllib based communication protocol. This PR solves this problem, accommodating the different HTTP request/response formats that different facilities have. 

This should allow #866 to move forward. 