### PR TITLE
Better Finder Positions

### DIFF
--- a/skyportal/handlers/api/candidate.py
+++ b/skyportal/handlers/api/candidate.py
@@ -385,10 +385,6 @@ class CandidateHandler(BaseHandler):
         if not filters:
             return self.error("At least one valid filter ID must be provided.")
 
-        # use ra, dec as the discovery position unless it's already specified
-        obj.ra_dis = obj.ra if obj.ra_dis is None else obj.ra_dis
-        obj.dec_dis = obj.dec if obj.dec_dis is None else obj.dec_dis
-
         DBSession().add(obj)
         DBSession().add_all(
             [

--- a/skyportal/handlers/api/candidate.py
+++ b/skyportal/handlers/api/candidate.py
@@ -312,7 +312,7 @@ class CandidateHandler(BaseHandler):
     def post(self):
         """
         ---
-        description: POST a new candidate.
+        description: Create a new candidate.
         requestBody:
           content:
             application/json:
@@ -384,6 +384,11 @@ class CandidateHandler(BaseHandler):
         filters = Filter.query.filter(Filter.id.in_(filter_ids)).all()
         if not filters:
             return self.error("At least one valid filter ID must be provided.")
+
+        # use ra, dec as the discovery position unless it's already specified
+        obj.ra_dis = obj.ra if obj.ra_dis is None else obj.ra_dis
+        obj.dec_dis = obj.dec if obj.dec_dis is None else obj.dec_dis
+
         DBSession().add(obj)
         DBSession().add_all(
             [

--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -439,6 +439,11 @@ class SourceHandler(BaseHandler):
                 "Invalid group_ids field. Please specify at least "
                 "one valid group ID that you belong to."
             )
+
+        # use ra, dec as the discovery position unless it's already specified
+        obj.ra_dis = obj.ra if obj.ra_dis is None else obj.ra_dis
+        obj.dec_dis = obj.dec if obj.dec_dis is None else obj.dec_dis
+
         DBSession().add(obj)
         DBSession().add_all([Source(obj=obj, group=group) for group in groups])
         DBSession().commit()

--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -822,7 +822,7 @@ class SourceFinderHandler(BaseHandler):
             best_ra, best_dec = initial_pos[0], initial_pos[1]
 
         facility = self.get_query_argument('facility', 'Keck')
-        image_source = self.get_query_argument('image_source', 'desi')
+        image_source = self.get_query_argument('image_source', 'ztfref')
 
         how_many = 3
         obstime = self.get_query_argument(

--- a/skyportal/tests/tools/test_offset_util.py
+++ b/skyportal/tests/tools/test_offset_util.py
@@ -11,7 +11,7 @@ from skyportal.utils import (
     get_nearby_offset_stars,
     get_finding_chart,
     get_ztfref_url,
-    calculate_best_position,
+    _calculate_best_position_for_offset_stars,
 )
 from skyportal.utils.offset import irsa
 from skyportal.models import Photometry
@@ -19,13 +19,14 @@ from skyportal.models import Photometry
 
 def test_calculate_best_position_no_photometry():
 
-    ra, dec = calculate_best_position(
-        [], fallback=(10.0, -20.0), how="snr", max_offset=0.5, sigma_clip=4.0
+    ra, dec = _calculate_best_position_for_offset_stars(
+        [], fallback=(10.0, -20.0), how="snr2", max_offset=0.5, sigma_clip=4.0
     )
     npt.assert_almost_equal(ra, 10)
     npt.assert_almost_equal(dec, -20)
 
 
+@pytest.mark.flaky(reruns=2)
 def test_calculate_best_position_with_photometry(
     upload_data_token, view_only_token, ztf_camera, public_group
 ):
@@ -86,8 +87,8 @@ def test_calculate_best_position_with_photometry(
 
         phot_list.append(Photometry(**data['data']))
 
-    ra_calc_snr, dec_calc_snr = calculate_best_position(
-        phot_list, fallback=(ra, dec), how="snr", max_offset=0.5, sigma_clip=4.0
+    ra_calc_snr, dec_calc_snr = _calculate_best_position_for_offset_stars(
+        phot_list, fallback=(ra, dec), how="snr2", max_offset=0.5, sigma_clip=4.0
     )
     # make sure we get back a slightly different position than the true center
     with pytest.raises(AssertionError):
@@ -95,8 +96,8 @@ def test_calculate_best_position_with_photometry(
     with pytest.raises(AssertionError):
         npt.assert_almost_equal(dec_calc_snr, dec, decimal=10)
 
-    ra_calc_err, dec_calc_err = calculate_best_position(
-        phot_list, fallback=(ra, dec), how="err", max_offset=0.5, sigma_clip=4.0
+    ra_calc_err, dec_calc_err = _calculate_best_position_for_offset_stars(
+        phot_list, fallback=(ra, dec), how="invvar", max_offset=0.5, sigma_clip=4.0
     )
     # make sure we get back a slightly different position for two different
     # methods

--- a/skyportal/utils/__init__.py
+++ b/skyportal/utils/__init__.py
@@ -4,5 +4,5 @@ from .offset import (
     source_image_parameters,
     get_finding_chart,
     get_ztfref_url,
-    calculate_best_position,
+    _calculate_best_position_for_offset_stars,
 )

--- a/skyportal/utils/__init__.py
+++ b/skyportal/utils/__init__.py
@@ -4,4 +4,5 @@ from .offset import (
     source_image_parameters,
     get_finding_chart,
     get_ztfref_url,
+    calculate_best_position,
 )

--- a/skyportal/utils/offset.py
+++ b/skyportal/utils/offset.py
@@ -475,7 +475,7 @@ def fits_image(
     center_ra,
     center_dec,
     imsize=4.0,
-    image_source="desi",
+    image_source="ztfref",
     cache_dir="./cache/finder/",
     cache_max_items=5,
 ):
@@ -559,7 +559,7 @@ def get_finding_chart(
     source_ra,
     source_dec,
     source_name,
-    image_source='desi',
+    image_source='ztfref',
     output_format='pdf',
     imsize=3.0,
     tick_offset=0.02,

--- a/skyportal/utils/offset.py
+++ b/skyportal/utils/offset.py
@@ -2,7 +2,6 @@ import io
 import os
 import datetime
 import warnings
-import json
 
 import pandas as pd
 import requests
@@ -157,11 +156,12 @@ source_image_parameters = {
 }
 
 
-def calculate_best_position(
-    photometry, fallback=(None, None), how="snr", max_offset=0.5, sigma_clip=4.0
+def _calculate_best_position_for_offset_stars(
+    photometry, fallback=(None, None), how="snr2", max_offset=0.5, sigma_clip=4.0
 ):
     """Calculates the best position for a source from its photometric
-       points
+       points. Only small adjustments from the fallback position are
+       expected.
 
     Parameters
     ----------


### PR DESCRIPTION
The PR introduces a new default behavior to use photometry-based centroiding of a source position for the purposes of making finding charts and offset/starlists. Rather than use the position at discovery time or the highest SNR detection of the source, combine all the positions available from associated photometry. If the calculated position is far (> 0.5 arcsec by default) from discovery, revert back to the original discovery image.

- always save ra,dec as discovery position if not specified
- introduce two weighting schemes (`snr` and `err`) to determine the offset from fiducial
- default finder imaging to ztfref and change the display scale to look better around galaxies