### PR TITLE
Cosmology calculations and display

### DIFF
--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -228,6 +228,10 @@ services:
 misc:
   days_to_keep_unsaved_candidates: 7
   public_group_name: "Sitewide Group"
+  # Use a named cosmology from `astropy.cosmology.parameters.available`
+  # or supply the arguments for an FLRW cosmological instance
+  cosmology: Planck18_arXiv_v2
+  #cosmology: {H0: "65.0", Om0: 0.3, Ode0: 0.7, name: 'skyportal_user_cosmo'}
 
 cron:
   - interval: 1440

--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -228,8 +228,11 @@ services:
 misc:
   days_to_keep_unsaved_candidates: 7
   public_group_name: "Sitewide Group"
-  # Use a named cosmology from `astropy.cosmology.parameters.available`
-  # or supply the arguments for an FLRW cosmological instance
+  # Use a named cosmology from `astropy.cosmology.parameters.available` cosmologies
+  # or supply the arguments for an `astropy.cosmology.FLRW` cosmological instance.
+  # If {"flat": True} then use a subclass of the FLRW, called `FlatLambdaCMD`
+  # otherwise use `LambdaCDM`. See `utils.cosmology.py` for the way in which
+  # the user-supplied cosmology parameter set constructs the site-wide cosmology.
   cosmology: Planck18_arXiv_v2
   #cosmology: {H0: "65.0", Om0: 0.3, Ode0: 0.7, name: 'skyportal_user_cosmo'}
 

--- a/skyportal/handlers/api/candidate.py
+++ b/skyportal/handlers/api/candidate.py
@@ -169,6 +169,10 @@ class CandidateHandler(BaseHandler):
             candidate_info["last_detected"] = c.last_detected
             candidate_info["gal_lon"] = c.gal_lon_deg
             candidate_info["gal_lat"] = c.gal_lat_deg
+            candidate_info["luminosity_distance"] = c.luminosity_distance
+            candidate_info["dm"] = c.dm
+            candidate_info["angular_diameter_distance"] = c.angular_diameter_distance
+
             return self.success(data=candidate_info)
 
         page_number = self.get_query_argument("pageNumber", None) or 1
@@ -304,6 +308,11 @@ class CandidateHandler(BaseHandler):
             candidate_list[-1]["last_detected"] = obj.last_detected
             candidate_list[-1]["gal_lat"] = obj.gal_lat_deg
             candidate_list[-1]["gal_lon"] = obj.gal_lon_deg
+            candidate_list[-1]["luminosity_distance"] = obj.luminosity_distance
+            candidate_list[-1]["dm"] = obj.dm
+            candidate_list[-1][
+                "angular_diameter_distance"
+            ] = obj.angular_diameter_distance
 
         query_results["candidates"] = candidate_list
         return self.success(data=query_results)

--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -253,6 +253,10 @@ class SourceHandler(BaseHandler):
             source_info["last_detected"] = s.last_detected
             source_info["gal_lat"] = s.gal_lat_deg
             source_info["gal_lon"] = s.gal_lon_deg
+            source_info["luminosity_distance"] = s.luminosity_distance
+            source_info["dm"] = s.dm
+            source_info["angular_diameter_distance"] = s.angular_diameter_distance
+
             source_info["followup_requests"] = [
                 f for f in source_info['followup_requests'] if f.status != 'deleted'
             ]
@@ -266,7 +270,6 @@ class SourceHandler(BaseHandler):
                 )
                 .all()
             )
-
             return self.success(data=source_info)
 
         # Fetch multiple sources
@@ -355,6 +358,12 @@ class SourceHandler(BaseHandler):
             source_list[-1]["last_detected"] = source.last_detected
             source_list[-1]["gal_lon"] = source.gal_lon_deg
             source_list[-1]["gal_lat"] = source.gal_lat_deg
+            source_list[-1]["luminosity_distance"] = source.luminosity_distance
+            source_list[-1]["dm"] = source.dm
+            source_list[-1][
+                "angular_diameter_distance"
+            ] = source.angular_diameter_distance
+
             source_list[-1]["groups"] = (
                 DBSession()
                 .query(Group)

--- a/skyportal/handlers/api/sysinfo.py
+++ b/skyportal/handlers/api/sysinfo.py
@@ -1,7 +1,7 @@
 from baselayer.app.env import load_env
 from baselayer.app.access import auth_or_token
 from ..base import BaseHandler
-
+from skyportal.models import cosmo
 
 _, cfg = load_env()
 
@@ -30,4 +30,10 @@ class SysInfoHandler(BaseHandler):
                             Boolean indicating whether new user invitation pipeline
                             is enabled in current deployment.
         """
-        return self.success(data={"invitationsEnabled": cfg["invitations.enabled"]})
+        return self.success(
+            data={
+                "invitationsEnabled": cfg["invitations.enabled"],
+                "cosmology": str(cosmo),
+                "cosmoref": cosmo.__doc__,
+            }
+        )

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -467,7 +467,11 @@ class Obj(Base, ha.Point):
     def luminosity_distance(self):
         """
         The luminosity distance in Mpc, using either DM or distance data
-        in the altdata fields or using the cosmology/redshift
+        in the altdata fields or using the cosmology/redshift. Specifically
+        the user can add `dm` (mag), `parallax` (arcsec), `dist_kpc`,
+        `dist_Mpc`, `dist_pc` or `dist_cm` to `altdata` and
+        those will be picked up (in that order) as the distance
+        rather than the redshift.
 
         Return None if the redshift puts the source not within the Hubble flow
         """
@@ -498,8 +502,11 @@ class Obj(Base, ha.Point):
             if self.redshift * 2.99e5 * u.km / u.s < 350 * u.km / u.s:
                 # stubbornly refuse to give a distance if the source
                 # is not in the Hubble flow
+                # cf. https://www.aanda.org/articles/aa/full/2003/05/aa3077/aa3077.html
+                # within ~5 Mpc (cz ~ 350 km/s) a given galaxy velocty
+                # can be between between ~0-500 km/s
                 return None
-            return (cosmo.luminosity_distance(self.redshift)).value
+            return (cosmo.luminosity_distance(self.redshift)).to(u.Mpc).value
         return None
 
     @property
@@ -518,8 +525,7 @@ class Obj(Base, ha.Point):
                 # see eq (20) of https://ned.ipac.caltech.edu/level5/Hogg/Hogg7.html
                 return dl / (1 + self.redshift) ** 2
             return dl
-        else:
-            return None
+        return None
 
     def airmass(self, telescope, time, below_horizon=np.inf):
         """Return the airmass of the object at a given time. Uses the Pickering

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -4,6 +4,8 @@ from datetime import datetime, timezone
 import arrow
 from astropy import units as u
 from astropy import time as ap_time
+from astropy import cosmology
+
 import astroplan
 import numpy as np
 import sqlalchemy as sa
@@ -51,6 +53,9 @@ from skyportal import facility_apis
 # All DB fluxes are stored in microJy (AB).
 PHOT_ZP = 23.9
 PHOT_SYS = 'ab'
+
+# TODO: make this configurable
+cosmo = cosmology.WMAP9
 
 
 def is_owned_by(self, user_or_token):
@@ -458,6 +463,63 @@ class Obj(Base, ha.Point):
         """Get the galactic longitude of this object"""
         coord = ap_coord.SkyCoord(self.ra, self.dec, unit="deg")
         return coord.galactic.l.deg
+
+    @property
+    def luminosity_distance(self):
+        """
+        The luminosity distance in Mpc, using either DM or distance data
+        in the altdata fields or using the cosmology/redshift
+
+        Return None if the redshift puts the source not within the Hubble flow
+        """
+
+        # there may be a non-redshift based measurement of distance
+        # for nearby sources
+        if self.altdata:
+            if self.altdata.get("dm") is not None:
+                # see eq (24) of https://ned.ipac.caltech.edu/level5/Hogg/Hogg7.html
+                return (
+                    (10 ** (float(self.altdata.get("dm")) / 5.0)) * 1e-5 * u.Mpc
+                ).value
+            if self.altdata.get("parallax") is not None:
+                # assume parallax in arcsec
+                return (1e-6 * u.Mpc / float(self.altdata.get("parallax"))).value
+
+            if self.altdata.get("dist_kpc") is not None:
+                return (float(self.altdata.get("dist_kpc")) * 1e-3 * u.Mpc).value
+            if self.altdata.get("dist_Mpc") is not None:
+                return (float(self.altdata.get("dist_Mpc")) * u.Mpc).value
+            if self.altdata.get("dist_pc") is not None:
+                return (float(self.altdata.get("dist_pc")) * 1e-6 * u.Mpc).value
+            if self.altdata.get("dist_cm") is not None:
+                return (float(self.altdata.get("dist_cm")) * u.Mpc / 3.085e18).value
+
+        if self.redshift:
+            if self.redshift * 2.99e5 * u.km / u.s < 350 * u.km / u.s:
+                # stubbornly refuse to give a distance if the source
+                # is not in the Hubble flow
+                return None
+            return (cosmo.luminosity_distance(self.redshift)).value
+        return None
+
+    @property
+    def dm(self):
+        """Distance modulus to the object"""
+        dl = self.luminosity_distance
+        if dl:
+            return 5.0 * np.log10((dl * u.Mpc) / (10 * u.pc)).value
+        return None
+
+    @property
+    def angular_diameter_distance(self):
+        dl = self.luminosity_distance
+        if dl:
+            if self.redshift and self.redshift * 2.99e5 * u.km / u.s > 350 * u.km / u.s:
+                # see eq (20) of https://ned.ipac.caltech.edu/level5/Hogg/Hogg7.html
+                return dl / (1 + self.redshift) ** 2
+            return dl
+        else:
+            return None
 
     def airmass(self, telescope, time, below_horizon=np.inf):
         """Return the airmass of the object at a given time. Uses the Pickering

--- a/skyportal/tests/api/test_candidates.py
+++ b/skyportal/tests/api/test_candidates.py
@@ -15,14 +15,14 @@ def test_token_user_retrieving_candidate(view_only_token, public_candidate):
     )
     assert status == 200
     assert data["status"] == "success"
-    assert all(k in data["data"] for k in ["ra", "dec", "redshift"])
+    assert all(k in data["data"] for k in ["ra", "dec", "redshift", "dm"])
 
 
 def test_token_user_update_candidate(manage_sources_token, public_candidate):
     status, data = api(
         "PATCH",
         f"candidates/{public_candidate.id}",
-        data={"ra": 234.22, "redshift": 3, "transient": False, "ra_dis": 2.3,},
+        data={"ra": 234.22, "redshift": 3, "transient": False, "ra_dis": 2.3},
         token=manage_sources_token,
     )
     assert status == 200

--- a/skyportal/tests/api/test_sources.py
+++ b/skyportal/tests/api/test_sources.py
@@ -1,7 +1,9 @@
 import pytest
 import numpy.testing as npt
+import numpy as np
 import uuid
 from skyportal.tests import api
+from skyportal.models import cosmo
 
 
 def test_source_list(view_only_token):
@@ -14,7 +16,9 @@ def test_token_user_retrieving_source(view_only_token, public_source):
     status, data = api('GET', f'sources/{public_source.id}', token=view_only_token)
     assert status == 200
     assert data['status'] == 'success'
-    assert all(k in data['data'] for k in ['ra', 'dec', 'redshift', 'created_at', 'id'])
+    assert all(
+        k in data['data'] for k in ['ra', 'dec', 'redshift', 'dm', 'created_at', 'id']
+    )
 
 
 def test_token_user_update_source(manage_sources_token, public_source):
@@ -38,6 +42,85 @@ def test_token_user_update_source(manage_sources_token, public_source):
     assert data['status'] == 'success'
     npt.assert_almost_equal(data['data']['ra'], 234.22)
     npt.assert_almost_equal(data['data']['redshift'], 3.0)
+    npt.assert_almost_equal(
+        cosmo.luminosity_distance(3.0).value, data['data']['luminosity_distance']
+    )
+
+
+def test_distance_modulus(manage_sources_token, public_source):
+    status, data = api(
+        'PUT',
+        f'sources/{public_source.id}',
+        data={
+            'ra': 234.22,
+            'dec': -22.33,
+            'altdata': {"dm": 28.5},
+            'transient': False,
+            'ra_dis': 2.3,
+        },
+        token=manage_sources_token,
+    )
+    assert status == 200
+    assert data['status'] == 'success'
+
+    status, data = api('GET', f'sources/{public_source.id}', token=manage_sources_token)
+    assert status == 200
+    assert data['status'] == 'success'
+    npt.assert_almost_equal(10 ** ((28.5 / 5) - 5), data['data']['luminosity_distance'])
+    npt.assert_almost_equal(28.5, data['data']['dm'])
+    npt.assert_almost_equal(
+        10 ** ((28.5 / 5) - 5), data['data']['angular_diameter_distance']
+    )
+
+
+def test_parallax(manage_sources_token, public_source):
+    parallax = 0.001  # in arcsec = 1 kpc
+    d_pc = 1 / parallax
+    dm = 5.0 * np.log10(d_pc / (10.0))
+
+    status, data = api(
+        'PUT',
+        f'sources/{public_source.id}',
+        data={
+            'ra': 234.22,
+            'dec': -22.33,
+            'altdata': {"parallax": parallax},
+            'transient': False,
+            'ra_dis': 2.3,
+        },
+        token=manage_sources_token,
+    )
+    assert status == 200
+    assert data['status'] == 'success'
+
+    status, data = api('GET', f'sources/{public_source.id}', token=manage_sources_token)
+    assert status == 200
+    assert data['status'] == 'success'
+
+    npt.assert_almost_equal(dm, data['data']['dm'])
+
+
+def test_low_redshift(manage_sources_token, public_source):
+    status, data = api(
+        'PUT',
+        f'sources/{public_source.id}',
+        data={
+            'ra': 234.22,
+            'dec': -22.33,
+            'transient': False,
+            'ra_dis': 2.3,
+            'redshift': 0.00001,
+        },
+        token=manage_sources_token,
+    )
+    assert status == 200
+    assert data['status'] == 'success'
+
+    status, data = api('GET', f'sources/{public_source.id}', token=manage_sources_token)
+    assert status == 200
+    assert data['status'] == 'success'
+
+    assert data['data']['dm'] is None
 
 
 def test_cannot_update_source_without_permission(view_only_token, public_source):

--- a/skyportal/tests/utils/test_cosmology.py
+++ b/skyportal/tests/utils/test_cosmology.py
@@ -1,0 +1,36 @@
+from astropy import cosmology
+from astropy import units as u
+
+from skyportal.utils.cosmology import establish_cosmology
+
+fallback_cosmology = cosmology.Planck18_arXiv_v2
+
+
+def test_default_cosmology():
+    cosmo = establish_cosmology(cfg={}, fallback_cosmology=fallback_cosmology)
+    assert cosmo.name == fallback_cosmology.name
+
+
+def test_named_cosmology():
+    cfg = {"misc": {"cosmology": "WMAP9"}}
+    cosmo = establish_cosmology(cfg=cfg, fallback_cosmology=fallback_cosmology)
+    assert cosmo.name == "WMAP9"
+
+
+def test_user_define_cosmology():
+    cfg = {
+        "misc": {
+            "cosmology": {"H0": 65.0, "Om0": 0.3, "Ode0": 0.7, "name": 'test_cosmo'}
+        }
+    }
+    cosmo = establish_cosmology(cfg=cfg, fallback_cosmology=fallback_cosmology)
+    assert cosmo.name == 'test_cosmo'
+    assert cosmo.H0 == 65.0 * u.km / (u.s * u.Mpc)
+
+
+def test_bad_cosmology():
+    # missing H0 and Om0
+    cfg = {"misc": {"cosmology": {"Ode0": 1.0, "name": 'test_cosmo'}}}
+
+    cosmo = establish_cosmology(cfg=cfg, fallback_cosmology=fallback_cosmology)
+    assert cosmo.name == fallback_cosmology.name

--- a/skyportal/utils/cosmology.py
+++ b/skyportal/utils/cosmology.py
@@ -1,0 +1,64 @@
+from astropy import cosmology
+from astropy import units as u
+
+from baselayer.log import make_log
+
+log = make_log('cosmology')
+
+
+def establish_cosmology(cfg={}, fallback_cosmology=cosmology.Planck18_arXiv_v2):
+    def _get_cosmology():
+        if cfg.get('misc'):
+            if cfg["misc"].get('cosmology'):
+                log("here1")
+                if cfg["misc"]["cosmology"] in cosmology.parameters.available:
+                    cosmo = cosmology.default_cosmology.get_cosmology_from_string(
+                        cfg["misc"]["cosmology"]
+                    )
+                elif isinstance(cfg["misc"]["cosmology"], dict):
+                    log("here")
+                    par = cfg["misc"]["cosmology"]
+                    log(par)
+                    try:
+                        if par.get('flat'):
+                            cosmo = cosmology.FlatLambdaCDM(
+                                par['H0'],
+                                par['Om0'],
+                                Tcmb0=par.get('Tcmb0', 2.725),
+                                Neff=par.get('Neff', 3.04),
+                                m_nu=u.Quantity(par.get('m_nu', [0.0, 0.0, 0.0]), u.eV),
+                                name=par.get("name", "user_cosmology"),
+                                Ob0=par.get('Ob0', 0.0455),
+                            )
+                        else:
+                            cosmo = cosmology.LambdaCDM(
+                                par['H0'],
+                                par['Om0'],
+                                par['Ode0'],
+                                Tcmb0=par.get('Tcmb0', 2.725),
+                                Neff=par.get('Neff', 3.04),
+                                m_nu=u.Quantity(par.get('m_nu', [0.0, 0.0, 0.0]), u.eV),
+                                name=par.get("name", "user_cosmology"),
+                                Ob0=par.get('Ob0', 0.0455),
+                            )
+                    except (KeyError, NameError) as e:
+                        log(f'{e}')
+                        log('exception in determining user defined cosmology')
+                        cosmo = fallback_cosmology
+                else:
+                    log(
+                        'cosmology: dont know how to deal with the user supplied cosmology'
+                    )
+                    cosmo = fallback_cosmology
+        else:
+            cosmo = fallback_cosmology
+
+        log(f'using {cosmo.name} for cosmological calculations')
+        log(f'{cosmo}')
+        return cosmo
+
+    try:
+        return _get_cosmology()
+    except Exception:
+        log(f'Error setting cosmology using {fallback_cosmology.name} as a fallback')
+        return fallback_cosmology

--- a/skyportal/utils/cosmology.py
+++ b/skyportal/utils/cosmology.py
@@ -10,15 +10,12 @@ def establish_cosmology(cfg={}, fallback_cosmology=cosmology.Planck18_arXiv_v2):
     def _get_cosmology():
         if cfg.get('misc'):
             if cfg["misc"].get('cosmology'):
-                log("here1")
                 if cfg["misc"]["cosmology"] in cosmology.parameters.available:
                     cosmo = cosmology.default_cosmology.get_cosmology_from_string(
                         cfg["misc"]["cosmology"]
                     )
                 elif isinstance(cfg["misc"]["cosmology"], dict):
-                    log("here")
                     par = cfg["misc"]["cosmology"]
-                    log(par)
                     try:
                         if par.get('flat'):
                             cosmo = cosmology.FlatLambdaCDM(

--- a/static/js/components/About.jsx
+++ b/static/js/components/About.jsx
@@ -66,6 +66,9 @@ BibLink.propTypes = {
 const About = () => {
   const classes = useStyles();
   const version = useSelector((state) => state.sysInfo.version);
+  const cosmology = useSelector((state) => state.sysInfo.cosmology);
+  const cosmoref = useSelector((state) => state.sysInfo.cosmoref);
+
   return (
     <Box className={classes.root}>
       <h2>
@@ -117,6 +120,20 @@ const About = () => {
           .
         </BibLink>
       </div>
+      <h2>Cosmology</h2>
+      <p>
+        The cosmology currently used here is an instance of{" "}
+        <code>astropy.cosmology</code> with the parameters (see{" "}
+        <a href="https://github.com/astropy/astropy/blob/master/astropy/cosmology/parameters.py">
+          this link
+        </a>{" "}
+        for parameters definitions): <br />
+        <blockquote>{cosmology}</blockquote>
+        <b>Reference</b>: {cosmoref}
+        <br />
+        If you&apos;d like to change the cosmology, please do so in the{" "}
+        <code>config.yaml</code> under <code>misc.cosmology</code>.
+      </p>
     </Box>
   );
 };

--- a/static/js/components/Candidate.jsx
+++ b/static/js/components/Candidate.jsx
@@ -93,7 +93,26 @@ const Candidate = ({ route }) => {
                 )
                 <br />
                 <b>Redshift: &nbsp;</b>
-                {candidate.redshift}
+                {candidate.redshift.toFixed(4)}
+                {candidate.dm && (
+                  <>
+                    &nbsp;|&nbsp;
+                    <b>DM: &nbsp;</b>
+                    {candidate.dm.toFixed(3)}
+                    &nbsp; mag
+                  </>
+                )}
+                {candidate.luminosity_distance && (
+                  <>
+                    &nbsp;|&nbsp;
+                    <b>
+                      <i>D</i>
+                      <sub>L</sub>: &nbsp;
+                    </b>
+                    {candidate.luminosity_distance.toFixed(2)}
+                    &nbsp; Mpc
+                  </>
+                )}
               </div>
               <ThumbnailList
                 ra={candidate.ra}

--- a/static/js/components/SourceDesktop.jsx
+++ b/static/js/components/SourceDesktop.jsx
@@ -143,7 +143,26 @@ const SourceDesktop = ({ source }) => {
           )
           <br />
           <b>Redshift: &nbsp;</b>
-          {source.redshift}
+          {source.redshift.toFixed(4)}
+          {source.dm && (
+            <>
+              &nbsp;|&nbsp;
+              <b>DM: &nbsp;</b>
+              {source.dm.toFixed(3)}
+              &nbsp; mag
+            </>
+          )}
+          {source.luminosity_distance && (
+            <>
+              &nbsp;|&nbsp;
+              <b>
+                <i>D</i>
+                <sub>L</sub>: &nbsp;
+              </b>
+              {source.luminosity_distance.toFixed(2)}
+              &nbsp; Mpc
+            </>
+          )}
           &nbsp;|&nbsp;
           <Button href={`/api/sources/${source.id}/finder`}>
             PDF Finding Chart
@@ -355,6 +374,8 @@ SourceDesktop.propTypes = {
     groups: PropTypes.arrayOf(PropTypes.shape({})),
     gal_lon: PropTypes.number,
     gal_lat: PropTypes.number,
+    dm: PropTypes.number,
+    luminosity_distance: PropTypes.number,
     classifications: PropTypes.arrayOf(
       PropTypes.shape({
         author_name: PropTypes.string,

--- a/static/js/components/SourceMobile.jsx
+++ b/static/js/components/SourceMobile.jsx
@@ -166,7 +166,26 @@ const SourceMobile = ({ source }) => {
               )
               <br />
               <b>Redshift: &nbsp;</b>
-              {source.redshift}
+              {source.redshift.toFixed(4)}
+              {source.dm && (
+                <>
+                  &nbsp;|&nbsp;
+                  <b>DM: &nbsp;</b>
+                  {source.dm.toFixed(3)}
+                  &nbsp; mag
+                </>
+              )}
+              {source.luminosity_distance && (
+                <>
+                  &nbsp;|&nbsp;
+                  <b>
+                    <i>D</i>
+                    <sub>L</sub>: &nbsp;
+                  </b>
+                  {source.luminosity_distance.toFixed(2)}
+                  &nbsp; Mpc
+                </>
+              )}
               &nbsp;|&nbsp;
               <Button href={`/api/sources/${source.id}/finder`}>
                 PDF Finding Chart
@@ -366,6 +385,8 @@ SourceMobile.propTypes = {
     groups: PropTypes.arrayOf(PropTypes.shape({})),
     gal_lon: PropTypes.number,
     gal_lat: PropTypes.number,
+    dm: PropTypes.number,
+    luminosity_distance: PropTypes.number,
     classifications: PropTypes.arrayOf(
       PropTypes.shape({
         author_name: PropTypes.string,


### PR DESCRIPTION
![Kapture 2020-09-20 at 22 29 31](https://user-images.githubusercontent.com/480799/93735175-e8557b00-fb90-11ea-9d4e-820b740e81c8.gif)

  - Site-wide configured  cosmology in `config.yaml` (named cosmologies from `astropy` or custom):
   ```
  misc:
     cosmology: Planck18_arXiv_v2
    #cosmology: {H0: "65.0", Om0: 0.3, Ode0: 0.7, name: 'skyportal_user_cosmo'}
  ```
 - Adding the distance calculations to Obj using either information in `altdata` (e.g. `altdata["parallax"]`) or using redshift + cosmology.
 - Show on front-end if DM/luminosity distance is determined
 - If redshift puts the source nearby (<350 km/s) then do no show DM/D_l unless a distance is established in altdata.