### PR TITLE
Make GroupList widget not resizable and add scrollbar

### DIFF
--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -190,7 +190,7 @@ app:
     GroupList:
       props:
         title: My Groups
-      resizeable: true
+      resizeable: false
       layouts:
         xlg: [14, 1, 2, 2]
         lg: [10, 1, 2, 2]

--- a/static/js/components/GroupList.jsx
+++ b/static/js/components/GroupList.jsx
@@ -12,6 +12,8 @@ import { makeStyles } from "@material-ui/core/styles";
 const useStyles = makeStyles(() => ({
   listContainer: {
     overflowX: "hidden",
+    overflowY: "scroll",
+    height: "85%",
   },
 }));
 


### PR DESCRIPTION
![Screenshot 2020-09-21 180726](https://user-images.githubusercontent.com/17696889/93835848-7be08780-fc35-11ea-8181-64739a361069.png)

Closes issue #896 

@dmitryduev This edits the default configs.