### PR TITLE
improve stability of followup request tests

### DIFF
--- a/skyportal/tests/frontend/test_followup_requests.py
+++ b/skyportal/tests/frontend/test_followup_requests.py
@@ -1,7 +1,6 @@
 import uuid
 import pytest
 import requests
-from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.common.action_chains import ActionChains
 from baselayer.app.env import load_env
 from skyportal.tests import api
@@ -80,17 +79,11 @@ def add_followup_request_using_frontend_and_verify(
 
     driver.get(f"/become_user/{super_admin_user.id}")
 
-    for _ in range(2):
-        try:
-            driver.get(f"/source/{public_source.id}")
-            # wait for the plots to load
-            driver.wait_for_xpath('//div[@class="bk-root"]//span[text()="Flux"]')
-            # this waits for the spectroscopy plot by looking for the element Mg
-            driver.wait_for_xpath('//div[@class="bk-root"]//label[text()="Mg"]')
-        except TimeoutException:
-            continue
-        else:
-            break
+    driver.get(f"/source/{public_source.id}")
+    # wait for the plots to load
+    driver.wait_for_xpath('//div[@class="bk-root"]//span[text()="Flux"]', timeout=20)
+    # this waits for the spectroscopy plot by looking for the element Mg
+    driver.wait_for_xpath('//div[@class="bk-root"]//label[text()="Mg"]', timeout=20)
 
     submit_button = driver.wait_for_xpath(
         '//form[@class="rjsf"]//button[@type="submit"]'


### PR DESCRIPTION
The followup request tests have been failing recently because they wait for the plots to load, and the plots have been taking a very long time to load on CI (>10s) causing the tests to timeout. 

This PR replaces the previous method of dealing with flakiness in the followup request frontend tests (refreshing the page and trying again in case of a plot timeout), and simply executes the page load once, but with an increased  timeout on the plot load from 10 to 20s. 

