### PR TITLE
display object groups on observing planner

### DIFF
--- a/skyportal/tests/frontend/test_observing_planner.py
+++ b/skyportal/tests/frontend/test_observing_planner.py
@@ -70,6 +70,8 @@ def test_assignment_posts_to_observing_run(
 
     driver.get(f"/run/{red_transients_run.id}")
     driver.wait_for_xpath(f'//*[text()="{public_source.id}"]')
+    for group in [s.group for s in public_source.sources]:
+        driver.wait_for_xpath(f'//*[text()="{group.name[:15]}"]')
 
 
 @pytest.mark.flaky(reruns=2)

--- a/static/js/components/RunSummary.jsx
+++ b/static/js/components/RunSummary.jsx
@@ -8,6 +8,7 @@ import TableRow from "@material-ui/core/TableRow";
 import Typography from "@material-ui/core/Typography";
 import IconButton from "@material-ui/core/IconButton";
 import Grid from "@material-ui/core/Grid";
+import Chip from "@material-ui/core/Chip";
 import BuildIcon from "@material-ui/icons/Build";
 
 import Link from "@material-ui/core/Link";
@@ -15,6 +16,8 @@ import PictureAsPdfIcon from "@material-ui/icons/PictureAsPdf";
 
 import Menu from "@material-ui/core/Menu";
 import MenuItem from "@material-ui/core/MenuItem";
+
+import { makeStyles } from "@material-ui/core/styles";
 
 import MUIDataTable from "mui-datatables";
 import ThumbnailList from "./ThumbnailList";
@@ -29,6 +32,12 @@ import SkyCam from "./SkyCam";
 
 const VegaPlot = React.lazy(() => import("./VegaPlot"));
 const AirmassPlot = React.lazy(() => import("./AirmassPlot"));
+
+const useStyles = makeStyles((theme) => ({
+  chip: {
+    margin: theme.spacing(0.5),
+  },
+}));
 
 const SimpleMenu = ({ assignment }) => {
   const [anchorEl, setAnchorEl] = React.useState(null);
@@ -246,6 +255,27 @@ const RunSummary = ({ route }) => {
   };
 
   // This is just passed to MUI datatables options -- not meant to be instantiated directly.
+  const RenderGroups = (dataIndex) => {
+    const classes = useStyles();
+    const assignment = assignments[dataIndex];
+    return (
+      <div key={`${assignment.obj.id}_groups`}>
+        {assignment.accessible_group_names.map((name) => (
+          <div key={name}>
+            <Chip
+              label={name.substring(0, 15)}
+              key={name}
+              size="small"
+              className={classes.chip}
+            />
+            <br />
+          </div>
+        ))}
+      </div>
+    );
+  };
+
+  // This is just passed to MUI datatables options -- not meant to be instantiated directly.
   const renderActionsButton = (dataIndex) => {
     const assignment = assignments[dataIndex];
     return <SimpleMenu assignment={assignment} key={`${assignment.id}_menu`} />;
@@ -320,6 +350,13 @@ const RunSummary = ({ route }) => {
       },
     },
     {
+      name: "Groups",
+      options: {
+        filter: false,
+        customBodyRenderLite: RenderGroups,
+      },
+    },
+    {
       name: "Finder",
       options: {
         filter: false,
@@ -353,6 +390,7 @@ const RunSummary = ({ route }) => {
     assignment.priority,
     assignment.rise_time_utc,
     assignment.set_time_utc,
+    assignment.accessible_group_names,
     null,
     null,
   ]);


### PR DESCRIPTION
Closes #980. 

[ch1135].

@AndyTza.

This PR adds chips that display an object's groups that are accessible to the current user on the observing run page.

<img width="1330" alt="Screen Shot 2020-09-25 at 1 58 30 PM" src="https://user-images.githubusercontent.com/2769632/94315422-54403680-ff37-11ea-9d0c-c05d3a0426e4.png">


