### PR TITLE
fix default zoom on photometry plot

### DIFF
--- a/skyportal/plot.py
+++ b/skyportal/plot.py
@@ -417,8 +417,24 @@ def photometry_plot(obj_id, user, width=600, height=300):
     p1 = Panel(child=layout, title='Flux')
 
     # now make the mag light curve
-    ymax = np.nanmax(data['mag']) + 0.1
-    ymin = np.nanmin(data['mag']) - 0.1
+    ymax = (
+        np.nanmax(
+            (
+                np.nanmax(data.loc[obsind, 'mag']),
+                np.nanmax(data.loc[~obsind, 'lim_mag']),
+            )
+        )
+        + 0.1
+    )
+    ymin = (
+        np.nanmin(
+            (
+                np.nanmin(data.loc[obsind, 'mag']),
+                np.nanmin(data.loc[~obsind, 'lim_mag']),
+            )
+        )
+        - 0.1
+    )
 
     plot = figure(
         plot_width=width,


### PR DESCRIPTION
Fixes #969. 

This PR updates the photometry plot to make the default zoom take non-detections into account, showing both detections and non detections by default in magnitude space. 
<img width="794" alt="Screen Shot 2020-09-25 at 3 18 32 PM" src="https://user-images.githubusercontent.com/2769632/94320698-73909100-ff42-11ea-89c7-a202f8e08871.png">
