### PR TITLE
Add absolute magnitude to the photometry plot right axis if `obj.dm is not None`

### DIFF
--- a/skyportal/plot.py
+++ b/skyportal/plot.py
@@ -606,7 +606,7 @@ def photometry_plot(obj_id, user, width=600, height=300):
             "Absolute Mag": Range1d(start=ymax - obj.dm, end=ymin - obj.dm)
         }
         plot.add_layout(
-            LinearAxis(y_range_name="Absolute Mag", axis_label="m - μ"), 'right'
+            LinearAxis(y_range_name="Absolute Mag", axis_label="m - DM"), 'right'
         )
 
     toggle = CheckboxWithLegendGroup(

--- a/skyportal/plot.py
+++ b/skyportal/plot.py
@@ -606,7 +606,7 @@ def photometry_plot(obj_id, user, width=600, height=300):
             "Absolute Mag": Range1d(start=ymax - obj.dm, end=ymin - obj.dm)
         }
         plot.add_layout(
-            LinearAxis(y_range_name="Absolute Mag", axis_label="Absolute Mag"), 'right'
+            LinearAxis(y_range_name="Absolute Mag", axis_label="m - μ"), 'right'
         )
 
     toggle = CheckboxWithLegendGroup(

--- a/skyportal/plot.py
+++ b/skyportal/plot.py
@@ -5,7 +5,7 @@ from bokeh.core.json_encoder import serialize_json
 from bokeh.core.properties import List, String
 from bokeh.document import Document
 from bokeh.layouts import row, column
-from bokeh.models import CustomJS, HoverTool, Range1d, Slider, Button
+from bokeh.models import CustomJS, HoverTool, Range1d, Slider, Button, LinearAxis
 from bokeh.models.widgets import CheckboxGroup, TextInput, Panel, Tabs, Div
 from bokeh.palettes import viridis
 from bokeh.plotting import figure, ColumnDataSource
@@ -599,6 +599,15 @@ def photometry_plot(obj_id, user, width=600, height=300):
     plot.xaxis.axis_label = 'MJD'
     plot.yaxis.axis_label = 'AB mag'
     plot.toolbar.logo = None
+
+    obj = DBSession().query(Obj).get(obj_id)
+    if obj.dm is not None:
+        plot.extra_y_ranges = {
+            "Absolute Mag": Range1d(start=ymax - obj.dm, end=ymin - obj.dm)
+        }
+        plot.add_layout(
+            LinearAxis(y_range_name="Absolute Mag", axis_label="Absolute Mag"), 'right'
+        )
 
     toggle = CheckboxWithLegendGroup(
         labels=list(data.label.unique()),


### PR DESCRIPTION
[ch1266]

Closes #975 . 
<img width="786" alt="Screen Shot 2020-09-25 at 4 14 13 PM" src="https://user-images.githubusercontent.com/2769632/94323496-e867c900-ff4a-11ea-9b00-c09ea0f5ff1a.png">


This PR adds an absolute magnitude axis to the photometry plot if `obj.dm is not None`, i.e., if the object has a distance modulus. 

If the distance modulus is not `None`, the loaded cosmology is used to calculate the distance modulus. 

