### PR TITLE
Show correct number of candidates on scanning page

### DIFF
--- a/static/js/components/CandidateList.jsx
+++ b/static/js/components/CandidateList.jsx
@@ -337,6 +337,7 @@ const CandidateList = () => {
                 download: false,
                 selectableRows: "none",
                 enableNestedDataAccess: ".",
+                rowsPerPage: 25,
               }}
             />
           </MuiThemeProvider>


### PR DESCRIPTION
Fixes #971 . 

With this PR, the scanning page now shows the number of candidates it says it shows. 