### PR TITLE
Fix broken filtered scanning page results pagination buttons

### DIFF
--- a/static/js/components/CandidateList.jsx
+++ b/static/js/components/CandidateList.jsx
@@ -14,6 +14,7 @@ import useMediaQuery from "@material-ui/core/useMediaQuery";
 import Button from "@material-ui/core/Button";
 import CircularProgress from "@material-ui/core/CircularProgress";
 import OpenInNewIcon from "@material-ui/icons/OpenInNew";
+import ArrowUpward from "@material-ui/icons/ArrowUpward";
 import Chip from "@material-ui/core/Chip";
 import Box from "@material-ui/core/Box";
 import MUIDataTable from "mui-datatables";
@@ -143,22 +144,6 @@ const CandidateList = () => {
       setQueryInProgress(false);
     }
   }, [candidates, dispatch]);
-
-  const handleClickNextPage = async () => {
-    setQueryInProgress(true);
-    await dispatch(
-      candidatesActions.fetchCandidates({ pageNumber: pageNumber + 1 })
-    );
-    setQueryInProgress(false);
-  };
-
-  const handleClickPreviousPage = async () => {
-    setQueryInProgress(true);
-    await dispatch(
-      candidatesActions.fetchCandidates({ pageNumber: pageNumber - 1 })
-    );
-    setQueryInProgress(false);
-  };
 
   const renderThumbnails = (dataIndex) => {
     const candidateObj = candidates[dataIndex];
@@ -307,8 +292,6 @@ const CandidateList = () => {
         </Typography>
         <FilterCandidateList
           userAccessibleGroups={userAccessibleGroups}
-          handleClickNextPage={handleClickNextPage}
-          handleClickPreviousPage={handleClickPreviousPage}
           pageNumber={pageNumber}
           numberingStart={numberingStart}
           numberingEnd={numberingEnd}
@@ -347,30 +330,12 @@ const CandidateList = () => {
         <div>
           <Button
             variant="contained"
-            onClick={handleClickPreviousPage}
-            disabled={pageNumber === 1}
+            onClick={() => {
+              window.scrollTo({ top: 0 });
+            }}
             size="small"
           >
-            Previous Page
-          </Button>
-        </div>
-        <div>
-          <i>
-            Displaying&nbsp;
-            {numberingStart}-{numberingEnd}
-            &nbsp; of&nbsp;
-            {totalMatches}
-            &nbsp; candidates.
-          </i>
-        </div>
-        <div>
-          <Button
-            variant="contained"
-            onClick={handleClickNextPage}
-            disabled={lastPage}
-            size="small"
-          >
-            Next Page
+            Back to top <ArrowUpward />
           </Button>
         </div>
       </div>

--- a/static/js/components/FilterCandidateList.jsx
+++ b/static/js/components/FilterCandidateList.jsx
@@ -46,8 +46,6 @@ const useStyles = makeStyles(() => ({
 
 const FilterCandidateList = ({
   userAccessibleGroups,
-  handleClickNextPage,
-  handleClickPreviousPage,
   pageNumber,
   numberingStart,
   numberingEnd,
@@ -102,16 +100,23 @@ const FilterCandidateList = ({
     setQueryInProgress(false);
   };
 
+  const handleClickNextPage = async () => {
+    const formData = getValues({ nest: true });
+    onSubmit({ ...formData, pageNumber: pageNumber + 1 });
+  };
+
+  const handleClickPreviousPage = async () => {
+    const formData = getValues({ nest: true });
+    onSubmit({ ...formData, pageNumber: pageNumber - 1 });
+  };
+
   const handleJumpToPageInputChange = (e) => {
     setJumpToPageInputValue(e.target.value);
   };
 
   const handleClickJumpToPage = async () => {
-    setQueryInProgress(true);
-    await dispatch(
-      candidatesActions.fetchCandidates({ pageNumber: jumpToPageInputValue })
-    );
-    setQueryInProgress(false);
+    const formData = getValues({ nest: true });
+    onSubmit({ ...formData, pageNumber: jumpToPageInputValue });
   };
 
   return (
@@ -253,8 +258,6 @@ const FilterCandidateList = ({
 };
 FilterCandidateList.propTypes = {
   userAccessibleGroups: PropTypes.arrayOf(PropTypes.object).isRequired,
-  handleClickNextPage: PropTypes.func.isRequired,
-  handleClickPreviousPage: PropTypes.func.isRequired,
   pageNumber: PropTypes.number.isRequired,
   numberingStart: PropTypes.number.isRequired,
   numberingEnd: PropTypes.number.isRequired,


### PR DESCRIPTION
Closes https://github.com/skyportal/skyportal/issues/933 

This PR fixes a bug where using the pagination buttons on the scanning page would result in the selected filter criteria being ignored in the associated fetch. The next/previous page buttons on the bottom of the page are replaced with a "Back to top :arrow_up:" button.

See screen capture demo:
![candidates_pagination](https://user-images.githubusercontent.com/7230285/94485961-92d22d00-0193-11eb-9824-b5ea32ea563c.gif)
