### PR TITLE
Allow anyone to create groups

### DIFF
--- a/static/js/components/GroupManagement.jsx
+++ b/static/js/components/GroupManagement.jsx
@@ -6,7 +6,6 @@ import Box from "@material-ui/core/Box";
 import Typography from "@material-ui/core/Typography";
 import { makeStyles } from "@material-ui/core/styles";
 
-import NewGroupForm from "./NewGroupForm";
 import GroupList from "./GroupList";
 
 const useStyles = makeStyles(() => ({
@@ -33,7 +32,6 @@ const GroupManagement = () => {
     <Paper variant="outlined">
       <Box p={1}>
         <Typography variant="h5">Group Management</Typography>
-        <NewGroupForm />
         <GroupList title="All Groups" groups={allGroups} classes={classes} />
       </Box>
     </Paper>

--- a/static/js/components/Groups.jsx
+++ b/static/js/components/Groups.jsx
@@ -5,6 +5,7 @@ import { makeStyles } from "@material-ui/core/styles";
 
 import GroupManagement from "./GroupManagement";
 import GroupList from "./GroupList";
+import NewGroupForm from "./NewGroupForm";
 
 const useStyles = makeStyles(() => ({
   // Hide drag handle icon since this isn't the home page
@@ -32,7 +33,7 @@ const Groups = () => {
   return (
     <div>
       <GroupList title="My Groups" groups={groups} classes={classes} />
-      <br />
+      <NewGroupForm />
       {roles.includes("Super admin") && <GroupManagement />}
     </div>
   );


### PR DESCRIPTION
This PR changes the permissions requirements around creating and editing groups, allowing anyone to create a group (which they are then an admin of by default) and allowing anyone who is an admin of a group to modify/delete that group. This allows for users to delete groups that they have created.

Closes https://github.com/skyportal/skyportal/issues/982 

![anyone_can_create_groups](https://user-images.githubusercontent.com/7230285/94493118-a9cb4c00-01a0-11eb-95bd-0ef3fd2444ed.gif)
