### PR TITLE
Allow group_ids='all' in phot, spec POST handlers

### DIFF
--- a/skyportal/schema.py
+++ b/skyportal/schema.py
@@ -246,7 +246,8 @@ class PhotBaseFlexible(object):
 
     group_ids = fields.List(
         fields.Integer(),
-        description="List of group IDs to which photometry " "points will be visible.",
+        description="List of group IDs to which photometry points will be visible. "
+        "If 'all', will be shared with all groups the associated source is visible to.",
         required=True,
     )
 

--- a/skyportal/schema.py
+++ b/skyportal/schema.py
@@ -246,7 +246,8 @@ class PhotBaseFlexible(object):
 
     group_ids = fields.Field(
         description="List of group IDs to which photometry points will be visible. "
-        "If 'all', will be shared with all groups the associated source is visible to.",
+        "If 'all', will be shared with site-wide public group (visible to all users "
+        "who can view associated source).",
         required=True,
     )
 

--- a/skyportal/schema.py
+++ b/skyportal/schema.py
@@ -244,8 +244,7 @@ class PhotBaseFlexible(object):
         "identical). Defaults to None."
     )
 
-    group_ids = fields.List(
-        fields.Integer(),
+    group_ids = fields.Field(
         description="List of group IDs to which photometry points will be visible. "
         "If 'all', will be shared with all groups the associated source is visible to.",
         required=True,

--- a/skyportal/tests/api/test_photometry.py
+++ b/skyportal/tests/api/test_photometry.py
@@ -1,6 +1,10 @@
+from baselayer.app.env import load_env
 from skyportal.tests import api
 import numpy as np
 import sncosmo
+
+
+_, cfg = load_env()
 
 
 def test_token_user_post_get_photometry_data(
@@ -91,6 +95,7 @@ def test_post_photometry_multiple_groups(
 
 def test_post_photometry_all_groups(
     upload_data_token_two_groups,
+    super_admin_token,
     public_source_two_groups,
     public_group,
     public_group2,
@@ -119,7 +124,7 @@ def test_post_photometry_all_groups(
 
     photometry_id = data['data']['ids'][0]
     status, data = api(
-        'GET', f'photometry/{photometry_id}?format=flux', token=upload_data_token
+        'GET', f'photometry/{photometry_id}?format=flux', token=super_admin_token,
     )
     assert status == 200
     assert data['status'] == 'success'
@@ -129,7 +134,8 @@ def test_post_photometry_all_groups(
     assert data['data']['ra_unc'] is None
     assert data['data']['dec_unc'] is None
 
-    assert len(data['data']['groups']) == 2
+    assert len(data['data']['groups']) == 1
+    assert data['data']['groups'][0]['name'] == cfg['misc']['public_group_name']
 
     np.testing.assert_allclose(
         data['data']['flux'], 12.24 * 10 ** (-0.4 * (25.0 - 23.9))

--- a/skyportal/tests/api/test_photometry.py
+++ b/skyportal/tests/api/test_photometry.py
@@ -82,6 +82,55 @@ def test_post_photometry_multiple_groups(
     assert data['data']['ra_unc'] is None
     assert data['data']['dec_unc'] is None
 
+    assert len(data['data']['groups']) == 2
+
+    np.testing.assert_allclose(
+        data['data']['flux'], 12.24 * 10 ** (-0.4 * (25.0 - 23.9))
+    )
+
+
+def test_post_photometry_all_groups(
+    upload_data_token_two_groups,
+    public_source_two_groups,
+    public_group,
+    public_group2,
+    ztf_camera,
+):
+    upload_data_token = upload_data_token_two_groups
+    public_source = public_source_two_groups
+    status, data = api(
+        'POST',
+        'photometry',
+        data={
+            'obj_id': str(public_source.id),
+            'mjd': 58000.0,
+            'instrument_id': ztf_camera.id,
+            'flux': 12.24,
+            'fluxerr': 0.031,
+            'zp': 25.0,
+            'magsys': 'ab',
+            'filter': 'ztfg',
+            'group_ids': "all",
+        },
+        token=upload_data_token,
+    )
+    assert status == 200
+    assert data['status'] == 'success'
+
+    photometry_id = data['data']['ids'][0]
+    status, data = api(
+        'GET', f'photometry/{photometry_id}?format=flux', token=upload_data_token
+    )
+    assert status == 200
+    assert data['status'] == 'success'
+
+    assert data['data']['ra'] is None
+    assert data['data']['dec'] is None
+    assert data['data']['ra_unc'] is None
+    assert data['data']['dec_unc'] is None
+
+    assert len(data['data']['groups']) == 2
+
     np.testing.assert_allclose(
         data['data']['flux'], 12.24 * 10 ** (-0.4 * (25.0 - 23.9))
     )
@@ -558,7 +607,7 @@ def test_token_user_post_photometry_limits(
     assert status == 200
     assert data['status'] == 'success'
 
-    assert data['data']['flux'] == None
+    assert data['data']['flux'] is None
     np.testing.assert_allclose(
         data['data']['fluxerr'], 10 ** (-0.4 * (22.3 - 23.9)) / 5
     )
@@ -589,7 +638,7 @@ def test_token_user_post_photometry_limits(
     assert status == 200
     assert data['status'] == 'success'
 
-    assert data['data']['flux'] == None
+    assert data['data']['flux'] is None
     np.testing.assert_allclose(
         data['data']['fluxerr'], 0.031 * 10 ** (-0.4 * (25.0 - 23.9))
     )

--- a/skyportal/tests/api/test_photometry.py
+++ b/skyportal/tests/api/test_photometry.py
@@ -221,30 +221,6 @@ def test_retrieve_photometry_error_group_membership_posted_by_other(
     assert "Insufficient permissions" in data['message']
 
 
-def test_post_photometry_unaccessed_group(
-    upload_data_token, public_source, public_group, public_group2, ztf_camera
-):
-    status, data = api(
-        'POST',
-        'photometry',
-        data={
-            'obj_id': str(public_source.id),
-            'mjd': 58000.0,
-            'instrument_id': ztf_camera.id,
-            'flux': 12.24,
-            'fluxerr': 0.031,
-            'zp': 25.0,
-            'magsys': 'ab',
-            'filter': 'ztfg',
-            'group_ids': [public_group.id, public_group2.id],
-        },
-        token=upload_data_token,
-    )
-    assert status == 400
-    assert data['status'] == 'error'
-    assert "Cannot upload photometry to groups" in data["message"]
-
-
 def test_cannot_post_photometry_no_groups(
     upload_data_token, public_source, public_group, ztf_camera
 ):

--- a/skyportal/tests/api/test_spectrum.py
+++ b/skyportal/tests/api/test_spectrum.py
@@ -30,6 +30,33 @@ def test_token_user_post_get_spectrum_data(
     assert data['data']['obj_id'] == public_source.id
 
 
+def test_token_user_post_spectrum_all_groups(
+    upload_data_token, public_source_two_groups,
+):
+    status, data = api(
+        'POST',
+        'spectrum',
+        data={
+            'obj_id': str(public_source_two_groups.id),
+            'observed_at': str(datetime.datetime.now()),
+            'instrument_id': 1,
+            'wavelengths': [664, 665, 666],
+            'fluxes': [234.2, 232.1, 235.3],
+            'group_ids': "all",
+        },
+        token=upload_data_token,
+    )
+    assert status == 200
+    assert data['status'] == 'success'
+
+    spectrum_id = data['data']['id']
+    status, data = api('GET', f'spectrum/{spectrum_id}', token=upload_data_token)
+    assert status == 200
+    assert data['status'] == 'success'
+    assert data['data']['fluxes'][0] == 234.2
+    assert data['data']['obj_id'] == public_source_two_groups.id
+
+
 def test_token_user_post_spectrum_no_access(
     view_only_token, public_source, public_group
 ):


### PR DESCRIPTION
This PR adds the ability to specify `group_ids="all"` in API calls for adding photometry and spectra. When specified as such, data will be shared with the site-wide public group.

Closes https://github.com/skyportal/skyportal/issues/990 