### PR TITLE
Add toggle admin status button in group users list

### DIFF
--- a/skyportal/handlers/api/group.py
+++ b/skyportal/handlers/api/group.py
@@ -422,6 +422,62 @@ class GroupUserHandler(BaseHandler):
         )
 
     @permissions(["Manage users"])
+    def patch(self, group_id, *ignored_args):
+        """
+        ---
+        description: Update a group user's admin status
+        parameters:
+          - in: path
+            name: group_id
+            required: true
+            schema:
+              type: integer
+        requestBody:
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  userID:
+                    type: integer
+                  admin:
+                    type: boolean
+                required:
+                  - username
+                  - admin
+        responses:
+          200:
+            content:
+              application/json:
+                schema: Success
+        """
+        data = self.get_json()
+        try:
+            group_id = int(group_id)
+        except ValueError:
+            return self.error("Invalid group ID")
+        user_id = data.get("userID")
+        try:
+            user_id = int(user_id)
+        except ValueError:
+            return self.error("Invalid userID parameter")
+        groupuser = (
+            DBSession()
+            .query(GroupUser)
+            .filter(GroupUser.group_id == group_id)
+            .filter(GroupUser.user_id == user_id)
+            .first()
+        )
+        if groupuser is None:
+            return self.error("Specified user is not a member of specified group.")
+        if data.get("admin") is None:
+            return self.error("Missing required parameter: `admin`")
+        admin = data.get("admin") in [True, "true", "True", "t", "T"]
+        groupuser.admin = admin
+        DBSession().commit()
+        return self.success()
+
+    @permissions(["Manage users"])
     def delete(self, group_id, username):
         """
         ---

--- a/skyportal/tests/frontend/test_groups.py
+++ b/skyportal/tests/frontend/test_groups.py
@@ -136,7 +136,7 @@ def test_delete_group_user(driver, super_admin_user, user, public_group):
     driver.execute_script("arguments[0].click();", el)
     username_link = driver.wait_for_xpath(f'//a[contains(.,"{user.username}")]')
     delete_button = username_link.find_elements_by_xpath("../../*/button")
-    delete_button[0].click()
+    delete_button[-1].click()
     driver.wait_for_xpath_to_disappear(f'//a[contains(.,"{user.username}")]')
 
 

--- a/skyportal/tests/frontend/test_groups.py
+++ b/skyportal/tests/frontend/test_groups.py
@@ -135,7 +135,7 @@ def test_delete_group_user(driver, super_admin_user, user, public_group):
     el = driver.wait_for_xpath(f'//a[contains(.,"{public_group.name}")]')
     driver.execute_script("arguments[0].click();", el)
     username_link = driver.wait_for_xpath(f'//a[contains(.,"{user.username}")]')
-    delete_button = username_link.find_elements_by_xpath("../../*/button")
+    delete_button = username_link.find_elements_by_xpath("../../*//button")
     delete_button[-1].click()
     driver.wait_for_xpath_to_disappear(f'//a[contains(.,"{user.username}")]')
 

--- a/static/js/components/Group.jsx
+++ b/static/js/components/Group.jsx
@@ -120,6 +120,7 @@ const ManageUserButtons = ({ group, loadedId, user, isAdmin }) => {
         onClick={() => {
           toggleUserAdmin(user);
         }}
+        disabled={isAdmin(user) && numAdmins === 1}
       >
         <span style={{ whiteSpace: "nowrap" }}>
           {isAdmin(user) ? "Remove admin" : "Make admin"}

--- a/static/js/components/Group.jsx
+++ b/static/js/components/Group.jsx
@@ -123,7 +123,7 @@ const ManageUserButtons = ({ group, loadedId, user, isAdmin }) => {
         disabled={isAdmin(user) && numAdmins === 1}
       >
         <span style={{ whiteSpace: "nowrap" }}>
-          {isAdmin(user) ? "Remove admin" : "Make admin"}
+          {isAdmin(user) ? "Revoke admin status" : "Grant admin status"}
         </span>
       </Button>
       <IconButton

--- a/static/js/components/Group.jsx
+++ b/static/js/components/Group.jsx
@@ -87,9 +87,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const ManageUserButtons = ({ loadedId, user, isAdmin }) => {
-  const group = useSelector((state) => state.group);
-
+const ManageUserButtons = ({ group, loadedId, user, isAdmin }) => {
   const dispatch = useDispatch();
 
   let numAdmins = 0;
@@ -153,6 +151,7 @@ ManageUserButtons.propTypes = {
     username: PropTypes.string,
   }).isRequired,
   isAdmin: PropTypes.func.isRequired,
+  group: PropTypes.shape(PropTypes.object).isRequired,
 };
 
 const Group = () => {
@@ -410,6 +409,7 @@ const Group = () => {
                               loadedId={loadedId}
                               user={user}
                               isAdmin={isAdmin}
+                              group={group}
                             />
                           </div>
                         </Popover>
@@ -419,6 +419,7 @@ const Group = () => {
                         loadedId={loadedId}
                         user={user}
                         isAdmin={isAdmin}
+                        group={group}
                       />
                     )}
                   </ListItemSecondaryAction>

--- a/static/js/components/Group.jsx
+++ b/static/js/components/Group.jsx
@@ -230,6 +230,23 @@ const Group = () => {
     }
   });
 
+  const toggleUserAdmin = async (user) => {
+    const result = await dispatch(
+      groupsActions.updateGroupUser(loadedId, {
+        userID: user.id,
+        admin: !isAdmin(user),
+      })
+    );
+    if (result.status === "success") {
+      dispatch(
+        showNotification(
+          "User admin status for this group successfully updated."
+        )
+      );
+      dispatch(groupActions.fetchGroup(loadedId));
+    }
+  };
+
   const groupStreamIds = group?.streams?.map((stream) => stream.id);
 
   const isStreamIdInStreams = (sid) =>
@@ -293,25 +310,39 @@ const Group = () => {
                     <Chip label="Admin" size="small" color="secondary" />
                   </div>
                 )}
-                {currentUser.acls?.includes("Manage users") &&
-                  ((isAdmin(user) && numAdmins > 1) || !isAdmin(user)) && (
-                    <ListItemSecondaryAction>
-                      <IconButton
-                        edge="end"
-                        aria-label="delete"
-                        onClick={() =>
-                          dispatch(
-                            groupsActions.deleteGroupUser({
-                              username: user.username,
-                              group_id: group.id,
-                            })
-                          )
-                        }
-                      >
-                        <DeleteIcon />
-                      </IconButton>
-                    </ListItemSecondaryAction>
-                  )}
+                &nbsp;
+                {currentUser.acls?.includes("Manage users") && (
+                  <Button
+                    size="small"
+                    onClick={() => {
+                      toggleUserAdmin(user);
+                    }}
+                  >
+                    <span style={{ whiteSpace: "nowrap" }}>
+                      {isAdmin(user) ? "Remove admin" : "Make admin"}
+                    </span>
+                  </Button>
+                )}
+                &nbsp;
+                {currentUser.acls?.includes("Manage users") && (
+                  <ListItemSecondaryAction>
+                    <IconButton
+                      edge="end"
+                      aria-label="delete"
+                      onClick={() =>
+                        dispatch(
+                          groupsActions.deleteGroupUser({
+                            username: user.username,
+                            group_id: group.id,
+                          })
+                        )
+                      }
+                      disabled={isAdmin(user) && numAdmins === 1}
+                    >
+                      <DeleteIcon />
+                    </IconButton>
+                  </ListItemSecondaryAction>
+                )}
               </ListItem>
             ))}
           </List>

--- a/static/js/components/Group.jsx
+++ b/static/js/components/Group.jsx
@@ -5,6 +5,7 @@ import PropTypes from "prop-types";
 import { useDispatch, useSelector } from "react-redux";
 import { makeStyles, useTheme } from "@material-ui/core/styles";
 import Button from "@material-ui/core/Button";
+import MoreVertIcon from "@material-ui/icons/MoreVert";
 import DeleteIcon from "@material-ui/icons/Delete";
 import List from "@material-ui/core/List";
 import ListItem from "@material-ui/core/ListItem";
@@ -12,6 +13,7 @@ import ListItemSecondaryAction from "@material-ui/core/ListItemSecondaryAction";
 import ListItemText from "@material-ui/core/ListItemText";
 import IconButton from "@material-ui/core/IconButton";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
+import Popover from "@material-ui/core/Popover";
 
 import Accordion from "@material-ui/core/Accordion";
 import AccordionSummary from "@material-ui/core/AccordionSummary";
@@ -76,9 +78,82 @@ const useStyles = makeStyles((theme) => ({
     marginTop: theme.spacing(2),
   },
   filterLink: {
-    width: "100%",
+    marginRight: theme.spacing(1),
+  },
+  manageUserPopover: {
+    display: "flex",
+    flexDirection: "column",
+    padding: theme.spacing(1),
   },
 }));
+
+const ManageUserButtons = ({ loadedId, user, isAdmin }) => {
+  const group = useSelector((state) => state.group);
+
+  const dispatch = useDispatch();
+
+  let numAdmins = 0;
+  group?.group_users?.forEach((groupUser) => {
+    if (groupUser?.admin) {
+      numAdmins += 1;
+    }
+  });
+
+  const toggleUserAdmin = async (usr) => {
+    const result = await dispatch(
+      groupsActions.updateGroupUser(loadedId, {
+        userID: usr.id,
+        admin: !isAdmin(usr),
+      })
+    );
+    if (result.status === "success") {
+      dispatch(
+        showNotification(
+          "User admin status for this group successfully updated."
+        )
+      );
+      dispatch(groupActions.fetchGroup(loadedId));
+    }
+  };
+  return (
+    <div>
+      <Button
+        size="small"
+        onClick={() => {
+          toggleUserAdmin(user);
+        }}
+      >
+        <span style={{ whiteSpace: "nowrap" }}>
+          {isAdmin(user) ? "Remove admin" : "Make admin"}
+        </span>
+      </Button>
+      <IconButton
+        edge="end"
+        aria-label="delete"
+        onClick={() =>
+          dispatch(
+            groupsActions.deleteGroupUser({
+              username: user.username,
+              group_id: group.id,
+            })
+          )
+        }
+        disabled={isAdmin(user) && numAdmins === 1}
+      >
+        <DeleteIcon />
+      </IconButton>
+    </div>
+  );
+};
+
+ManageUserButtons.propTypes = {
+  loadedId: PropTypes.number.isRequired,
+  user: PropTypes.shape({
+    id: PropTypes.number,
+    username: PropTypes.string,
+  }).isRequired,
+  isAdmin: PropTypes.func.isRequired,
+};
 
 const Group = () => {
   const classes = useStyles();
@@ -101,6 +176,24 @@ const Group = () => {
   );
   const [dialogOpen, setDialogOpen] = React.useState(false);
   const fullScreen = !useMediaQuery(theme.breakpoints.up("md"));
+
+  // Mobile manage user popover
+  const mobile = !useMediaQuery(theme.breakpoints.up("sm"));
+  const [anchorEl, setAnchorEl] = React.useState(null);
+  const [openedPopoverId, setOpenedPopoverId] = React.useState(null);
+
+  const handlePopoverOpen = (event, popoverId) => {
+    setOpenedPopoverId(popoverId);
+    setAnchorEl(event.target);
+  };
+
+  const handlePopoverClose = () => {
+    setOpenedPopoverId(null);
+    setAnchorEl(null);
+  };
+
+  const openManageUserPopover = Boolean(anchorEl);
+  const popoverId = openManageUserPopover ? "manage-user-popover" : undefined;
 
   const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
 
@@ -223,30 +316,6 @@ const Group = () => {
     );
   };
 
-  let numAdmins = 0;
-  group?.group_users?.forEach((groupUser) => {
-    if (groupUser?.admin) {
-      numAdmins += 1;
-    }
-  });
-
-  const toggleUserAdmin = async (user) => {
-    const result = await dispatch(
-      groupsActions.updateGroupUser(loadedId, {
-        userID: user.id,
-        admin: !isAdmin(user),
-      })
-    );
-    if (result.status === "success") {
-      dispatch(
-        showNotification(
-          "User admin status for this group successfully updated."
-        )
-      );
-      dispatch(groupActions.fetchGroup(loadedId));
-    }
-  };
-
   const groupStreamIds = group?.streams?.map((stream) => stream.id);
 
   const isStreamIdInStreams = (sid) =>
@@ -312,35 +381,46 @@ const Group = () => {
                 )}
                 &nbsp;
                 {currentUser.acls?.includes("Manage users") && (
-                  <Button
-                    size="small"
-                    onClick={() => {
-                      toggleUserAdmin(user);
-                    }}
-                  >
-                    <span style={{ whiteSpace: "nowrap" }}>
-                      {isAdmin(user) ? "Remove admin" : "Make admin"}
-                    </span>
-                  </Button>
-                )}
-                &nbsp;
-                {currentUser.acls?.includes("Manage users") && (
                   <ListItemSecondaryAction>
-                    <IconButton
-                      edge="end"
-                      aria-label="delete"
-                      onClick={() =>
-                        dispatch(
-                          groupsActions.deleteGroupUser({
-                            username: user.username,
-                            group_id: group.id,
-                          })
-                        )
-                      }
-                      disabled={isAdmin(user) && numAdmins === 1}
-                    >
-                      <DeleteIcon />
-                    </IconButton>
+                    {mobile ? (
+                      <div>
+                        <IconButton
+                          edge="end"
+                          aria-label="open-manage-user-popover"
+                          onClick={(e) => handlePopoverOpen(e, user.id)}
+                        >
+                          <MoreVertIcon />
+                        </IconButton>
+                        <Popover
+                          id={popoverId}
+                          open={openedPopoverId === user.id}
+                          anchorEl={anchorEl}
+                          onClose={handlePopoverClose}
+                          anchorOrigin={{
+                            vertical: "bottom",
+                            horizontal: "center",
+                          }}
+                          transformOrigin={{
+                            vertical: "top",
+                            horizontal: "center",
+                          }}
+                        >
+                          <div className={classes.manageUserPopover}>
+                            <ManageUserButtons
+                              loadedId={loadedId}
+                              user={user}
+                              isAdmin={isAdmin}
+                            />
+                          </div>
+                        </Popover>
+                      </div>
+                    ) : (
+                      <ManageUserButtons
+                        loadedId={loadedId}
+                        user={user}
+                        isAdmin={isAdmin}
+                      />
+                    )}
                   </ListItemSecondaryAction>
                 )}
               </ListItem>

--- a/static/js/ducks/groups.js
+++ b/static/js/ducks/groups.js
@@ -15,6 +15,9 @@ export const DELETE_GROUP_OK = "skyportal/DELETE_GROUP_OK";
 export const ADD_GROUP_USER = "skyportal/ADD_GROUP_USER";
 export const ADD_GROUP_USER_OK = "skyportal/ADD_GROUP_USER_OK";
 
+export const UPDATE_GROUP_USER = "skyportal/UPDATE_GROUP_USER";
+export const UPDATE_GROUP_USER_OK = "skyportal/UPDATE_GROUP_USER_OK";
+
 export const DELETE_GROUP_USER = "skyportal/DELETE_GROUP_USER";
 export const DELETE_GROUP_USER_OK = "skyportal/DELETE_GROUP_USER_OK";
 
@@ -40,6 +43,9 @@ export function addGroupUser({ username, admin, group_id }) {
     group_id,
   });
 }
+
+export const updateGroupUser = (groupID, params) =>
+  API.PATCH(`/api/groups/${groupID}/users`, UPDATE_GROUP_USER, params);
 
 export function deleteGroupUser({ username, group_id }) {
   return API.DELETE(


### PR DESCRIPTION
This PR introduces a button to change the admin status of group users (only displayed to users with the "Manage users" ACL). `GroupUserHandler.patch` is implemented, along with an associated action creator. An additional change: disable the delete user icon button in the case of a single remaining group admin instead of setting its display property to "none", which caused a jarring misalignment.

Closes https://github.com/skyportal/skyportal/issues/578 

Screen capture demo:
![toggle_admin_status](https://user-images.githubusercontent.com/7230285/94749179-0f057580-0338-11eb-9cf4-13014145cf12.gif)

