### PR TITLE
Comment groups permissions updates & bug fixes

### DIFF
--- a/skyportal/handlers/api/comment.py
+++ b/skyportal/handlers/api/comment.py
@@ -106,32 +106,24 @@ class CommentHandler(BaseHandler):
             )
 
         # Only post to groups source/candidate is actually associated with
-        if DBSession().query(Candidate).filter(Candidate.obj_id == obj_id).all():
-            candidate_group_ids = [
-                f.group_id
-                for f in (
-                    DBSession()
-                    .query(Filter)
-                    .filter(Filter.id.in_(user_accessible_filter_ids))
-                    .filter(
-                        Filter.id.in_(
-                            DBSession()
-                            .query(Candidate.filter_id)
-                            .filter(Candidate.obj_id == obj_id)
-                        )
-                    )
-                    .all()
-                )
-            ]
-        else:
-            candidate_group_ids = []
-        matching_sources = (
-            DBSession().query(Source).filter(Source.obj_id == obj_id).all()
-        )
-        if matching_sources:
-            source_group_ids = [source.group_id for source in matching_sources]
-        else:
-            source_group_ids = []
+        candidate_group_ids = [
+            f.group_id
+            for f in (
+                DBSession()
+                .query(Filter)
+                .join(Candidate)
+                .filter(Filter.id.in_(user_accessible_filter_ids))
+                .filter(Candidate.obj_id == obj_id)
+                .all()
+            )
+        ]
+        source_group_ids = [
+            source.group_id
+            for source in DBSession()
+            .query(Source)
+            .filter(Source.obj_id == obj_id)
+            .all()
+        ]
         group_ids = set(group_ids).intersection(candidate_group_ids + source_group_ids)
         if not group_ids:
             return self.error("Obj is not associated with any of the specified groups.")

--- a/skyportal/handlers/api/comment.py
+++ b/skyportal/handlers/api/comment.py
@@ -129,11 +129,18 @@ class CommentHandler(BaseHandler):
             return self.error("Obj is not associated with any of the specified groups.")
 
         groups = Group.query.filter(Group.id.in_(group_ids)).all()
-        if 'attachment' in data and 'body' in data['attachment']:
-            attachment_bytes = str.encode(
-                data['attachment']['body'].split('base64,')[-1]
-            )
-            attachment_name = data['attachment']['name']
+        if 'attachment' in data:
+            if (
+                isinstance(data['attachment'], dict)
+                and 'body' in data['attachment']
+                and 'name' in data['attachment']
+            ):
+                attachment_bytes = str.encode(
+                    data['attachment']['body'].split('base64,')[-1]
+                )
+                attachment_name = data['attachment']['name']
+            else:
+                return self.error("Malformed comment attachment")
         else:
             attachment_bytes, attachment_name = None, None
 

--- a/static/js/components/CommentEntry.jsx
+++ b/static/js/components/CommentEntry.jsx
@@ -13,7 +13,7 @@ import FormValidationError from "./FormValidationError";
 import styles from "./CommentEntry.css";
 
 const CommentEntry = ({ addComment }) => {
-  const userGroups = useSelector((state) => state.groups.user);
+  const { userAccessible: groups } = useSelector((state) => state.groups);
 
   const {
     handleSubmit,
@@ -32,9 +32,9 @@ const CommentEntry = ({ addComment }) => {
 
   useEffect(() => {
     reset({
-      group_ids: Array(userGroups.length).fill(true),
+      group_ids: Array(groups.length).fill(true),
     });
-  }, [reset, userGroups]);
+  }, [reset, groups]);
 
   const [groupSelectVisible, setGroupSelectVisible] = useState(false);
   const toggleGroupSelectVisible = () => {
@@ -42,7 +42,7 @@ const CommentEntry = ({ addComment }) => {
   };
 
   const onSubmit = (data) => {
-    const groupIDs = userGroups.map((g) => g.id);
+    const groupIDs = groups.map((g) => g.id);
     const selectedGroupIDs = groupIDs.filter((ID, idx) => data.group_ids[idx]);
     data.group_ids = selectedGroupIDs;
     addComment(data);
@@ -98,7 +98,7 @@ const CommentEntry = ({ addComment }) => {
           display={groupSelectVisible ? "flex" : "none"}
           className={styles.customizeGroupsContainer}
         >
-          {userGroups.map((userGroup, idx) => (
+          {groups.map((userGroup, idx) => (
             <FormControlLabel
               key={userGroup.id}
               control={


### PR DESCRIPTION
This PR fixes a bug where a user with System admin ACL could view a source saved to group(s) they're not part of, but could not use the front-end form to comment, as the front-end form only selects the users groups they're part of (here changed to all groups accessible to user).

Also, malformed comment attachments are better handled (used to fail silently, now returns informative error message)