### PR TITLE
change detect threshold to 3 sigma in bokeh plots

### DIFF
--- a/skyportal/plot.py
+++ b/skyportal/plot.py
@@ -31,7 +31,7 @@ from skyportal.models import (
 import sncosmo
 
 
-DETECT_THRESH = 5  # sigma
+DETECT_THRESH = 3  # sigma
 
 SPEC_LINES = {
     'H': ([3970, 4102, 4341, 4861, 6563], '#ff0000'),


### PR DESCRIPTION
This updates the photometry plot to show 3 sigma detections. 

Fixes #999