### PR TITLE
Allow configuring multiple logos in header bar

### DIFF
--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -1,6 +1,8 @@
 app:
   title: SkyPortal
-  logo: /static/images/skyportal_logo.png
+  logos: # Logos to place in the top-left of the header bar (zero or more)
+    - src: /static/images/skyportal_logo_dark.png
+      alt_text: Skyportal logo
   login_message: |
     For more information about the project, see
     <a href="https://github.com/skyportal/skyportal">

--- a/static/js/components/HeaderContent.jsx.template
+++ b/static/js/components/HeaderContent.jsx.template
@@ -10,7 +10,13 @@ import styles from "./Main.css";
 const HeaderContent = () => (
   <div className={styles.topBannerContent}>
     <div style= {%- raw -%} {{display: "inline-flex", flexDirection: "row" }} {%- endraw -%} >
-      <Logo className={styles.logo} />
+      <div className={styles.logos}>
+        {%- for logo in app.logos %}
+        <div className={styles.logoContainer}>
+          <Logo src="{{ logo.src }}" altText="{{ logo.alt_text }}" />
+        </div>
+        {%- endfor %}
+      </div>
       <Link className={styles.title} to="/">
         {{ app.title }}
       </Link>

--- a/static/js/components/Logo.css
+++ b/static/js/components/Logo.css
@@ -14,7 +14,6 @@
 .noRotateLogo {
   vertical-align: middle;
   height: 50px;
-  margin-top: -0.5em;
 }
 
 .rotateLogo {

--- a/static/js/components/Logo.jsx
+++ b/static/js/components/Logo.jsx
@@ -1,16 +1,29 @@
 import React from "react";
 import { useSelector } from "react-redux";
+import PropTypes from "prop-types";
 import styles from "./Logo.css";
 
-const Logo = () => {
+const Logo = ({ src, altText }) => {
   const rotateLogo = useSelector((state) => state.logo.rotateLogo);
   return (
-    <img
-      alt="SkyPortal logo"
-      className={rotateLogo ? styles.rotateLogo : styles.noRotateLogo}
-      src="/static/images/skyportal_logo_dark.png"
-    />
+    <div className={styles.logoContainer}>
+      <img
+        alt={altText}
+        className={rotateLogo ? styles.rotateLogo : styles.noRotateLogo}
+        src={src}
+      />
+    </div>
   );
+};
+
+Logo.propTypes = {
+  src: PropTypes.string,
+  altText: PropTypes.string,
+};
+
+Logo.defaultProps = {
+  src: "/static/images/skyportal_logo_dark.png",
+  altText: "SkyPortal logo",
 };
 
 export default Logo;

--- a/static/js/components/Main.css
+++ b/static/js/components/Main.css
@@ -21,3 +21,20 @@
 .websocket {
   display: none;
 }
+
+.logos {
+  display: inline-flex;
+  flex-direction: row;
+}
+
+.logoContainer {
+  margin-top: -0.5em;
+  height: 50px;
+  border-right: 1px solid white;
+  padding: 0 0.75rem;
+}
+
+.logoContainer:last-of-type {
+  border-right: none;
+  padding-right: 0;
+}

--- a/static/js/components/SidebarAndHeader.jsx.template
+++ b/static/js/components/SidebarAndHeader.jsx.template
@@ -49,8 +49,10 @@ const useStyles = makeStyles((theme) => ({
     }),
   },
   menuButton: {
-    marginRight: theme.spacing(2),
     marginTop: "0.8em",
+    [theme.breakpoints.up('sm')]: {
+      marginRight: theme.spacing(2),
+    }
   },
   hide: {
     display: 'none',


### PR DESCRIPTION
Will put up corresponding PR to Fritz to add the GROWTH logo as in sample image below:
![Screenshot 2020-10-06 134117](https://user-images.githubusercontent.com/17696889/95258060-10bcb680-07da-11eb-8db2-cf52c866a2cf.png)

Also a small spacing improvement on mobile for header bar (removed a margin if there's less space available)