### PR TITLE
Selectively display git commits; parse commits on backend and render on frontend

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "react-grid-layout": "1.1.1",
     "react-hook-form": "5.7.2",
     "react-markdown": "4.3.1",
-    "react-html-parser": "2.0.2",
     "react-redux": "7.2.1",
     "react-responsive": "8.1.0",
     "react-router-dom": "5.2.0",

--- a/skyportal/handlers/api/sysinfo.py
+++ b/skyportal/handlers/api/sysinfo.py
@@ -14,11 +14,11 @@ _, cfg = load_env()
 # This file is generated with
 #
 #   git log --no-merges --first-parent \
-#           --pretty='format:[%cI %h %cE] %s' -250
+#           --pretty='format:[%cI %h %cE] %s' -1000
 #
-# We query for more than the number desired (250 instead of 25), because
+# We query for more than the number desired (1000 instead of 100), because
 # we filter out all commits by noreply@github.com and hope to end up
-# with 25 commits still.
+# with 100 commits still.
 
 
 gitlog_file = "data/gitlog.txt"
@@ -79,22 +79,19 @@ class SysInfoHandler(BaseHandler):
             )
             loginfo = p.stdout
 
-        raw_gitlog = loginfo.splitlines()
-
-        log = gitlog.parse_gitlog(raw_gitlog)
-        log = [
+        parsed_log = gitlog.parse_gitlog(loginfo.splitlines())
+        parsed_log = [
             entry
-            for entry in log
+            for entry in parsed_log
             if not (entry['description'].lower().startswith(('bump', 'pin')))
         ]
-
-        log = log[:max_log_lines]
+        parsed_log = parsed_log[:max_log_lines]
 
         return self.success(
             data={
                 "invitationsEnabled": cfg["invitations.enabled"],
                 "cosmology": str(cosmo),
                 "cosmoref": cosmo.__doc__,
-                "gitlog": log,
+                "gitlog": parsed_log,
             }
         )

--- a/skyportal/handlers/api/sysinfo.py
+++ b/skyportal/handlers/api/sysinfo.py
@@ -11,6 +11,11 @@ from skyportal.utils import gitlog
 
 _, cfg = load_env()
 
+# This file is generated with
+#
+#   git log --no-merges --first-parent \
+#           --pretty='format:[%ci %h] %s' -25
+
 gitlog_file = "data/gitlog.txt"
 default_log_lines = 25
 

--- a/skyportal/tests/utils/test_gitlog.py
+++ b/skyportal/tests/utils/test_gitlog.py
@@ -3,7 +3,7 @@ from skyportal.utils import gitlog
 
 log = '''
 [2020-10-06T19:38:32-07:00 f3542fa8 someone@berkeley.edu] Pass git log to frontend as parsed components
-[2020-10-05T14:06:20-07:00 a4052098 noreply@github.com] Bump emoji-dictionary from 1.0.10 to 1.0.11 (#1040)
+[2020-10-05T14:06:20+03:00 a4052098f noreply@github.com] Bump emoji-dictionary from 1.0.10 to 1.0.11 (#1040)
 '''.split(
     '\n'
 )
@@ -24,12 +24,12 @@ def test_gitlog_parse():
         f"https://github.com/skyportal/skyportal/commit/f3542fa8"
     )
 
-    assert e1['time'] == '2020-10-05T14:06:20-07:00'
-    assert e1['sha'] == 'a4052098'
+    assert e1['time'] == '2020-10-05T14:06:20+03:00'
+    assert e1['sha'] == 'a4052098f'
     assert e1['email'] == 'noreply@github.com'
     assert e1['description'] == 'Bump emoji-dictionary from 1.0.10 to 1.0.11'
     assert e1['pr_nr'] == '1040'
     assert e1['pr_url'] == 'https://github.com/skyportal/skyportal/pull/1040'
     assert e1['commit_url'] == (
-        f"https://github.com/skyportal/skyportal/commit/a4052098"
+        f"https://github.com/skyportal/skyportal/commit/a4052098f"
     )

--- a/skyportal/tests/utils/test_gitlog.py
+++ b/skyportal/tests/utils/test_gitlog.py
@@ -1,0 +1,33 @@
+from skyportal.utils import gitlog
+
+
+log = '''
+[2020-10-06 19:38:32 -0700 f3542fa8] Pass git log to frontend as parsed components
+[2020-10-05 14:06:20 -0700 a4052098] Bump emoji-dictionary from 1.0.10 to 1.0.11 (#1040)
+'''.split(
+    '\n'
+)
+
+
+def test_gitlog_parse():
+    entries = gitlog.parse_gitlog(log)
+    e0 = entries[0]
+    e1 = entries[1]
+
+    assert e0['time'] == '2020-10-06 19:38:32 -0700'
+    assert e0['sha'] == 'f3542fa8'
+    assert e0['pr_desc'] == 'Pass git log to frontend as parsed components'
+    assert e0['pr_nr'] is None
+    assert e0['pr_url'] == ''
+    assert e0['commit_url'] == (
+        f"https://github.com/skyportal/skyportal/commit/f3542fa8"
+    )
+
+    assert e1['time'] == '2020-10-05 14:06:20 -0700'
+    assert e1['sha'] == 'a4052098'
+    assert e1['pr_desc'] == 'Bump emoji-dictionary from 1.0.10 to 1.0.11'
+    assert e1['pr_nr'] == '1040'
+    assert e1['pr_url'] == 'https://github.com/skyportal/skyportal/pull/1040'
+    assert e1['commit_url'] == (
+        f"https://github.com/skyportal/skyportal/commit/a4052098"
+    )

--- a/skyportal/tests/utils/test_gitlog.py
+++ b/skyportal/tests/utils/test_gitlog.py
@@ -2,8 +2,8 @@ from skyportal.utils import gitlog
 
 
 log = '''
-[2020-10-06 19:38:32 -0700 f3542fa8] Pass git log to frontend as parsed components
-[2020-10-05 14:06:20 -0700 a4052098] Bump emoji-dictionary from 1.0.10 to 1.0.11 (#1040)
+[2020-10-06T19:38:32-07:00 f3542fa8 someone@berkeley.edu] Pass git log to frontend as parsed components
+[2020-10-05T14:06:20-07:00 a4052098 noreply@github.com] Bump emoji-dictionary from 1.0.10 to 1.0.11 (#1040)
 '''.split(
     '\n'
 )
@@ -14,18 +14,20 @@ def test_gitlog_parse():
     e0 = entries[0]
     e1 = entries[1]
 
-    assert e0['time'] == '2020-10-06 19:38:32 -0700'
+    assert e0['time'] == '2020-10-06T19:38:32-07:00'
     assert e0['sha'] == 'f3542fa8'
-    assert e0['pr_desc'] == 'Pass git log to frontend as parsed components'
+    assert e0['email'] == 'someone@berkeley.edu'
+    assert e0['description'] == 'Pass git log to frontend as parsed components'
     assert e0['pr_nr'] is None
     assert e0['pr_url'] == ''
     assert e0['commit_url'] == (
         f"https://github.com/skyportal/skyportal/commit/f3542fa8"
     )
 
-    assert e1['time'] == '2020-10-05 14:06:20 -0700'
+    assert e1['time'] == '2020-10-05T14:06:20-07:00'
     assert e1['sha'] == 'a4052098'
-    assert e1['pr_desc'] == 'Bump emoji-dictionary from 1.0.10 to 1.0.11'
+    assert e1['email'] == 'noreply@github.com'
+    assert e1['description'] == 'Bump emoji-dictionary from 1.0.10 to 1.0.11'
     assert e1['pr_nr'] == '1040'
     assert e1['pr_url'] == 'https://github.com/skyportal/skyportal/pull/1040'
     assert e1['commit_url'] == (

--- a/skyportal/utils/gitlog.py
+++ b/skyportal/utils/gitlog.py
@@ -1,0 +1,50 @@
+import re
+
+
+pr_url_base = "https://github.com/skyportal/skyportal/pull"
+commit_url_base = "https://github.com/skyportal/skyportal/commit"
+
+
+def parse_gitlog(log):
+    """Parse git log.
+
+    Parameters
+    ----------
+    log : list
+        The log should be passed in as a list of lines, obtained using::
+
+          git log --no-merges --first-parent \
+                  --pretty='format:[%ci %h] %s' -25
+
+    Returns
+    -------
+    parsed_log : list of dict
+        Each entry has keys `time` (commit time), `sha` (commit hash),
+        `commit_url`, `pr_desc` (commit description), `pr_nr`, `pr_url`.
+
+    """
+    timestamp_re = '(?P<time>[0-9\\-:].*)'
+    sha_re = '(?P<sha>[0-9a-f]{8})'
+    pr_desc_re = '(?P<pr_desc>.*?)'
+    pr_nr_re = '( \\(\\#(?P<pr_nr>[0-9]*)\\))?'
+    log_re = f'\\[{timestamp_re} {sha_re}\\] {pr_desc_re}{pr_nr_re}$'
+
+    gitlog = []
+    for line in log:
+        if not line:
+            continue
+
+        m = re.match(log_re, line)
+        if m is None:
+            print(f'sysinfo: could not parse gitlog line: [{line}]')
+            continue
+
+        log_fields = m.groupdict()
+        pr_nr = log_fields['pr_nr']
+        sha = log_fields['sha']
+        log_fields['pr_url'] = f'{pr_url_base}/{pr_nr}' if pr_nr else ''
+        log_fields['commit_url'] = f'{commit_url_base}/{sha}'
+
+        gitlog.append(log_fields)
+
+    return gitlog

--- a/skyportal/utils/gitlog.py
+++ b/skyportal/utils/gitlog.py
@@ -14,20 +14,23 @@ def parse_gitlog(log):
         The log should be passed in as a list of lines, obtained using::
 
           git log --no-merges --first-parent \
-                  --pretty='format:[%ci %h] %s' -25
+                  --pretty='format:[%cI %h %cE] %s' -25
 
     Returns
     -------
     parsed_log : list of dict
         Each entry has keys `time` (commit time), `sha` (commit hash),
-        `commit_url`, `pr_desc` (commit description), `pr_nr`, `pr_url`.
+        `email` (committer email), `commit_url`, `pr_desc` (commit description),
+        `pr_nr`, `pr_url`.
 
     """
-    timestamp_re = '(?P<time>[0-9\\-:].*)'
+    timechars = '[0-9\\-:]'
+    timestamp_re = f'(?P<time>{timechars}+T{timechars}+)'
     sha_re = '(?P<sha>[0-9a-f]{8})'
-    pr_desc_re = '(?P<pr_desc>.*?)'
+    email_re = '(?P<email>\\S*@\\S*?)'
+    pr_desc_re = '(?P<description>.*?)'
     pr_nr_re = '( \\(\\#(?P<pr_nr>[0-9]*)\\))?'
-    log_re = f'\\[{timestamp_re} {sha_re}\\] {pr_desc_re}{pr_nr_re}$'
+    log_re = f'\\[{timestamp_re} {sha_re} {email_re}\\] {pr_desc_re}{pr_nr_re}$'
 
     gitlog = []
     for line in log:
@@ -36,7 +39,7 @@ def parse_gitlog(log):
 
         m = re.match(log_re, line)
         if m is None:
-            print(f'sysinfo: could not parse gitlog line: [{line}]')
+            print(f'sysinfo: could not parse gitlog line: `{line}`')
             continue
 
         log_fields = m.groupdict()

--- a/static/js/components/About.jsx
+++ b/static/js/components/About.jsx
@@ -13,6 +13,7 @@ import Box from "@material-ui/core/Box";
 import Paper from "@material-ui/core/Paper";
 
 import clsx from "clsx";
+import dayjs from "dayjs";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -32,6 +33,10 @@ const useStyles = makeStyles((theme) => ({
   },
   hidden: {
     display: "none",
+  },
+  gitlogPaper: {
+    maxHeight: "30rem",
+    overflow: "auto",
   },
   gitlogList: {
     fontFamily: "monospace",
@@ -134,17 +139,23 @@ const About = () => {
       {gitlog && (
         <>
           <h2>Recent Changelog</h2>
-          <Paper mt={1}>
+          <Paper mt={1} className={classes.gitlogPaper}>
             <Box p={1}>
+              <div>
+                See all pull requests at{" "}
+                <a href="https://github.com/skyportal/skyportal/pulls?q=is%3Apr+">
+                  https://github.com/skyportal/skyportal/pulls
+                </a>
+              </div>
               <ul className={classes.gitlogList}>
                 {gitlog.map(
-                  ({ time, sha, pr_desc, pr_nr, pr_url, commit_url }) => (
+                  ({ time, sha, description, pr_nr, pr_url, commit_url }) => (
                     <li key={sha}>
-                      [{time}
+                      [{dayjs(time).format("YYYY-MM-DD")}
                       <a className={classes.gitlogSHA} href={commit_url}>
                         &nbsp;{sha}
                       </a>
-                      ] {pr_desc}
+                      ] {description}
                       {pr_nr && (
                         <a href={pr_url}>
                           &nbsp;(
@@ -155,12 +166,6 @@ const About = () => {
                   )
                 )}
               </ul>
-              <div>
-                See all the pull requests at{" "}
-                <a href="https://github.com/skyportal/skyportal/pulls">
-                  https://github.com/skyportal/skyportal/pulls
-                </a>
-              </div>
             </Box>
           </Paper>
         </>

--- a/static/js/components/About.jsx
+++ b/static/js/components/About.jsx
@@ -10,7 +10,7 @@ import CardActions from "@material-ui/core/CardActions";
 import Button from "@material-ui/core/Button";
 import Typography from "@material-ui/core/Typography";
 import Box from "@material-ui/core/Box";
-import ReactHtmlParser from "react-html-parser";
+import Paper from "@material-ui/core/Paper";
 
 import clsx from "clsx";
 
@@ -32,6 +32,15 @@ const useStyles = makeStyles((theme) => ({
   },
   hidden: {
     display: "none",
+  },
+  gitlogList: {
+    fontFamily: "monospace",
+  },
+  gitlogSHA: {
+    color: `${theme.palette.secondary.dark} !important`,
+  },
+  gitlogPR: {
+    color: theme.palette.primary.dark,
   },
 }));
 
@@ -125,17 +134,35 @@ const About = () => {
       {gitlog && (
         <>
           <h2>Recent Changelog</h2>
-          <ul>
-            {gitlog.map((val) => (
-              <li key={val.slice(-6)}> {ReactHtmlParser(val)} </li>
-            ))}
-          </ul>
-          <div>
-            See all the pull requests at{" "}
-            <a href="https://github.com/skyportal/skyportal/pulls">
-              https://github.com/skyportal/skyportal/pulls
-            </a>
-          </div>
+          <Paper mt={1}>
+            <Box p={1}>
+              <ul className={classes.gitlogList}>
+                {gitlog.map(
+                  ({ time, sha, pr_desc, pr_nr, pr_url, commit_url }) => (
+                    <li key={sha}>
+                      [{time}
+                      <a className={classes.gitlogSHA} href={commit_url}>
+                        &nbsp;{sha}
+                      </a>
+                      ] {pr_desc}
+                      {pr_nr && (
+                        <a href={pr_url}>
+                          &nbsp;(
+                          <span className={classes.gitlogPR}>#{pr_nr}</span>)
+                        </a>
+                      )}
+                    </li>
+                  )
+                )}
+              </ul>
+              <div>
+                See all the pull requests at{" "}
+                <a href="https://github.com/skyportal/skyportal/pulls">
+                  https://github.com/skyportal/skyportal/pulls
+                </a>
+              </div>
+            </Box>
+          </Paper>
         </>
       )}
       <h2>Cosmology</h2>


### PR DESCRIPTION
- Ignore merge commits and display their parent commits instead
- Move hash into date bracket (instead of displaying at end of line)
- Use a regexp to ensure that PR number is from the end of the line
- Parse components of gitlog and send to frontend, where it is rendered into the template

![2020-10-06_19:37:52](https://user-images.githubusercontent.com/45071/95282704-e3d6c680-080e-11eb-95b4-07d46b7b7fb3.png)

(See updated screenshot below.)