### PR TITLE
add a new ACL for managing allocations - manage allocations

### DIFF
--- a/skyportal/handlers/api/allocation.py
+++ b/skyportal/handlers/api/allocation.py
@@ -74,7 +74,7 @@ class AllocationHandler(BaseHandler):
         allocations = allocations.all()
         return self.success(data=allocations)
 
-    @permissions(['System admin'])
+    @permissions(['Manage allocations'])
     def post(self):
         """
         ---
@@ -120,7 +120,7 @@ class AllocationHandler(BaseHandler):
         DBSession().commit()
         return self.success(data={"id": allocation.id})
 
-    @permissions(['System admin'])
+    @permissions(['Manage allocations'])
     def put(self, allocation_id):
         """
         ---
@@ -163,7 +163,7 @@ class AllocationHandler(BaseHandler):
         DBSession().commit()
         return self.success()
 
-    @permissions(['System admin'])
+    @permissions(['Manage allocations'])
     def delete(self, allocation_id):
         """
         ---

--- a/skyportal/model_util.py
+++ b/skyportal/model_util.py
@@ -9,6 +9,7 @@ all_acl_ids = [
     'Manage users',
     'Manage sources',
     'Manage groups',
+    'Manage allocations',
     'Upload data',
     'System admin',
     'Post taxonomy',


### PR DESCRIPTION
This PR creates a new ACL - "Manage allocations", and replaces the requirement that only a System admin manage allocations with anyone who has this ACL. This will allow designated users to manage allocations (e.g., @rswalters).

