### PR TITLE
Starlist and finder fixes

### DIFF
--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -781,6 +781,7 @@ class SourceOffsetsHandler(BaseHandler):
                 query_string,
                 queries_issued,
                 noffsets,
+                used_ztfref,
             ) = get_nearby_offset_stars(
                 best_ra,
                 best_dec,
@@ -795,13 +796,13 @@ class SourceOffsetsHandler(BaseHandler):
                 allowed_queries=2,
                 use_ztfref=use_ztfref,
             )
-
         except ValueError:
             return self.error('Error while querying for nearby offset stars')
 
         starlist_str = "\n".join(
             [x["str"].replace(" ", "&nbsp;") for x in starlist_info]
         )
+
         return self.success(
             data={
                 'facility': facility,

--- a/skyportal/tests/frontend/test_sources.py
+++ b/skyportal/tests/frontend/test_sources.py
@@ -325,9 +325,9 @@ def test_super_user_can_delete_unowned_comment(
 def test_show_starlist(driver, user, public_source):
     driver.get(f"/become_user/{user.id}")
     driver.get(f"/source/{public_source.id}")
-    button = driver.wait_for_xpath(f'//span[text()="Show Starlist"]')
+    button = driver.wait_for_xpath('//span[text()="Show Starlist"]')
     button.click()
-    driver.wait_for_xpath(f"//code/div[text()[contains(., '_off1')]]", timeout=20)
+    driver.wait_for_xpath("//code/div[text()[contains(., '_o1')]]", timeout=45)
 
 
 @pytest.mark.flaky(reruns=2)
@@ -407,7 +407,7 @@ def test_dropdown_facility_change(driver, user, public_source):
     driver.scroll_to_element_and_click(
         driver.wait_for_xpath('//span[text()="Show Starlist"]')
     )
-    driver.wait_for_xpath("//code/div[text()[contains(., 'raoffset')]]", timeout=20)
+    driver.wait_for_xpath("//code/div[text()[contains(., 'raoffset')]]", timeout=45)
 
     xpath = '//*[@id="mui-component-select-StarListSelectElement"]'
     element = driver.wait_for_xpath(xpath)
@@ -415,7 +415,7 @@ def test_dropdown_facility_change(driver, user, public_source):
     xpath = '//li[@data-value="P200"]'
     element = driver.wait_for_xpath(xpath)
     ActionChains(driver).move_to_element(element).click_and_hold().perform()
-    driver.wait_for_xpath("//code/div[text()[contains(., 'dist')]]", timeout=20)
+    driver.wait_for_xpath("//code/div[text()[contains(., 'dist')]]", timeout=45)
 
 
 @pytest.mark.flaky(reruns=2)

--- a/skyportal/tests/frontend/test_sources.py
+++ b/skyportal/tests/frontend/test_sources.py
@@ -407,7 +407,7 @@ def test_dropdown_facility_change(driver, user, public_source):
     driver.scroll_to_element_and_click(
         driver.wait_for_xpath('//span[text()="Show Starlist"]')
     )
-    driver.wait_for_xpath("//code/div[text()[contains(., 'raoffset')]]", timeout=45)
+    driver.wait_for_xpath("//code/div/pre[text()[contains(., 'raoffset')]]", timeout=45)
 
     xpath = '//*[@id="mui-component-select-StarListSelectElement"]'
     element = driver.wait_for_xpath(xpath)
@@ -415,7 +415,7 @@ def test_dropdown_facility_change(driver, user, public_source):
     xpath = '//li[@data-value="P200"]'
     element = driver.wait_for_xpath(xpath)
     ActionChains(driver).move_to_element(element).click_and_hold().perform()
-    driver.wait_for_xpath("//code/div[text()[contains(., 'dist')]]", timeout=45)
+    driver.wait_for_xpath("//code/div/pre[text()[contains(., 'dist')]]", timeout=45)
 
 
 @pytest.mark.flaky(reruns=2)

--- a/skyportal/tests/frontend/test_sources.py
+++ b/skyportal/tests/frontend/test_sources.py
@@ -327,7 +327,7 @@ def test_show_starlist(driver, user, public_source):
     driver.get(f"/source/{public_source.id}")
     button = driver.wait_for_xpath('//span[text()="Show Starlist"]')
     button.click()
-    driver.wait_for_xpath("//code/div[text()[contains(., '_o1')]]", timeout=45)
+    driver.wait_for_xpath("//code/div/pre[text()[contains(., '_o1')]]", timeout=45)
 
 
 @pytest.mark.flaky(reruns=2)

--- a/skyportal/tests/tools/test_offset_util.py
+++ b/skyportal/tests/tools/test_offset_util.py
@@ -210,8 +210,13 @@ def test_get_nearby_offset_stars():
     rez = get_nearby_offset_stars(
         123.0, 33.3, "testSource", how_many=how_many, radius_degrees=3 / 60.0
     )
-
-    assert len(rez) == 4
+    # expecting 5 parameters:
+    #   a list of the source+offset stars,
+    #   What query was used against Gaia,
+    #   number of queries_issued,
+    #   number of offset stars
+    #   whether ZRF ref was used for astrometry
+    assert len(rez) == 5
     assert isinstance(rez[0], list)
     assert len(rez[0]) == how_many + 1
 

--- a/skyportal/utils/offset.py
+++ b/skyportal/utils/offset.py
@@ -882,7 +882,7 @@ def get_finding_chart(
     starlist_str = (
         f"# Note: {origin} used for offset star positions\n"
         "# Note: spacing in starlist many not copy/paste correctly in PDF\n"
-        + f"#       you can get starlist directly from"
+        + "#       you can get starlist directly from"
         + f" /api/sources/{source_name}/offsets?"
         + f"facility={offset_star_kwargs.get('facility', 'Keck')}\n"
         + "\n".join([x["str"] for x in star_list])

--- a/skyportal/utils/offset.py
+++ b/skyportal/utils/offset.py
@@ -342,6 +342,7 @@ def get_nearby_offset_stars(
     allowed_queries=2,
     queries_issued=0,
     use_ztfref=True,
+    required_ztfref_source_distance=60,
 ):
     """Finds good list of nearby offset stars for spectroscopy
        and returns info about those stars, including their
@@ -377,6 +378,12 @@ def get_nearby_offset_stars(
         before giving up on getting the number of offset stars we desire?
     queries_issued : int, optional
         How many times have we issued a query? Bookkeeping parameter.
+    use_ztfref : boolean, optional
+        Use the ZTFref catalog for offset star positions if possible
+    required_ztfref_source_distance : float, optional
+        If there are zero ZTF ref stars within this distance in arcsec,
+        then do not use the ztfref catalog even if asked. This probably
+        means that the source is at the end of the ref catalog.
 
     Returns
     -------
@@ -438,6 +445,21 @@ def get_nearby_offset_stars(
                 'Warning: Could not find the ZTF reference catalog'
                 f' at position {source_ra} {source_dec}'
             )
+        else:
+            if (
+                sum(
+                    center.separation(ztfcatalog)
+                    < required_ztfref_source_distance * u.arcsec
+                )
+                == 0
+            ):
+                ztfcatalog = None
+                log(
+                    'Warning: The ZTF reference catalog is empty near'
+                    f' position {source_ra} {source_dec}. This probably means'
+                    ' that the source is at the edge of the ref catalog.'
+                )
+                use_ztfref = False
 
     # star needs to be this far away
     # from another star
@@ -516,45 +538,49 @@ def get_nearby_offset_stars(
             queries_issued=queries_issued,
             allowed_queries=allowed_queries,
             use_ztfref=use_ztfref,
+            required_ztfref_source_distance=required_ztfref_source_distance,
         )
 
     # default to Keck starlist
-    sep = ' '  # 'fromunit'
-    commentstr = "#"
-    giveoffsets = True
-    maxname_size = 16
-    # truncate the source_name if we need to
-    if len(source_name) > 10:
-        basename = source_name[0:3] + ".." + source_name[-6:]
-    else:
-        basename = source_name
 
     if starlist_type == 'Keck':
-        pass
+        sep = ' '  # 'fromunit'
+        commentstr = "#"
+        giveoffsets = True
+        maxname_size = 15
+        first_line = None
     elif starlist_type == 'P200':
         sep = ':'  # 'fromunit'
         commentstr = "!"
         giveoffsets = False
         maxname_size = 20
-
-        # truncate the source_name if we need to
-        if len(source_name) > 15:
-            basename = source_name[0:3] + ".." + source_name[-11:]
-        else:
-            basename = source_name
-
+        first_line = None
+    elif starlist_type == 'Shane':
+        sep = ' '  # 'fromunit'
+        commentstr = "#"
+        giveoffsets = True
+        maxname_size = 15
+        # see https://mthamilton.ucolick.org/techdocs/telescopes/Shane/coords/
+        first_line = "!Data {name %16} ra_h ra_m ra_s dec_d dec_m dec_s equinox keyval {comment *}"
     else:
         log("Warning: Do not recognize this starlist format. Using Keck.")
 
-    basename = basename.strip().replace(" ", "")
+    basename = source_name.strip().replace(" ", "")
+    if len(basename) > maxname_size:
+        basename = basename[3:]
+
+    abrev_basename = source_name.strip().replace(" ", "")
+    if len(abrev_basename) > maxname_size - 3:
+        abrev_basename = basename[3:maxname_size]
+
     space = " "
     star_list_format = (
         f"{basename:{space}<{maxname_size}} "
         + f"{center.to_string('hmsdms', sep=sep, decimal=False, precision=2, alwayssign=True)[1:]}"
-        + f" 2000.0 {commentstr}"
+        + f" 2000.0 {commentstr} source_name={source_name}"
     )
 
-    star_list = []
+    star_list = [{"str": first_line}] if first_line else []
     if use_source_pos_in_starlist:
         star_list.append(
             {
@@ -576,7 +602,7 @@ def get_nearby_offset_stars(
         else:
             offsets = ""
 
-        name = f"{basename}_off{i+1}"
+        name = f"{abrev_basename}_o{i+1}"
 
         star_list_format = (
             f"{name:{space}<{maxname_size}} "
@@ -605,6 +631,7 @@ def get_nearby_offset_stars(
         query_string.replace("\n", " "),
         queries_issued,
         len(star_list) - 1,
+        use_ztfref,
     )
 
 
@@ -692,6 +719,7 @@ def fits_image(
     return get_hdu(url)
 
 
+@warningfilter(action="error", category=AstropyWarning)
 def get_finding_chart(
     source_ra,
     source_dec,
@@ -796,11 +824,19 @@ def get_finding_chart(
     wcs.wcs.cd = np.array([[-pixscale / 3600, 0], [0, pixscale / 3600]])
     wcs.wcs.ctype = ["RA---TAN", "DEC--TAN"]
 
+    fallback = True
     if hdu is not None:
         im = hdu.data
 
         # replace the nans with medians
         im[np.isnan(im)] = np.nanmedian(im)
+
+        # Fix the header keyword for the input system, if needed
+        hdr = hdu.header
+        if 'RADECSYS' in hdr:
+            hdr.set('RADESYSa', hdr['RADECSYS'], before='RADECSYS')
+            del hdr['RADECSYS']
+
         if source_image_parameters[image_source].get("reproject", False):
             # project image to the skeleton WCS solution
             log("Reprojecting image to requested position and orientation")
@@ -813,12 +849,20 @@ def get_finding_chart(
                 hdu.data, source_image_parameters[image_source]["smooth"] / pixscale
             )
 
-        percents = np.nanpercentile(im.flatten(), [10, 99.0])
-        vmin = percents[0]
-        vmax = percents[1]
-        norm = ImageNormalize(im, vmin=vmin, vmax=vmax, interval=ZScaleInterval())
-        watermark = source_image_parameters[image_source]["str"]
-    else:
+        cent = int(npixels / 2)
+        width = int(0.05 * npixels)
+        test_slice = slice(cent - width, cent + width)
+        all_nans = np.isnan(im[test_slice, test_slice].flatten()).all()
+        all_zeros = (im[test_slice, test_slice].flatten() == 0).all()
+        if not (all_zeros or all_nans):
+            percents = np.nanpercentile(im.flatten(), [10, 99.0])
+            vmin = percents[0]
+            vmax = percents[1]
+            norm = ImageNormalize(im, vmin=vmin, vmax=vmax, interval=ZScaleInterval())
+            watermark = source_image_parameters[image_source]["str"]
+            fallback = False
+
+    if hdu is None or fallback:
         # if we got back a blank image, try to fallback on another survey
         # and return the results from that call
         if fallback_image_source is not None:
@@ -862,7 +906,7 @@ def get_finding_chart(
         f'{source_name} Finder ({obstime})', fontsize='large', fontweight='bold'
     )
 
-    star_list, _, _, _ = get_nearby_offset_stars(
+    star_list, _, _, _, used_ztfref = get_nearby_offset_stars(
         source_ra, source_dec, source_name, **offset_star_kwargs
     )
 
@@ -875,10 +919,12 @@ def get_finding_chart(
         }
 
     ncolors = len(star_list)
+    if star_list[0]['str'].startswith("!Data"):
+        ncolors -= 1
     colors = sns.color_palette("colorblind", ncolors)
 
     start_text = [-0.35, 0.99]
-    origin = "GaiaDR2" if not offset_star_kwargs.get("use_ztfref") else "ZTFref"
+    origin = "GaiaDR2" if not used_ztfref else "ZTFref"
     starlist_str = (
         f"# Note: {origin} used for offset star positions\n"
         "# Note: spacing in starlist many not copy/paste correctly in PDF\n"
@@ -899,7 +945,7 @@ def get_finding_chart(
     )
 
     # add the watermark for the survey
-    props = dict(boxstyle='round', facecolor='gray', alpha=0.5)
+    props = dict(boxstyle='round', facecolor='gray', alpha=0.7)
 
     if watermark is not None:
         ax.text(
@@ -961,6 +1007,10 @@ def get_finding_chart(
             fontweight='bold',
         )
 
+    # account for Shane header
+    if star_list[0]['str'].startswith("!Data"):
+        star_list = star_list[1:]
+
     for i, star in enumerate(star_list):
 
         c1 = SkyCoord(star["ra"] * u.deg, star["dec"] * u.deg, frame='icrs')
@@ -997,7 +1047,9 @@ def get_finding_chart(
 
         # work on making marks where the stars are
         for ang in [0, 90]:
-            position_angle = ang * u.deg
+            # for the source itself (i=0), change the angle of the lines in
+            # case the offset star is the same as the source itself
+            position_angle = ang * u.deg if i != 0 else (ang + 195) * u.deg
             separation = (tick_offset * imsize * 60) * u.arcsec
             p1 = c1.directional_offset_by(position_angle, separation)
             separation = (tick_offset + tick_length) * imsize * 60 * u.arcsec
@@ -1008,10 +1060,11 @@ def get_finding_chart(
                 transform=ax.get_transform('world'),
                 color=colors[i],
                 linewidth=3 if imsize <= 4 else 2,
+                alpha=0.8,
             )
-        if star["name"].find("_off") != -1:
+        if star["name"].find("_o") != -1:
             # this is an offset star
-            text = star["name"].split("_off")[-1]
+            text = star["name"].split("_o")[-1]
             position_angle = 14 * u.deg
             separation = (tick_offset + tick_length * 1.6) * imsize * 60 * u.arcsec
             p1 = c1.directional_offset_by(position_angle, separation)

--- a/skyportal/utils/offset.py
+++ b/skyportal/utils/offset.py
@@ -720,6 +720,7 @@ def fits_image(
     return get_hdu(url)
 
 
+@warningfilter(action="error", category=AstropyWarning)
 def get_finding_chart(
     source_ra,
     source_dec,

--- a/skyportal/utils/offset.py
+++ b/skyportal/utils/offset.py
@@ -720,7 +720,6 @@ def fits_image(
     return get_hdu(url)
 
 
-@warningfilter(action="error", category=AstropyWarning)
 def get_finding_chart(
     source_ra,
     source_dec,

--- a/skyportal/utils/offset.py
+++ b/skyportal/utils/offset.py
@@ -719,7 +719,6 @@ def fits_image(
     return get_hdu(url)
 
 
-@warningfilter(action="error", category=AstropyWarning)
 def get_finding_chart(
     source_ra,
     source_dec,

--- a/static/js/components/StarList.jsx
+++ b/static/js/components/StarList.jsx
@@ -19,14 +19,16 @@ const StarListBody = ({ starList, facility, setFacility, setStarList }) => {
     <div className={styles.starListDiv}>
       <code className={styles.starList}>
         <div className={styles.codeText}>
-          {starList &&
-            starList.map((item, idx) => (
-              // eslint-disable-next-line react/no-array-index-key
-              <React.Fragment key={idx}>
-                {item.str}
-                <br />
-              </React.Fragment>
-            ))}
+          <pre>
+            {starList &&
+              starList.map((item, idx) => (
+                // eslint-disable-next-line react/no-array-index-key
+                <React.Fragment key={idx}>
+                  {item.str}
+                  <br />
+                </React.Fragment>
+              ))}
+          </pre>
         </div>
       </code>
       <div className={styles.dropDown}>


### PR DESCRIPTION
<img width="1092" alt="image" src="https://user-images.githubusercontent.com/480799/95922851-12055a80-0d69-11eb-91b3-d7ad72456403.png">

Here, the full name of the source is preserved in the starlist. ZTF20abayrkw is outside of the public ZTF footprint so the DSS image is used as a backup/fallback. The source itself is bright enough (in the Gaia DR2) to qualify as an offset star (so it's also _o1). Notice that the source position and the offset position are slightly off (~30 mas)--the source position comes from the discovery position (and other astrometry of the event available) whereas the offset position comes from the ZTFref catalog position. The agreement is well within the tolerances expected for telescope offsets + guiding.

~~Please merge https://github.com/skyportal/skyportal/pull/1075 before this one.~~

  - try to keep the full name of a source (for bookkeeping purposes)
  - Add "Shane" format for starlist
  - detect when the source is off the edge of the image (closes #964)
  - detect when the ZTF ref catalog does not cover around the source position
  - fix the formatting of the displayed starlist to include the whitespaces

