### PR TITLE
Automatically take screenshots and capture page source when tests fail 

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -153,3 +153,10 @@ jobs:
         with:
           name: logs
           path: log
+
+      - name: Upload test post-mortem reports
+        uses: actions/upload-artifact@v2
+        if: ${{ always() }}
+        with:
+          name: test-results
+          path: test-results

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ doc/images/erd.png
 
 # gitlog info
 data/gitlog.txt
+
+# test results
+test-results/

--- a/skyportal/tests/conftest.py
+++ b/skyportal/tests/conftest.py
@@ -91,7 +91,7 @@ def take_screenshot_and_page_source(webdriver, nodeid):
     file_name = f'{nodeid}_{datetime.today().strftime("%Y-%m-%d_%H:%M")}.png'.replace(
         "/", "_"
     ).replace("::", "__")
-    file_name = os.path.join(os.path.dirname(__file__), '../../test_results', file_name)
+    file_name = os.path.join(os.path.dirname(__file__), '../../test-results', file_name)
     Path(file_name).parent.mkdir(parents=True, exist_ok=True)
     webdriver.save_screenshot(file_name)
     with open(file_name.replace('png', 'html'), 'w') as f:

--- a/skyportal/tests/conftest.py
+++ b/skyportal/tests/conftest.py
@@ -90,7 +90,7 @@ def test_failed_check(request):
 def take_screenshot_and_page_source(webdriver, nodeid):
     file_name = f'{nodeid}_{datetime.today().strftime("%Y-%m-%d_%H:%M")}.png'.replace(
         "/", "_"
-    ).replace("::", "__")
+    ).replace(":", "_")
     file_name = os.path.join(os.path.dirname(__file__), '../../test-results', file_name)
     Path(file_name).parent.mkdir(parents=True, exist_ok=True)
     webdriver.save_screenshot(file_name)

--- a/skyportal/tests/conftest.py
+++ b/skyportal/tests/conftest.py
@@ -79,8 +79,8 @@ def test_failed_check(request):
     yield
     # request.node is an "item" because we use the default
     # "function" scope
-    if request.node.rep_call.failed:
-        webdriver = request.node.funcargs['selenium_driver']
+    if request.node.rep_call.failed and 'driver' in request.node.funcargs:
+        webdriver = request.node.funcargs['driver']
         take_screenshot_and_page_source(webdriver, request.node.nodeid)
 
 

--- a/skyportal/tests/conftest.py
+++ b/skyportal/tests/conftest.py
@@ -5,6 +5,7 @@ import os
 import uuid
 import pathlib
 from datetime import datetime
+from pathlib import Path
 
 from baselayer.app import models
 from baselayer.app.config import load_config
@@ -90,7 +91,8 @@ def take_screenshot_and_page_source(webdriver, nodeid):
     file_name = f'{nodeid}_{datetime.today().strftime("%Y-%m-%d_%H:%M")}.png'.replace(
         "/", "_"
     ).replace("::", "__")
-    file_name = os.path.join(os.path.dirname(__file__), '../test_results', file_name)
+    file_name = os.path.join(os.path.dirname(__file__), '../../test_results', file_name)
+    Path(file_name).parent.mkdir(parents=True, exist_ok=True)
     webdriver.save_screenshot(file_name)
     with open(file_name.replace('png', 'html'), 'w') as f:
         f.write(webdriver.page_source)


### PR DESCRIPTION
This PR adds the following automated behavior to the test suite:

1. When a test fails that uses the `driver` fixture, a screenshot is immediately captured showing the state of the screen on failure. These are saved to `test-results/`
2. When a test fails that uses the `driver` fixture, the web page source is immediately saved to `test-results/`.
3. On GA, the `test-results` directory is uploaded automatically as an artifact. 