### PR TITLE
normalize spectra by their integrated flux in source page spectroscopy plot

### DIFF
--- a/skyportal/plot.py
+++ b/skyportal/plot.py
@@ -719,13 +719,16 @@ def spectroscopy_plot(obj_id, spec_id=None):
     data = []
     for i, s in enumerate(spectra):
 
-        # normalize spectra to a common total flux (facilitates easy visual comparison)
-        normfac = np.sum(np.gradient(s.wavelengths) * s.fluxes)
+        # normalize spectra to a common average flux per resolving
+        # element of 1 (facilitates easy visual comparison)
+        normfac = np.sum(np.gradient(s.wavelengths) * s.fluxes) / len(s.fluxes)
 
         if not (np.isfinite(normfac) and normfac > 0):
-            # otherwise normalize the value at 6000A to 2e-4
-            minimum_wave_index = np.argmin(np.abs(s.wavelengths - 6000.0))
-            normfac = s.fluxes[minimum_wave_index] / 2.0e-4
+            # otherwise normalize the value at the median wavelength to 1
+            median_wave_index = np.argmin(
+                np.abs(s.wavelengths - np.median(s.wavelengths))
+            )
+            normfac = s.fluxes[median_wave_index]
 
         df = pd.DataFrame(
             {

--- a/skyportal/plot.py
+++ b/skyportal/plot.py
@@ -722,6 +722,11 @@ def spectroscopy_plot(obj_id, spec_id=None):
         # normalize spectra to a common total flux (facilitates easy visual comparison)
         normfac = np.sum(np.gradient(s.wavelengths) * s.fluxes)
 
+        if not (np.isfinite(normfac) and normfac > 0):
+            # otherwise normalize the value at 6000A to 2e-4
+            minimum_wave_index = np.argmin(np.abs(s.wavelengths - 6000.0))
+            normfac = s.fluxes[minimum_wave_index] / 2.0e-4
+
         df = pd.DataFrame(
             {
                 'wavelength': s.wavelengths,


### PR DESCRIPTION
Fixes #1051 .

This normalizes the spectra in the `spectroscopy_plot` function so they can be easily compared. The method used is to normalize by the integrated flux. 

Before: 
<img width="808" alt="Screen Shot 2020-10-14 at 10 36 20 PM" src="https://user-images.githubusercontent.com/2769632/96081330-ecae4480-0e6d-11eb-992b-e9551a36e878.png">

After:
<img width="796" alt="Screen Shot 2020-10-14 at 10 35 25 PM" src="https://user-images.githubusercontent.com/2769632/96081343-f20b8f00-0e6d-11eb-8d0e-b1216deaf905.png">

cc @mansikasliwal @scizen9