### PR TITLE
Source/candidate fetching optimization

### DIFF
--- a/skyportal/handlers/api/candidate.py
+++ b/skyportal/handlers/api/candidate.py
@@ -14,7 +14,6 @@ from ...models import (
     Obj,
     Candidate,
     Photometry,
-    Instrument,
     Source,
     Filter,
     Annotation,
@@ -152,6 +151,14 @@ class CandidateHandler(BaseHandler):
             description: |
               The sort order for annotations - either "asc" or "desc".
               Defaults to "asc".
+          - in: query
+            name: includePhotometry
+            nullable: true
+            schema:
+              type: boolean
+            description: |
+              Boolean indicating whether to include associated photometry. Defaults to
+              false.
           responses:
             200:
               content:
@@ -189,17 +196,18 @@ class CandidateHandler(BaseHandler):
                   schema: Error
         """
         user_accessible_group_ids = [g.id for g in self.current_user.accessible_groups]
+        include_photometry = self.get_query_argument("includePhotometry", False)
 
         if obj_id is not None:
-            c = Candidate.get_obj_if_owned_by(
-                obj_id,
-                self.current_user,
-                options=[
-                    joinedload(Candidate.obj).joinedload(Obj.thumbnails),
+            query_options = [joinedload(Candidate.obj).joinedload(Obj.thumbnails)]
+            if include_photometry:
+                query_options.append(
                     joinedload(Candidate.obj)
                     .joinedload(Obj.photometry)
-                    .joinedload(Photometry.instrument),
-                ],
+                    .joinedload(Photometry.instrument)
+                )
+            c = Candidate.get_obj_if_owned_by(
+                obj_id, self.current_user, options=query_options,
             )
             if c is None:
                 return self.error("Invalid ID")
@@ -349,7 +357,13 @@ class CandidateHandler(BaseHandler):
             ]
         try:
             query_results = grab_query_results_page(
-                q, total_matches, page, n_per_page, "candidates", order_by=order_by
+                q,
+                total_matches,
+                page,
+                n_per_page,
+                "candidates",
+                order_by=order_by,
+                include_photometry=include_photometry,
             )
         except ValueError as e:
             if "Page number out of range" in str(e):
@@ -562,7 +576,13 @@ class CandidateHandler(BaseHandler):
 
 
 def grab_query_results_page(
-    q, total_matches, page, n_items_per_page, items_name, order_by=None
+    q,
+    total_matches,
+    page,
+    n_items_per_page,
+    items_name,
+    order_by=None,
+    include_photometry=False,
 ):
     # The query will return multiple rows per candidate object if it has multiple
     # annotations associated with it, with rows appearing at the end of the query
@@ -633,17 +653,13 @@ def grab_query_results_page(
         ordered_ids.limit(n_items_per_page).offset((page - 1) * n_items_per_page).all()
     )
     items = []
-    for item_id in page_ids:
-        items.append(
-            Obj.query.options(
-                [
-                    joinedload(Obj.thumbnails),
-                    joinedload(Obj.photometry)
-                    .joinedload(Photometry.instrument)
-                    .joinedload(Instrument.telescope),
-                ]
-            ).get(item_id)
+    query_options = [joinedload(Obj.thumbnails)]
+    if include_photometry:
+        query_options.append(
+            joinedload(Obj.photometry).joinedload(Photometry.instrument)
         )
+    for item_id in page_ids:
+        items.append(Obj.query.options(query_options).get(item_id))
     info[items_name] = items
     info["pageNumber"] = page
     info["lastPage"] = info["totalMatches"] <= page * n_items_per_page

--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -40,6 +40,7 @@ from ...utils import (
 )
 from .candidate import grab_query_results_page, update_redshift_history_if_relevant
 
+
 SOURCES_PER_PAGE = 100
 
 _, cfg = load_env()
@@ -159,6 +160,14 @@ class SourceHandler(BaseHandler):
                 type: integer
             description: |
                If provided, filter only sources saved to one of these group IDs.
+          - in: query
+            name: includePhotometry
+            nullable: true
+            schema:
+              type: boolean
+            description: |
+              Boolean indicating whether to include associated photometry. Defaults to
+              false.
           responses:
             200:
               content:
@@ -200,6 +209,7 @@ class SourceHandler(BaseHandler):
         start_date = self.get_query_argument('startDate', None)
         end_date = self.get_query_argument('endDate', None)
         sourceID = self.get_query_argument('sourceID', None)  # Partial ID to match
+        include_photometry = self.get_query_argument("includePhotometry", False)
 
         # parse the group ids:
         group_ids = self.get_query_argument('group_ids', None)
@@ -218,6 +228,31 @@ class SourceHandler(BaseHandler):
         total_matches = self.get_query_argument('totalMatches', None)
         is_token_request = isinstance(self.current_user, Token)
         if obj_id is not None:
+            query_options = [
+                joinedload(Source.obj)
+                .joinedload(Obj.followup_requests)
+                .joinedload(FollowupRequest.requester),
+                joinedload(Source.obj)
+                .joinedload(Obj.followup_requests)
+                .joinedload(FollowupRequest.allocation)
+                .joinedload(Allocation.instrument),
+                joinedload(Source.obj)
+                .joinedload(Obj.assignments)
+                .joinedload(ClassicalAssignment.run)
+                .joinedload(ObservingRun.instrument)
+                .joinedload(Instrument.telescope),
+                joinedload(Source.obj).joinedload(Obj.thumbnails),
+                joinedload(Source.obj)
+                .joinedload(Obj.followup_requests)
+                .joinedload(FollowupRequest.allocation)
+                .joinedload(Allocation.group),
+            ]
+            if include_photometry:
+                query_options.append(
+                    joinedload(Source.obj)
+                    .joinedload(Obj.photometry)
+                    .joinedload(Photometry.instrument)
+                )
             if is_token_request:
                 # Logic determining whether to register front-end request as view lives in front-end
                 register_source_view(
@@ -227,30 +262,7 @@ class SourceHandler(BaseHandler):
                 )
                 self.push_all(action="skyportal/FETCH_TOP_SOURCES")
             s = Source.get_obj_if_owned_by(
-                obj_id,
-                self.current_user,
-                options=[
-                    joinedload(Source.obj)
-                    .joinedload(Obj.followup_requests)
-                    .joinedload(FollowupRequest.requester),
-                    joinedload(Source.obj)
-                    .joinedload(Obj.followup_requests)
-                    .joinedload(FollowupRequest.allocation)
-                    .joinedload(Allocation.instrument),
-                    joinedload(Source.obj)
-                    .joinedload(Obj.assignments)
-                    .joinedload(ClassicalAssignment.run)
-                    .joinedload(ObservingRun.instrument)
-                    .joinedload(Instrument.telescope),
-                    joinedload(Source.obj).joinedload(Obj.thumbnails),
-                    joinedload(Source.obj)
-                    .joinedload(Obj.photometry)
-                    .joinedload(Photometry.instrument),
-                    joinedload(Source.obj)
-                    .joinedload(Obj.followup_requests)
-                    .joinedload(FollowupRequest.allocation)
-                    .joinedload(Allocation.group),
-                ],
+                obj_id, self.current_user, options=query_options,
             )
             if s is None:
                 return self.error("Invalid source ID.")
@@ -297,6 +309,11 @@ class SourceHandler(BaseHandler):
             return self.success(data=source_info)
 
         # Fetch multiple sources
+        query_options = [joinedload(Obj.thumbnails)]
+        if include_photometry:
+            query_options.append(
+                joinedload(Obj.photometry).joinedload(Photometry.instrument)
+            )
         q = (
             DBSession()
             .query(Obj)
@@ -306,12 +323,7 @@ class SourceHandler(BaseHandler):
                     user_accessible_group_ids
                 )  # only give sources the user has access to
             )
-            .options(
-                [
-                    joinedload(Obj.thumbnails),
-                    joinedload(Obj.photometry).joinedload(Photometry.instrument),
-                ]
-            )
+            .options(query_options)
         )
 
         if sourceID:
@@ -359,7 +371,12 @@ class SourceHandler(BaseHandler):
                 return self.error("Invalid page number value.")
             try:
                 query_results = grab_query_results_page(
-                    q, total_matches, page, num_per_page, "sources"
+                    q,
+                    total_matches,
+                    page,
+                    num_per_page,
+                    "sources",
+                    include_photometry=include_photometry,
                 )
             except ValueError as e:
                 if "Page number out of range" in str(e):

--- a/skyportal/tests/api/test_candidates.py
+++ b/skyportal/tests/api/test_candidates.py
@@ -16,6 +16,18 @@ def test_token_user_retrieving_candidate(view_only_token, public_candidate):
     assert status == 200
     assert data["status"] == "success"
     assert all(k in data["data"] for k in ["ra", "dec", "redshift", "dm"])
+    assert "photometry" not in data["data"]
+
+
+def test_token_user_retrieving_candidate_with_phot(view_only_token, public_candidate):
+    status, data = api(
+        "GET",
+        f"candidates/{public_candidate.id}?includePhotometry=true",
+        token=view_only_token,
+    )
+    assert status == 200
+    assert data["status"] == "success"
+    assert all(k in data["data"] for k in ["ra", "dec", "redshift", "dm", "photometry"])
 
 
 def test_token_user_update_candidate(manage_sources_token, public_candidate):

--- a/skyportal/tests/api/test_sources.py
+++ b/skyportal/tests/api/test_sources.py
@@ -1,7 +1,7 @@
+import uuid
 import pytest
 import numpy.testing as npt
 import numpy as np
-import uuid
 from skyportal.tests import api
 from skyportal.models import cosmo
 
@@ -18,6 +18,21 @@ def test_token_user_retrieving_source(view_only_token, public_source):
     assert data['status'] == 'success'
     assert all(
         k in data['data'] for k in ['ra', 'dec', 'redshift', 'dm', 'created_at', 'id']
+    )
+    assert "photometry" not in data['data']
+
+
+def test_token_user_retrieving_source_with_phot(view_only_token, public_source):
+    status, data = api(
+        'GET',
+        f'sources/{public_source.id}?includePhotometry=true',
+        token=view_only_token,
+    )
+    assert status == 200
+    assert data['status'] == 'success'
+    assert all(
+        k in data['data']
+        for k in ['ra', 'dec', 'redshift', 'dm', 'created_at', 'id', 'photometry']
     )
 
 


### PR DESCRIPTION
This PR greatly improves performance when fetching sources/candidates by not including photometry by default. An optional query parameter `includePhotometry` is added to both endpoints that, when set to `true` (JSON) (becomes `True` in Python), includes associated photometry. Locally with the demo data, this results in a 10-20x speed up in fetching source/candidate data.