### PR TITLE
Show source save history on source page

### DIFF
--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -469,6 +469,11 @@ class SourceHandler(BaseHandler):
                 "angular_diameter_distance"
             ] = source.angular_diameter_distance
 
+            source_filter_condition = (
+                or_(Source.requested.is_(True), Source.active.is_(True))
+                if include_requested
+                else Source.active.is_(True)
+            )
             source_list[-1]["groups"] = [
                 g.to_dict()
                 for g in (
@@ -477,6 +482,7 @@ class SourceHandler(BaseHandler):
                     .join(Source)
                     .filter(
                         Source.obj_id == source_list[-1]["id"],
+                        source_filter_condition,
                         Group.id.in_(user_accessible_group_ids),
                     )
                     .all()

--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -362,6 +362,12 @@ class SourceHandler(BaseHandler):
                 ).first()
                 group["active"] = source_table_row.active
                 group["requested"] = source_table_row.requested
+                group["saved_at"] = source_table_row.saved_at
+                group["saved_by"] = (
+                    source_table_row.saved_by.to_dict()
+                    if source_table_row.saved_by is not None
+                    else None
+                )
 
             return self.success(data=source_info)
 
@@ -494,6 +500,12 @@ class SourceHandler(BaseHandler):
                 ).first()
                 group["active"] = source_table_row.active
                 group["requested"] = source_table_row.requested
+                group["saved_at"] = source_table_row.saved_at
+                group["saved_by"] = (
+                    source_table_row.saved_by.to_dict()
+                    if source_table_row.saved_by is not None
+                    else None
+                )
 
         query_results["sources"] = source_list
 

--- a/static/js/components/SourceDesktop.jsx
+++ b/static/js/components/SourceDesktop.jsx
@@ -6,6 +6,7 @@ import { Link } from "react-router-dom";
 import { makeStyles } from "@material-ui/core/styles";
 import Button from "@material-ui/core/Button";
 import Chip from "@material-ui/core/Chip";
+import Tooltip from "@material-ui/core/Tooltip";
 import Accordion from "@material-ui/core/Accordion";
 import AccordionSummary from "@material-ui/core/AccordionSummary";
 import AccordionDetails from "@material-ui/core/AccordionDetails";
@@ -31,6 +32,7 @@ import EditSourceGroups from "./EditSourceGroups";
 import UpdateSourceRedshift from "./UpdateSourceRedshift";
 import SourceRedshiftHistory from "./SourceRedshiftHistory";
 import ObjPageAnnotations from "./ObjPageAnnotations";
+import SourceSaveHistory from "./SourceSaveHistory";
 
 const CentroidPlot = React.lazy(() =>
   import(/* webpackChunkName: "CentroidPlot" */ "./CentroidPlot")
@@ -190,17 +192,21 @@ const SourceDesktop = ({ source }) => {
           <br />
           {showStarList && <StarList sourceId={source.id} />}
           {source.groups.map((group) => (
-            <Chip
-              label={
-                group.nickname
-                  ? group.nickname.substring(0, 15)
-                  : group.name.substring(0, 15)
-              }
+            <Tooltip
+              title={`Saved at ${group.saved_at} by ${group.saved_by.username}`}
               key={group.id}
-              size="small"
-              className={classes.chip}
-              data-testid={`groupChip_${group.id}`}
-            />
+            >
+              <Chip
+                label={
+                  group.nickname
+                    ? group.nickname.substring(0, 15)
+                    : group.name.substring(0, 15)
+                }
+                size="small"
+                className={classes.chip}
+                data-testid={`groupChip_${group.id}`}
+              />
+            </Tooltip>
           ))}
           <EditSourceGroups
             source={{
@@ -210,6 +216,7 @@ const SourceDesktop = ({ source }) => {
             userGroups={userAccessibleGroups}
             icon
           />
+          <SourceSaveHistory groups={source.groups} />
         </div>
         <div className={classes.columnItem}>
           <ThumbnailList

--- a/static/js/components/SourceDesktop.jsx
+++ b/static/js/components/SourceDesktop.jsx
@@ -193,7 +193,7 @@ const SourceDesktop = ({ source }) => {
           {showStarList && <StarList sourceId={source.id} />}
           {source.groups.map((group) => (
             <Tooltip
-              title={`Saved at ${group.saved_at} by ${group.saved_by.username}`}
+              title={`Saved at ${group.saved_at} by ${group.saved_by?.username}`}
               key={group.id}
             >
               <Chip

--- a/static/js/components/SourceMobile.jsx
+++ b/static/js/components/SourceMobile.jsx
@@ -222,7 +222,7 @@ const SourceMobile = ({ source }) => {
               {showStarList && <StarList sourceId={source.id} />}
               {source.groups.map((group) => (
                 <Tooltip
-                  title={`Saved at ${group.saved_at} by ${group.saved_by.username}`}
+                  title={`Saved at ${group.saved_at} by ${group.saved_by?.username}`}
                   key={group.id}
                 >
                   <Chip

--- a/static/js/components/SourceMobile.jsx
+++ b/static/js/components/SourceMobile.jsx
@@ -7,6 +7,7 @@ import { makeStyles } from "@material-ui/core/styles";
 import useMediaQuery from "@material-ui/core/useMediaQuery";
 import Button from "@material-ui/core/Button";
 import Chip from "@material-ui/core/Chip";
+import Tooltip from "@material-ui/core/Tooltip";
 import Accordion from "@material-ui/core/Accordion";
 import AccordionSummary from "@material-ui/core/AccordionSummary";
 import AccordionDetails from "@material-ui/core/AccordionDetails";
@@ -33,6 +34,7 @@ import SourceNotification from "./SourceNotification";
 import UpdateSourceRedshift from "./UpdateSourceRedshift";
 import SourceRedshiftHistory from "./SourceRedshiftHistory";
 import ObjPageAnnotations from "./ObjPageAnnotations";
+import SourceSaveHistory from "./SourceSaveHistory";
 
 const CentroidPlot = React.lazy(() =>
   import(/* webpackChunkName: "CentroidPlot" */ "./CentroidPlot")
@@ -219,16 +221,20 @@ const SourceMobile = ({ source }) => {
               <br />
               {showStarList && <StarList sourceId={source.id} />}
               {source.groups.map((group) => (
-                <Chip
-                  label={
-                    group.nickname
-                      ? group.nickname.substring(0, 15)
-                      : group.name.substring(0, 15)
-                  }
+                <Tooltip
+                  title={`Saved at ${group.saved_at} by ${group.saved_by.username}`}
                   key={group.id}
-                  size="small"
-                  className={classes.chip}
-                />
+                >
+                  <Chip
+                    label={
+                      group.nickname
+                        ? group.nickname.substring(0, 15)
+                        : group.name.substring(0, 15)
+                    }
+                    size="small"
+                    className={classes.chip}
+                  />
+                </Tooltip>
               ))}
               <EditSourceGroups
                 source={{
@@ -238,6 +244,7 @@ const SourceMobile = ({ source }) => {
                 userGroups={userAccessibleGroups}
                 icon
               />
+              <SourceSaveHistory groups={source.groups} />
             </div>
             <div className={classes.thumbnails}>
               <ThumbnailList

--- a/static/js/components/SourceSaveHistory.jsx
+++ b/static/js/components/SourceSaveHistory.jsx
@@ -1,0 +1,92 @@
+import React, { useState } from "react";
+import PropTypes from "prop-types";
+import HistoryIcon from "@material-ui/icons/History";
+import Dialog from "@material-ui/core/Dialog";
+import Tooltip from "@material-ui/core/Tooltip";
+import IconButton from "@material-ui/core/IconButton";
+import DialogContent from "@material-ui/core/DialogContent";
+import DialogTitle from "@material-ui/core/DialogTitle";
+import { makeStyles } from "@material-ui/core/styles";
+import Table from "@material-ui/core/Table";
+import TableBody from "@material-ui/core/TableBody";
+import TableCell from "@material-ui/core/TableCell";
+import TableHead from "@material-ui/core/TableHead";
+import TableRow from "@material-ui/core/TableRow";
+
+const useStyles = makeStyles(() => ({
+  historyIcon: {
+    display: "inline-block",
+  },
+  iconButton: {
+    display: "inline-block",
+  },
+}));
+
+const SourceSaveHistory = ({ groups }) => {
+  const classes = useStyles();
+
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  // Sort history from newest to oldest
+  const sortedHistory = groups?.sort((a, b) => {
+    const dateA = new Date(a.saved_at);
+    const dateB = new Date(b.saved_at);
+    return dateB - dateA;
+  });
+
+  return (
+    <>
+      <Tooltip title="Source save history">
+        <span>
+          <IconButton
+            aria-label="source-save-history"
+            data-testid="save_history"
+            onClick={() => {
+              setDialogOpen(true);
+            }}
+            size="small"
+            className={classes.iconButton}
+          >
+            <HistoryIcon />
+          </IconButton>
+        </span>
+      </Tooltip>
+      <Dialog
+        open={dialogOpen}
+        onClose={() => {
+          setDialogOpen(false);
+        }}
+        style={{ position: "fixed" }}
+      >
+        <DialogTitle>Save History</DialogTitle>
+        <DialogContent>
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableCell>Group Name</TableCell>
+                <TableCell>Saved By</TableCell>
+                <TableCell>Time (UTC)</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {sortedHistory &&
+                sortedHistory.map((historyItem) => (
+                  <TableRow key={historyItem.saved_at}>
+                    <TableCell>{historyItem.name}</TableCell>
+                    <TableCell>{historyItem.saved_by.username}</TableCell>
+                    <TableCell>{historyItem.saved_at}</TableCell>
+                  </TableRow>
+                ))}
+            </TableBody>
+          </Table>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+};
+
+SourceSaveHistory.propTypes = {
+  groups: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
+};
+
+export default SourceSaveHistory;

--- a/static/js/components/SourceSaveHistory.jsx
+++ b/static/js/components/SourceSaveHistory.jsx
@@ -86,7 +86,15 @@ const SourceSaveHistory = ({ groups }) => {
 };
 
 SourceSaveHistory.propTypes = {
-  groups: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
+  groups: PropTypes.arrayOf(
+    PropTypes.shape({
+      name: PropTypes.string,
+      saved_at: PropTypes.string,
+      saved_by: PropTypes.shape({
+        username: PropTypes.string,
+      }),
+    })
+  ).isRequired,
 };
 
 export default SourceSaveHistory;

--- a/static/js/components/SourceSaveHistory.jsx
+++ b/static/js/components/SourceSaveHistory.jsx
@@ -73,7 +73,7 @@ const SourceSaveHistory = ({ groups }) => {
                 sortedHistory.map((historyItem) => (
                   <TableRow key={historyItem.saved_at}>
                     <TableCell>{historyItem.name}</TableCell>
-                    <TableCell>{historyItem.saved_by.username}</TableCell>
+                    <TableCell>{historyItem.saved_by?.username}</TableCell>
                     <TableCell>{historyItem.saved_at}</TableCell>
                   </TableRow>
                 ))}


### PR DESCRIPTION
This PR adds save history to the source page, including tooltip for each group chip which shows who saved to each group when, as well as a table that can be displayed containing the entire save history (see screen capture demo below).

Closes https://github.com/skyportal/skyportal/issues/1083

![source_save_history_2](https://user-images.githubusercontent.com/7230285/96658305-0382ea00-12f9-11eb-8e15-1f88d3ce1a29.gif)
