### PR TITLE
Scanning page filtering on annotations

### DIFF
--- a/skyportal/app_server.py
+++ b/skyportal/app_server.py
@@ -60,6 +60,7 @@ from skyportal.handlers.api.internal import (
     LogHandler,
     RecentSourcesHandler,
     PlotAirmassHandler,
+    AnnotationsInfoHandler,
 )
 
 from . import models, model_util, openapi
@@ -145,6 +146,7 @@ def make_app(cfg, baselayer_handlers, baselayer_settings):
         (r'/api/internal/plot/airmass/(.*)', PlotAirmassHandler),
         (r'/api/internal/log', LogHandler),
         (r'/api/internal/recent_sources(/.*)?', RecentSourcesHandler),
+        (r'/api/internal/annotations_info', AnnotationsInfoHandler),
         (r'/api/.*', InvalidEndpointHandler),
         (r'/become_user(/.*)?', BecomeUserHandler),
         (r'/logout', LogoutHandler),

--- a/skyportal/handlers/api/internal/__init__.py
+++ b/skyportal/handlers/api/internal/__init__.py
@@ -11,3 +11,4 @@ from .recent_sources import RecentSourcesHandler
 from .robotic_instruments import RoboticInstrumentsHandler
 from .source_counts import SourceCountHandler
 from .log import LogHandler
+from .annotations_info import AnnotationsInfoHandler

--- a/skyportal/handlers/api/internal/annotations_info.py
+++ b/skyportal/handlers/api/internal/annotations_info.py
@@ -1,0 +1,143 @@
+from collections import defaultdict
+from sqlalchemy import func, literal
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.sql import functions
+from sqlalchemy.sql.elements import ColumnClause
+from sqlalchemy.sql.selectable import FromClause
+from baselayer.app.access import auth_or_token
+from ...base import BaseHandler
+from ....models import (
+    DBSession,
+    Obj,
+    Candidate,
+    Annotation,
+    GroupAnnotation,
+)
+
+
+# Helper classes/functions below provide a workaround for PostgreSQL functions
+# returning multiple columns, unsupported by SA
+# See https://stackoverflow.com/questions/33865038/joining-with-set-returning-function-srf-and-access-columns-in-sqlalchemy
+# for details
+class FunctionColumn(ColumnClause):
+    def __init__(self, function, name, type_=None):
+        self.function = self.table = function
+        self.name = self.key = name
+        self.key = self.name
+        self.type_ = type_
+        self.is_literal = False
+
+    @property
+    def _from_objects(self):
+        return []
+
+    def _make_proxy(
+        self, selectable, name=None, attach=True, name_is_truncatable=False, **kw
+    ):
+        print('_make_proxy')
+        if self.name == self.function.name:
+            name = selectable.name
+        else:
+            name = self.name
+
+        co = ColumnClause(name, self.type)
+        co.key = self.name
+        co._proxies = [self]
+        if selectable._is_clone_of is not None:
+            co._is_clone_of = selectable._is_clone_of.columns.get(co.key)
+        co.table = selectable
+        co.named_with_table = False
+        if attach:
+            selectable._columns[co.key] = co
+        return co
+
+
+@compiles(FunctionColumn)
+def _compile_function_column(element, compiler, **kw):
+    if kw.get('asfrom', False):
+        return "(%s).%s" % (
+            compiler.process(element.function, **kw),
+            compiler.preparer.quote(element.name),
+        )
+    else:
+        return element.name
+
+
+class ColumnFunction(functions.FunctionElement):
+    __visit_name__ = 'function'
+
+    @property
+    def columns(self):
+        return FromClause.columns.fget(self)
+
+    def _populate_column_collection(self):
+        for name in self.column_names:
+            self._columns[name] = FunctionColumn(self, name)
+
+
+class jsonb_each_func(ColumnFunction):
+    name = 'jsonb_each'
+    column_names = ['key', 'value']
+
+
+@compiles(jsonb_each_func)
+def _compile_jsonb_each_func(element, compiler, **kw):
+    return compiler.visit_function(element, **kw)
+
+
+class AnnotationsInfoHandler(BaseHandler):
+    @auth_or_token
+    def get(self):
+        """
+        ---
+        description: Collects valid annotation origin/key pairs to filter on for scanning
+        responses:
+          200:
+            content:
+              application/json:
+                schema:
+                  allOf:
+                    - $ref: '#/components/schemas/Success'
+                    - type: object
+                      description: |
+                        An object in which each key is an annotation origin, and
+                        the values are arrays of { key: value_type } objects
+        """
+        user_accessible_group_ids = [g.id for g in self.current_user.accessible_groups]
+        user_accessible_filter_ids = [
+            filtr.id
+            for g in self.current_user.accessible_groups
+            for filtr in g.filters
+            if g.filters is not None
+        ]
+
+        annotations = jsonb_each_func(Annotation.data)
+        q = (
+            DBSession()
+            .query(Annotation.origin)
+            .add_columns(
+                annotations.c.key, func.jsonb_typeof(annotations.c.value).label("type")
+            )
+            .outerjoin(annotations, literal(True))
+            .join(Obj)
+            .filter(
+                Obj.id.in_(
+                    DBSession()
+                    .query(Candidate.obj_id)
+                    .filter(Candidate.filter_id.in_(user_accessible_filter_ids))
+                )
+            )
+            .join(GroupAnnotation)
+            .filter(GroupAnnotation.group_id.in_(user_accessible_group_ids))
+        )
+
+        results = q.all()
+        grouped = defaultdict(list)
+        keys_seen = defaultdict(set)
+        for annotation in results:
+            if annotation.key not in keys_seen[annotation.origin]:
+                grouped[annotation.origin].append({annotation.key: annotation.type})
+
+            keys_seen[annotation.origin].add(annotation.key)
+
+        return self.success(data=grouped)

--- a/skyportal/tests/api/test_candidates.py
+++ b/skyportal/tests/api/test_candidates.py
@@ -290,3 +290,123 @@ def test_candidate_list_sorting_null_value(
     assert status == 200
     assert data["data"]["candidates"][0]["id"] == public_candidate.id
     assert data["data"]["candidates"][1]["id"] == public_candidate2.id
+
+
+def test_candidate_list_filtering_numeric(
+    annotation_token, view_only_token, public_candidate, public_candidate2
+):
+    origin = str(uuid.uuid4())
+    status, data = api(
+        "POST",
+        "annotation",
+        data={
+            "obj_id": public_candidate.id,
+            "origin": origin,
+            "data": {"numeric_field": 1},
+        },
+        token=annotation_token,
+    )
+    assert status == 200
+
+    status, data = api(
+        "POST",
+        "annotation",
+        data={
+            "obj_id": public_candidate2.id,
+            "origin": origin,
+            "data": {"numeric_field": 2},
+        },
+        token=annotation_token,
+    )
+    assert status == 200
+
+    # Filter by the numeric field with max value 1.5 so that only public_candidate
+    # is returned
+    status, data = api(
+        "GET",
+        f"candidates/?annotationFilterList={origin}:numeric_field:0:1.5",
+        token=view_only_token,
+    )
+    assert status == 200
+    assert len(data["data"]["candidates"]) == 1
+    assert data["data"]["candidates"][0]["id"] == public_candidate.id
+
+
+def test_candidate_list_filtering_boolean(
+    annotation_token, view_only_token, public_candidate, public_candidate2
+):
+    origin = str(uuid.uuid4())
+    status, data = api(
+        "POST",
+        "annotation",
+        data={
+            "obj_id": public_candidate.id,
+            "origin": origin,
+            "data": {"bool_field": True},
+        },
+        token=annotation_token,
+    )
+    assert status == 200
+
+    status, data = api(
+        "POST",
+        "annotation",
+        data={
+            "obj_id": public_candidate2.id,
+            "origin": origin,
+            "data": {"bool_field": False},
+        },
+        token=annotation_token,
+    )
+    assert status == 200
+
+    # Filter by the numeric field with value == true so that only public_candidate
+    # is returned
+    status, data = api(
+        "GET",
+        f"candidates/?annotationFilterList={origin}:bool_field:True",
+        token=view_only_token,
+    )
+    assert status == 200
+    assert len(data["data"]["candidates"]) == 1
+    assert data["data"]["candidates"][0]["id"] == public_candidate.id
+
+
+def test_candidate_list_filtering_string(
+    annotation_token, view_only_token, public_candidate, public_candidate2
+):
+    origin = str(uuid.uuid4())
+    status, data = api(
+        "POST",
+        "annotation",
+        data={
+            "obj_id": public_candidate.id,
+            "origin": origin,
+            "data": {"string_field": "a"},
+        },
+        token=annotation_token,
+    )
+    assert status == 200
+
+    status, data = api(
+        "POST",
+        "annotation",
+        data={
+            "obj_id": public_candidate2.id,
+            "origin": origin,
+            "data": {"string_field": "b"},
+        },
+        token=annotation_token,
+    )
+    assert status == 200
+
+    # Filter by the numeric field with value == "a" so that only public_candidate
+    # is returned
+    status, data = api(
+        "GET",
+        f"candidates/?annotationFilterList={origin}:string_field:a",
+        token=view_only_token,
+    )
+    assert status == 200
+    assert len(data["data"]["candidates"]) == 1
+    assert data["data"]["candidates"][0]["id"] == public_candidate.id

--- a/skyportal/tests/api/test_candidates.py
+++ b/skyportal/tests/api/test_candidates.py
@@ -324,7 +324,7 @@ def test_candidate_list_filtering_numeric(
     # is returned
     status, data = api(
         "GET",
-        f"candidates/?annotationFilterList={origin}:numeric_field:0:1.5",
+        f'candidates/?annotationFilterList={{"origin":"{origin}","key":"numeric_field","min":0, "max":1.5}}',
         token=view_only_token,
     )
     assert status == 200
@@ -364,7 +364,7 @@ def test_candidate_list_filtering_boolean(
     # is returned
     status, data = api(
         "GET",
-        f"candidates/?annotationFilterList={origin}:bool_field:True",
+        f'candidates/?annotationFilterList={{"origin":"{origin}","key":"bool_field","value":"true"}}',
         token=view_only_token,
     )
     assert status == 200
@@ -404,7 +404,7 @@ def test_candidate_list_filtering_string(
     # is returned
     status, data = api(
         "GET",
-        f"candidates/?annotationFilterList={origin}:string_field:a",
+        f'candidates/?annotationFilterList={{"origin":"{origin}","key":"string_field","value":"a"}}',
         token=view_only_token,
     )
     assert status == 200

--- a/skyportal/tests/frontend/test_scanning_page.py
+++ b/skyportal/tests/frontend/test_scanning_page.py
@@ -354,7 +354,7 @@ def test_submit_annotations_sorting(
     )
 
 
-# @pytest.mark.flaky(reruns=2)
+@pytest.mark.flaky(reruns=2)
 def test_submit_annotations_filtering(
     driver,
     view_only_user,

--- a/static/js/components/CandidateList.jsx
+++ b/static/js/components/CandidateList.jsx
@@ -341,14 +341,6 @@ const CandidateList = () => {
       : `${annotationObj.key} (${annotationObj.origin}): ${annotationObj.min} - ${annotationObj.max}`;
   };
 
-  const filterAnnotationObjToQueryString = (annotationObj) => {
-    // Convert an object representing an annotation filter to a formatted string
-    // to be sent as the API query params
-    return "value" in annotationObj
-      ? `${annotationObj.origin}:${annotationObj.key}:${annotationObj.value}`
-      : `${annotationObj.origin}:${annotationObj.key}:${annotationObj.min}:${annotationObj.max}`;
-  };
-
   const handleFilterSubmit = async (filterListQueryString) => {
     setQueryInProgress(true);
 
@@ -379,7 +371,7 @@ const CandidateList = () => {
 
   const handleFilterAdd = ({ formData }) => {
     const filterListChip = filterAnnotationObjToChip(formData);
-    const filterListQueryItem = filterAnnotationObjToQueryString(formData);
+    const filterListQueryItem = JSON.stringify(formData);
 
     setTableFilterList(tableFilterList.concat([filterListChip]));
     const newFilterListQueryStrings = filterListQueryStrings.concat([
@@ -623,7 +615,7 @@ const CandidateList = () => {
       setTableFilterList(annotationsFilterList);
       const newFilterListQueryStrings = annotationsFilterList.map((chip) => {
         const annotationObject = filterChipToAnnotationObj(chip);
-        return filterAnnotationObjToQueryString(annotationObject);
+        return JSON.stringify(annotationObject);
       });
       setFilterListQueryStrings(newFilterListQueryStrings);
 

--- a/static/js/components/CandidateList.jsx
+++ b/static/js/components/CandidateList.jsx
@@ -84,6 +84,8 @@ const useStyles = makeStyles((theme) => ({
   }),
   annotations: (props) => ({
     minWidth: props.annotationsMinWidth,
+    maxWidth: props.annotationsMaxWidth,
+    overflowWrap: "break-word",
   }),
   sortButtton: {
     verticalAlign: "top",
@@ -233,11 +235,13 @@ const CandidateList = () => {
   const infoMinWidth = largeScreen ? "7rem" : 0;
   const infoMaxWidth = "14rem";
   const annotationsMinWidth = largeScreen ? "10rem" : 0;
+  const annotationsMaxWidth = "25rem";
   const classes = useStyles({
     thumbnailsMinWidth,
     infoMinWidth,
     infoMaxWidth,
     annotationsMinWidth,
+    annotationsMaxWidth,
   });
   const theme = useTheme();
   const {

--- a/static/js/components/CandidateList.jsx
+++ b/static/js/components/CandidateList.jsx
@@ -24,6 +24,7 @@ import Box from "@material-ui/core/Box";
 import Tooltip from "@material-ui/core/Tooltip";
 import Popover from "@material-ui/core/Popover";
 import HelpOutlineIcon from "@material-ui/icons/HelpOutline";
+import Form from "@rjsf/material-ui";
 import MUIDataTable from "mui-datatables";
 
 import * as candidatesActions from "../ducks/candidates";
@@ -98,6 +99,15 @@ const useStyles = makeStyles((theme) => ({
   },
   helpButton: {
     display: "inline-block",
+  },
+  formControl: {
+    margin: theme.spacing(1),
+    minWidth: 120,
+  },
+  formContainer: {
+    display: "flex",
+    flexFlow: "row wrap",
+    alignItems: "center",
   },
 }));
 
@@ -244,6 +254,10 @@ const CandidateList = () => {
     (state) => state.groups.userAccessible
   );
 
+  const availableAnnotationsInfo = useSelector(
+    (state) => state.candidates.annotationsInfo
+  );
+
   const dispatch = useDispatch();
 
   useEffect(() => {
@@ -252,6 +266,8 @@ const CandidateList = () => {
       dispatch(
         candidatesActions.fetchCandidates({ numPerPage: defaultNumPerPage })
       );
+      // Grab the available annotation fields for filtering
+      dispatch(candidatesActions.fetchAnnotationsInfo());
     } else {
       setQueryInProgress(false);
     }
@@ -284,6 +300,94 @@ const CandidateList = () => {
     return getAnnotationValueString(
       annotation.data[selectedAnnotationSortOptions.key]
     );
+  };
+
+  // Annotations filtering
+  const [tableFilterList, setTableFilterList] = useState([]);
+  const [filterListQueryStrings, setFilterListQueryStrings] = useState([]);
+
+  const filterChipToAnnotationObj = (chip) => {
+    // Convert a MuiDataTable filter list chip-formatted string to an object.
+    // Returns null for improperly formatted strings
+    const tokens = chip.split(/\s\(|\):|-/);
+    let returnObject = null;
+    switch (tokens.length) {
+      case 3:
+        returnObject = {
+          origin: tokens[1].trim(),
+          key: tokens[0].trim(),
+          value: tokens[2].trim(),
+        };
+        break;
+      case 4:
+        returnObject = {
+          origin: tokens[1].trim(),
+          key: tokens[0].trim(),
+          min: tokens[2].trim(),
+          max: tokens[3].trim(),
+        };
+        break;
+      default:
+        break;
+    }
+    return returnObject;
+  };
+
+  const filterAnnotationObjToChip = (annotationObj) => {
+    // Convert an object representing an annotation filter to a formatted string
+    // to be displayed by the MuiDataTable
+    return "value" in annotationObj
+      ? `${annotationObj.key} (${annotationObj.origin}): ${annotationObj.value}`
+      : `${annotationObj.key} (${annotationObj.origin}): ${annotationObj.min} - ${annotationObj.max}`;
+  };
+
+  const filterAnnotationObjToQueryString = (annotationObj) => {
+    // Convert an object representing an annotation filter to a formatted string
+    // to be sent as the API query params
+    return "value" in annotationObj
+      ? `${annotationObj.origin}:${annotationObj.key}:${annotationObj.value}`
+      : `${annotationObj.origin}:${annotationObj.key}:${annotationObj.min}:${annotationObj.max}`;
+  };
+
+  const handleFilterSubmit = async (filterListQueryString) => {
+    setQueryInProgress(true);
+
+    let data = {
+      pageNumber: 1,
+      numPerPage: rowsPerPage,
+    };
+    if (filterListQueryString !== null) {
+      data = {
+        ...data,
+        annotationFilterList: filterListQueryString,
+      };
+    }
+
+    if (selectedAnnotationSortOptions !== null) {
+      data = {
+        ...data,
+        sortByAnnotationOrigin: selectedAnnotationSortOptions.origin,
+        sortByAnnotationKey: selectedAnnotationSortOptions.key,
+        sortByAnnotationOrder: selectedAnnotationSortOptions.order,
+      };
+    }
+
+    await dispatch(candidatesActions.fetchCandidates(data));
+
+    setQueryInProgress(false);
+  };
+
+  const handleFilterAdd = ({ formData }) => {
+    const filterListChip = filterAnnotationObjToChip(formData);
+    const filterListQueryItem = filterAnnotationObjToQueryString(formData);
+
+    setTableFilterList(tableFilterList.concat([filterListChip]));
+    const newFilterListQueryStrings = filterListQueryStrings.concat([
+      filterListQueryItem,
+    ]);
+    setFilterListQueryStrings(newFilterListQueryStrings);
+
+    handleFilterSubmit(newFilterListQueryStrings.join());
   };
 
   const renderThumbnails = (dataIndex) => {
@@ -491,6 +595,13 @@ const CandidateList = () => {
       };
     }
 
+    if (filterListQueryStrings.length !== 0) {
+      data = {
+        ...data,
+        annotationFilterList: filterListQueryStrings.join(),
+      };
+    }
+
     await dispatch(candidatesActions.fetchCandidates(data));
     setQueryInProgress(false);
   };
@@ -504,6 +615,125 @@ const CandidateList = () => {
         break;
       default:
     }
+  };
+
+  const handleTableFilterChipChange = (column, filterList, type) => {
+    if (type === "chip") {
+      const annotationsFilterList = filterList[3];
+      setTableFilterList(annotationsFilterList);
+      const newFilterListQueryStrings = annotationsFilterList.map((chip) => {
+        const annotationObject = filterChipToAnnotationObj(chip);
+        return filterAnnotationObjToQueryString(annotationObject);
+      });
+      setFilterListQueryStrings(newFilterListQueryStrings);
+
+      handleFilterSubmit(
+        newFilterListQueryStrings.length === 0
+          ? null
+          : newFilterListQueryStrings.join()
+      );
+    }
+  };
+
+  // Assemble json form schema for possible annotation filtering values
+  const filterFormSchema = {
+    description: "Add an annotation filter field.",
+    type: "object",
+    properties: {
+      origin: {
+        type: "string",
+        title: "Origin",
+        enum: [],
+      },
+    },
+    required: ["origin", "key"],
+    dependencies: {
+      origin: {
+        oneOf: [],
+      },
+      key: {
+        oneOf: [],
+      },
+    },
+  };
+
+  if (availableAnnotationsInfo !== null) {
+    Object.entries(availableAnnotationsInfo).forEach(([origin, fields]) => {
+      // Add origin to the list selectable from
+      filterFormSchema.properties.origin.enum.push(origin);
+
+      // Make a list of keys to select from based on the origin
+      const keySelect = {
+        properties: {
+          origin: {
+            enum: [origin],
+          },
+          key: {
+            type: "string",
+            title: "Key",
+            enum: fields.map((field) => Object.keys(field)[0]),
+          },
+        },
+      };
+      filterFormSchema.dependencies.origin.oneOf.push(keySelect);
+
+      // Add filter value selection based on selected key type
+      fields.forEach((field) => {
+        const key = Object.keys(field)[0];
+        const keyType = field[key];
+        const valueSelect = {
+          properties: {
+            key: {
+              enum: [key],
+            },
+          },
+          required: [],
+        };
+        switch (keyType) {
+          case "string":
+          case "object":
+            valueSelect.properties.value = {
+              type: "string",
+              title: "Value (exact match)",
+            };
+            valueSelect.required.push("value");
+            break;
+          case "number":
+            valueSelect.properties.min = {
+              type: "number",
+              title: "Min",
+            };
+            valueSelect.properties.max = {
+              type: "number",
+              title: "Max",
+            };
+            valueSelect.required.push("min");
+            valueSelect.required.push("max");
+            break;
+          case "boolean":
+            valueSelect.properties.value = {
+              type: "boolean",
+              title: "Is True",
+              default: false,
+            };
+            valueSelect.required.push("value");
+            break;
+          default:
+            break;
+        }
+        filterFormSchema.dependencies.key.oneOf.push(valueSelect);
+      });
+    });
+  }
+
+  const annotationsFilterDisplay = () => {
+    return !queryInProgress ? (
+      <div>
+        <Form schema={filterFormSchema} onSubmit={handleFilterAdd} />
+      </div>
+    ) : (
+      <div />
+    );
   };
 
   const columns = [
@@ -539,7 +769,13 @@ const CandidateList = () => {
       options: {
         customBodyRenderLite: renderAutoannotations,
         sort: false,
-        filter: false,
+        filter: !queryInProgress,
+        filterType: "custom",
+        filterList: tableFilterList,
+        filterOptions: {
+          // eslint-disable-next-line react/display-name
+          display: annotationsFilterDisplay,
+        },
         customHeadLabelRender: renderAutoannotationsHeader,
       },
     },
@@ -551,7 +787,8 @@ const CandidateList = () => {
     print: false,
     download: false,
     sort: false,
-    filter: false,
+    filter: !queryInProgress,
+    filterType: "custom",
     count: totalMatches,
     selectableRows: "none",
     enableNestedDataAccess: ".",
@@ -572,6 +809,7 @@ const CandidateList = () => {
         loaded={!queryInProgress}
       />
     ),
+    onFilterChange: handleTableFilterChipChange,
   };
 
   return (

--- a/static/js/components/ScanningPageCandidateAnnotations.jsx
+++ b/static/js/components/ScanningPageCandidateAnnotations.jsx
@@ -40,7 +40,7 @@ export const getAnnotationValueString = (value) => {
       valueString = value.toFixed(4);
       break;
     case "object":
-      valueString = JSON.stringify(value);
+      valueString = JSON.stringify(value, null, 2);
       break;
     default:
       valueString = value.toString();

--- a/static/js/ducks/annotations.js
+++ b/static/js/ducks/annotations.js
@@ -1,0 +1,32 @@
+import * as API from "../API";
+import store from "../store";
+
+export const FETCH_ANNOTATIONS_INFO = "skyportal/FETCH_ANNOTATIONS_INFO";
+export const FETCH_ANNOTATIONS_INFO_OK = "skyportal/FETCH_ANNOTATIONS_INFO_OK";
+
+export const fetchAnnotationsInfo = (filterParams = {}) => {
+  const params = new URLSearchParams(filterParams);
+  const queryString = params.toString();
+  return API.GET(
+    `/api/internal/annotations_info?${queryString}`,
+    FETCH_ANNOTATIONS_INFO
+  );
+};
+
+const initialState = {};
+
+const reducer = (state = initialState, action) => {
+  switch (action.type) {
+    case FETCH_ANNOTATIONS_INFO_OK: {
+      const annotationsInfo = action.data;
+      return {
+        ...state,
+        annotationsInfo,
+      };
+    }
+    default:
+      return state;
+  }
+};
+
+store.injectReducer("annotationsInfo", reducer);

--- a/static/js/ducks/candidates.js
+++ b/static/js/ducks/candidates.js
@@ -17,6 +17,9 @@ export const REFRESH_CANDIDATE = "skyportal/REFRESH_CANDIDATE";
 export const SET_CANDIDATES_ANNOTATION_SORT_OPTIONS =
   "skyportal/SET_CANDIDATES_ANNOTATION_SORT_OPTIONS";
 
+export const FETCH_ANNOTATIONS_INFO = "skyportal/FETCH_ANNOTATIONS_INFO";
+export const FETCH_ANNOTATIONS_INFO_OK = "skyportal/FETCH_ANNOTATIONS_INFO_OK";
+
 export const fetchCandidates = (filterParams = {}) => {
   if (!Object.keys(filterParams).includes("pageNumber")) {
     filterParams.pageNumber = 1;
@@ -31,6 +34,10 @@ export const setCandidatesAnnotationSortOptions = (item) => {
     type: SET_CANDIDATES_ANNOTATION_SORT_OPTIONS,
     item,
   };
+};
+
+export const fetchAnnotationsInfo = () => {
+  return API.GET(`/api/internal/annotations_info`, FETCH_ANNOTATIONS_INFO);
 };
 
 // Websocket message handler
@@ -61,6 +68,7 @@ const initialState = {
   numberingStart: 0,
   numberingEnd: 0,
   selectedAnnotationSortOptions: null,
+  annotationsInfo: null,
 };
 
 const reducer = (state = initialState, action) => {
@@ -92,6 +100,13 @@ const reducer = (state = initialState, action) => {
     }
     case SET_CANDIDATES_ANNOTATION_SORT_OPTIONS: {
       return { ...state, selectedAnnotationSortOptions: action.item };
+    }
+    case FETCH_ANNOTATIONS_INFO_OK: {
+      const annotationsInfo = action.data;
+      return {
+        ...state,
+        annotationsInfo,
+      };
     }
     default:
       return state;


### PR DESCRIPTION
Implement filtering on annotation values on scanning page.
- Numeric annotation fields can be filtered for a provided range [min, max]
- Boolean annotations fields are filtered for `true` or `false`
- String annotations (and nested annotations converted to JSON strings) are filtered on exact matches for the string value provided.

![filter](https://user-images.githubusercontent.com/17696889/96658984-c3246b80-12fa-11eb-95f7-7d9e4a3462a9.gif)
