### PR TITLE
link database migrations page in docs

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -85,6 +85,7 @@ User Guide
    adding_features
    styling
    database
+   migrations
 
 Contributing
 ------------


### PR DESCRIPTION
This PR adds a link to the database migrations page in the docs 

<img width="310" alt="Screen Shot 2020-10-21 at 10 59 41 AM" src="https://user-images.githubusercontent.com/2769632/96759377-cd8f4580-138c-11eb-91d2-5ef3c890d84b.png">
