### PR TITLE
Implement form for adding all users from other group(s) to group page & associated back-end handler

### DIFF
--- a/skyportal/app_server.py
+++ b/skyportal/app_server.py
@@ -18,6 +18,7 @@ from skyportal.handlers.api import (
     FacilityMessageHandler,
     GroupHandler,
     GroupUserHandler,
+    GroupUsersFromOtherGroupsHandler,
     PublicGroupHandler,
     GroupStreamHandler,
     InstrumentHandler,
@@ -108,6 +109,10 @@ def make_app(cfg, baselayer_handlers, baselayer_settings):
         (r'/api/groups/public', PublicGroupHandler),
         (r'/api/groups(/[0-9]+)/streams(/[0-9]+)?', GroupStreamHandler),
         (r'/api/groups(/[0-9]+)/users(/.*)?', GroupUserHandler),
+        (
+            r'/api/groups(/[0-9]+)/usersFromGroups(/.*)?',
+            GroupUsersFromOtherGroupsHandler,
+        ),
         (r'/api/groups(/[0-9]+)?', GroupHandler),
         (r'/api/instrument(/[0-9]+)?', InstrumentHandler),
         (r'/api/invitations(/.*)?', InvitationHandler),

--- a/skyportal/handlers/api/__init__.py
+++ b/skyportal/handlers/api/__init__.py
@@ -6,7 +6,12 @@ from .annotation import AnnotationHandler
 from .filter import FilterHandler
 from .followup_request import FollowupRequestHandler, AssignmentHandler
 from .facility_listener import FacilityMessageHandler
-from .group import GroupHandler, GroupUserHandler, GroupStreamHandler
+from .group import (
+    GroupHandler,
+    GroupUserHandler,
+    GroupStreamHandler,
+    GroupUsersFromOtherGroupsHandler,
+)
 from .instrument import InstrumentHandler
 from .invalid import InvalidEndpointHandler
 from .invitations import InvitationHandler

--- a/skyportal/handlers/api/group.py
+++ b/skyportal/handlers/api/group.py
@@ -549,7 +549,7 @@ class GroupUserHandler(BaseHandler):
 
 class GroupUsersFromOtherGroupsHandler(BaseHandler):
     @auth_or_token
-    def post(self, group_id):
+    def post(self, group_id, *ignored_args):
         """
         ---
         description: Add users from other group(s) to specified group

--- a/skyportal/handlers/api/group.py
+++ b/skyportal/handlers/api/group.py
@@ -547,6 +547,98 @@ class GroupUserHandler(BaseHandler):
         return self.success()
 
 
+class GroupUsersFromOtherGroupsHandler(BaseHandler):
+    @auth_or_token
+    def post(self, group_id, *ignored_args):
+        """
+        ---
+        description: Add users from other group(s) to specified group
+        parameters:
+          - in: path
+            name: group_id
+            required: true
+            schema:
+              type: integer
+        requestBody:
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  fromGroupIDs:
+                    type: array
+                    items:
+                      type: integer
+                    type: boolean
+                required:
+                  - fromGroupIDs
+        responses:
+          200:
+            content:
+              application/json:
+                schema: Success
+        """
+        try:
+            group_id = int(group_id)
+        except (TypeError, ValueError):
+            return self.error("Invalid group_id parameter: must be an integer")
+
+        if not has_admin_access_for_group(self.associated_user_object, group_id):
+            return self.error("Inadequate permissions.")
+
+        data = self.get_json()
+
+        from_group_ids = data.get("fromGroupIDs")
+        if from_group_ids is None:
+            return self.error("Missing required parameter: fromGroupIDs")
+        if not isinstance(from_group_ids, (list, tuple)):
+            return self.error(
+                "Improperly formatted fromGroupIDs parameter; "
+                "must be an array of integers."
+            )
+        group = DBSession().query(Group).get(group_id)
+        from_groups = (
+            DBSession().query(Group).filter(Group.id.in_(from_group_ids)).all()
+        )
+        user_ids = set()
+        for group in from_groups:
+            for user in group.users:
+                # Ensure user has sufficient stream access to be added to group
+                if group.streams and "System admin" not in user.permissions:
+                    user_stream_ids = [
+                        su.stream_id
+                        for su in DBSession()
+                        .query(StreamUser)
+                        .filter(StreamUser.user_id == user.id)
+                        .all()
+                    ]
+                    if not all(
+                        [stream.id in user_stream_ids for stream in group.streams]
+                    ):
+                        return self.error(
+                            "All users do not have sufficient stream access "
+                            "to be added to this group."
+                        )
+                user_ids.add(user.id)
+
+        for user_id in user_ids:
+            # Add user to group
+            gu = (
+                GroupUser.query.filter(GroupUser.group_id == group_id)
+                .filter(GroupUser.user_id == user_id)
+                .first()
+            )
+            if gu is None:
+                DBSession.add(
+                    GroupUser(group_id=group_id, user_id=user_id, admin=False)
+                )
+
+        DBSession().commit()
+
+        self.push_all(action='skyportal/REFRESH_GROUP', payload={'group_id': group_id})
+        return self.success()
+
+
 class GroupStreamHandler(BaseHandler):
     @permissions(['System admin'])
     def post(self, group_id, *ignored_args):

--- a/skyportal/handlers/api/group.py
+++ b/skyportal/handlers/api/group.py
@@ -584,7 +584,7 @@ class GroupUsersFromOtherGroupsHandler(BaseHandler):
             return self.error("Invalid group_id parameter: must be an integer")
 
         if not has_admin_access_for_group(self.associated_user_object, group_id):
-            return self.error("Inadequate permissions.")
+            return self.error("Requesting user is not an admin of this group.")
 
         data = self.get_json()
 

--- a/skyportal/tests/conftest.py
+++ b/skyportal/tests/conftest.py
@@ -308,6 +308,13 @@ def user(public_group):
 
 
 @pytest.fixture()
+def user_group2(public_group2):
+    return UserFactory(
+        groups=[public_group2], roles=[models.Role.query.get("Full user")]
+    )
+
+
+@pytest.fixture()
 def user_no_groups():
     return UserFactory(roles=[models.Role.query.get("Full user")])
 

--- a/skyportal/tests/frontend/test_groups.py
+++ b/skyportal/tests/frontend/test_groups.py
@@ -139,7 +139,7 @@ def test_invite_all_users_from_other_group(
     driver.execute_script("arguments[0].click();", el)
     driver.click_xpath('//*[@id="addUsersFromGroupsSelect"]')
     driver.click_xpath(f'//li[text()="{public_group2.name}"]')
-    driver.click_xpath('//*[text()="Submit"]')
+    driver.click_xpath('//*[text()="Add users"]')
     driver.wait_for_xpath(
         "//*[text()='Successfully added users from specified group(s)']"
     )

--- a/skyportal/tests/frontend/test_groups.py
+++ b/skyportal/tests/frontend/test_groups.py
@@ -128,6 +128,25 @@ def test_add_new_group_user_new_username(driver, super_admin_user, user, public_
 
 
 @pytest.mark.flaky(reruns=2)
+def test_invite_all_users_from_other_group(
+    driver, super_admin_user, public_group, public_group2, user, user_group2
+):
+    driver.get(f'/become_user/{super_admin_user.id}')
+    driver.get('/groups')
+    driver.wait_for_xpath('//h6[text()="All Groups"]')
+    el = driver.wait_for_xpath(f'//a[contains(.,"{public_group.name}")]')
+    driver.wait_for_xpath_to_disappear(f'//a[contains(.,"{user_group2.username}")]')
+    driver.execute_script("arguments[0].click();", el)
+    driver.click_xpath('//*[@id="addUsersFromGroupsSelect"]')
+    driver.click_xpath(f'//li[text()="{public_group2.name}"]')
+    driver.click_xpath('//*[text()="Submit"]')
+    driver.wait_for_xpath(
+        "//*[text()='Successfully added users from specified group(s)']"
+    )
+    driver.wait_for_xpath(f'//*[text()="{user_group2.username}"]')
+
+
+@pytest.mark.flaky(reruns=2)
 def test_delete_group_user(driver, super_admin_user, user, public_group):
     driver.get(f'/become_user/{super_admin_user.id}')
     driver.get('/groups')

--- a/static/js/components/AddUsersFromGroupForm.jsx
+++ b/static/js/components/AddUsersFromGroupForm.jsx
@@ -1,0 +1,105 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { useSelector, useDispatch } from "react-redux";
+import Typography from "@material-ui/core/Typography";
+import { useForm, Controller } from "react-hook-form";
+import Autocomplete from "@material-ui/lab/Autocomplete";
+import Button from "@material-ui/core/Button";
+import TextField from "@material-ui/core/TextField";
+import { makeStyles } from "@material-ui/core/styles";
+
+import { showNotification } from "baselayer/components/Notifications";
+
+import * as groupsActions from "../ducks/groups";
+import FormValidationError from "./FormValidationError";
+
+const useStyles = makeStyles(() => ({
+  groupSelect: {
+    width: "20rem",
+  },
+  heading: {
+    fontSize: "1.0625rem",
+    fontWeight: 500,
+  },
+}));
+
+const AddUsersFromGroupForm = ({ groupID }) => {
+  const dispatch = useDispatch();
+  let { all: groups } = useSelector((state) => state.groups);
+  const { handleSubmit, errors, reset, control, getValues } = useForm();
+  const classes = useStyles();
+  groups = groups?.filter((g) => g.id !== groupID);
+
+  const validateGroups = () => {
+    const formState = getValues({ nest: true });
+    return formState.groups.length >= 1;
+  };
+
+  const onSubmit = async (formData) => {
+    const fromGroupIDs = formData.groups.map((g) => g.id);
+    const result = await dispatch(
+      groupsActions.addAllUsersFromGroups({ toGroupID: groupID, fromGroupIDs })
+    );
+    if (result.status === "success") {
+      dispatch(
+        showNotification("Successfully added users from specified group(s)")
+      );
+      reset({ groups: [] });
+    }
+  };
+
+  return (
+    <div>
+      <Typography className={classes.heading}>
+        Add all users from other group(s)
+      </Typography>
+      <form onSubmit={handleSubmit(onSubmit)}>
+        {!!errors.groups && (
+          <FormValidationError message="Please select at least one group/user" />
+        )}
+        <Controller
+          name="groups"
+          id="addUsersFromGroupsSelect"
+          data-testid="addUsersFromGroupsSelect"
+          as={
+            <Autocomplete
+              multiple
+              options={groups}
+              getOptionLabel={(group) => group.name}
+              filterSelectedOptions
+              renderInput={(params) => (
+                <TextField
+                  // eslint-disable-next-line react/jsx-props-no-spreading
+                  {...params}
+                  error={!!errors.groups}
+                  variant="outlined"
+                  label="Select Groups/Users"
+                  className={classes.groupSelect}
+                />
+              )}
+            />
+          }
+          control={control}
+          onChange={([, data]) => data}
+          rules={{ validate: validateGroups }}
+          defaultValue={[]}
+        />
+        <div>
+          <Button
+            variant="contained"
+            type="submit"
+            name="submitAddFromGroupsButton"
+            data-testid="submitAddFromGroupsButton"
+          >
+            Submit
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+};
+AddUsersFromGroupForm.propTypes = {
+  groupID: PropTypes.number.isRequired,
+};
+
+export default AddUsersFromGroupForm;

--- a/static/js/components/AddUsersFromGroupForm.jsx
+++ b/static/js/components/AddUsersFromGroupForm.jsx
@@ -28,7 +28,7 @@ const AddUsersFromGroupForm = ({ groupID }) => {
   let { all: groups } = useSelector((state) => state.groups);
   const { handleSubmit, errors, reset, control, getValues } = useForm();
   const classes = useStyles();
-  groups = groups?.filter((g) => g.id !== groupID);
+  groups = groups?.filter((g) => g.id !== groupID) || [];
 
   const validateGroups = () => {
     const formState = getValues({ nest: true });
@@ -60,13 +60,13 @@ const AddUsersFromGroupForm = ({ groupID }) => {
         <Controller
           name="groups"
           id="addUsersFromGroupsSelect"
-          data-testid="addUsersFromGroupsSelect"
           as={
             <Autocomplete
               multiple
               options={groups}
               getOptionLabel={(group) => group.name}
               filterSelectedOptions
+              data-testid="addUsersFromGroupsSelect"
               renderInput={(params) => (
                 <TextField
                   // eslint-disable-next-line react/jsx-props-no-spreading
@@ -75,6 +75,7 @@ const AddUsersFromGroupForm = ({ groupID }) => {
                   variant="outlined"
                   label="Select Groups/Users"
                   className={classes.groupSelect}
+                  data-testid="addUsersFromGroupsTextField"
                 />
               )}
             />

--- a/static/js/components/AddUsersFromGroupForm.jsx
+++ b/static/js/components/AddUsersFromGroupForm.jsx
@@ -16,6 +16,7 @@ import FormValidationError from "./FormValidationError";
 const useStyles = makeStyles(() => ({
   groupSelect: {
     width: "20rem",
+    marginBottom: "0.75rem",
   },
   heading: {
     fontSize: "1.0625rem",
@@ -74,6 +75,7 @@ const AddUsersFromGroupForm = ({ groupID }) => {
                   error={!!errors.groups}
                   variant="outlined"
                   label="Select Groups/Users"
+                  size="small"
                   className={classes.groupSelect}
                   data-testid="addUsersFromGroupsTextField"
                 />
@@ -91,8 +93,10 @@ const AddUsersFromGroupForm = ({ groupID }) => {
             type="submit"
             name="submitAddFromGroupsButton"
             data-testid="submitAddFromGroupsButton"
+            size="small"
+            disableElevation
           >
-            Submit
+            Add users
           </Button>
         </div>
       </form>

--- a/static/js/components/Group.jsx
+++ b/static/js/components/Group.jsx
@@ -46,6 +46,7 @@ import * as groupsActions from "../ducks/groups";
 import * as streamsActions from "../ducks/streams";
 import * as filterActions from "../ducks/filter";
 import NewGroupUserForm from "./NewGroupUserForm";
+import AddUsersFromGroupForm from "./AddUsersFromGroupForm";
 
 const useStyles = makeStyles((theme) => ({
   padding_bottom: {
@@ -430,9 +431,14 @@ const Group = () => {
           </List>
           <Divider />
           <div className={classes.paper}>
-            {/*eslint-disable */}
-            {isAdmin(currentUser) && <NewGroupUserForm group_id={group.id} />}
-            {/* eslint-enable */}
+            {isAdmin(currentUser) && (
+              <>
+                <br />
+                <NewGroupUserForm group_id={group.id} />
+                <br />
+                <AddUsersFromGroupForm groupID={group.id} />
+              </>
+            )}
           </div>
         </AccordionDetails>
       </Accordion>

--- a/static/js/components/NewGroupUserForm.jsx
+++ b/static/js/components/NewGroupUserForm.jsx
@@ -11,6 +11,8 @@ import DialogActions from "@material-ui/core/DialogActions";
 import DialogContent from "@material-ui/core/DialogContent";
 import DialogContentText from "@material-ui/core/DialogContentText";
 import DialogTitle from "@material-ui/core/DialogTitle";
+import Typography from "@material-ui/core/Typography";
+import { makeStyles } from "@material-ui/core/styles";
 
 import { showNotification } from "baselayer/components/Notifications";
 import * as groupsActions from "../ducks/groups";
@@ -18,6 +20,13 @@ import * as usersActions from "../ducks/users";
 import * as inviteUsersActions from "../ducks/inviteUsers";
 
 const filter = createFilterOptions();
+
+const useStyles = makeStyles(() => ({
+  heading: {
+    fontSize: "1.0625rem",
+    fontWeight: 500,
+  },
+}));
 
 const NewGroupUserForm = ({ group_id }) => {
   const dispatch = useDispatch();
@@ -29,6 +38,7 @@ const NewGroupUserForm = ({ group_id }) => {
     invitingNewUser: false,
   });
   const [confirmDialogOpen, setConfirmDialogOpen] = React.useState(false);
+  const classes = useStyles();
 
   useEffect(() => {
     if (allUsers.length === 0) {
@@ -97,6 +107,9 @@ const NewGroupUserForm = ({ group_id }) => {
 
   return (
     <div>
+      <Typography className={classes.heading}>
+        Add or invite a new user to this group
+      </Typography>
       <Autocomplete
         id="newUserEmail"
         value={formState.newUserEmail || ""}

--- a/static/js/ducks/groups.js
+++ b/static/js/ducks/groups.js
@@ -15,6 +15,9 @@ export const DELETE_GROUP_OK = "skyportal/DELETE_GROUP_OK";
 export const ADD_GROUP_USER = "skyportal/ADD_GROUP_USER";
 export const ADD_GROUP_USER_OK = "skyportal/ADD_GROUP_USER_OK";
 
+export const ADD_GROUP_USERS = "skyportal/ADD_GROUP_USERS";
+export const ADD_GROUP_USERS_OK = "skyportal/ADD_GROUP_USERS_OK";
+
 export const UPDATE_GROUP_USER = "skyportal/UPDATE_GROUP_USER";
 export const UPDATE_GROUP_USER_OK = "skyportal/UPDATE_GROUP_USER_OK";
 
@@ -43,6 +46,11 @@ export function addGroupUser({ username, admin, group_id }) {
     group_id,
   });
 }
+
+export const addAllUsersFromGroups = ({ toGroupID, fromGroupIDs }) =>
+  API.POST(`/api/groups/${toGroupID}/usersFromGroups`, ADD_GROUP_USERS, {
+    fromGroupIDs,
+  });
 
 export const updateGroupUser = (groupID, params) =>
   API.PATCH(`/api/groups/${groupID}/users`, UPDATE_GROUP_USER, params);


### PR DESCRIPTION
This PR adds a form to the group page that allows all users from selected group(s) to be added to a group.

A new back-end handler and associated endpoint (`/api/groups/<group_id>/usersFromGroups`) are added.

![add_users_from_other_groups](https://user-images.githubusercontent.com/7230285/96805188-e49e5980-13c5-11eb-9c79-8e7ac7ad1d35.gif)
