### PR TITLE
Hotfix for group sources page 

### DIFF
--- a/static/js/components/GroupSources.jsx
+++ b/static/js/components/GroupSources.jsx
@@ -448,11 +448,11 @@ const GroupSources = ({ route }) => {
 
   const savedSources = sources.filter((source) => {
     const matchingGroup = source.groups.filter((g) => g.id === groupID)[0];
-    return matchingGroup.active;
+    return matchingGroup?.active;
   });
   const pendingSources = sources.filter((source) => {
     const matchingGroup = source.groups.filter((g) => g.id === groupID)[0];
-    return matchingGroup.requested;
+    return matchingGroup?.requested;
   });
 
   return (


### PR DESCRIPTION
This fixes #1129 

```
TypeError: Cannot read property 'active' of undefined
        if (0 === a.length)
            return "No sources have been saved to this group yet. ";
        var u = parseInt(r.id, 10)
          , d = (null === (t = s.filter((function(e) {
            return e.id === u
        }
        ))[0]) || void 0 === t ? void 0 : t.name) || ""
          , p = a.filter((function(e) {
            return e.groups.filter((function(e) {
                return e.id === u
            }
            ))[0].active
        }
```