### PR TITLE
Fix observing run MUI datatable bug

### DIFF
--- a/static/js/components/RunSummary.jsx
+++ b/static/js/components/RunSummary.jsx
@@ -166,7 +166,7 @@ const RunSummary = ({ route }) => {
     }
 
     const colSpan = rowData.length + 1;
-    const assignment = assignments[rowMeta.rowIndex];
+    const assignment = assignments[rowMeta.dataIndex];
 
     return (
       <TableRow>


### PR DESCRIPTION
This fixes a bug where only the first N elements were rendering in pullout rows on the observing run page, due to the use of rowIndex instead of dataIndex. So if there were 10 elements per page, the same 10 pullout rows would show on every page. This should map the pullout rows to the proper assignments on page number > 1