### PR TITLE
lock the photometry table in SHARE ROW EXCLUSIVE mode to prevent concurrent data updates from K

### DIFF
--- a/skyportal/handlers/api/photometry.py
+++ b/skyportal/handlers/api/photometry.py
@@ -602,18 +602,6 @@ class PhotometryHandler(BaseHandler):
                                 points in a single request.
         """
 
-        # The Repeatable Read isolation level only sees data committed before
-        # the transaction began; it never sees either uncommitted data or
-        # changes committed during transaction execution by concurrent
-        # transactions. (However, the query does see the effects of previous
-        # updates executed within its own transaction, even though they are
-        # not yet committed.) We use it here to ensure internally consistent
-        # deduplication queries (i.e., to ensure that SELECT queries against
-        # the photometry table do not return different results within this
-        # method's transaction due to concurrent inserts or updates.
-
-        DBSession().rollback()
-        DBSession().execute('SET TRANSACTION ISOLATION LEVEL REPEATABLE READ')
         try:
             group_ids = self.get_group_ids()
         except ValidationError as e:
@@ -624,6 +612,15 @@ class PhotometryHandler(BaseHandler):
         except ValidationError as e:
             return self.error(e.args[0])
 
+        # This lock ensures that the Photometry table data are not modified in any way
+        # between when the query for duplicate photometry is first executed and
+        # when the insert statement with the new photometry is performed.
+        # From the psql docs: This mode protects a table against concurrent
+        # data changes, and is self-exclusive so that only one session can
+        # hold it at a time.
+        DBSession().execute(
+            f'LOCK TABLE {Photometry.__tablename__} IN SHARE ROW EXCLUSIVE MODE'
+        )
         try:
             ids, upload_id = self.insert_new_photometry_data(
                 df, instrument_cache, group_ids
@@ -671,18 +668,6 @@ class PhotometryHandler(BaseHandler):
                                 points in a single request.
         """
 
-        # The Repeatable Read isolation level only sees data committed before
-        # the transaction began; it never sees either uncommitted data or
-        # changes committed during transaction execution by concurrent
-        # transactions. (However, the query does see the effects of previous
-        # updates executed within its own transaction, even though they are
-        # not yet committed.) We use it here to ensure internally consistent
-        # deduplication queries (i.e., to ensure that SELECT queries against
-        # the photometry table do not return different results within this
-        # method's transaction due to concurrent inserts or updates.
-
-        DBSession().rollback()
-        DBSession().execute('SET TRANSACTION ISOLATION LEVEL REPEATABLE READ')
         try:
             group_ids = self.get_group_ids()
         except ValidationError as e:
@@ -694,6 +679,16 @@ class PhotometryHandler(BaseHandler):
             return self.error(e.args[0])
 
         values_table, condition = self.get_values_table_and_condition(df)
+
+        # This lock ensures that the Photometry table data are not modified
+        # in any way between when the query for duplicate photometry is first
+        # executed and when the insert statement with the new photometry is
+        # performed. From the psql docs: This mode protects a table against
+        # concurrent data changes, and is self-exclusive so that only one
+        # session can hold it at a time.
+        DBSession().execute(
+            f'LOCK TABLE {Photometry.__tablename__} IN SHARE ROW EXCLUSIVE MODE'
+        )
 
         new_photometry_query = (
             DBSession()
@@ -744,10 +739,11 @@ class PhotometryHandler(BaseHandler):
             for (df_index, _), id in zip(new_photometry.iterrows(), ids):
                 id_map[df_index] = id
 
+        # release the lock
+        DBSession().commit()
+
         # get ids in the correct order
         ids = [id_map[pdidx] for pdidx, _ in df.iterrows()]
-
-        DBSession().commit()
         return self.success(data={'ids': ids})
 
     @auth_or_token


### PR DESCRIPTION
This PR locks the photometry table in SHARE ROW EXCLUSIVE mode when querying for duplicate photometry, inserting new photometry, and updating existing photometry via the API. This replaces the logic of transaction mode REPEATABLE READ and is an attempt to fix the bug shown here

```
Oct 21 21:21:48 fritz-1601421112-web-5fbf4d5bc6-xpxmk Fritz [!] Error in `/api/photometry`: (psycopg2.errors.UniqueViolation) duplicate key value violates unique constraint "deduplication_index" 
Oct 21 21:21:48 fritz-1601421112-web-5fbf4d5bc6-xpxmk Fritz     raise value.with_traceback(tb) 
Oct 21 21:21:48 fritz-1601421112-web-5fbf4d5bc6-xpxmk Fritz   File "/skyportal_env/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 1243, in _execute_context 
Oct 21 21:21:48 fritz-1601421112-web-5fbf4d5bc6-xpxmk Fritz DETAIL:  Key (obj_id, instrument_id, origin, mjd, fluxerr, flux)=(ZTF18aborwcz, 1, , 58346.34232639987, 3.8112735971772573, NaN) already exists. 
Oct 21 21:21:48 fritz-1601421112-web-5fbf4d5bc6-xpxmk Fritz     self.dialect.do_execute( 
Oct 21 21:21:48 fritz-1601421112-web-5fbf4d5bc6-xpxmk Fritz   File "/skyportal_env/lib/python3.8/site-packages/sqlalchemy/engine/default.py", line 552, in do_execute 
Oct 21 21:21:48 fritz-1601421112-web-5fbf4d5bc6-xpxmk Fritz     cursor.execute(statement, parameters) 
Oct 21 21:21:48 fritz-1601421112-web-5fbf4d5bc6-xpxmk Fritz [SQL: INSERT INTO photometry (id, created_at, modified, ra, dec, mjd, flux, fluxerr, filter, ra_unc, dec_unc, original_user_data, altdata, upload_id, origin, obj_id, instrument_id) VALUES (%(id)s, timezone(%(timezone_1)s, CURRENT_TIMESTAMP), timezone(%(timezone_1)s, CURRENT_TIMESTAMP), %(ra)s, %(dec)s, %(mjd)s, %(flux)s, %(fluxerr)s, %(filter)s, %(ra_unc)s, %(dec_unc)s, %(original_user_data)s, %(altdata)s, %(upload_id)s, %(origin)s, %(obj_id)s, %(instrument_id)s)] 
Oct 21 21:21:48 fritz-1601421112-web-5fbf4d5bc6-xpxmk Fritz [parameters: ({'id': 467174, 'timezone_1': 'UTC', 'ra': None, 'dec': None, 'mjd': 58346.34232639987, 'flux': nan, 'fluxerr': 3.8112735971772573, 'filter': 'ztfg', 'ra_unc': None, 'dec_unc': None, 'original_user_data': '{"limiting_mag": 20.699899673461914, "magsys": "ab", "limiting_mag_nsigma": 5}', 'altdata': 'null', 'upload_id': '8a620828-23c1-4f2a-b8c4-c16c0f96dfb2', 'origin': '', 'obj_id': 'ZTF18aborwcz', 'instrument_id': 1}, {'id': 467175, 'timezone_1': 'UTC', 'ra': None, 'dec': None, 'mjd': 58349.38560190005, 'flux': nan, 'fluxerr': 3.873201539136732, 'filter': 'ztfg', 'ra_unc': None, 'dec_unc': None, 'original_user_data': '{"limiting_mag": 20.68239974975586, "magsys": "ab", "limiting_mag_nsigma": 5}', 'altdata': 'null', 'upload_id': '8a620828-23c1-4f2a-b8c4-c16c0f96dfb2', 'origin': '', 'obj_id': 'ZTF18aborwcz', 'instrument_id': 1}, {'id': 467176, 'timezone_1': 'UTC', 'ra': 348.9630221, 'dec': 72.2988188, 'mjd': 58352.37037040014, 'flux': 1322.5126697941096, 'fluxerr': 102.05920258184257, 'filter': 'ztfg', 'ra_unc': None, 'dec_unc': None, 'original_user_data': '{"limiting_mag": 20.02239990234375, "magsys": "ab", "limiting_mag_nsigma": 5}', 'altdata': 'null', 'upload_id': '8a620828-23c1-4f2a-b8c4-c16c0f96dfb2', 'origin': '', 'obj_id': 'ZTF18aborwcz', 'instrument_id': 1}, {'id': 467177, 'timezone_1': 'UTC', 'ra': 348.9630378, 'dec': 72.2987302, 'mjd': 58361.384386599995, 'flux': 2956.921831366329, 'fluxerr': 118.94562001085887, 'filter': 'ztfg', 'ra_unc': None, 'dec_unc': None, 'original_user_data': '{"limiting_mag": 19.653200149536133, "magsys": "ab", "limiting_mag_nsigma": 5}', 'altdata': 'null', 'upload_id': '8a620828-23c1-4f2a-b8c4-c16c0f96dfb2', 'origin': '', 'obj_id': 'ZTF18aborwcz', 'instrument_id': 1}, {'id': 467178, 'timezone_1': 'UTC', 'ra': 348.9629686, 'dec': 72.2987831, 'mjd': 58364.26166669978, 'flux': 1263.1060616834154, 'fluxerr': 80.10457028075513, 'filter': 'ztfg', 'ra_unc': None, 'dec_unc': None, 'original_user_data': '{"limiting_mag": 20.903499603271484, "magsys": "ab", "limiting_mag_nsigma": 5}', 'altdata': 'null', 'upload_id': '8a620828-23c1-4f2a-b8c4-c16c0f96dfb2', 'origin': '', 'obj_id': 'ZTF18aborwcz', 'instrument_id': 1}, {'id': 467179, 'timezone_1': 'UTC', 'ra': 348.9630327, 'dec': 72.2987571, 'mjd': 58367.31184029998, 'flux': 1276.674009424858, 'fluxerr': 59.84187717466379, 'filter': 'ztfg', 'ra_unc': None, 'dec_unc': None, 'original_user_data': '{"limiting_mag": 20.477500915527344, "magsys": "ab", "limiting_mag_nsigma": 5}', 'altdata': 'null', 'upload_id': '8a620828-23c1-4f2a-b8c4-c16c0f96dfb2', 'origin': '', 'obj_id': 'ZTF18aborwcz', 'instrument_id': 1}, {'id': 467180, 'timezone_1': 'UTC', 'ra': 348.9630186, 'dec': 72.2988018, 'mjd': 58370.34164350014, 'flux': 8362.959635074225, 'fluxerr': 244.53349279085043, 'filter': 'ztfg', 'ra_unc': None, 'dec_unc': None, 'original_user_data': '{"limiting_mag": 20.952299118041992, "magsys": "ab", "limiting_mag_nsigma": 5}', 'altdata': 'null', 'upload_id': '8a620828-23c1-4f2a-b8c4-c16c0f96dfb2', 'origin': '', 'obj_id': 'ZTF18aborwcz', 'instrument_id': 1}, {'id': 467181, 'timezone_1': 'UTC', 'ra': 348.9630524, 'dec': 72.2987916, 'mjd': 58373.37156250002, 'flux': 2775.875369463679, 'fluxerr': 127.02075894732994, 'filter': 'ztfg', 'ra_unc': None, 'dec_unc': None, 'original_user_data': '{"limiting_mag": 20.886699676513672, "magsys": "ab", "limiting_mag_nsigma": 5}', 'altdata': 'null', 'upload_id': '8a620828-23c1-4f2a-b8c4-c16c0f96dfb2', 'origin': '', 'obj_id': 'ZTF18aborwcz', 'instrument_id': 1}  ... displaying 10 of 420 total bound parameter sets ...  {'id': 468012, 'timezone_1': 'UTC', 'ra': None, 'dec': None, 'mjd': 59142.26309029991, 'flux': nan, 'fluxerr': 58.032297705557255, 'filter': 'ztfr', 'ra_unc': None, 'dec_unc': None, 'original_user_data': '{"limiting_mag": 17.74340057373047, "magsys": "ab", "limiting_mag_nsigma": 5}', 'altdata': 'null', 'upload_id': '8a620828-23c1-4f2a-b8c4-c16c0f96dfb2', 'origin': '', 'obj_id': 'ZTF18aborwcz', 'instrument_id': 1}, {'id': 468013, 'timezone_1': 'UTC', 'ra': 348.9630416, 'dec': 72.2988082, 'mjd': 59144.17364579998, 'flux': 18411.338930968235, 'fluxerr': 644.3689873582866, 'filter': 'ztfg', 'ra_unc': None, 'dec_unc': None, 'original_user_data': '{"limiting_mag": 19.71756362915039, "magsys": "ab", "limiting_mag_nsigma": 5}', 'altdata': 'null', 'upload_id': '8a620828-23c1-4f2a-b8c4-c16c0f96dfb2', 'origin': '', 'obj_id': 'ZTF18aborwcz', 'instrument_id': 1})] 
```

which is almost certainly due to a race condition in which two separate K threads post the same photometry to SP at the same time. Both SP threads query for duplicates before either has committed, leading both threads to attempt to insert the same new phot. 

This PR should prevent this from happening. 