### PR TITLE
Quick fix for null RA and Dec

### DIFF
--- a/data/db_demo.yaml
+++ b/data/db_demo.yaml
@@ -199,6 +199,8 @@ candidates:
 
 sources:
   - id: 14gqr
+    ra: 353.36647
+    dec: 33.646149
     group_ids:
       # Adding the public_group_id is a hack until the admin token i
       # allowed to create sources outside of its own groups, as per
@@ -207,6 +209,8 @@ sources:
       - =program_A
       - =program_B
   - id: 16fil
+    ra: 322.718872
+    dec: 27.574113
     group_ids:
       - =public_group_id
       - =program_A

--- a/skyportal/handlers/api/candidate.py
+++ b/skyportal/handlers/api/candidate.py
@@ -596,11 +596,11 @@ class CandidateHandler(BaseHandler):
         ra = data.get('ra', None)
         dec = data.get('dec', None)
 
-        if ra is None:
-            return self.error("RA must not be null")
+        if ra is None and not obj_already_exists:
+            return self.error("RA must not be null for a new Obj")
 
-        if dec is None:
-            return self.error("Dec must not be null")
+        if dec is None and not obj_already_exists:
+            return self.error("Dec must not be null for a new Obj")
 
         passing_alert_id = data.pop("passing_alert_id", None)
         passed_at = data.pop("passed_at", None)

--- a/skyportal/handlers/api/candidate.py
+++ b/skyportal/handlers/api/candidate.py
@@ -593,6 +593,15 @@ class CandidateHandler(BaseHandler):
         obj_already_exists = Obj.query.get(data["id"]) is not None
         schema = Obj.__schema__()
 
+        ra = data.get('ra', None)
+        dec = data.get('dec', None)
+
+        if ra is None:
+            return self.error("RA must not be null")
+
+        if dec is None:
+            return self.error("Dec must not be null")
+
         passing_alert_id = data.pop("passing_alert_id", None)
         passed_at = data.pop("passed_at", None)
         if passed_at is not None:

--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -578,6 +578,16 @@ class SourceHandler(BaseHandler):
         data = self.get_json()
         obj_already_exists = Obj.query.get(data["id"]) is not None
         schema = Obj.__schema__()
+
+        ra = data.get('ra', None)
+        dec = data.get('dec', None)
+
+        if ra is None:
+            return self.error("RA must not be null")
+
+        if dec is None:
+            return self.error("Dec must not be null")
+
         user_group_ids = [g.id for g in self.current_user.groups]
         user_accessible_group_ids = [g.id for g in self.current_user.accessible_groups]
         if not user_group_ids:

--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -582,11 +582,11 @@ class SourceHandler(BaseHandler):
         ra = data.get('ra', None)
         dec = data.get('dec', None)
 
-        if ra is None:
-            return self.error("RA must not be null")
+        if ra is None and not obj_already_exists:
+            return self.error("RA must not be null for a new Obj")
 
-        if dec is None:
-            return self.error("Dec must not be null")
+        if dec is None and not obj_already_exists:
+            return self.error("Dec must not be null for a new Obj")
 
         user_group_ids = [g.id for g in self.current_user.groups]
         user_accessible_group_ids = [g.id for g in self.current_user.accessible_groups]

--- a/skyportal/tests/api/test_sources.py
+++ b/skyportal/tests/api/test_sources.py
@@ -196,6 +196,27 @@ def test_token_user_post_new_source(upload_data_token, view_only_token, public_g
     assert abs(saved_at - t0) < timedelta(seconds=2)
 
 
+def test_cannot_post_source_with_null_radec(
+    upload_data_token, view_only_token, public_group
+):
+    obj_id = str(uuid.uuid4())
+    status, data = api(
+        'POST',
+        'sources',
+        data={
+            'id': obj_id,
+            'ra': None,
+            'dec': None,
+            'redshift': 3,
+            'transient': False,
+            'ra_dis': 2.3,
+            'group_ids': [public_group.id],
+        },
+        token=upload_data_token,
+    )
+    assert status == 400
+
+
 def test_add_source_without_group_id(upload_data_token, view_only_token, public_group):
     obj_id = str(uuid.uuid4())
     status, data = api(


### PR DESCRIPTION
Until we can converge on the more long-term solution for the ra/dec bug we are seeing on fritz.science via #1132, this PR should fix the problem. It's just a simple change of the API validator to require that RA and Dec be nonnull in Source.POST and Candidate.POST. 
