### PR TITLE
Let PS1 thumbnail URL generation function error rather than silently return None

### DIFF
--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -47,7 +47,10 @@ _, cfg = load_env()
 
 
 def add_ps1_thumbnail_and_push_ws_msg(obj, request_handler):
-    obj.add_ps1_thumbnail()
+    try:
+        obj.add_ps1_thumbnail()
+    except (ValueError, ConnectionError) as e:
+        return request_handler.error(f"Unable to generate PS1 thumbnail URL: {e}")
     request_handler.push_all(
         action="skyportal/REFRESH_SOURCE", payload={"obj_key": obj.internal_key}
     )

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -497,19 +497,14 @@ class Obj(Base, ha.Point):
         best we can do is request a page that contains a link to the image we
         want (in this case a combination of the g/r/i filters).
         """
-        try:
-            ps_query_url = (
-                f"http://ps1images.stsci.edu/cgi-bin/ps1cutouts"
-                f"?pos={self.ra}+{self.dec}&filter=color&filter=g"
-                f"&filter=r&filter=i&filetypes=stack&size=250"
-            )
-            response = requests.get(ps_query_url)
-            match = re.search(
-                'src="//ps1images.stsci.edu.*?"', response.content.decode()
-            )
-            return match.group().replace('src="', 'http:').replace('"', '')
-        except (ValueError, ConnectionError):
-            return None
+        ps_query_url = (
+            f"http://ps1images.stsci.edu/cgi-bin/ps1cutouts"
+            f"?pos={self.ra}+{self.dec}&filter=color&filter=g"
+            f"&filter=r&filter=i&filetypes=stack&size=250"
+        )
+        response = requests.get(ps_query_url)
+        match = re.search('src="//ps1images.stsci.edu.*?"', response.content.decode())
+        return match.group().replace('src="', 'http:').replace('"', '')
 
     @property
     def target(self):


### PR DESCRIPTION
This will keep the `Thumbnail` from being added to the DB w/ null `public_url`, and will instead re-try next time the source page is loaded.