### PR TITLE
vectorize calculation of ephemerides

### DIFF
--- a/skyportal/handlers/api/observingrun.py
+++ b/skyportal/handlers/api/observingrun.py
@@ -153,14 +153,16 @@ class ObservingRunHandler(BaseHandler):
                     del a['obj'].sources
 
                 # vectorized calculation of ephemerides
-                targets = [a.obj.target for a in run.assignments]
 
-                rise_times = run.rise_time(targets).isot
-                set_times = run.set_time(targets).isot
+                if len(run.assignments) > 0:
+                    targets = [a.obj.target for a in run.assignments]
 
-                for d, rt, st in zip(data["assignments"], rise_times, set_times):
-                    d["rise_time_utc"] = rt
-                    d["set_time_utc"] = st
+                    rise_times = run.rise_time(targets).isot
+                    set_times = run.set_time(targets).isot
+
+                    for d, rt, st in zip(data["assignments"], rise_times, set_times):
+                        d["rise_time_utc"] = rt
+                        d["set_time_utc"] = st
 
                 return self.success(data=data)
 

--- a/skyportal/handlers/api/observingrun.py
+++ b/skyportal/handlers/api/observingrun.py
@@ -152,10 +152,15 @@ class ObservingRunHandler(BaseHandler):
                     ]
                     del a['obj'].sources
 
-                # calculate when the targets rise and set
-                for d, a in zip(data["assignments"], run.assignments):
-                    d["rise_time_utc"] = a.rise_time.isot
-                    d["set_time_utc"] = a.set_time.isot
+                # vectorized calculation of ephemerides
+                targets = [a.obj.target for a in run.assignments]
+
+                rise_times = run.rise_time(targets).isot
+                set_times = run.set_time(targets).isot
+
+                for d, rt, st in zip(data["assignments"], rise_times, set_times):
+                    d["rise_time_utc"] = rt
+                    d["set_time_utc"] = st
 
                 return self.success(data=data)
 

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -2353,6 +2353,20 @@ class ObservingRun(Base):
             self._calendar_noon, which='next'
         )
 
+    def rise_time(self, target_or_targets):
+        """The rise time of the specified targets as an astropy.time.Time."""
+        observer = self.instrument.telescope.observer
+        return observer.target_rise_time(
+            self.sunset, target_or_targets, which='next', horizon=30 * u.degree
+        )
+
+    def set_time(self, target_or_targets):
+        """The set time of the specified targets as an astropy.time.Time."""
+        observer = self.instrument.telescope.observer
+        return observer.target_set_time(
+            self.sunset, target_or_targets, which='next', horizon=30 * u.degree
+        )
+
 
 User.observing_runs = relationship(
     'ObservingRun',
@@ -2441,20 +2455,14 @@ class ClassicalAssignment(Base):
     @property
     def rise_time(self):
         """The UTC time at which the object rises on this run."""
-        observer = self.instrument.telescope.observer
         target = self.obj.target
-        return observer.target_rise_time(
-            self.run.sunset, target, which='next', horizon=30 * u.degree
-        )
+        return self.run.rise_time(target)
 
     @property
     def set_time(self):
         """The UTC time at which the object sets on this run."""
-        observer = self.instrument.telescope.observer
         target = self.obj.target
-        return observer.target_set_time(
-            self.rise_time, target, which='next', horizon=30 * u.degree
-        )
+        return self.run.set_time(target)
 
 
 User.assignments = relationship(


### PR DESCRIPTION
Supersedes #1171, Fixes #1102 

This PR vectorizes the calculation of rise and set times of observing run assignments. Previously, this was being done one-by-one, and consequently took ~200ms per assignment. This PR should reduce this to ~200ms for the whole run.