### PR TITLE
Filtering fixes for scanning page

### DIFF
--- a/skyportal/handlers/api/candidate.py
+++ b/skyportal/handlers/api/candidate.py
@@ -433,6 +433,21 @@ class CandidateHandler(BaseHandler):
                             == value,
                         )
                     else:
+                        # Test if the value is a nested object
+                        try:
+                            value = json.loads(value)
+                            # If a nested object, we put the value through the
+                            # JSON loads/dumps pipeline to get a string formatted
+                            # like Postgres will for its JSONB ->> text operation
+                            # For some reason, for example, not doing this will
+                            # have value = { "key": "value" } (with the extra
+                            # spaces around the braces) and cause the filter to
+                            # fail.
+                            value = json.dumps(value)
+                        except json.decoder.JSONDecodeError:
+                            # If not, this is just a string field and we don't
+                            # need the string formatting above
+                            pass
                         q = q.filter(
                             Annotation.origin == new_filter["origin"],
                             Annotation.data[new_filter["key"]].astext == value,

--- a/static/js/components/CandidateList.jsx
+++ b/static/js/components/CandidateList.jsx
@@ -153,6 +153,7 @@ const defaultNumPerPage = 25;
 const CustomSortToolbar = ({
   selectedAnnotationSortOptions,
   rowsPerPage,
+  filterFormData,
   setQueryInProgress,
   loaded,
 }) => {
@@ -169,13 +170,20 @@ const CustomSortToolbar = ({
     setSortOrder(newSortOrder);
 
     setQueryInProgress(true);
-    const data = {
+    let data = {
       pageNumber: 1,
       numPerPage: rowsPerPage,
       sortByAnnotationOrigin: selectedAnnotationSortOptions.origin,
       sortByAnnotationKey: selectedAnnotationSortOptions.key,
       sortByAnnotationOrder: newSortOrder,
     };
+
+    if (filterFormData !== null) {
+      data = {
+        ...data,
+        ...filterFormData,
+      };
+    }
 
     await dispatch(
       candidatesActions.setCandidatesAnnotationSortOptions({
@@ -218,6 +226,7 @@ CustomSortToolbar.propTypes = {
   }),
   setQueryInProgress: PropTypes.func.isRequired,
   rowsPerPage: PropTypes.number.isRequired,
+  filterFormData: PropTypes.shape({}).isRequired,
   loaded: PropTypes.bool.isRequired,
 };
 
@@ -260,6 +269,10 @@ const CandidateList = () => {
 
   const availableAnnotationsInfo = useSelector(
     (state) => state.candidates.annotationsInfo
+  );
+
+  const filterFormData = useSelector(
+    (state) => state.candidates.filterFormData
   );
 
   const dispatch = useDispatch();
@@ -365,6 +378,13 @@ const CandidateList = () => {
         sortByAnnotationOrigin: selectedAnnotationSortOptions.origin,
         sortByAnnotationKey: selectedAnnotationSortOptions.key,
         sortByAnnotationOrder: selectedAnnotationSortOptions.order,
+      };
+    }
+
+    if (filterFormData !== null) {
+      data = {
+        ...data,
+        ...filterFormData,
       };
     }
 
@@ -598,6 +618,13 @@ const CandidateList = () => {
       };
     }
 
+    if (filterFormData !== null) {
+      data = {
+        ...data,
+        ...filterFormData,
+      };
+    }
+
     await dispatch(candidatesActions.fetchCandidates(data));
     setQueryInProgress(false);
   };
@@ -801,6 +828,7 @@ const CandidateList = () => {
       <CustomSortToolbar
         selectedAnnotationSortOptions={selectedAnnotationSortOptions}
         rowsPerPage={rowsPerPage}
+        filterFormData={filterFormData}
         setQueryInProgress={setQueryInProgress}
         loaded={!queryInProgress}
       />

--- a/static/js/components/FilterCandidateList.jsx
+++ b/static/js/components/FilterCandidateList.jsx
@@ -87,6 +87,7 @@ const FilterCandidateList = ({ userAccessibleGroups, setQueryInProgress }) => {
     if (data.endDate) {
       data.endDate = data.endDate.toISOString();
     }
+    await dispatch(candidatesActions.setFilterFormData(data));
     await dispatch(candidatesActions.fetchCandidates(data));
     setQueryInProgress(false);
   };

--- a/static/js/ducks/candidates.js
+++ b/static/js/ducks/candidates.js
@@ -20,6 +20,9 @@ export const SET_CANDIDATES_ANNOTATION_SORT_OPTIONS =
 export const FETCH_ANNOTATIONS_INFO = "skyportal/FETCH_ANNOTATIONS_INFO";
 export const FETCH_ANNOTATIONS_INFO_OK = "skyportal/FETCH_ANNOTATIONS_INFO_OK";
 
+export const SET_CANDIDATES_FILTER_FORM_DATA =
+  "skyportal/SET_CANDIDATES_FILTER_FORM_DATA";
+
 export const fetchCandidates = (filterParams = {}) => {
   if (!Object.keys(filterParams).includes("pageNumber")) {
     filterParams.pageNumber = 1;
@@ -38,6 +41,13 @@ export const setCandidatesAnnotationSortOptions = (item) => {
 
 export const fetchAnnotationsInfo = () => {
   return API.GET(`/api/internal/annotations_info`, FETCH_ANNOTATIONS_INFO);
+};
+
+export const setFilterFormData = (formData) => {
+  return {
+    type: SET_CANDIDATES_FILTER_FORM_DATA,
+    formData,
+  };
 };
 
 // Websocket message handler
@@ -69,6 +79,7 @@ const initialState = {
   numberingEnd: 0,
   selectedAnnotationSortOptions: null,
   annotationsInfo: null,
+  filterFormData: null,
 };
 
 const reducer = (state = initialState, action) => {
@@ -106,6 +117,13 @@ const reducer = (state = initialState, action) => {
       return {
         ...state,
         annotationsInfo,
+      };
+    }
+    case SET_CANDIDATES_FILTER_FORM_DATA: {
+      const { formData } = action;
+      return {
+        ...state,
+        filterFormData: formData,
       };
     }
     default:


### PR DESCRIPTION
In this PR:
- Proper coercion of annotation filter values for fields that are booleans, strings, or nested objects
- Hook up the scanning page filter form (for groups and dates) state with the paging state in the MUI data table

Closes #1169 

Remaining known issue: 
Cannot have multiple filters set on annotation fields from different origins at the same time (i.e. cannot filter for `some_key (origin A): true` and `some_other_key (origin B): true` at the same time even if a candidate has both). Vague impressions is that this will require a bigger change to the sqlalchemy code for the candidates handler and more thinking than a quick change. Something like merge annotation rows into one big jsonb field so that one row knows it has both origins? Right now the queries technically look for entries in the Annotation table that have both fields instead of objects with entries in the Annotation table that fit the fields. 