### PR TITLE
Add wheel as a requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,3 +38,4 @@ sendgrid>=6.4.6
 twilio>=6.45.3
 jsonschema-to-openapi>=0.2.1
 responses>=0.12.0
+wheel


### PR DESCRIPTION
This is needed by astroplan, which is a dependency of astropy