### PR TITLE
Fix candidate passed_at parsing

### DIFF
--- a/skyportal/handlers/api/candidate.py
+++ b/skyportal/handlers/api/candidate.py
@@ -663,7 +663,7 @@ class CandidateHandler(BaseHandler):
         return self.success(data={"id": obj.id})
 
     @permissions(["Manage sources"])
-    def patch(self, obj_id):
+    def put(self, obj_id):
         """
         ---
         description: Update a candidate
@@ -676,7 +676,24 @@ class CandidateHandler(BaseHandler):
         requestBody:
           content:
             application/json:
-              schema: ObjNoID
+              schema:
+                type: object
+                properties:
+                  filter_ids:
+                    type: array
+                    items:
+                      type: integer
+                    description: List of associated filter IDs
+                  passing_alert_id:
+                    type: integer
+                    description: ID of associated filter that created candidate
+                    nullable: true
+                  passed_at:
+                    type: string
+                    description: Arrow-parseable datetime string indicating when alert passed filter.
+                    nullable: true
+                required:
+                  - filter_ids
         responses:
           200:
             content:
@@ -687,21 +704,51 @@ class CandidateHandler(BaseHandler):
               application/json:
                 schema: Error
         """
-        # Ensure user has access to candidate
-        c = Candidate.get_obj_if_owned_by(obj_id, self.current_user)
-        if c is None:
-            return self.error("Invalid ID.")
         data = self.get_json()
-        data["id"] = obj_id
+        data["obj_id"] = obj_id
 
-        schema = Obj.__schema__()
+        # Ensure user has access to candidate
+        if (
+            DBSession().query(Candidate).filter(Candidate.obj_id == obj_id).first()
+            is None
+        ):
+            return self.error("Invalid ID.")
+
+        passing_alert_id = data.pop("passing_alert_id", None)
+        passed_at = data.pop("passed_at", None)
+        if passed_at is not None:
+            passed_at = arrow.get(passed_at).datetime
         try:
-            obj = schema.load(data, partial=True)
-        except ValidationError as e:
+            filter_ids = data.pop("filter_ids")
+        except KeyError:
+            return self.error("Missing required filter_ids parameter.")
+        user_accessible_filter_ids = [
+            filtr.id
+            for g in self.current_user.accessible_groups
+            for filtr in g.filters
+            if g.filters is not None
+        ]
+        if not all([fid in user_accessible_filter_ids for fid in filter_ids]):
             return self.error(
-                "Invalid/missing parameters: " f"{e.normalized_messages()}"
+                "Insufficient permissions - you must only specify "
+                "filters that you have access to."
             )
-        update_redshift_history_if_relevant(data, obj, self.associated_user_object)
+
+        filters = Filter.query.filter(Filter.id.in_(filter_ids)).all()
+        if not filters:
+            return self.error("At least one valid filter ID must be provided.")
+
+        candidates = (
+            DBSession()
+            .query(Candidate)
+            .filter(Candidate.obj_id == obj_id, Candidate.filter_id.in_(filter_ids))
+            .all()
+        )
+
+        for candidate in candidates:
+            candidate.passed_at = passed_at
+            candidate.passing_alert_id = passing_alert_id
+
         DBSession().commit()
 
         self.push_all(action="skyportal/FETCH_CANDIDATES")

--- a/skyportal/handlers/api/candidate.py
+++ b/skyportal/handlers/api/candidate.py
@@ -605,7 +605,7 @@ class CandidateHandler(BaseHandler):
         passing_alert_id = data.pop("passing_alert_id", None)
         passed_at = data.pop("passed_at", None)
         if passed_at is not None:
-            passed_at = arrow.get(passed_at)
+            passed_at = arrow.get(passed_at).datetime
         try:
             filter_ids = data.pop("filter_ids")
         except KeyError:

--- a/skyportal/handlers/api/candidate.py
+++ b/skyportal/handlers/api/candidate.py
@@ -277,8 +277,18 @@ class CandidateHandler(BaseHandler):
             )
             filter_ids = [cand.filter_id for cand in accessible_candidates]
 
+            passing_alerts = [
+                {
+                    "filter_id": cand.filter_id,
+                    "passing_alert_id": cand.passing_alert_id,
+                    "passed_at": cand.passed_at,
+                }
+                for cand in accessible_candidates
+            ]
+
             candidate_info = c.to_dict()
             candidate_info["filter_ids"] = filter_ids
+            candidate_info["passing_alerts"] = passing_alerts
             candidate_info["comments"] = sorted(
                 [cmt.to_dict() for cmt in c.get_comments_owned_by(self.current_user)],
                 key=lambda x: x["created_at"],

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -716,11 +716,13 @@ Candidate.__doc__ = (
     "An Obj that passed a Filter, becoming scannable on the " "Filter's scanning page."
 )
 Candidate.passed_at = sa.Column(
-    sa.DateTime, nullable=True, doc="ISO UTC time when the Candidate passed the Filter."
+    sa.DateTime,
+    nullable=True,
+    doc="ISO UTC time when the Candidate passed the Filter last time.",
 )
 
 Candidate.passing_alert_id = sa.Column(
-    sa.BigInteger, doc="ID of the Stream alert that passed the Filter."
+    sa.BigInteger, doc="ID of the latest Stream alert that passed the Filter."
 )
 
 

--- a/skyportal/tests/api/test_candidates.py
+++ b/skyportal/tests/api/test_candidates.py
@@ -53,7 +53,7 @@ def test_token_user_update_candidate(
         f"candidates/{public_candidate.id}",
         data={
             "filter_ids": [public_filter.id],
-            "passing_alert_id": 1234567890,
+            "passing_alert_id": passing_alert_id,
             "passed_at": passed_at,
         },
         token=manage_sources_token,
@@ -69,16 +69,19 @@ def test_token_user_update_candidate(
     assert data["data"]["passing_alerts"][0]["passing_alert_id"] == passing_alert_id
 
 
-def test_cannot_update_candidate_without_permission(view_only_token, public_candidate):
+def test_cannot_update_candidate_without_permission(
+    view_only_token, public_candidate, public_filter
+):
+    passing_alert_id = 1234567890
+    passed_at = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%f")
+
     status, data = api(
-        "PAT",
+        "PUT",
         f"candidates/{public_candidate.id}",
         data={
-            "ra": 234.22,
-            "dec": -22.33,
-            "redshift": 3,
-            "transient": False,
-            "ra_dis": 2.3,
+            "filter_ids": [public_filter.id],
+            "passing_alert_id": passing_alert_id,
+            "passed_at": passed_at,
         },
         token=view_only_token,
     )

--- a/skyportal/tests/api/test_candidates.py
+++ b/skyportal/tests/api/test_candidates.py
@@ -1,5 +1,7 @@
-import uuid
+import datetime
 import numpy.testing as npt
+import uuid
+
 from skyportal.tests import api
 
 
@@ -40,11 +42,20 @@ def test_token_user_retrieving_candidate_with_phot(view_only_token, public_candi
     assert all(k in data["data"] for k in ["ra", "dec", "redshift", "dm", "photometry"])
 
 
-def test_token_user_update_candidate(manage_sources_token, public_candidate):
+def test_token_user_update_candidate(
+    manage_sources_token, public_candidate, public_filter
+):
+    passing_alert_id = 1234567890
+    passed_at = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%f")
+
     status, data = api(
-        "PATCH",
+        "PUT",
         f"candidates/{public_candidate.id}",
-        data={"ra": 234.22, "redshift": 3, "transient": False, "ra_dis": 2.3},
+        data={
+            "filter_ids": [public_filter.id],
+            "passing_alert_id": 1234567890,
+            "passed_at": passed_at,
+        },
         token=manage_sources_token,
     )
     assert status == 200
@@ -55,13 +66,12 @@ def test_token_user_update_candidate(manage_sources_token, public_candidate):
     )
     assert status == 200
     assert data["status"] == "success"
-    npt.assert_almost_equal(data["data"]["ra"], 234.22)
-    npt.assert_almost_equal(data["data"]["redshift"], 3.0)
+    assert data["data"]["passing_alerts"][0]["passing_alert_id"] == passing_alert_id
 
 
 def test_cannot_update_candidate_without_permission(view_only_token, public_candidate):
     status, data = api(
-        "PATCH",
+        "PAT",
         f"candidates/{public_candidate.id}",
         data={
             "ra": 234.22,


### PR DESCRIPTION
In this PR:

- In `/api/candidates.POST`, ingest `passed_at` into the db as `arrow.get(passed_at).datetime` (to preserve the current data model)
- Report filter_id,passed_at,passing_alert_id in `/api/candidates.GET` as in
![image](https://user-images.githubusercontent.com/7557205/97371835-6b907d80-186f-11eb-9485-b01c312cb5c0.png)
