### PR TITLE
pin astroplan to 0.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ jsonschema
 jsonpath_ng>=1.5.1
 pytest-rerunfailures>=9.0
 timezonefinder>=4.4.0
-astroplan>=0.6
+astroplan==0.6
 phonenumbers>=8.12.7
 py3-validate-email>=0.2.9
 alembic>=1.4.2


### PR DESCRIPTION
Fixes an issue in the automated deploy of https://fritz.science where the image could not build due to astroplan 0.7 throwing an error related to bdist wheel. 