### PR TITLE
make observing run page load much faster

### DIFF
--- a/skyportal/handlers/api/observingrun.py
+++ b/skyportal/handlers/api/observingrun.py
@@ -102,15 +102,9 @@ class ObservingRunHandler(BaseHandler):
                     joinedload(ObservingRun.assignments)
                     .joinedload(ClassicalAssignment.obj)
                     .joinedload(Obj.thumbnails),
-                    joinedload(ObservingRun.assignments)
-                    .joinedload(ClassicalAssignment.obj)
-                    .joinedload(Obj.photometry),
                     joinedload(ObservingRun.assignments).joinedload(
                         ClassicalAssignment.requester
                     ),
-                    joinedload(ObservingRun.assignments)
-                    .joinedload(ClassicalAssignment.obj)
-                    .joinedload(Obj.comments),
                     joinedload(ObservingRun.instrument).joinedload(
                         Instrument.telescope
                     ),


### PR DESCRIPTION
The observing run page was loading slowly due to an inefficient query that was sorting on unindexed columns that were not even needed to render the page. This PR fixes #1193. Fixes #1171 (and also is the true fix to #1102). 