### PR TITLE
Remove caching and renewal of IERS table downloads

### DIFF
--- a/skyportal/tests/conftest.py
+++ b/skyportal/tests/conftest.py
@@ -37,8 +37,6 @@ from skyportal.models import (
 )
 
 import astroplan
-import warnings
-from astroplan import utils as ap_utils
 
 
 print("Loading test configuration from _test_config.yaml")
@@ -96,20 +94,6 @@ def take_screenshot_and_page_source(webdriver, nodeid):
     webdriver.save_screenshot(file_name)
     with open(file_name.replace('png', 'html'), 'w') as f:
         f.write(webdriver.page_source)
-
-
-@pytest.fixture(scope='session')
-def iers_data():
-    # grab the latest earth orientation data for observatory calculations
-    if ap_utils.IERS_A_in_cache():
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "error", category=astroplan.OldEarthOrientationDataWarning
-            )
-            try:
-                ap_utils._get_IERS_A_table()
-            except astroplan.OldEarthOrientationDataWarning:
-                astroplan.download_IERS_A()
 
 
 @pytest.fixture()

--- a/skyportal/tests/tools/test_sky.py
+++ b/skyportal/tests/tools/test_sky.py
@@ -40,7 +40,7 @@ if not ads_down:
 
 @pytest.mark.skipif(ads_down, reason='Star data server is down.')
 @pytest.mark.parametrize('star', ['polaris', 'skat'])
-def test_airmass(ztf_camera, star, iers_data):
+def test_airmass(ztf_camera, star):
     star_obj = star_dict[star]['target']
     star_obj = Obj(ra=star_obj.ra.deg, dec=star_obj.dec.deg)
     telescope = ztf_camera.telescope
@@ -67,7 +67,7 @@ def test_airmass(ztf_camera, star, iers_data):
 
 
 @pytest.mark.skipif(ads_down, reason='Star data server is down.')
-def test_airmass_single(ztf_camera, public_source, iers_data):
+def test_airmass_single(ztf_camera, public_source):
     telescope = ztf_camera.telescope
     time = night_times[-1]
     airmass_calc = public_source.airmass(telescope, time)


### PR DESCRIPTION
We were using internal functions that are no longer available.
AstroPy now handles the caching internally, so we don't need these
fixtures any longer.