### PR TITLE
Record Users that reduced and observed a spectrum

### DIFF
--- a/alembic/versions/f94174183e7e_add_spectrumreducers_and_.py
+++ b/alembic/versions/f94174183e7e_add_spectrumreducers_and_.py
@@ -1,0 +1,58 @@
+"""add spectrumreducers and spectrumobservers
+
+Revision ID: f94174183e7e
+Revises: d0195eb7ecd0
+Create Date: 2020-10-27 23:59:14.316018
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'f94174183e7e'
+down_revision = 'd0195eb7ecd0'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'spectrum_observers',
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('modified', sa.DateTime(), nullable=False),
+        sa.Column('spectr_id', sa.Integer(), nullable=False),
+        sa.Column('user_id', sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(['spectr_id'], ['spectra.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('spectr_id', 'user_id'),
+    )
+    op.create_index(
+        'spectrum_observers_reverse_ind',
+        'spectrum_observers',
+        ['user_id', 'spectr_id'],
+        unique=False,
+    )
+    op.create_table(
+        'spectrum_reducers',
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('modified', sa.DateTime(), nullable=False),
+        sa.Column('spectr_id', sa.Integer(), nullable=False),
+        sa.Column('user_id', sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(['spectr_id'], ['spectra.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('spectr_id', 'user_id'),
+    )
+    op.create_index(
+        'spectrum_reducers_reverse_ind',
+        'spectrum_reducers',
+        ['user_id', 'spectr_id'],
+        unique=False,
+    )
+
+
+def downgrade():
+    op.drop_index('spectrum_reducers_reverse_ind', table_name='spectrum_reducers')
+    op.drop_table('spectrum_reducers')
+    op.drop_index('spectrum_observers_reverse_ind', table_name='spectrum_observers')
+    op.drop_table('spectrum_observers')

--- a/skyportal/handlers/api/spectrum.py
+++ b/skyportal/handlers/api/spectrum.py
@@ -146,7 +146,12 @@ class SpectrumHandler(BaseHandler):
         if spectrum is not None:
             # Permissions check
             _ = Source.get_obj_if_owned_by(spectrum.obj_id, self.current_user)
-            return self.success(data=spectrum)
+            spec_dict = spectrum.to_dict()
+            spec_dict["instrument_name"] = spectrum.instrument.name
+            spec_dict["groups"] = spectrum.groups
+            spec_dict["reducers"] = spectrum.reducers
+            spec_dict["observers"] = spectrum.observers
+            return self.success(data=spec_dict)
         else:
             return self.error(f"Could not load spectrum with ID {spectrum_id}")
 
@@ -449,5 +454,7 @@ class ObjSpectraHandler(BaseHandler):
             spec_dict = spec.to_dict()
             spec_dict["instrument_name"] = spec.instrument.name
             spec_dict["groups"] = spec.groups
+            spec_dict["reducers"] = spec.reducers
+            spec_dict["observers"] = spec.observers
             return_values.append(spec_dict)
         return self.success(data=return_values)

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -1892,6 +1892,13 @@ class Spectrum(Base):
         doc='Groups that can view this spectrum.',
     )
 
+    reducers = relationship(
+        "User", secondary="spectrum_reducers", doc="Users that reduced this spectrum."
+    )
+    observers = relationship(
+        "User", secondary="spectrum_observers", doc="Users that observed this spectrum."
+    )
+
     followup_request_id = sa.Column(sa.ForeignKey('followuprequests.id'), nullable=True)
     followup_request = relationship('FollowupRequest', back_populates='spectra')
 
@@ -2105,6 +2112,8 @@ User.spectra = relationship(
     'Spectrum', doc='Spectra uploaded by this User.', back_populates='owner'
 )
 
+SpectrumReducer = join_model("spectrum_reducers", Spectrum, User)
+SpectrumObserver = join_model("spectrum_observers", Spectrum, User)
 
 GroupSpectrum = join_model("group_spectra", Group, Spectrum)
 GroupSpectrum.__doc__ = 'Join table mapping Groups to Spectra.'

--- a/skyportal/schema.py
+++ b/skyportal/schema.py
@@ -965,6 +965,16 @@ class SpectrumAsciiFilePostJSON(SpectrumAsciiFileParseJSON):
     filename = fields.String(
         description="The original filename (for bookkeeping purposes).", required=True,
     )
+    reduced_by = fields.List(
+        fields.Integer,
+        description="IDs of the Users who reduced this Spectrum.",
+        missing=[],
+    )
+    observed_by = fields.List(
+        fields.Integer,
+        description="IDs of the Users who observed this Spectrum.",
+        missing=[],
+    )
 
 
 class SpectrumPost(_Schema):
@@ -992,14 +1002,17 @@ class SpectrumPost(_Schema):
         description='The ISO UTC time the spectrum was taken.', required=True
     )
 
-    """
-    observed_at = fields.DateTime(
-        required=True,
-        description="Median UTC ISO time stamp of the exposure or "
-                    "exposures in which the Spectrum was acquired.",
-        format='iso'
+    reduced_by = fields.List(
+        fields.Integer,
+        description="IDs of the Users who reduced this Spectrum.",
+        missing=[],
     )
-    """
+
+    observed_by = fields.List(
+        fields.Integer,
+        description="IDs of the Users who observed this Spectrum.",
+        missing=[],
+    )
 
     origin = fields.String(required=False, description="Origin of the spectrum.")
 

--- a/static/js/components/UploadSpectrum.jsx
+++ b/static/js/components/UploadSpectrum.jsx
@@ -25,6 +25,7 @@ import { HtmlTooltip } from "./UploadPhotometry";
 
 import * as Actions from "../ducks/spectra";
 import { fetchSource } from "../ducks/source";
+import { fetchUsers } from "../ducks/users";
 import { RESET_PARSED_SPECTRUM } from "../ducks/spectra";
 
 dayjs.extend(utc);
@@ -120,6 +121,7 @@ const UploadSpectrumForm = ({ route }) => {
   useEffect(() => {
     const blockingFunc = async () => {
       dispatch({ type: Actions.RESET_PARSED_SPECTRUM });
+      dispatch(fetchUsers());
       const result = await dispatch(fetchSource(route.id));
       const defaultFormData = {
         file: undefined,
@@ -142,7 +144,7 @@ const UploadSpectrumForm = ({ route }) => {
     !groups ||
     !instrumentList ||
     !telescopes ||
-    !users ||
+    users.length === 0 ||
     source.id !== route.id
   ) {
     return <p>Loading...</p>;

--- a/static/js/components/UploadSpectrum.jsx
+++ b/static/js/components/UploadSpectrum.jsx
@@ -105,6 +105,7 @@ SpectrumPreview.propTypes = {
 const UploadSpectrumForm = ({ route }) => {
   const { parsed } = useSelector((state) => state.spectra);
   const groups = useSelector((state) => state.groups.all);
+  const users = useSelector((state) => state.users.allUsers);
   const instrumentList = useSelector(
     (state) => state.instruments.instrumentList
   );
@@ -129,13 +130,21 @@ const UploadSpectrumForm = ({ route }) => {
         has_fluxerr: "No",
         instrument_id: undefined,
         fluxerr_column: undefined,
+        observed_by: undefined,
+        reduced_by: undefined,
       };
       setPersistentFormData(defaultFormData);
     };
     blockingFunc();
   }, [dispatch, route.id]);
 
-  if (!groups || !instrumentList || !telescopes || source.id !== route.id) {
+  if (
+    !groups ||
+    !instrumentList ||
+    !telescopes ||
+    !users ||
+    source.id !== route.id
+  ) {
     return <p>Loading...</p>;
   }
 
@@ -258,6 +267,30 @@ const UploadSpectrumForm = ({ route }) => {
         },
         uniqueItems: true,
       },
+      reduced_by: {
+        type: "array",
+        title: "Reducers",
+        items: {
+          type: "integer",
+          anyOf: users.map((user) => ({
+            enum: [user.id],
+            title: user.username,
+          })),
+        },
+        uniqueItems: true,
+      },
+      observed_by: {
+        type: "array",
+        title: "Observers",
+        items: {
+          type: "integer",
+          anyOf: users.map((user) => ({
+            enum: [user.id],
+            title: user.username,
+          })),
+        },
+        uniqueItems: true,
+      },
       mjd: {
         type: "number",
         title: "Observation MJD",
@@ -366,6 +399,8 @@ const UploadSpectrumForm = ({ route }) => {
         .utc()
         .format(),
       filename,
+      observed_by: persistentFormData.observed_by,
+      reduced_by: persistentFormData.reduced_by,
     };
     const result = await dispatch(Actions.uploadASCIISpectrum(payload));
     if (result.status === "success") {
@@ -380,6 +415,8 @@ const UploadSpectrumForm = ({ route }) => {
         has_fluxerr: "No",
         instrument_id: undefined,
         fluxerr_column: undefined,
+        observed_by: undefined,
+        reduced_by: undefined,
       });
       setFormKey(Date.now());
     }


### PR DESCRIPTION
cc @mansikasliwal

This PR introduces a dropdown to the upload spectrum page that keeps track of who reduced and observed a spectrum. The uploader can select any number of users on the website from the menu to populate each field. This will make it easier to track who should be cited when a spectrum is used in a paper. 