### PR TITLE
Fix test_delete_annotation

### DIFF
--- a/skyportal/tests/api/test_annotations.py
+++ b/skyportal/tests/api/test_annotations.py
@@ -1,3 +1,4 @@
+import uuid
 from skyportal.tests import api
 
 
@@ -251,12 +252,14 @@ def test_cannot_add_annotation_without_permission(view_only_token, public_source
 
 
 def test_delete_annotation(annotation_token, public_source):
+    origin = str(uuid.uuid4())
+
     status, data = api(
         'POST',
         'annotation',
         data={
             'obj_id': public_source.id,
-            'origin': 'kowalski',
+            'origin': origin,
             'data': {'offset_from_host_galaxy': 1.5},
         },
         token=annotation_token,
@@ -267,7 +270,7 @@ def test_delete_annotation(annotation_token, public_source):
     status, data = api('GET', f'annotation/{annotation_id}', token=annotation_token)
     assert status == 200
     assert data['data']['data'] == {'offset_from_host_galaxy': 1.5}
-    assert data['data']['origin'] == 'kowalski'
+    assert data['data']['origin'] == origin
 
     status, data = api('DELETE', f'annotation/{annotation_id}', token=annotation_token)
     assert status == 200


### PR DESCRIPTION
This PR fixes a transient failure in test_annotations.py::test_delete_annotation, which depends on the order the tests are run, as discovered by @stefanv:
![image](https://user-images.githubusercontent.com/7557205/97404298-1aa27880-18b3-11eb-8cd2-d8684d765a25.png)
