### PR TITLE
Update user ACLs and Roles via user management page

### DIFF
--- a/skyportal/app_server.py
+++ b/skyportal/app_server.py
@@ -32,6 +32,8 @@ from skyportal.handlers.api import (
     BulkDeletePhotometryHandler,
     ObjPhotometryHandler,
     PhotometryRangeHandler,
+    RoleHandler,
+    UserRoleHandler,
     SharingHandler,
     SourceHandler,
     SourceOffsetsHandler,
@@ -95,7 +97,6 @@ def make_app(cfg, baselayer_handlers, baselayer_settings):
 
     handlers = baselayer_handlers + [
         # API endpoints
-        (r'/api/acls(/[0-9]+)/users(/.*)?', UserACLHandler),
         (r'/api/acls', ACLHandler),
         (r'/api/allocation(/.*)?', AllocationHandler),
         (r'/api/assignment(/.*)?', AssignmentHandler),
@@ -126,6 +127,7 @@ def make_app(cfg, baselayer_handlers, baselayer_settings):
         (r'/api/sharing', SharingHandler),
         (r'/api/photometry/bulk_delete/(.*)', BulkDeletePhotometryHandler),
         (r'/api/photometry/range(/.*)?', PhotometryRangeHandler),
+        (r'/api/roles', RoleHandler),
         (r'/api/sources(/[0-9A-Za-z-_]+)/photometry', ObjPhotometryHandler),
         (r'/api/sources(/[0-9A-Za-z-_]+)/spectra', ObjSpectraHandler),
         (r'/api/sources(/[0-9A-Za-z-_]+)/offsets', SourceOffsetsHandler),
@@ -142,6 +144,8 @@ def make_app(cfg, baselayer_handlers, baselayer_settings):
         (r'/api/taxonomy(/.*)?', TaxonomyHandler),
         (r'/api/telescope(/[0-9]+)?', TelescopeHandler),
         (r'/api/thumbnail(/[0-9]+)?', ThumbnailHandler),
+        (r'/api/user(/[0-9]+)/acls(/.*)?', UserACLHandler),
+        (r'/api/user(/[0-9]+)/roles(/.*)?', UserRoleHandler),
         (r'/api/user(/.*)?', UserHandler),
         (r'/api/weather(/.*)?', WeatherHandler),
         (r'/api/internal/tokens(/.*)?', TokenHandler),

--- a/skyportal/app_server.py
+++ b/skyportal/app_server.py
@@ -6,6 +6,8 @@ from baselayer.log import make_log
 
 from skyportal.handlers import BecomeUserHandler, LogoutHandler
 from skyportal.handlers.api import (
+    ACLHandler,
+    UserACLHandler,
     AllocationHandler,
     AssignmentHandler,
     CandidateHandler,
@@ -93,6 +95,8 @@ def make_app(cfg, baselayer_handlers, baselayer_settings):
 
     handlers = baselayer_handlers + [
         # API endpoints
+        (r'/api/acls(/[0-9]+)/users(/.*)?', UserACLHandler),
+        (r'/api/acls', ACLHandler),
         (r'/api/allocation(/.*)?', AllocationHandler),
         (r'/api/assignment(/.*)?', AssignmentHandler),
         (r'/api/candidates(/.*)?', CandidateHandler),

--- a/skyportal/handlers/api/__init__.py
+++ b/skyportal/handlers/api/__init__.py
@@ -1,3 +1,4 @@
+from .acls import ACLHandler, UserACLHandler
 from .allocation import AllocationHandler
 from .candidate import CandidateHandler
 from .classification import ClassificationHandler

--- a/skyportal/handlers/api/__init__.py
+++ b/skyportal/handlers/api/__init__.py
@@ -25,6 +25,7 @@ from .photometry import (
     PhotometryRangeHandler,
 )
 from .public_group import PublicGroupHandler
+from .roles import RoleHandler, UserRoleHandler
 from .sharing import SharingHandler
 from .source import (
     SourceHandler,

--- a/skyportal/handlers/api/acls.py
+++ b/skyportal/handlers/api/acls.py
@@ -1,0 +1,115 @@
+from baselayer.app.access import auth_or_token, permissions
+
+from ..base import BaseHandler
+from ...models import DBSession, ACL, User, UserACL
+
+
+class ACLHandler(BaseHandler):
+    @auth_or_token
+    def get(self):
+        """
+        description: Retrieve list of all ACL IDs (strings)
+        responses:
+          200:
+            content:
+              application/json:
+                schema:
+                  allOf:
+                    - $ref: '#/components/schemas/Success'
+                    - type: object
+                      properties:
+                        data:
+                          type: array
+                          items:
+                            type: string
+                          description: List of all ACL IDs.
+        """
+        return self.success(data=ACL.query.all())
+
+
+class UserACLHandler(BaseHandler):
+    @permissions(["Manage users"])
+    def post(self, user_id, *ignored_args):
+        """
+        ---
+        description: Grant new ACL(s) to a user
+        parameters:
+          - in: path
+            name: user_id
+            required: true
+            schema:
+              type: integer
+        requestBody:
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  aclIds:
+                    type: array
+                    items:
+                      type: string
+                    description: Array of ACL IDs (strings) to be granted to user
+                required:
+                  - aclIds
+        responses:
+          200:
+            content:
+              application/json:
+                schema: Success
+        """
+        data = self.get_json()
+        new_acl_ids = data.get("aclIds")
+        if new_acl_ids is None:
+            return self.error("Missing required parameter aclIds")
+        if (not isinstance(new_acl_ids, (list, tuple))) or (
+            not all([ACL.query.get(acl_id) is not None for acl_id in new_acl_ids])
+        ):
+            return self.error(
+                "Improperly formatted parameter aclIds; " "must be an array of strings."
+            )
+        user = User.query.get(user_id)
+        if user is None:
+            return self.error("Invalid user_id parameter.")
+        new_acls = ACL.query.filter(ACL.id.in_(new_acl_ids)).all()
+        user.acls = list(set(user.acls).union(set(new_acls)))
+        DBSession().commit()
+        self.push_all(action="skyportal/FETCH_USERS")
+        return self.success()
+
+    @permissions(["Manage users"])
+    def delete(self, user_id, acl_id):
+        """
+        ---
+        description: Remove ACL from user permissions
+        parameters:
+          - in: path
+            name: user_id
+            required: true
+            schema:
+              type: integer
+          - in: path
+            name: acl_id
+            required: true
+            schema:
+              type: string
+        responses:
+          200:
+            content:
+              application/json:
+                schema: Success
+        """
+        user = User.query.get(user_id)
+        if user is None:
+            return self.error("Invalid user_id")
+        acl = ACL.query.get("acl_id")
+        if acl is None:
+            return self.error("Invalid acl_id")
+        (
+            UserACL.query.filter(UserACL.user_id == user_id)
+            .filter(UserACL.acl_id == acl_id)
+            .delete()
+        )
+        DBSession().commit()
+        self.push_all(action="skyportal/FETCH_USERS")
+        return self.success()

--- a/skyportal/handlers/api/acls.py
+++ b/skyportal/handlers/api/acls.py
@@ -66,7 +66,7 @@ class UserACLHandler(BaseHandler):
             not all([ACL.query.get(acl_id) is not None for acl_id in new_acl_ids])
         ):
             return self.error(
-                "Improperly formatted parameter aclIds; " "must be an array of strings."
+                "Improperly formatted parameter aclIds; must be an array of strings."
             )
         user = User.query.get(user_id)
         if user is None:

--- a/skyportal/handlers/api/acls.py
+++ b/skyportal/handlers/api/acls.py
@@ -24,7 +24,7 @@ class ACLHandler(BaseHandler):
                             type: string
                           description: List of all ACL IDs.
         """
-        return self.success(data=ACL.query.all())
+        return self.success(data=[acl.id for acl in ACL.query.all()])
 
 
 class UserACLHandler(BaseHandler):
@@ -74,7 +74,6 @@ class UserACLHandler(BaseHandler):
         new_acls = ACL.query.filter(ACL.id.in_(new_acl_ids)).all()
         user.acls = list(set(user.acls).union(set(new_acls)))
         DBSession().commit()
-        self.push_all(action="skyportal/FETCH_USERS")
         return self.success()
 
     @permissions(["Manage users"])
@@ -102,7 +101,7 @@ class UserACLHandler(BaseHandler):
         user = User.query.get(user_id)
         if user is None:
             return self.error("Invalid user_id")
-        acl = ACL.query.get("acl_id")
+        acl = ACL.query.get(acl_id)
         if acl is None:
             return self.error("Invalid acl_id")
         (
@@ -111,5 +110,4 @@ class UserACLHandler(BaseHandler):
             .delete()
         )
         DBSession().commit()
-        self.push_all(action="skyportal/FETCH_USERS")
         return self.success()

--- a/skyportal/handlers/api/roles.py
+++ b/skyportal/handlers/api/roles.py
@@ -21,10 +21,14 @@ class RoleHandler(BaseHandler):
                         data:
                           type: array
                           items:
-                            type: string
-                          description: List of all Role IDs.
+                            - $ref: '#/components/schemas/Role'
+                          description: List of all Roles.
         """
-        return self.success(data=[role.id for role in Role.query.all()])
+        roles = Role.query.all()
+        for i, role in enumerate(roles):
+            roles[i] = role.to_dict()
+            roles[i]['acls'] = [acl.id for acl in role.acls]
+        return self.success(data=roles)
 
 
 class UserRoleHandler(BaseHandler):

--- a/skyportal/handlers/api/roles.py
+++ b/skyportal/handlers/api/roles.py
@@ -1,0 +1,114 @@
+from baselayer.app.access import auth_or_token, permissions
+
+from ..base import BaseHandler
+from ...models import DBSession, Role, User, UserRole
+
+
+class RoleHandler(BaseHandler):
+    @auth_or_token
+    def get(self):
+        """
+        description: Retrieve list of all Role IDs (strings)
+        responses:
+          200:
+            content:
+              application/json:
+                schema:
+                  allOf:
+                    - $ref: '#/components/schemas/Success'
+                    - type: object
+                      properties:
+                        data:
+                          type: array
+                          items:
+                            type: string
+                          description: List of all Role IDs.
+        """
+        return self.success(data=[role.id for role in Role.query.all()])
+
+
+class UserRoleHandler(BaseHandler):
+    @permissions(["Manage users"])
+    def post(self, user_id, *ignored_args):
+        """
+        ---
+        description: Grant new Role(s) to a user
+        parameters:
+          - in: path
+            name: user_id
+            required: true
+            schema:
+              type: integer
+        requestBody:
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  roleIds:
+                    type: array
+                    items:
+                      type: string
+                    description: Array of Role IDs (strings) to be granted to user
+                required:
+                  - roleIds
+        responses:
+          200:
+            content:
+              application/json:
+                schema: Success
+        """
+        data = self.get_json()
+        new_role_ids = data.get("roleIds")
+        if new_role_ids is None:
+            return self.error("Missing required parameter roleIds")
+        if (not isinstance(new_role_ids, (list, tuple))) or (
+            not all([Role.query.get(role_id) is not None for role_id in new_role_ids])
+        ):
+            return self.error(
+                "Improperly formatted parameter roleIds; must be an array of strings."
+            )
+        user = User.query.get(user_id)
+        if user is None:
+            return self.error("Invalid user_id parameter.")
+        new_roles = Role.query.filter(Role.id.in_(new_role_ids)).all()
+        user.roles = list(set(user.roles).union(set(new_roles)))
+        DBSession().commit()
+        return self.success()
+
+    @permissions(["Manage users"])
+    def delete(self, user_id, role_id):
+        """
+        ---
+        description: Delete user role
+        parameters:
+          - in: path
+            name: user_id
+            required: true
+            schema:
+              type: integer
+          - in: path
+            name: role_id
+            required: true
+            schema:
+              type: string
+        responses:
+          200:
+            content:
+              application/json:
+                schema: Success
+        """
+        print(user_id, role_id)
+        user = User.query.get(user_id)
+        if user is None:
+            return self.error("Invalid user_id")
+        role = Role.query.get(role_id)
+        if role is None:
+            return self.error("Invalid role_id")
+        (
+            UserRole.query.filter(UserRole.user_id == user_id)
+            .filter(UserRole.role_id == role_id)
+            .delete()
+        )
+        DBSession().commit()
+        return self.success()

--- a/skyportal/handlers/api/roles.py
+++ b/skyportal/handlers/api/roles.py
@@ -98,7 +98,6 @@ class UserRoleHandler(BaseHandler):
               application/json:
                 schema: Success
         """
-        print(user_id, role_id)
         user = User.query.get(user_id)
         if user is None:
             return self.error("Invalid user_id")

--- a/skyportal/handlers/api/user.py
+++ b/skyportal/handlers/api/user.py
@@ -111,12 +111,17 @@ class UserHandler(BaseHandler):
                 user_info["contact_phone"] = user_info["contact_phone"].e164
 
             user_info["permissions"] = sorted(user.permissions)
+            user_info["roles"] = sorted([role.id for role in user.roles])
+            user_info["acls"] = sorted([acl.id for acl in user.acls])
             return self.success(data=user_info)
 
         return_values = []
         for user in User.query.all():
             return_values.append(user.to_dict())
+            del return_values[-1]["preferences"]
             return_values[-1]["permissions"] = sorted(user.permissions)
+            return_values[-1]["roles"] = sorted([role.id for role in user.roles])
+            return_values[-1]["acls"] = sorted([acl.id for acl in user.acls])
             if user.contact_phone:
                 return_values[-1]["contact_phone"] = user.contact_phone.e164
             return_values[-1]["contact_email"] = user.contact_email

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -43,6 +43,7 @@ from baselayer.app.models import (  # noqa
     User,
     Token,
     UserACL,
+    UserRole,
 )
 from baselayer.app.custom_exceptions import AccessError
 from baselayer.app.env import load_env

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -42,6 +42,7 @@ from baselayer.app.models import (  # noqa
     Role,
     User,
     Token,
+    UserACL,
 )
 from baselayer.app.custom_exceptions import AccessError
 from baselayer.app.env import load_env

--- a/skyportal/tests/frontend/test_user_management.py
+++ b/skyportal/tests/frontend/test_user_management.py
@@ -1,6 +1,48 @@
 import pytest
 
 
+def test_delete_user_role(driver, super_admin_user, user):
+    driver.get(f'/become_user/{super_admin_user.id}')
+    driver.get('/user_management')
+    driver.click_xpath(
+        f"//div[@id='deleteUserRoleButton_{user.id}_Full user']//*[contains(@class, 'MuiChip-deleteIcon')]"
+    )
+    driver.wait_for_xpath(f"//div[text()='User role successfully removed.']")
+    driver.wait_for_xpath_to_disappear(
+        f"//div[@id='deleteUserRoleButton_{user.id}_Full user']//*[contains(@class, 'MuiChip-deleteIcon')]"
+    )
+
+
+def test_grant_and_delete_user_acl(driver, super_admin_user, user):
+    driver.get(f'/become_user/{super_admin_user.id}')
+    driver.get('/user_management')
+    driver.click_xpath(f'//*[@data-testid="addUserACLsButton{user.id}"]')
+    driver.click_xpath('//*[@id="addUserACLsSelect"]')
+    driver.click_xpath('//li[text()="Annotate"]')
+    driver.click_xpath('//*[text()="Submit"]')
+    driver.wait_for_xpath('//*[text()="User successfully granted specified ACL(s)."]')
+    driver.click_xpath(
+        f"//div[@id='deleteUserACLButton_{user.id}_Annotate']//*[contains(@class, 'MuiChip-deleteIcon')]"
+    )
+    driver.wait_for_xpath(f"//div[text()='User ACL successfully removed.']")
+    driver.wait_for_xpath_to_disappear(
+        f"//div[@id='deleteUserACLButton_{user.id}_Annotate']//*[contains(@class, 'MuiChip-deleteIcon')]"
+    )
+
+
+def test_add_user_role(driver, super_admin_user, user):
+    driver.get(f'/become_user/{super_admin_user.id}')
+    driver.get('/user_management')
+    driver.click_xpath(f'//*[@data-testid="addUserRolesButton{user.id}"]')
+    driver.click_xpath('//*[@id="addUserRolesSelect"]')
+    driver.click_xpath('//li[text()="Group admin"]')
+    driver.click_xpath('//*[text()="Submit"]')
+    driver.wait_for_xpath('//*[text()="User successfully granted specified role(s)."]')
+    driver.wait_for_xpath(
+        f"//div[@id='deleteUserRoleButton_{user.id}_Group admin']//*[contains(@class, 'MuiChip-deleteIcon')]"
+    )
+
+
 def test_delete_group_user(driver, super_admin_user, user, public_group):
     driver.get(f'/become_user/{super_admin_user.id}')
     driver.get('/user_management')

--- a/static/js/components/UserManagement.jsx
+++ b/static/js/components/UserManagement.jsx
@@ -16,10 +16,13 @@ import Autocomplete from "@material-ui/lab/Autocomplete";
 import Button from "@material-ui/core/Button";
 import TextField from "@material-ui/core/TextField";
 import AddCircleIcon from "@material-ui/icons/AddCircle";
+import HelpIcon from "@material-ui/icons/Help";
 import IconButton from "@material-ui/core/IconButton";
 import Dialog from "@material-ui/core/Dialog";
 import DialogContent from "@material-ui/core/DialogContent";
 import DialogTitle from "@material-ui/core/DialogTitle";
+import Tooltip from "@material-ui/core/Tooltip";
+import { makeStyles } from "@material-ui/core/styles";
 import PapaParse from "papaparse";
 import { useForm, Controller } from "react-hook-form";
 
@@ -33,10 +36,20 @@ import * as inviteUsersActions from "../ducks/inviteUsers";
 import * as aclsActions from "../ducks/acls";
 import * as rolesActions from "../ducks/roles";
 
+const useStyles = makeStyles(() => ({
+  icon: {
+    height: "1rem",
+  },
+  headerCell: {
+    verticalAlign: "bottom",
+  },
+}));
+
 const sampleCSVText = `example1@gmail.com,1,3,false
 example2@gmail.com,1 2 3,2 5 9,false false true`;
 
 const UserManagement = () => {
+  const classes = useStyles();
   const dispatch = useDispatch();
   const { invitationsEnabled } = useSelector((state) => state.sysInfo);
   const currentUser = useSelector((state) => state.profile);
@@ -180,7 +193,7 @@ const UserManagement = () => {
     const result = await dispatch(
       rolesActions.addUserRoles({
         userID: clickedUser.id,
-        roleIds: formData.roles,
+        roleIds: formData.roles.map((role) => role.id),
       })
     );
     if (result.status === "success") {
@@ -272,8 +285,51 @@ const UserManagement = () => {
               <TableCell align="center">Name</TableCell>
               <TableCell align="center">Username</TableCell>
               <TableCell align="center">Email</TableCell>
-              <TableCell align="center">Roles</TableCell>
-              <TableCell align="center">Additional ACLs</TableCell>
+              <TableCell align="center" className={classes.headerCell}>
+                Roles&nbsp;
+                <Tooltip
+                  interactive
+                  title={
+                    <>
+                      <b>Each role is associated with the following ACLs:</b>
+                      <ul>
+                        {roles.map((role) => (
+                          <li key={role.id}>
+                            {role.id}: {role.acls.join(", ")}
+                          </li>
+                        ))}
+                      </ul>
+                    </>
+                  }
+                >
+                  <HelpIcon
+                    color="disabled"
+                    size="small"
+                    className={classes.icon}
+                  />
+                </Tooltip>
+              </TableCell>
+              <TableCell align="center" className={classes.headerCell}>
+                Additional ACLs&nbsp;
+                <Tooltip
+                  interactive
+                  title={
+                    <>
+                      <p>
+                        These are in addition to those ACLs associated with user
+                        role(s). See help icon tooltip in roles column header
+                        for those ACLs.
+                      </p>
+                    </>
+                  }
+                >
+                  <HelpIcon
+                    color="disabled"
+                    size="small"
+                    className={classes.icon}
+                  />
+                </Tooltip>
+              </TableCell>
               <TableCell align="center">Groups</TableCell>
               <TableCell align="center">Streams</TableCell>
             </TableRow>
@@ -617,10 +673,10 @@ const UserManagement = () => {
               as={
                 <Autocomplete
                   multiple
-                  options={roles.filter(
-                    (role) => !clickedUser?.roles?.includes(role)
+                  options={roles?.filter(
+                    (role) => !clickedUser?.roles?.includes(role.id)
                   )}
-                  getOptionLabel={(role) => role}
+                  getOptionLabel={(role) => role.id}
                   filterSelectedOptions
                   data-testid="addUserRolesSelect"
                   renderInput={(params) => (

--- a/static/js/components/UserManagement.jsx
+++ b/static/js/components/UserManagement.jsx
@@ -30,6 +30,8 @@ import * as groupsActions from "../ducks/groups";
 import * as usersActions from "../ducks/users";
 import * as streamsActions from "../ducks/streams";
 import * as inviteUsersActions from "../ducks/inviteUsers";
+import * as aclsActions from "../ducks/acls";
+import * as rolesActions from "../ducks/roles";
 
 const sampleCSVText = `example1@gmail.com,1,3,false
 example2@gmail.com,1 2 3,2 5 9,false false true`;
@@ -41,39 +43,40 @@ const UserManagement = () => {
   const { allUsers } = useSelector((state) => state.users);
   const streams = useSelector((state) => state.streams);
   let { all: allGroups } = useSelector((state) => state.groups);
+  const acls = useSelector((state) => state.acls);
+  const roles = useSelector((state) => state.roles);
   const [csvData, setCsvData] = useState("");
   const [addUserGroupsDialogOpen, setAddUserGroupsDialogOpen] = useState(false);
+  const [addUserRolesDialogOpen, setAddUserRolesDialogOpen] = useState(false);
+  const [addUserACLsDialogOpen, setAddUserACLsDialogOpen] = useState(false);
   const [addUserStreamsDialogOpen, setAddUserStreamsDialogOpen] = useState(
     false
   );
-  const [addGroupsFormUsername, setAddGroupsFormUsername] = useState("");
-  const [addStreamsFormUserID, setAddStreamsFormUserID] = useState(null);
+  const [clickedUser, setClickedUser] = useState(null);
+  const [dataFetched, setDataFetched] = useState(false);
 
   const { handleSubmit, errors, reset, control, getValues } = useForm();
 
   useEffect(() => {
-    const fetchUsers = () => {
+    const fetchData = () => {
       dispatch(usersActions.fetchUsers());
-    };
-    if (!allUsers?.length) {
-      fetchUsers();
-    }
-  }, [allUsers, dispatch]);
-
-  useEffect(() => {
-    const fetchStreams = () => {
       dispatch(streamsActions.fetchStreams());
+      dispatch(aclsActions.fetchACLs());
+      dispatch(rolesActions.fetchRoles());
     };
-    if (!streams?.length) {
-      fetchStreams();
+    if (!dataFetched) {
+      fetchData();
+      setDataFetched(true);
     }
-  }, [streams, dispatch]);
+  }, [dataFetched, dispatch]);
 
   if (
     !allUsers?.length ||
     !currentUser?.username?.length ||
     !allGroups?.length ||
-    !streams?.length
+    !streams?.length ||
+    !acls?.length ||
+    !roles?.length
   ) {
     return (
       <div>
@@ -102,12 +105,22 @@ const UserManagement = () => {
     return formState.streams.length >= 1;
   };
 
+  const validateACLs = () => {
+    const formState = getValues({ nest: true });
+    return formState.acls.length >= 1;
+  };
+
+  const validateRoles = () => {
+    const formState = getValues({ nest: true });
+    return formState.roles.length >= 1;
+  };
+
   const handleAddUserToGroups = async (formData) => {
     const groupIDs = formData.groups.map((g) => g.id);
     const promises = groupIDs.map((gid) =>
       dispatch(
         groupsActions.addGroupUser({
-          username: addGroupsFormUsername,
+          username: clickedUser.username,
           admin: false,
           group_id: gid,
         })
@@ -121,7 +134,7 @@ const UserManagement = () => {
       reset({ groups: [] });
       setAddUserGroupsDialogOpen(false);
       dispatch(usersActions.fetchUsers());
-      setAddGroupsFormUsername("");
+      setClickedUser(null);
     }
   };
 
@@ -130,7 +143,7 @@ const UserManagement = () => {
     const promises = streamIDs.map((sid) =>
       dispatch(
         streamsActions.addStreamUser({
-          user_id: addStreamsFormUserID,
+          user_id: clickedUser.id,
           stream_id: sid,
         })
       )
@@ -143,7 +156,41 @@ const UserManagement = () => {
       reset({ streams: [] });
       setAddUserStreamsDialogOpen(false);
       dispatch(usersActions.fetchUsers());
-      setAddStreamsFormUserID(null);
+      setClickedUser(null);
+    }
+  };
+
+  const handleAddUserACLs = async (formData) => {
+    const result = await dispatch(
+      aclsActions.addUserACLs({
+        userID: clickedUser.id,
+        aclIds: formData.acls,
+      })
+    );
+    if (result.status === "success") {
+      dispatch(showNotification("User successfully granted specified ACL(s)."));
+      reset({ acls: [] });
+      setAddUserACLsDialogOpen(false);
+      dispatch(usersActions.fetchUsers());
+      setClickedUser(null);
+    }
+  };
+
+  const handleAddUserRoles = async (formData) => {
+    const result = await dispatch(
+      rolesActions.addUserRoles({
+        userID: clickedUser.id,
+        roleIds: formData.roles,
+      })
+    );
+    if (result.status === "success") {
+      dispatch(
+        showNotification("User successfully granted specified role(s).")
+      );
+      reset({ roles: [] });
+      setAddUserRolesDialogOpen(false);
+      dispatch(usersActions.fetchUsers());
+      setClickedUser(null);
     }
   };
 
@@ -165,6 +212,24 @@ const UserManagement = () => {
     );
     if (result.status === "success") {
       dispatch(showNotification("Stream access successfully revoked."));
+      dispatch(usersActions.fetchUsers());
+    }
+  };
+
+  const handleClickDeleteUserACL = async (userID, acl) => {
+    const result = await dispatch(aclsActions.deleteUserACL({ userID, acl }));
+    if (result.status === "success") {
+      dispatch(showNotification("User ACL successfully removed."));
+      dispatch(usersActions.fetchUsers());
+    }
+  };
+
+  const handleClickDeleteUserRole = async (userID, role) => {
+    const result = await dispatch(
+      rolesActions.deleteUserRole({ userID, role })
+    );
+    if (result.status === "success") {
+      dispatch(showNotification("User role successfully removed."));
       dispatch(usersActions.fetchUsers());
     }
   };
@@ -204,11 +269,13 @@ const UserManagement = () => {
         <Table>
           <TableHead>
             <TableRow>
-              <TableCell>Name</TableCell>
-              <TableCell>Username</TableCell>
-              <TableCell>Email</TableCell>
-              <TableCell>Groups</TableCell>
-              <TableCell>Streams</TableCell>
+              <TableCell align="center">Name</TableCell>
+              <TableCell align="center">Username</TableCell>
+              <TableCell align="center">Email</TableCell>
+              <TableCell align="center">Roles</TableCell>
+              <TableCell align="center">Additional ACLs</TableCell>
+              <TableCell align="center">Groups</TableCell>
+              <TableCell align="center">Streams</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
@@ -223,10 +290,56 @@ const UserManagement = () => {
                 <TableCell>{user.contact_email}</TableCell>
                 <TableCell>
                   <IconButton
+                    aria-label="add-role"
+                    data-testid={`addUserRolesButton${user.id}`}
+                    onClick={() => {
+                      setClickedUser(user);
+                      setAddUserRolesDialogOpen(true);
+                    }}
+                    size="small"
+                  >
+                    <AddCircleIcon color="disabled" />
+                  </IconButton>
+                  {user.roles.map((role) => (
+                    <Chip
+                      label={role}
+                      onDelete={() => {
+                        handleClickDeleteUserRole(user.id, role);
+                      }}
+                      key={role}
+                      id={`deleteUserRoleButton_${user.id}_${role}`}
+                    />
+                  ))}
+                </TableCell>
+                <TableCell>
+                  <IconButton
+                    aria-label="add-acl"
+                    data-testid={`addUserACLsButton${user.id}`}
+                    onClick={() => {
+                      setClickedUser(user);
+                      setAddUserACLsDialogOpen(true);
+                    }}
+                    size="small"
+                  >
+                    <AddCircleIcon color="disabled" />
+                  </IconButton>
+                  {user.acls.map((acl) => (
+                    <Chip
+                      label={acl}
+                      onDelete={() => {
+                        handleClickDeleteUserACL(user.id, acl);
+                      }}
+                      key={acl}
+                      id={`deleteUserACLButton_${user.id}_${acl}`}
+                    />
+                  ))}
+                </TableCell>
+                <TableCell>
+                  <IconButton
                     aria-label="add-group"
                     data-testid={`addUserGroupsButton${user.id}`}
                     onClick={() => {
-                      setAddGroupsFormUsername(user.username);
+                      setClickedUser(user);
                       setAddUserGroupsDialogOpen(true);
                     }}
                     size="small"
@@ -254,7 +367,7 @@ const UserManagement = () => {
                     aria-label="add-stream"
                     data-testid={`addUserStreamsButton${user.id}`}
                     onClick={() => {
-                      setAddStreamsFormUserID(user.id);
+                      setClickedUser(user);
                       setAddUserStreamsDialogOpen(true);
                     }}
                     size="small"
@@ -314,7 +427,7 @@ const UserManagement = () => {
         }}
         style={{ position: "fixed" }}
       >
-        <DialogTitle>{`Add user ${addGroupsFormUsername} to selected groups:`}</DialogTitle>
+        <DialogTitle>{`Add user ${clickedUser?.username} to selected groups:`}</DialogTitle>
         <DialogContent>
           <form onSubmit={handleSubmit(handleAddUserToGroups)}>
             {!!errors.groups && (
@@ -328,10 +441,7 @@ const UserManagement = () => {
                   multiple
                   options={allGroups.filter(
                     (g) =>
-                      !allUsers
-                        .filter((u) => u.username === addGroupsFormUsername)[0]
-                        ?.groups?.map((gr) => gr.id)
-                        ?.includes(g.id)
+                      !clickedUser?.groups?.map((gr) => gr.id)?.includes(g.id)
                   )}
                   getOptionLabel={(group) => group.name}
                   filterSelectedOptions
@@ -375,9 +485,7 @@ const UserManagement = () => {
         style={{ position: "fixed" }}
       >
         <DialogTitle>
-          {`Grant user ${
-            allUsers.filter((u) => u.id === addStreamsFormUserID)[0]?.username
-          } access to selected streams:`}
+          {`Grant user ${clickedUser?.username} access to selected streams:`}
         </DialogTitle>
         <DialogContent>
           <form onSubmit={handleSubmit(handleAddUserToStreams)}>
@@ -392,9 +500,8 @@ const UserManagement = () => {
                   multiple
                   options={streams.filter(
                     (s) =>
-                      !allUsers
-                        .filter((u) => u.id === addStreamsFormUserID)[0]
-                        ?.streams?.map((strm) => strm.id)
+                      !clickedUser?.streams
+                        ?.map((strm) => strm.id)
                         ?.includes(s.id)
                   )}
                   getOptionLabel={(stream) => stream.name}
@@ -424,6 +531,122 @@ const UserManagement = () => {
                 type="submit"
                 name="submitAddStreamsButton"
                 data-testid="submitAddStreamsButton"
+              >
+                Submit
+              </Button>
+            </div>
+          </form>
+        </DialogContent>
+      </Dialog>
+      <Dialog
+        open={addUserACLsDialogOpen}
+        onClose={() => {
+          setAddUserACLsDialogOpen(false);
+        }}
+        style={{ position: "fixed" }}
+      >
+        <DialogTitle>
+          {`Grant user ${clickedUser?.username} selected ACLs:`}
+        </DialogTitle>
+        <DialogContent>
+          <form onSubmit={handleSubmit(handleAddUserACLs)}>
+            {!!errors.acls && (
+              <FormValidationError message="Please select at least one ACL" />
+            )}
+            <Controller
+              name="acls"
+              id="addUserACLsSelect"
+              as={
+                <Autocomplete
+                  multiple
+                  options={acls.filter(
+                    (acl) => !clickedUser?.permissions?.includes(acl)
+                  )}
+                  getOptionLabel={(acl) => acl}
+                  filterSelectedOptions
+                  data-testid="addUserACLsSelect"
+                  renderInput={(params) => (
+                    <TextField
+                      // eslint-disable-next-line react/jsx-props-no-spreading
+                      {...params}
+                      error={!!errors.acls}
+                      variant="outlined"
+                      label="Select ACLs"
+                      data-testid="addUserACLsTextField"
+                    />
+                  )}
+                />
+              }
+              control={control}
+              onChange={([, data]) => data}
+              rules={{ validate: validateACLs }}
+              defaultValue={[]}
+            />
+            <br />
+            <div>
+              <Button
+                variant="contained"
+                type="submit"
+                name="submitAddACLsButton"
+                data-testid="submitAddACLsButton"
+              >
+                Submit
+              </Button>
+            </div>
+          </form>
+        </DialogContent>
+      </Dialog>
+      <Dialog
+        open={addUserRolesDialogOpen}
+        onClose={() => {
+          setAddUserRolesDialogOpen(false);
+        }}
+        style={{ position: "fixed" }}
+      >
+        <DialogTitle>
+          {`Grant user ${clickedUser?.username} selected roles:`}
+        </DialogTitle>
+        <DialogContent>
+          <form onSubmit={handleSubmit(handleAddUserRoles)}>
+            {!!errors.roles && (
+              <FormValidationError message="Please select at least one role" />
+            )}
+            <Controller
+              name="roles"
+              id="addUserRolesSelect"
+              as={
+                <Autocomplete
+                  multiple
+                  options={roles.filter(
+                    (role) => !clickedUser?.roles?.includes(role)
+                  )}
+                  getOptionLabel={(role) => role}
+                  filterSelectedOptions
+                  data-testid="addUserRolesSelect"
+                  renderInput={(params) => (
+                    <TextField
+                      // eslint-disable-next-line react/jsx-props-no-spreading
+                      {...params}
+                      error={!!errors.roles}
+                      variant="outlined"
+                      label="Select Roles"
+                      data-testid="addUserRolesTextField"
+                    />
+                  )}
+                />
+              }
+              control={control}
+              onChange={([, data]) => data}
+              rules={{ validate: validateRoles }}
+              defaultValue={[]}
+            />
+            <br />
+            <div>
+              <Button
+                variant="contained"
+                type="submit"
+                name="submitAddRolesButton"
+                data-testid="submitAddRolesButton"
               >
                 Submit
               </Button>

--- a/static/js/ducks/acls.js
+++ b/static/js/ducks/acls.js
@@ -1,0 +1,29 @@
+import * as API from "../API";
+import store from "../store";
+
+export const FETCH_ACLS = "skyportal/FETCH_ACLS";
+export const FETCH_ACLS_OK = "skyportal/FETCH_ACLS_OK";
+
+export const ADD_USER_ACLS = "skyportal/ADD_USER_ACLS";
+
+export const DELETE_USER_ACL = "skyportal/DELETE_USER_ACL";
+
+export const fetchACLs = () => API.GET("/api/acls", FETCH_ACLS);
+
+export const addUserACLs = ({ userID, aclIds }) =>
+  API.POST(`/api/user/${userID}/acls`, ADD_USER_ACLS, { aclIds });
+
+export const deleteUserACL = ({ userID, acl }) =>
+  API.DELETE(`/api/user/${userID}/acls/${acl}`, DELETE_USER_ACL);
+
+function reducer(state = null, action) {
+  switch (action.type) {
+    case FETCH_ACLS_OK: {
+      return action.data;
+    }
+    default:
+      return state;
+  }
+}
+
+store.injectReducer("acls", reducer);

--- a/static/js/ducks/roles.js
+++ b/static/js/ducks/roles.js
@@ -1,0 +1,29 @@
+import * as API from "../API";
+import store from "../store";
+
+export const FETCH_ROLES = "skyportal/FETCH_ROLES";
+export const FETCH_ROLES_OK = "skyportal/FETCH_ROLES_OK";
+
+export const ADD_USER_ROLES = "skyportal/ADD_USER_ROLES";
+
+export const DELETE_USER_ROLE = "skyportal/DELETE_USER_ROLE";
+
+export const fetchRoles = () => API.GET("/api/roles", FETCH_ROLES);
+
+export const addUserRoles = ({ userID, roleIds }) =>
+  API.POST(`/api/user/${userID}/roles`, ADD_USER_ROLES, { roleIds });
+
+export const deleteUserRole = ({ userID, role }) =>
+  API.DELETE(`/api/user/${userID}/roles/${role}`, DELETE_USER_ROLE);
+
+function reducer(state = null, action) {
+  switch (action.type) {
+    case FETCH_ROLES_OK: {
+      return action.data;
+    }
+    default:
+      return state;
+  }
+}
+
+store.injectReducer("roles", reducer);


### PR DESCRIPTION
This PR expands the user management page by adding functionality for editing user roles and ACLs.

ACLs/roles handlers and associated endpoints are added.

Partially addresses https://github.com/skyportal/skyportal/issues/914

![edit_user_roles_acls](https://user-images.githubusercontent.com/7230285/97624626-99e39980-19e4-11eb-84bf-d0dde6b29e08.gif)
