### PR TITLE
merge migrations 886b65_and_f94174

### DIFF
--- a/alembic/versions/99822318096d_merge_886b65_and_f94174.py
+++ b/alembic/versions/99822318096d_merge_886b65_and_f94174.py
@@ -1,0 +1,21 @@
+"""merge 886b65 and  f94174
+
+Revision ID: 99822318096d
+Revises: f94174183e7e, 886b65e82e3e
+Create Date: 2020-10-29 15:54:09.623122
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '99822318096d'
+down_revision = ('f94174183e7e', '886b65e82e3e')
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
This merges the two migrations that currently revise the same migration on master, going from 

```
(skyportal2) Dannys-MBP:skyportal danny$ alembic history
d0195eb7ecd0 -> 886b65e82e3e (head), Add user_acls join table
d0195eb7ecd0 -> f94174183e7e (head), add spectrumreducers and spectrumobservers
93d1e086aafb -> d0195eb7ecd0 (branchpoint), migration script for 1135
<base> -> 93d1e086aafb, Initial schema checkpoint
```

to

```
(skyportal2) Dannys-MBP:skyportal danny$ alembic history
f94174183e7e, 886b65e82e3e -> 99822318096d (head) (mergepoint), merge 886b65 and  f94174
d0195eb7ecd0 -> f94174183e7e, add spectrumreducers and spectrumobservers
d0195eb7ecd0 -> 886b65e82e3e, Add user_acls join table
93d1e086aafb -> d0195eb7ecd0 (branchpoint), migration script for 1135
<base> -> 93d1e086aafb, Initial schema checkpoint
```