### PR TITLE
Scanning page filtering updates

### DIFF
--- a/alembic/versions/1300e24dcfe9_scanning_page_filtering_updates.py
+++ b/alembic/versions/1300e24dcfe9_scanning_page_filtering_updates.py
@@ -1,0 +1,53 @@
+"""scanning page filtering updates
+
+Revision ID: 1300e24dcfe9
+Revises: e1141138d4c6
+Create Date: 2020-10-29 18:45:35.520499
+
+"""
+from alembic import op
+from sqlalchemy.dialects import postgresql
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '1300e24dcfe9'
+down_revision = 'e1141138d4c6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+
+    # Data migration: takes a few steps...
+    # Declare ORM table views. Note that the view contains old and new columns!
+    candidates = sa.Table(
+        'candidates',
+        sa.MetaData(),
+        sa.Column('id', sa.Integer()),
+        sa.Column('passed_at', postgresql.TIMESTAMP()),  # column to be updated
+        sa.Column(
+            'created_at', postgresql.TIMESTAMP()
+        ),  # column with the imputation values
+    )
+    connection = op.get_bind()
+
+    # set candidates with a null passed at to be created_at
+    connection.execute(
+        candidates.update()
+        .where(candidates.c.passed_at.is_(None))
+        .values(passed_at=candidates.c.created_at)
+    )
+
+    op.alter_column(
+        'candidates', 'passed_at', existing_type=postgresql.TIMESTAMP(), nullable=False
+    )
+    op.create_index(
+        op.f('ix_candidates_passed_at'), 'candidates', ['passed_at'], unique=False
+    )
+
+
+def downgrade():
+    op.drop_index(op.f('ix_candidates_passed_at'), table_name='candidates')
+    op.alter_column(
+        'candidates', 'passed_at', existing_type=postgresql.TIMESTAMP(), nullable=True
+    )

--- a/data/db_demo.yaml
+++ b/data/db_demo.yaml
@@ -167,6 +167,7 @@ candidates:
     altdata:
       simbad:
         class: RRLyr
+    passed_at: "2020-10-30 21:17:06.475748"
   - id: 14gqr
     filter_ids:
       - =example_filter
@@ -177,7 +178,7 @@ candidates:
     altdata:
       simbad:
         class: RRLyr
-
+    passed_at: "2020-10-30 21:18:06.475748"
   - id: 16fil_unsaved_copy
     filter_ids:
       - =example_filter
@@ -187,6 +188,7 @@ candidates:
     altdata:
       simbad:
         class: RRLyr
+    passed_at: "2020-10-30 21:19:06.475748"
   - id: 16fil
     filter_ids:
       - =example_filter
@@ -196,6 +198,7 @@ candidates:
     altdata:
       simbad:
         class: RRLyr
+    passed_at: "2020-10-30 21:13:06.475748"
 
 sources:
   - id: 14gqr

--- a/skyportal/handlers/api/candidate.py
+++ b/skyportal/handlers/api/candidate.py
@@ -135,7 +135,7 @@ class CandidateHandler(BaseHandler):
               type: string
             description: |
               Arrow-parseable date string (e.g. 2020-01-01). If provided, filter by
-              last_detected >= startDate
+              Candidate.passed_at >= startDate
           - in: query
             name: endDate
             nullable: true
@@ -143,7 +143,7 @@ class CandidateHandler(BaseHandler):
               type: string
             description: |
               Arrow-parseable date string (e.g. 2020-01-01). If provided, filter by
-              last_detected <= endDate
+              Candidate.passed_at <= endDate
           - in: query
             name: groupIDs
             nullable: true
@@ -383,14 +383,18 @@ class CandidateHandler(BaseHandler):
             return self.error("Invalid numPerPage value.")
 
         # We'll join in the nested data for Obj (like photometry) later
-        q = Obj.query.filter(
-            Obj.id.in_(
-                DBSession()
-                .query(Candidate.obj_id)
-                .filter(Candidate.filter_id.in_(filter_ids))
+        q = (
+            DBSession()
+            .query(Obj)
+            .join(Candidate)
+            .filter(
+                Obj.id.in_(
+                    DBSession()
+                    .query(Candidate.obj_id)
+                    .filter(Candidate.filter_id.in_(filter_ids))
+                )
             )
-        ).outerjoin(
-            Annotation
+            .outerjoin(Annotation)
         )  # Join in annotations info for sort/filter
         if sort_by_origin is None:
             # Don't apply the order by just yet. Save it so we can pass it to
@@ -411,10 +415,10 @@ class CandidateHandler(BaseHandler):
             "undefined",
         ]:
             start_date = arrow.get(start_date).datetime
-            q = q.filter(Obj.last_detected >= start_date)
+            q = q.filter(Candidate.passed_at >= start_date)
         if end_date is not None and end_date.strip() not in ["", "null", "undefined"]:
             end_date = arrow.get(end_date).datetime
-            q = q.filter(Obj.last_detected <= end_date)
+            q = q.filter(Candidate.passed_at <= end_date)
         if annotation_filter_list is not None:
             # Parse annotation filter list objects from the query string
             # and apply the filters to the query
@@ -639,7 +643,9 @@ class CandidateHandler(BaseHandler):
 
         passing_alert_id = data.pop("passing_alert_id", None)
         passed_at = data.pop("passed_at", None)
-        if passed_at is not None:
+        if passed_at is None:
+            passed_at = datetime.datetime.utcnow()
+        else:
             passed_at = arrow.get(passed_at).datetime
         try:
             filter_ids = data.pop("filter_ids")

--- a/skyportal/handlers/api/candidate.py
+++ b/skyportal/handlers/api/candidate.py
@@ -612,6 +612,7 @@ class CandidateHandler(BaseHandler):
                         nullable: true
                     required:
                       - filter_ids
+                      - passed_at
         responses:
           200:
             content:
@@ -644,9 +645,8 @@ class CandidateHandler(BaseHandler):
         passing_alert_id = data.pop("passing_alert_id", None)
         passed_at = data.pop("passed_at", None)
         if passed_at is None:
-            passed_at = datetime.datetime.utcnow()
-        else:
-            passed_at = arrow.get(passed_at).datetime
+            return self.error("Missing required parameter: `passed_at`.")
+        passed_at = arrow.get(passed_at).datetime
         try:
             filter_ids = data.pop("filter_ids")
         except KeyError:

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -717,7 +717,8 @@ Candidate.__doc__ = (
 )
 Candidate.passed_at = sa.Column(
     sa.DateTime,
-    nullable=True,
+    nullable=False,
+    index=True,
     doc="ISO UTC time when the Candidate passed the Filter last time.",
 )
 

--- a/skyportal/tests/api/test_candidates.py
+++ b/skyportal/tests/api/test_candidates.py
@@ -104,6 +104,7 @@ def test_token_user_post_new_candidate(
             "transient": False,
             "ra_dis": 2.3,
             "filter_ids": [public_filter.id],
+            "passed_at": datetime.datetime.utcnow(),
         },
         token=upload_data_token,
     )
@@ -128,6 +129,7 @@ def test_cannot_add_candidate_without_filter_id(upload_data_token):
             "redshift": 3,
             "transient": False,
             "ra_dis": 2.3,
+            "passed_at": datetime.datetime.utcnow(),
         },
         token=upload_data_token,
     )

--- a/skyportal/tests/api/test_candidates.py
+++ b/skyportal/tests/api/test_candidates.py
@@ -104,7 +104,7 @@ def test_token_user_post_new_candidate(
             "transient": False,
             "ra_dis": 2.3,
             "filter_ids": [public_filter.id],
-            "passed_at": datetime.datetime.utcnow(),
+            "passed_at": str(datetime.datetime.utcnow()),
         },
         token=upload_data_token,
     )
@@ -129,7 +129,7 @@ def test_cannot_add_candidate_without_filter_id(upload_data_token):
             "redshift": 3,
             "transient": False,
             "ra_dis": 2.3,
-            "passed_at": datetime.datetime.utcnow(),
+            "passed_at": str(datetime.datetime.utcnow()),
         },
         token=upload_data_token,
     )

--- a/skyportal/tests/conftest.py
+++ b/skyportal/tests/conftest.py
@@ -181,7 +181,7 @@ def public_source_group2(public_group2):
 @pytest.fixture()
 def public_candidate(public_filter):
     obj = ObjFactory(groups=[public_filter.group])
-    DBSession.add(Candidate(obj=obj, filter=public_filter))
+    DBSession.add(Candidate(obj=obj, filter=public_filter, passed_at=datetime.utcnow()))
     DBSession.commit()
     return obj
 
@@ -191,8 +191,10 @@ def public_candidate_two_groups(
     public_filter, public_filter2, public_group, public_group2
 ):
     obj = ObjFactory(groups=[public_group, public_group2])
-    DBSession.add(Candidate(obj=obj, filter=public_filter))
-    DBSession.add(Candidate(obj=obj, filter=public_filter2))
+    DBSession.add(Candidate(obj=obj, filter=public_filter, passed_at=datetime.utcnow()))
+    DBSession.add(
+        Candidate(obj=obj, filter=public_filter2, passed_at=datetime.utcnow())
+    )
     DBSession.commit()
     return obj
 
@@ -200,7 +202,7 @@ def public_candidate_two_groups(
 @pytest.fixture()
 def public_candidate2(public_filter):
     obj = ObjFactory(groups=[public_filter.group])
-    DBSession.add(Candidate(obj=obj, filter=public_filter))
+    DBSession.add(Candidate(obj=obj, filter=public_filter, passed_at=datetime.utcnow()))
     DBSession.commit()
     return obj
 

--- a/skyportal/tests/frontend/test_scanning_page.py
+++ b/skyportal/tests/frontend/test_scanning_page.py
@@ -1,4 +1,5 @@
 import uuid
+import datetime
 import pytest
 from selenium.common.exceptions import TimeoutException
 
@@ -28,6 +29,7 @@ def test_candidate_group_filtering(
                 "altdata": {"simbad": {"class": "RRLyr"}},
                 "transient": False,
                 "ra_dis": 2.3,
+                "passed_at": datetime.datetime.utcnow(),
                 "filter_ids": [public_filter.id],
             },
             token=upload_data_token,
@@ -98,6 +100,7 @@ def test_candidate_unsaved_only_filtering(
                 "transient": False,
                 "ra_dis": 2.3,
                 "filter_ids": [public_filter.id],
+                "passed_at": datetime.datetime.utcnow(),
             },
             token=upload_data_token,
         )
@@ -143,6 +146,7 @@ def test_candidate_date_filtering(
                 "transient": False,
                 "ra_dis": 2.3,
                 "filter_ids": [public_filter.id],
+                "passed_at": datetime.datetime.utcnow(),
             },
             token=upload_data_token,
         )

--- a/skyportal/tests/frontend/test_scanning_page.py
+++ b/skyportal/tests/frontend/test_scanning_page.py
@@ -29,7 +29,7 @@ def test_candidate_group_filtering(
                 "altdata": {"simbad": {"class": "RRLyr"}},
                 "transient": False,
                 "ra_dis": 2.3,
-                "passed_at": datetime.datetime.utcnow(),
+                "passed_at": str(datetime.datetime.utcnow()),
                 "filter_ids": [public_filter.id],
             },
             token=upload_data_token,
@@ -100,7 +100,7 @@ def test_candidate_unsaved_only_filtering(
                 "transient": False,
                 "ra_dis": 2.3,
                 "filter_ids": [public_filter.id],
-                "passed_at": datetime.datetime.utcnow(),
+                "passed_at": str(datetime.datetime.utcnow()),
             },
             token=upload_data_token,
         )
@@ -146,7 +146,7 @@ def test_candidate_date_filtering(
                 "transient": False,
                 "ra_dis": 2.3,
                 "filter_ids": [public_filter.id],
-                "passed_at": datetime.datetime.utcnow(),
+                "passed_at": str(datetime.datetime.utcnow()),
             },
             token=upload_data_token,
         )

--- a/skyportal/tests/frontend/test_scanning_page.py
+++ b/skyportal/tests/frontend/test_scanning_page.py
@@ -5,12 +5,6 @@ from selenium.common.exceptions import TimeoutException
 from skyportal.tests import api
 
 
-def test_candidates_page_render(driver, user, public_candidate):
-    driver.get(f"/become_user/{user.id}")
-    driver.get("/candidates")
-    driver.wait_for_xpath(f'//a[text()="{public_candidate.id}"]')
-
-
 @pytest.mark.flaky(reruns=2)
 def test_candidate_group_filtering(
     driver,
@@ -51,21 +45,17 @@ def test_candidate_group_filtering(
 
     driver.get(f"/become_user/{user.id}")
     driver.get("/candidates")
-    for i in range(5):
-        driver.wait_for_xpath(f'//a[text()="{candidate_id}_{i}"]')
-
-    group_checkbox = driver.wait_for_xpath(
-        f'//*[contains(@data-testid,"groupID-{public_group.id}")]'
-    )
+    group_checkbox = driver.wait_for_xpath('//input[@name="groupIDs[0]"]')
     driver.scroll_to_element_and_click(group_checkbox)
     submit_button = driver.wait_for_xpath('//span[text()="Search"]')
     driver.scroll_to_element_and_click(submit_button)
     for i in range(5):
-        driver.wait_for_xpath_to_disappear(f'//a[text()="{candidate_id}_{i}"]')
+        driver.wait_for_xpath(f'//a[text()="{candidate_id}_{i}"]')
     driver.scroll_to_element_and_click(group_checkbox)
+    driver.click_xpath('//input[@name="groupIDs[1]"]', wait_clickable=False)
     driver.scroll_to_element_and_click(submit_button)
     for i in range(5):
-        driver.wait_for_xpath(f'//a[text()="{candidate_id}_{i}"]')
+        driver.wait_for_xpath_to_disappear(f'//a[text()="{candidate_id}_{i}"]')
 
 
 @pytest.mark.flaky(reruns=2)
@@ -116,8 +106,7 @@ def test_candidate_unsaved_only_filtering(
 
     driver.get(f"/become_user/{user.id}")
     driver.get("/candidates")
-    for i in range(5):
-        driver.wait_for_xpath(f'//a[text()="{candidate_id}_{i}"]')
+    driver.click_xpath('//input[@name="groupIDs[0]"]', wait_clickable=False)
     unsaved_only_checkbox = driver.wait_for_xpath('//input[@name="unsavedOnly"]')
     driver.scroll_to_element_and_click(unsaved_only_checkbox)
     submit_button = driver.wait_for_xpath('//span[text()="Search"]')
@@ -180,8 +169,7 @@ def test_candidate_date_filtering(
 
     driver.get(f"/become_user/{user.id}")
     driver.get("/candidates")
-    for i in range(5):
-        driver.wait_for_xpath(f'//a[text()="{candidate_id}_{i}"]')
+    driver.click_xpath('//input[@name="groupIDs[0]"]', wait_clickable=False)
     start_date_input = driver.wait_for_xpath("//input[@name='startDate']")
     start_date_input.clear()
     start_date_input.send_keys("200012120000")
@@ -206,6 +194,8 @@ def test_save_candidate_quick_save(
 ):
     driver.get(f"/become_user/{group_admin_user.id}")
     driver.get("/candidates")
+    driver.click_xpath('//input[@name="groupIDs[0]"]', wait_clickable=False)
+    driver.click_xpath('//span[text()="Search"]', wait_clickable=False)
     driver.wait_for_xpath(f'//a[text()="{public_candidate.id}"]')
     save_button = driver.wait_for_xpath(
         f'//button[@name="initialSaveCandidateButton{public_candidate.id}"]'
@@ -230,6 +220,8 @@ def test_save_candidate_select_groups(
 ):
     driver.get(f"/become_user/{group_admin_user.id}")
     driver.get("/candidates")
+    driver.click_xpath('//input[@name="groupIDs[0]"]', wait_clickable=False)
+    driver.click_xpath('//span[text()="Search"]')
     driver.wait_for_xpath(f'//a[text()="{public_candidate.id}"]')
     carat = driver.wait_for_xpath(
         f'//button[@name="saveCandidateButtonDropDownArrow{public_candidate.id}"]'
@@ -270,6 +262,8 @@ def test_save_candidate_no_groups_error_message(
 ):
     driver.get(f"/become_user/{group_admin_user.id}")
     driver.get("/candidates")
+    driver.click_xpath('//input[@name="groupIDs[0]"]', wait_clickable=False)
+    driver.click_xpath('//span[text()="Search"]')
     driver.wait_for_xpath(f'//a[text()="{public_candidate.id}"]')
     carat = driver.wait_for_xpath_to_be_clickable(
         f'//button[@name="saveCandidateButtonDropDownArrow{public_candidate.id}"]'
@@ -290,12 +284,6 @@ def test_save_candidate_no_groups_error_message(
     assert group_checkbox.is_selected()
     group_checkbox.click()
     assert not group_checkbox.is_selected()
-
-    group_checkbox = driver.wait_for_xpath("//input[@name='group_ids[1]']")
-    assert group_checkbox.is_selected()
-    group_checkbox.click()
-    assert not group_checkbox.is_selected()
-
     second_save_button = driver.wait_for_xpath_to_be_clickable(
         f'//button[@name="finalSaveCandidateButton{public_candidate.id}"]'
     )
@@ -338,6 +326,8 @@ def test_submit_annotations_sorting(
 
     driver.get(f"/become_user/{view_only_user.id}")
     driver.get("/candidates")
+    driver.click_xpath('//input[@name="groupIDs[0]"]', wait_clickable=False)
+    driver.click_xpath('//span[text()="Search"]')
     driver.wait_for_xpath(f'//a[text()="{public_candidate.id}"]')
 
     driver.click_xpath(f"//p[text()='numeric_field: 1.0000']")
@@ -398,6 +388,8 @@ def test_submit_annotations_filtering(
 
     driver.get(f"/become_user/{view_only_user.id}")
     driver.get("/candidates")
+    driver.click_xpath('//input[@name="groupIDs[0]"]', wait_clickable=False)
+    driver.click_xpath('//span[text()="Search"]')
     driver.wait_for_xpath(f'//a[text()="{public_candidate.id}"]')
 
     driver.click_xpath("//button[@data-testid='Filter Table-iconButton']")

--- a/static/js/components/CandidateList.jsx
+++ b/static/js/components/CandidateList.jsx
@@ -300,17 +300,9 @@ const CandidateList = () => {
   const dispatch = useDispatch();
 
   useEffect(() => {
-    if (candidates === null) {
-      setQueryInProgress(true);
-      dispatch(
-        candidatesActions.fetchCandidates({ numPerPage: defaultNumPerPage })
-      );
-      // Grab the available annotation fields for filtering
-      dispatch(candidatesActions.fetchAnnotationsInfo());
-    } else {
-      setQueryInProgress(false);
-    }
-  }, [candidates, dispatch]);
+    // Grab the available annotation fields for filtering
+    dispatch(candidatesActions.fetchAnnotationsInfo());
+  }, [dispatch]);
 
   const [annotationsHeaderAnchor, setAnnotationsHeaderAnchor] = useState(null);
   const annotationsHelpOpen = Boolean(annotationsHeaderAnchor);

--- a/static/js/components/FilterCandidateList.jsx
+++ b/static/js/components/FilterCandidateList.jsx
@@ -159,12 +159,13 @@ const FilterCandidateList = ({
               {errors.groupIDs && (
                 <FormValidationError message="Select at least one group." />
               )}
-              {userAccessibleGroups.map((group) => (
+              {userAccessibleGroups.map((group, idx) => (
                 <FormControlLabel
                   key={group.id}
                   control={
                     <Controller
                       as={Checkbox}
+                      name={`groupIDs[${idx}]`}
                       data-testid={`groupID-${group.id}`}
                       control={control}
                       rules={{ validate: validateGroups }}

--- a/static/js/components/FilterCandidateList.jsx
+++ b/static/js/components/FilterCandidateList.jsx
@@ -56,7 +56,7 @@ const FilterCandidateList = ({
 
   useEffect(() => {
     reset({
-      groupIDs: Array(userAccessibleGroups.length).fill(true),
+      groupIDs: Array(userAccessibleGroups.length).fill(false),
       startDate: null,
       endDate: null,
     });

--- a/static/js/components/FilterCandidateList.jsx
+++ b/static/js/components/FilterCandidateList.jsx
@@ -166,7 +166,7 @@ const FilterCandidateList = ({
                     <Controller
                       as={Checkbox}
                       name={`groupIDs[${idx}]`}
-                      data-testid={`groupID-${group.id}`}
+                      data-testid={`filteringFormGroupCheckbox-${group.id}`}
                       control={control}
                       rules={{ validate: validateGroups }}
                       defaultValue

--- a/static/js/components/SaveCandidateButton.jsx
+++ b/static/js/components/SaveCandidateButton.jsx
@@ -200,6 +200,7 @@ const SaveCandidateButton = ({ candidate, userGroups, filterGroups }) => {
                   <Controller
                     as={Checkbox}
                     name={`group_ids[${idx}]`}
+                    data-testid={`saveCandGroupCheckbox-${userGroup.id}`}
                     control={control}
                     rules={{ validate: validateGroups }}
                   />


### PR DESCRIPTION
In this PR:
- change the scanning page filtering form to default to zero groups selected;
- apply date range filtering to `Candidate.passed_at` rather than `Obj.last_detected`;
- `Candidate.passed_at` is required both at the API level and DB level (and is now indexed);
- test updates

Closes https://github.com/skyportal/skyportal/issues/1226
Partially addresses https://github.com/skyportal/skyportal/issues/1223