### PR TITLE
dont reload starlist anytime an assignment changes

### DIFF
--- a/static/js/components/StarList.jsx
+++ b/static/js/components/StarList.jsx
@@ -105,7 +105,7 @@ export const ObservingRunStarList = () => {
     };
     fetchStarList();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [assignments, dispatch, facility]);
+  }, [dispatch, facility]);
   return (
     <StarListBody
       starList={starList}


### PR DESCRIPTION
This PR produces a significant speedup on the observing run page by only loading the starlist once, when the page first loads. Otherwise, any action to edit an assignment on the page force-reloads the starlist, causing simple operations to take a very long time to complete (e.g., 10 seconds to mark an assignment "observed".) 