### PR TITLE
fix upload spectrum link on observing run page

### DIFF
--- a/static/js/components/RunSummary.jsx
+++ b/static/js/components/RunSummary.jsx
@@ -104,11 +104,14 @@ const SimpleMenu = ({ assignment }) => {
           </MenuItem>
         )}
         {assignment.status === "complete" && (
-          <MenuItem
-            key={`${assignment.id}_upload_spec (Coming Soon)`}
-            onClick={handleClose}
-          >
-            Upload Spectrum
+          <MenuItem key={`${assignment.id}_upload_spec`} onClick={handleClose}>
+            <Link
+              href={`/upload_spectrum/${assignment.obj.id}`}
+              underline="none"
+              color="textPrimary"
+            >
+              Upload Spectrum
+            </Link>
           </MenuItem>
         )}
         {assignment.status === "complete" && (


### PR DESCRIPTION
This PR activates the upload spectrum link on the observing run actions menu

![Kapture 2020-11-01 at 17 35 36](https://user-images.githubusercontent.com/2769632/97821869-c60f4c80-1c68-11eb-8745-121e6da2ebc7.gif)
