### PR TITLE
Change behavior of SourceGroupHandler.post and wording of EditSourceGroups

### DIFF
--- a/skyportal/tests/frontend/test_group_sources.py
+++ b/skyportal/tests/frontend/test_group_sources.py
@@ -149,7 +149,7 @@ def test_request_source(
 
     obj_id = str(uuid.uuid4())
 
-    # upload a new source, saved to the public group
+    # upload a new source, saved to public_group2
     status, data = api(
         'POST',
         'sources',
@@ -161,7 +161,7 @@ def test_request_source(
             'altdata': {'simbad': {'class': 'RRLyr'}},
             'transient': False,
             'ra_dis': 2.3,
-            'group_ids': [public_group2.id],
+            'group_ids': [public_group.id],
         },
         token=upload_data_token_two_groups,
     )
@@ -169,22 +169,22 @@ def test_request_source(
     assert data['data']['id'] == f'{obj_id}'
 
     # reload the group sources page
-    driver.get(f"/group_sources/{public_group.id}")
+    driver.get(f"/group_sources/{public_group2.id}")
 
-    # there should not be any new sources (the source is in group2)
+    # there should not be any new sources (the source is in group1)
     driver.wait_for_xpath("//*[text()[contains(., 'No sources')]]")
 
-    # request this source to be added to group1
+    # request this source to be added to group2
     status, data = api(
         'POST',
         'source_groups',
-        data={'objId': f'{obj_id}', 'inviteGroupIds': [public_group.id]},
+        data={'objId': f'{obj_id}', 'inviteGroupIds': [public_group2.id]},
         token=upload_data_token,
     )
     assert status == 200
 
     # reload the group sources page
-    driver.get(f"/group_sources/{public_group.id}")
+    driver.get(f"/group_sources/{public_group2.id}")
 
     # make sure the second table appears
     driver.wait_for_xpath("//*[text()[contains(., 'Requested to save')]]")

--- a/skyportal/tests/frontend/test_group_sources.py
+++ b/skyportal/tests/frontend/test_group_sources.py
@@ -135,6 +135,7 @@ def test_request_source(
     super_admin_user_two_groups,
     public_group,
     public_group2,
+    upload_data_token,
     upload_data_token_two_groups,
 ):
 
@@ -178,7 +179,7 @@ def test_request_source(
         'POST',
         'source_groups',
         data={'objId': f'{obj_id}', 'inviteGroupIds': [public_group.id]},
-        token=upload_data_token_two_groups,
+        token=upload_data_token,
     )
     assert status == 200
 

--- a/skyportal/tests/frontend/test_sources.py
+++ b/skyportal/tests/frontend/test_sources.py
@@ -495,7 +495,10 @@ def test_unsave_from_group(
     driver.get(f"/source/{public_source.id}")
     driver.wait_for_xpath(f'//div[text()="{public_source.id}"]')
     driver.click_xpath(f'//*[@data-testid="editGroups_{public_source.id}"]')
-    driver.click_xpath(f'//*[@data-testid="unsaveGroupCheckbox_{public_group2.id}"]')
+    driver.click_xpath(
+        f'//*[@data-testid="unsaveGroupCheckbox_{public_group2.id}"]',
+        scroll_parent=True,
+    )
     driver.click_xpath(f'//button[@name="editSourceGroupsButton_{public_source.id}"]')
     driver.wait_for_xpath('//*[text()="Source groups updated successfully"]')
     driver.wait_for_xpath_to_disappear(
@@ -510,7 +513,10 @@ def test_request_group_to_save_then_save(
     driver.get(f"/source/{public_source.id}")
     driver.wait_for_xpath(f'//div[text()="{public_source.id}"]')
     driver.click_xpath(f'//*[@data-testid="editGroups_{public_source.id}"]')
-    driver.click_xpath(f'//*[@data-testid="inviteGroupCheckbox_{public_group2.id}"]')
+    driver.click_xpath(
+        f'//*[@data-testid="inviteGroupCheckbox_{public_group2.id}"]',
+        scroll_parent=True,
+    )
     driver.click_xpath(f'//button[@name="editSourceGroupsButton_{public_source.id}"]')
     driver.wait_for_xpath('//*[text()="Source groups updated successfully"]')
     driver.get(f"/become_user/{user_two_groups.id}")

--- a/skyportal/tests/frontend/test_sources.py
+++ b/skyportal/tests/frontend/test_sources.py
@@ -504,15 +504,16 @@ def test_unsave_from_group(
 
 
 def test_request_group_to_save_then_save(
-    driver, user_two_groups, public_source, public_group2
+    driver, user, user_two_groups, public_source, public_group2
 ):
-    driver.get(f"/become_user/{user_two_groups.id}")
+    driver.get(f"/become_user/{user.id}")
     driver.get(f"/source/{public_source.id}")
     driver.wait_for_xpath(f'//div[text()="{public_source.id}"]')
     driver.click_xpath(f'//*[@data-testid="editGroups_{public_source.id}"]')
     driver.click_xpath(f'//*[@data-testid="inviteGroupCheckbox_{public_group2.id}"]')
     driver.click_xpath(f'//button[@name="editSourceGroupsButton_{public_source.id}"]')
     driver.wait_for_xpath('//*[text()="Source groups updated successfully"]')
+    driver.get(f"/become_user/{user_two_groups.id}")
     driver.get(f"/group_sources/{public_group2.id}")
     driver.click_xpath(f'//button[@data-testid="saveSourceButton_{public_source.id}"]')
     driver.wait_for_xpath_to_disappear(

--- a/skyportal/tests/frontend/test_weather.py
+++ b/skyportal/tests/frontend/test_weather.py
@@ -26,5 +26,5 @@ def test_weather_widget(driver, user, public_group, upload_data_token, p60_teles
     driver.get('/')
 
     driver.click_xpath('//*[@data-testid="tel-list-button"]')
-    driver.click_xpath(f'//*[text()="{p60_telescope.name}"]')
+    driver.click_xpath(f'//*[text()="{p60_telescope.name}"]', scroll_parent=True)
     driver.wait_for_xpath(f'//h6[text()="{p60_telescope.name}"]')

--- a/static/js/components/CandidateList.jsx
+++ b/static/js/components/CandidateList.jsx
@@ -285,6 +285,9 @@ const CandidateList = () => {
   const userAccessibleGroups = useSelector(
     (state) => state.groups.userAccessible
   );
+  const allGroups = (useSelector((state) => state.groups.all) || []).filter(
+    (g) => !g.single_user_group
+  );
 
   useEffect(() => {
     if (userAccessibleGroups?.length && filterGroups.length === 0) {
@@ -481,7 +484,7 @@ const CandidateList = () => {
                   id: candidateObj.id,
                   currentGroupIds: candidateObj.saved_groups.map((g) => g.id),
                 }}
-                userGroups={userAccessibleGroups}
+                groups={allGroups}
               />
             </div>
             <div className={classes.infoItem}>

--- a/static/js/components/EditSourceGroups.jsx
+++ b/static/js/components/EditSourceGroups.jsx
@@ -135,20 +135,20 @@ const EditSourceGroups = ({ source, groups, icon }) => {
       >
         <DialogTitle>Unsave or save to new groups:</DialogTitle>
         <DialogContent>
-          <p>
-            You can save to groups you belong to or request group admins of
-            groups you are not a member of to save this source to their group.
-          </p>
           <form onSubmit={handleSubmit(onSubmit)}>
             {(errors.inviteGroupIds || errors.unsaveGroupIds) && (
               <FormValidationError message="Select at least one group." />
             )}
             {!!unsavedGroups.length && (
               <>
-                <div>
+                <>
+                  You can save to groups you belong to or request group admins
+                  of groups you are not a member of to save this source to their
+                  group.
+                  <br />
                   <b>Save</b> (or request save, for groups you do not belong to)
                   to selected groups:
-                </div>
+                </>
                 {unsavedGroups.map((unsavedGroup, idx) => (
                   <FormControlLabel
                     key={unsavedGroup.id}

--- a/static/js/components/EditSourceGroups.jsx
+++ b/static/js/components/EditSourceGroups.jsx
@@ -100,10 +100,10 @@ const EditSourceGroups = ({ source, userGroups, icon }) => {
     <>
       <div className={classes.editIcon}>
         {icon ? (
-          <Tooltip title="Edit source groups">
+          <Tooltip title="Manage source groups">
             <span>
               <IconButton
-                aria-label="add-group"
+                aria-label="manage-groups"
                 data-testid={`editGroups_${source.id}`}
                 onClick={openDialog}
                 size="small"
@@ -123,7 +123,7 @@ const EditSourceGroups = ({ source, userGroups, icon }) => {
             onClick={openDialog}
             disabled={isSubmitting}
           >
-            Edit groups
+            Manage groups
           </Button>
         )}
       </div>
@@ -133,8 +133,12 @@ const EditSourceGroups = ({ source, userGroups, icon }) => {
         onClose={closeDialog}
         style={{ position: "fixed" }}
       >
-        <DialogTitle>Edit source groups:</DialogTitle>
+        <DialogTitle>Unsave or save to new groups:</DialogTitle>
         <DialogContent>
+          <p>
+            You can save to groups you belong to or request group admins of
+            groups you are not a member of to save this source to their group.
+          </p>
           <form onSubmit={handleSubmit(onSubmit)}>
             {(errors.inviteGroupIds || errors.unsaveGroupIds) && (
               <FormValidationError message="Select at least one group." />
@@ -142,7 +146,8 @@ const EditSourceGroups = ({ source, userGroups, icon }) => {
             {!!unsavedGroups.length && (
               <>
                 <div>
-                  Request selected group(s) to <b>save</b> source:
+                  <b>Save</b> (or request save, for groups you do not belong to)
+                  to selected groups:
                 </div>
                 {unsavedGroups.map((unsavedGroup, idx) => (
                   <FormControlLabel
@@ -165,7 +170,7 @@ const EditSourceGroups = ({ source, userGroups, icon }) => {
             {!!savedGroups.length && (
               <>
                 <div>
-                  Select groups from which to <b>unsave</b> source:
+                  <b>Unsave</b> source from selected groups:
                 </div>
                 <div>
                   <em>

--- a/static/js/components/EditSourceGroups.jsx
+++ b/static/js/components/EditSourceGroups.jsx
@@ -27,7 +27,7 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-const EditSourceGroups = ({ source, userGroups, icon }) => {
+const EditSourceGroups = ({ source, groups, icon }) => {
   const classes = useStyles();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -35,23 +35,23 @@ const EditSourceGroups = ({ source, userGroups, icon }) => {
 
   const { handleSubmit, errors, reset, control, getValues } = useForm();
 
-  const unsavedGroups = userGroups.filter(
+  const unsavedGroups = groups.filter(
     (g) => !source.currentGroupIds.includes(g.id)
   );
-  const savedGroups = userGroups.filter((g) =>
+  const savedGroups = groups.filter((g) =>
     source.currentGroupIds.includes(g.id)
   );
 
   useEffect(() => {
     reset({
       inviteGroupIds: Array(
-        userGroups.filter((g) => !source.currentGroupIds.includes(g.id)).length
+        groups.filter((g) => !source.currentGroupIds.includes(g.id)).length
       ).fill(false),
       unsaveGroupIds: Array(
-        userGroups.filter((g) => source.currentGroupIds.includes(g.id)).length
+        groups.filter((g) => source.currentGroupIds.includes(g.id)).length
       ).fill(false),
     });
-  }, [reset, userGroups, source]);
+  }, [reset, groups, source]);
 
   const openDialog = () => {
     setDialogOpen(true);
@@ -215,7 +215,7 @@ EditSourceGroups.propTypes = {
     id: PropTypes.string,
     currentGroupIds: PropTypes.arrayOf(PropTypes.number),
   }).isRequired,
-  userGroups: PropTypes.arrayOf(
+  groups: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.number,
       name: PropTypes.string,

--- a/static/js/components/SourceDesktop.jsx
+++ b/static/js/components/SourceDesktop.jsx
@@ -128,8 +128,8 @@ const SourceDesktop = ({ source }) => {
   );
   const { observingRunList } = useSelector((state) => state.observingRuns);
   const { taxonomyList } = useSelector((state) => state.taxonomies);
-  const userAccessibleGroups = useSelector(
-    (state) => state.groups.userAccessible
+  const groups = (useSelector((state) => state.groups.all) || []).filter(
+    (g) => !g.single_user_group
   );
 
   return (
@@ -224,7 +224,7 @@ const SourceDesktop = ({ source }) => {
               id: source.id,
               currentGroupIds: source.groups.map((g) => g.id),
             }}
-            userGroups={userAccessibleGroups}
+            groups={groups}
             icon
           />
           <SourceSaveHistory groups={source.groups} />

--- a/static/js/components/SourceMobile.jsx
+++ b/static/js/components/SourceMobile.jsx
@@ -151,8 +151,8 @@ const SourceMobile = ({ source }) => {
   );
   const { observingRunList } = useSelector((state) => state.observingRuns);
   const { taxonomyList } = useSelector((state) => state.taxonomies);
-  const userAccessibleGroups = useSelector(
-    (state) => state.groups.userAccessible
+  const groups = (useSelector((state) => state.groups.all) || []).filter(
+    (g) => !g.single_user_group
   );
 
   return (
@@ -252,7 +252,7 @@ const SourceMobile = ({ source }) => {
                   id: source.id,
                   currentGroupIds: source.groups.map((g) => g.id),
                 }}
-                userGroups={userAccessibleGroups}
+                groups={groups}
                 icon
               />
               <SourceSaveHistory groups={source.groups} />


### PR DESCRIPTION
This PR changes the default behavior of the edit source groups handler by automatically saving the source as active if the requesting user has access to the target group, otherwise it is marked as inactive and requested. 

Instead of only user accessible groups, now all groups are shown in "save or request to save" part of dialog.

The wording displayed in the dialog is updated. 

See screen capture demo below.

Closes #1217 

![edit_source_groups](https://user-images.githubusercontent.com/7230285/98159150-ee798f80-1e90-11eb-8386-59b9ef0737b0.gif)
