### PR TITLE
Fix display of classifications with null probabilities

### DIFF
--- a/static/js/components/CandidateList.jsx
+++ b/static/js/components/CandidateList.jsx
@@ -148,8 +148,10 @@ const getMostRecentClassification = (classifications) => {
   const sortedClasses = filteredClasses.sort((a, b) =>
     a.modified < b.modified ? 1 : -1
   );
+  const recentClassification =
+    sortedClasses.length > 0 ? `${sortedClasses[0].classification}` : null;
 
-  return `${sortedClasses[0].classification}`;
+  return recentClassification;
 };
 
 const getMuiPopoverTheme = () =>
@@ -439,6 +441,11 @@ const CandidateList = () => {
 
   const renderInfo = (dataIndex) => {
     const candidateObj = candidates[dataIndex];
+    const recentClassification =
+      candidateObj.classifications && candidateObj.classifications.length > 0
+        ? getMostRecentClassification(candidateObj.classifications)
+        : null;
+
     return (
       <div className={classes.info}>
         <span className={classes.itemPaddingBottom}>
@@ -538,15 +545,12 @@ const CandidateList = () => {
             {candidateObj.gal_lat.toFixed(3)}
           </span>
         </div>
-        {candidateObj.classifications &&
-          candidateObj.classifications.length > 0 && (
-            <div className={classes.infoItem}>
-              <b>Classification: </b>
-              <span>
-                {getMostRecentClassification(candidateObj.classifications)}
-              </span>
-            </div>
-          )}
+        {candidateObj.classifications && recentClassification && (
+          <div className={classes.infoItem}>
+            <b>Classification: </b>
+            <span>{recentClassification}</span>
+          </div>
+        )}
         {selectedAnnotationSortOptions !== null &&
           candidateHasAnnotationWithSelectedKey(candidateObj) && (
             <div className={classes.infoItem}>

--- a/static/js/components/RecentSources.jsx
+++ b/static/js/components/RecentSources.jsx
@@ -114,7 +114,9 @@ const RecentSourcesList = ({ sources, styles }) => {
               a.modified < b.modified ? 1 : -1
             );
 
-            recentSourceName += ` (${sortedClasses[0].classification})`;
+            if (sortedClasses.length > 0) {
+              recentSourceName += ` (${sortedClasses[0].classification})`;
+            }
           }
 
           return (

--- a/static/js/components/TopSources.jsx
+++ b/static/js/components/TopSources.jsx
@@ -80,7 +80,9 @@ const TopSourcesList = ({ sources, styles }) => {
               a.modified < b.modified ? 1 : -1
             );
 
-            topsourceName += ` (${sortedClasses[0].classification})`;
+            if (sortedClasses.length > 0) {
+              topsourceName += ` (${sortedClasses[0].classification})`;
+            }
           }
 
           return (


### PR DESCRIPTION
Properly ignore classifications with null probabilities on scanning page and home page widgets