### PR TITLE
require system admin access or ownership for comment deletion

### DIFF
--- a/skyportal/handlers/api/comment.py
+++ b/skyportal/handlers/api/comment.py
@@ -269,9 +269,7 @@ class CommentHandler(BaseHandler):
         if c is None:
             return self.error("Invalid comment ID")
         obj_key = c.obj.internal_key
-        if (
-            "System admin" in user.permissions or "Manage groups" in user.permissions
-        ) or (c.author == user):
+        if ("System admin" in user.permissions) or (c.author == user):
             Comment.query.filter_by(id=comment_id).delete()
             DBSession().commit()
         else:


### PR DESCRIPTION
The current access model allows anyone with the `Manage groups` ACL to delete comments. This PR limits comment deletion to system admins and comment authors. 