### PR TITLE
fix group display on observing planner

### DIFF
--- a/skyportal/handlers/api/observingrun.py
+++ b/skyportal/handlers/api/observingrun.py
@@ -133,10 +133,16 @@ class ObservingRunHandler(BaseHandler):
             data = ObservingRunGetWithAssignments.dump(run)
             data["assignments"] = [a.to_dict() for a in assignments]
 
-            gids = [g.id for g in self.current_user.accessible_groups]
+            gids = [
+                g.id
+                for g in self.current_user.accessible_groups
+                if not g.single_user_group
+            ]
             for a in data["assignments"]:
                 a['accessible_group_names'] = [
-                    s.group.name for s in a['obj'].sources if s.group_id in gids
+                    (s.group.nickname if s.group.nickname is not None else s.group.name)
+                    for s in a['obj'].sources
+                    if s.group_id in gids
                 ]
                 del a['obj'].sources
 

--- a/skyportal/tests/frontend/test_observing_planner.py
+++ b/skyportal/tests/frontend/test_observing_planner.py
@@ -79,7 +79,11 @@ def test_assignment_posts_to_observing_run(
     # 20 second timeout to give the backend time to perform ephemeris calcs
     driver.wait_for_xpath(f'//*[text()="{public_source.id}"]', timeout=20)
     for group in [s.group for s in public_source.sources]:
-        driver.wait_for_xpath(f'//*[text()="{group.name[:15]}"]')
+        if group.single_user_group:
+            func = driver.wait_for_xpath_to_disappear
+        else:
+            func = driver.wait_for_xpath
+        func(f'//span[text()="{group.name[:15]}"]')
 
 
 @pytest.mark.flaky(reruns=2)

--- a/static/js/components/RunSummary.jsx
+++ b/static/js/components/RunSummary.jsx
@@ -270,6 +270,7 @@ const RunSummary = ({ route }) => {
               key={name}
               size="small"
               className={classes.chip}
+              data-testid={`chip-assignment_${assignment.id}-group_${name}`}
             />
             <br />
           </div>


### PR DESCRIPTION
This PR fixes the group chip display on the observing run page. Fixes #1155. 

Whereas before long group names would be shown on the observing planner, causing groups to get cut off, and single user groups would be shown, this PR shows only group nicknames, and does not show single user groups. 

A test is updated to check that this is enforced. 