### PR TITLE
Remove unsaved sources from source GET results

### DIFF
--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -398,6 +398,7 @@ class SourceHandler(BaseHandler):
             DBSession()
             .query(Obj)
             .join(Source)
+            .filter(Source.unsaved_at.is_(None))
             .filter(
                 Source.group_id.in_(
                     user_accessible_group_ids


### PR DESCRIPTION
Don't include sources that were unsaved from the GET multiple sources handler.

Partially addresses #1303 and #1224 (likely fixes backend cause of the error, frontend patched in #1295)