### PR TITLE
Improve weather fetching

### DIFF
--- a/skyportal/handlers/api/internal/profile.py
+++ b/skyportal/handlers/api/internal/profile.py
@@ -213,8 +213,6 @@ class ProfileHandler(BaseHandler):
             self.push(action="skyportal/FETCH_RECENT_SOURCES")
         if "sourceCounts" in preferences:
             self.push(action="skyportal/FETCH_SOURCE_COUNTS")
-        if "weather" in preferences:
-            self.push(action="skyportal/FETCH_WEATHER")
 
         if username_updated:
             self.push_all(action="skyportal/FETCH_GROUPS")

--- a/static/js/actions.js
+++ b/static/js/actions.js
@@ -11,7 +11,6 @@ import * as sourceCountsActions from "./ducks/sourceCounts";
 import * as observingRunsActions from "./ducks/observingRuns";
 import * as telescopesActions from "./ducks/telescopes";
 import * as taxonomyActions from "./ducks/taxonomies";
-import * as weatherActions from "./ducks/weather";
 
 export default function hydrate() {
   return (dispatch) => {
@@ -29,6 +28,5 @@ export default function hydrate() {
     dispatch(observingRunsActions.fetchObservingRuns());
     dispatch(telescopesActions.fetchTelescopes());
     dispatch(taxonomyActions.fetchTaxonomies());
-    dispatch(weatherActions.fetchWeather());
   };
 }

--- a/static/js/components/WeatherWidget.jsx
+++ b/static/js/components/WeatherWidget.jsx
@@ -17,13 +17,13 @@ import IconButton from "@material-ui/core/IconButton";
 import MoreVertIcon from "@material-ui/icons/MoreVert";
 
 import * as profileActions from "../ducks/profile";
-import * as fetchWeather from "../ducks/weather";
+import * as weatherActions from "../ducks/weather";
 
 dayjs.extend(relativeTime);
 dayjs.extend(utc);
 
 const defaultPrefs = {
-  telescopeID: "1",
+  telescopeID: 1,
 };
 
 const useStyles = makeStyles(() => ({
@@ -149,15 +149,17 @@ const WeatherWidget = ({ classes }) => {
     }
     return 0;
   });
-  const weatherPrefs = userPrefs || defaultPrefs;
+  const weatherPrefs = userPrefs?.telescopeID ? userPrefs : defaultPrefs;
   const [anchorEl, setAnchorEl] = useState(null);
 
   useEffect(() => {
-    // eslint-disable-next-line no-unused-vars
-    const getWeatherData = () => {
-      dispatch(fetchWeather(weatherPrefs.telescopeID));
+    const fetchWeatherData = () => {
+      dispatch(weatherActions.fetchWeather());
     };
-  }, [weatherPrefs, dispatch]);
+    if (weather?.id !== weatherPrefs?.telescopeID || weather === undefined) {
+      fetchWeatherData();
+    }
+  }, [weatherPrefs, weather, dispatch]);
 
   const handleClose = () => {
     setAnchorEl(null);


### PR DESCRIPTION
This PR removes initial weather fetching from `hydrate` to the weather component itself and refactors the fetching logic to minimize the number of requests when user preferences are updated.

Closes https://github.com/skyportal/skyportal/issues/1215