### PR TITLE
increase GA timeout to 90 minutes

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,7 +10,7 @@ jobs:
   test:
     name: Test SkyPortal
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 90
 
     services:
       postgres:


### PR DESCRIPTION
Most of the current GA builds are timing out. This PR increases the GA build timeout to 90 minutes from 45 minutes. 