### PR TITLE
attempt to circumvent spam filters from invite text 

### DIFF
--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -2615,7 +2615,8 @@ def send_user_invite_email(mapper, connection, target):
         subject=cfg["invitations.email_subject"],
         html_content=(
             f'{cfg["invitations.email_body_preamble"]}<br /><br />'
-            f'Please click <a href="{link_location}">here</a> to join.'
+            f'To confirm your invite, click on the following link: '
+            f'<br /><br /><a href="{link_location}">{link_location}</a>.'
         ),
     )
     sg = SendGridAPIClient(cfg["twilio.sendgrid_api_key"])


### PR DESCRIPTION
Fritz.science invites were being filtered to spam. I think it may be because some of the text of the invite appears in the spam list of triggering words, specifically "click here." 

https://blog.hubspot.com/blog/tabid/6307/bid/30684/The-Ultimate-List-of-Email-SPAM-Trigger-Words.aspx

This PR rewrites the invite text somewhat to clear out these triggering words 