### PR TITLE
Speed up observing run page

### DIFF
--- a/skyportal/handlers/api/observingrun.py
+++ b/skyportal/handlers/api/observingrun.py
@@ -145,6 +145,7 @@ class ObservingRunHandler(BaseHandler):
                     if s.group_id in gids
                 ]
                 del a['obj'].sources
+                del a['obj'].users
 
             # vectorized calculation of ephemerides
 


### PR DESCRIPTION
The observing run page was loading quite slowly as an intermediate step in the `ObservingRun.get` handler was loading the `Obj.users` attribute for each assignment, which produced a record of ~100 users on fritz.science for each assignment, each of which had preferences loaded. This bloated the response size of a typical observing run.GET to ~20MB for, e.g., fritz.science/run/8. 

This PR prevents this data (which is not used at all on the frontend, and was never intended to be returned by this handler) from being returned. 

Fixes #1336 (hopefully). 