### PR TITLE
increase timeout on test_token_user_post_new_source

### DIFF
--- a/skyportal/tests/api/test_sources.py
+++ b/skyportal/tests/api/test_sources.py
@@ -193,7 +193,7 @@ def test_token_user_post_new_source(upload_data_token, view_only_token, public_g
     npt.assert_almost_equal(data['data']['ra'], 234.22)
 
     saved_at = parser.parse(data['data']['groups'][0]['saved_at'] + " UTC")
-    assert abs(saved_at - t0) < timedelta(seconds=2)
+    assert abs(saved_at - t0) < timedelta(seconds=4)
 
 
 def test_cannot_post_source_with_null_radec(


### PR DESCRIPTION
Sometimes this test fails on the CI because because it can take a bit longer than 2s for the above POST to go through. This PR just increases that timeout a bit so that the test can pass 