### PR TITLE
Make SourceOffsetHandler asynchronous

### DIFF
--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -930,13 +930,16 @@ class SourceOffsetsHandler(BaseHandler):
             use_ztfref=use_ztfref,
         )
 
-        (
-            starlist_info,
-            query_string,
-            queries_issued,
-            noffsets,
-            used_ztfref,
-        ) = await IOLoop.current().run_in_executor(None, offset_func)
+        try:
+            (
+                starlist_info,
+                query_string,
+                queries_issued,
+                noffsets,
+                used_ztfref,
+            ) = await IOLoop.current().run_in_executor(None, offset_func)
+        except ValueError:
+            return self.error("Error querying for nearby offset stars")
 
         starlist_str = "\n".join(
             [x["str"].replace(" ", "&nbsp;") for x in starlist_info]

--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -746,7 +746,7 @@ class SourceHandler(BaseHandler):
 
 class SourceOffsetsHandler(BaseHandler):
     @auth_or_token
-    def get(self, obj_id):
+    async def get(self, obj_id):
         """
         ---
         description: Retrieve offset stars to aid in spectroscopy
@@ -914,29 +914,29 @@ class SourceOffsetsHandler(BaseHandler):
             # could not handle inputs
             return self.error('Invalid argument for `num_offset_stars`')
 
-        try:
-            (
-                starlist_info,
-                query_string,
-                queries_issued,
-                noffsets,
-                used_ztfref,
-            ) = get_nearby_offset_stars(
-                best_ra,
-                best_dec,
-                obj_id,
-                how_many=num_offset_stars,
-                radius_degrees=radius_degrees,
-                mag_limit=mag_limit,
-                min_sep_arcsec=min_sep_arcsec,
-                starlist_type=facility,
-                mag_min=mag_min,
-                obstime=obstime,
-                allowed_queries=2,
-                use_ztfref=use_ztfref,
-            )
-        except ValueError:
-            return self.error('Error while querying for nearby offset stars')
+        offset_func = functools.partial(
+            get_nearby_offset_stars,
+            best_ra,
+            best_dec,
+            obj_id,
+            how_many=num_offset_stars,
+            radius_degrees=radius_degrees,
+            mag_limit=mag_limit,
+            min_sep_arcsec=min_sep_arcsec,
+            starlist_type=facility,
+            mag_min=mag_min,
+            obstime=obstime,
+            allowed_queries=2,
+            use_ztfref=use_ztfref,
+        )
+
+        (
+            starlist_info,
+            query_string,
+            queries_issued,
+            noffsets,
+            used_ztfref,
+        ) = await IOLoop.current().run_in_executor(None, offset_func)
 
         starlist_str = "\n".join(
             [x["str"].replace(" ", "&nbsp;") for x in starlist_info]


### PR DESCRIPTION
This PR makes the compute-intensive part of the source offsets query asynchronous. This should vastly improve site stability and fix those intermittent 502s we have been seeing. 

Fixes #1349 (hopefully). 