### PR TITLE
Implement server-side sorting for source tables

### DIFF
--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -39,7 +39,7 @@ from ...utils import (
     get_finding_chart,
     _calculate_best_position_for_offset_stars,
 )
-from .candidate import grab_query_results_page, update_redshift_history_if_relevant
+from .candidate import grab_query_results, update_redshift_history_if_relevant
 
 
 SOURCES_PER_PAGE = 100
@@ -574,6 +574,7 @@ class SourceHandler(BaseHandler):
                     if sort_order == "asc"
                     else [Obj.ra.desc().nullslast()]
                 )
+                print(sort_by, sort_order)
             elif sort_by == "dec":
                 order_by = (
                     [Obj.dec.nullslast()]
@@ -599,7 +600,7 @@ class SourceHandler(BaseHandler):
             except ValueError:
                 return self.error("Invalid page number value.")
             try:
-                query_results = grab_query_results_page(
+                query_results = grab_query_results(
                     q,
                     total_matches,
                     page,
@@ -613,7 +614,15 @@ class SourceHandler(BaseHandler):
                     return self.error("Page number out of range.")
                 raise
         else:
-            query_results = {"sources": q.all()}
+            query_results = grab_query_results(
+                q,
+                total_matches,
+                None,
+                None,
+                "sources",
+                order_by=order_by,
+                include_photometry=include_photometry,
+            )
 
         if not save_summary:
             source_list = []

--- a/skyportal/tests/frontend/test_group_sources.py
+++ b/skyportal/tests/frontend/test_group_sources.py
@@ -210,7 +210,7 @@ def test_sources_sorting(
             'id': f'{obj_id}',
             'ra': 234.22,
             'dec': -22.33,
-            'redshift': 0.153,
+            'redshift': 0.0,
             'altdata': {'simbad': {'class': 'RRLyr'}},
             'transient': False,
             'ra_dis': 2.3,
@@ -246,16 +246,6 @@ def test_sources_sorting(
     # Wait for the group name appears
     driver.wait_for_xpath(f"//*[text()[contains(., '{public_group.name}')]]")
 
-    # By default, the first one posted should be the first row
-    # Col 0, Row 0 should be the first sources's id (MuiDataTableBodyCell-0-0)
-    driver.wait_for_xpath(
-        f'//td[contains(@data-testid, "MuiDataTableBodyCell-0-0")][.//a[text()="{obj_id}"]]'
-    )
-    # Col 0, Row 1 should be the second sources's id (MuiDataTableBodyCell-0-1)
-    driver.wait_for_xpath(
-        f'//td[contains(@data-testid, "MuiDataTableBodyCell-0-1")][.//a[text()="{obj_id2}"]]'
-    )
-
     # Now sort by date saved
     driver.click_xpath("//button[@data-testid='sortButton']")
     driver.click_xpath("//div[@id='root_column']")
@@ -271,4 +261,21 @@ def test_sources_sorting(
     # Col 0, Row 1 should be the first sources's id (MuiDataTableBodyCell-0-1)
     driver.wait_for_xpath(
         f'//td[contains(@data-testid, "MuiDataTableBodyCell-0-1")][.//a[text()="{obj_id}"]]'
+    )
+
+    # Now sort by redshift ascending, which would put obj_id first
+    driver.click_xpath("//button[@data-testid='sortButton']")
+    driver.click_xpath("//div[@id='root_column']")
+    driver.click_xpath("//li[@data-value='redshift']", scroll_parent=True)
+    driver.click_xpath("//input[@value='true']", wait_clickable=False)
+    driver.click_xpath("//span[text()='Submit']")
+
+    # Now, the first one posted should be the second row
+    # Col 0, Row 0 should be the second sources's id (MuiDataTableBodyCell-0-0)
+    driver.wait_for_xpath(
+        f'//td[contains(@data-testid, "MuiDataTableBodyCell-0-0")][.//a[text()="{obj_id}"]]'
+    )
+    # Col 0, Row 1 should be the first sources's id (MuiDataTableBodyCell-0-1)
+    driver.wait_for_xpath(
+        f'//td[contains(@data-testid, "MuiDataTableBodyCell-0-1")][.//a[text()="{obj_id2}"]]'
     )

--- a/skyportal/tests/frontend/test_group_sources.py
+++ b/skyportal/tests/frontend/test_group_sources.py
@@ -194,3 +194,81 @@ def test_request_source(
     # make sure the second table has "save/ignore" buttons
     driver.wait_for_xpath("//*[text()[contains(., 'Save')]]")
     driver.wait_for_xpath("//*[text()[contains(., 'Ignore')]]")
+
+
+def test_sources_sorting(
+    driver, super_admin_user, public_group, upload_data_token,
+):
+    obj_id = str(uuid.uuid4())
+    obj_id2 = str(uuid.uuid4())
+
+    # upload two new sources, saved to the public group
+    status, data = api(
+        'POST',
+        'sources',
+        data={
+            'id': f'{obj_id}',
+            'ra': 234.22,
+            'dec': -22.33,
+            'redshift': 0.153,
+            'altdata': {'simbad': {'class': 'RRLyr'}},
+            'transient': False,
+            'ra_dis': 2.3,
+            'group_ids': [public_group.id],
+        },
+        token=upload_data_token,
+    )
+    assert status == 200
+    assert data['data']['id'] == f'{obj_id}'
+    status, data = api(
+        'POST',
+        'sources',
+        data={
+            'id': f'{obj_id2}',
+            'ra': 234.22,
+            'dec': -22.33,
+            'redshift': 0.153,
+            'altdata': {'simbad': {'class': 'RRLyr'}},
+            'transient': False,
+            'ra_dis': 2.3,
+            'group_ids': [public_group.id],
+        },
+        token=upload_data_token,
+    )
+    assert status == 200
+    assert data['data']['id'] == f'{obj_id2}'
+
+    driver.get(f"/become_user/{super_admin_user.id}")  # become a super-user
+
+    # Go to the group sources page
+    driver.get(f"/group_sources/{public_group.id}")
+
+    # Wait for the group name appears
+    driver.wait_for_xpath(f"//*[text()[contains(., '{public_group.name}')]]")
+
+    # By default, the first one posted should be the first row
+    # Col 0, Row 0 should be the first sources's id (MuiDataTableBodyCell-0-0)
+    driver.wait_for_xpath(
+        f'//td[contains(@data-testid, "MuiDataTableBodyCell-0-0")][.//a[text()="{obj_id}"]]'
+    )
+    # Col 0, Row 1 should be the second sources's id (MuiDataTableBodyCell-0-1)
+    driver.wait_for_xpath(
+        f'//td[contains(@data-testid, "MuiDataTableBodyCell-0-1")][.//a[text()="{obj_id2}"]]'
+    )
+
+    # Now sort by date saved
+    driver.click_xpath("//button[@data-testid='sortButton']")
+    driver.click_xpath("//div[@id='root_column']")
+    driver.click_xpath("//li[@data-value='saved_at']", scroll_parent=True)
+    driver.click_xpath("//input[@value='false']", wait_clickable=False)
+    driver.click_xpath("//span[text()='Submit']")
+
+    # Now, the first one posted should be the second row
+    # Col 0, Row 0 should be the second sources's id (MuiDataTableBodyCell-0-0)
+    driver.wait_for_xpath(
+        f'//td[contains(@data-testid, "MuiDataTableBodyCell-0-0")][.//a[text()="{obj_id2}"]]'
+    )
+    # Col 0, Row 1 should be the first sources's id (MuiDataTableBodyCell-0-1)
+    driver.wait_for_xpath(
+        f'//td[contains(@data-testid, "MuiDataTableBodyCell-0-1")][.//a[text()="{obj_id}"]]'
+    )

--- a/static/js/components/GroupSources.jsx
+++ b/static/js/components/GroupSources.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import { useSelector, useDispatch } from "react-redux";
 
@@ -35,6 +35,10 @@ const GroupSources = ({ route }) => {
   );
   const groups = useSelector((state) => state.groups.userAccessible);
   const classes = useStyles();
+  const [savedSourcesRowsPerPage, setSavedSourcesRowsPerPage] = useState(10);
+  const [pendingSourcesRowsPerPage, setPendingSourcesRowsPerPage] = useState(
+    10
+  );
 
   // Load the group sources
   useEffect(() => {
@@ -65,7 +69,20 @@ const GroupSources = ({ route }) => {
 
   const groupName = groups.filter((g) => g.id === groupID)[0]?.name || "";
 
+  const handleSavedSourcesTableSorting = (formData) => {
+    dispatch(
+      sourcesActions.fetchSavedGroupSources({
+        group_ids: [route.id],
+        pageNumber: 1,
+        numPerPage: savedSourcesRowsPerPage,
+        sortBy: formData.column,
+        sortOrder: formData.ascending ? "asc" : "desc",
+      })
+    );
+  };
+
   const handleSavedSourcesTablePagination = (pageNumber, numPerPage) => {
+    setSavedSourcesRowsPerPage(numPerPage);
     dispatch(
       sourcesActions.fetchSavedGroupSources({
         group_ids: [route.id],
@@ -75,7 +92,20 @@ const GroupSources = ({ route }) => {
     );
   };
 
+  const handlePendingSourcesTableSorting = (formData) => {
+    dispatch(
+      sourcesActions.fetchPendingGroupSources({
+        group_ids: [route.id],
+        pageNumber: 1,
+        numPerPage: pendingSourcesRowsPerPage,
+        sortBy: formData.column,
+        sortOrder: formData.ascending ? "asc" : "desc",
+      })
+    );
+  };
+
   const handlePendingSourcesTablePagination = (pageNumber, numPerPage) => {
+    setPendingSourcesRowsPerPage(numPerPage);
     dispatch(
       sourcesActions.fetchPendingGroupSources({
         group_ids: [route.id],
@@ -118,6 +148,7 @@ const GroupSources = ({ route }) => {
           pageNumber={savedSourcesState.pageNumber}
           totalMatches={savedSourcesState.totalMatches}
           numPerPage={savedSourcesState.numPerPage}
+          sortingCallback={handleSavedSourcesTableSorting}
         />
       )}
       <br />
@@ -132,6 +163,7 @@ const GroupSources = ({ route }) => {
           pageNumber={pendingSourcesState.pageNumber}
           totalMatches={pendingSourcesState.totalMatches}
           numPerPage={pendingSourcesState.numPerPage}
+          sortingCallback={handlePendingSourcesTableSorting}
         />
       )}
     </div>

--- a/static/js/components/SourceList.jsx
+++ b/static/js/components/SourceList.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { useSelector, useDispatch } from "react-redux";
 
 import Paper from "@material-ui/core/Paper";
@@ -61,27 +61,42 @@ const SourceList = () => {
     (state) => state.dbInfo.source_table_empty
   );
 
+  const [rowsPerPage, setRowsPerPage] = useState(100);
+
   useEffect(() => {
     dispatch(sourcesActions.fetchSources());
   }, [dispatch]);
 
-  const { handleSubmit, register, getValues, control, reset } = useForm();
+  const { handleSubmit, register, getValues, control } = useForm();
 
   const onSubmit = (data) => {
     dispatch(sourcesActions.fetchSources(data));
   };
 
   const handleClickReset = () => {
-    reset({ numPerPage: 100 });
+    setRowsPerPage(100);
     dispatch(sourcesActions.fetchSources());
   };
 
   const handleSourceTablePagination = (pageNumber, numPerPage) => {
+    setRowsPerPage(numPerPage);
     const data = {
       ...getValues(),
       pageNumber,
       numPerPage,
       totalMatches: sourcesState.totalMatches,
+    };
+    dispatch(sourcesActions.fetchSources(data));
+  };
+
+  const handleSourceTableSorting = (formData) => {
+    const data = {
+      ...getValues(),
+      pageNumber: 1,
+      rowsPerPage,
+      totalMatches: sourcesState.totalMatches,
+      sortBy: formData.column,
+      sortOrder: formData.ascending ? "asc" : "desc",
     };
     dispatch(sourcesActions.fetchSources(data));
   };
@@ -209,7 +224,7 @@ const SourceList = () => {
             </div>
           </form>
         </Paper>
-        {!sourcesState.queryInProgress && (
+        {sourcesState.sources && (
           <Grid item className={classes.tableGrid}>
             <SourceTable
               sources={sourcesState.sources}
@@ -217,10 +232,11 @@ const SourceList = () => {
               totalMatches={sourcesState.totalMatches}
               pageNumber={sourcesState.pageNumber}
               numPerPage={sourcesState.numPerPage}
+              sortingCallback={handleSourceTableSorting}
             />
           </Grid>
         )}
-        {sourcesState.queryInProgress && (
+        {!sourcesState.sources && (
           <CircularProgress className={classes.spinner} />
         )}
       </div>


### PR DESCRIPTION
Adds sorting for source tables on the group sources page and the sources page (which all use SourceTable.jsx).
Partially closes [Fritz #100](https://github.com/fritz-marshal/fritz/issues/100) (There was a separate request in there about adding additional columns to the table; this PR is just sorting).
![sourcesort](https://user-images.githubusercontent.com/17696889/99443220-81321980-28e8-11eb-85a3-091ff6e8f1dd.gif)
