### PR TITLE
Fix source handler bug where invalid ID was not caught soon enough

### DIFF
--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -392,6 +392,10 @@ class SourceHandler(BaseHandler):
                 query_options.append(
                     joinedload(Obj.photometry).joinedload(Photometry.instrument)
                 )
+            s = Obj.get_if_owned_by(obj_id, self.current_user, options=query_options,)
+
+            if s is None:
+                return self.error("Source not found", status=404)
             if is_token_request:
                 # Logic determining whether to register front-end request as view lives in front-end
                 register_source_view(
@@ -401,10 +405,6 @@ class SourceHandler(BaseHandler):
                 )
                 self.push_all(action="skyportal/FETCH_TOP_SOURCES")
 
-            s = Obj.get_if_owned_by(obj_id, self.current_user, options=query_options,)
-
-            if s is None:
-                return self.error("Source not found", status=404)
             if "ps1" not in [thumb.type for thumb in s.thumbnails]:
                 IOLoop.current().add_callback(
                     lambda: add_ps1_thumbnail_and_push_ws_msg(s, self)


### PR DESCRIPTION
This PR fixes a bug where an invalid obj ID was not caught soon enough and was passed to `register_source_view` and `add_ps1_thumbnail` before erroring.

Closes https://github.com/skyportal/skyportal/issues/1372 