### PR TITLE
Update SourceHandler.get access control

### DIFF
--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -509,7 +509,12 @@ class SourceHandler(BaseHandler):
                 .query(Obj)
                 .join(Photometry)
                 .join(Source)
-                .filter(Photometry.groups.any(Group.id.in_(user_accessible_group_ids)))
+                .filter(
+                    or_(
+                        Photometry.groups.any(Group.id.in_(user_accessible_group_ids)),
+                        Source.group_id.in_(user_accessible_group_ids),
+                    )
+                )
                 .options(query_options)
             )
         else:
@@ -518,7 +523,12 @@ class SourceHandler(BaseHandler):
                 .query(Source)
                 .join(Obj)
                 .join(Photometry)
-                .filter(Photometry.groups.any(Group.id.in_(user_accessible_group_ids)))
+                .filter(
+                    or_(
+                        Photometry.groups.any(Group.id.in_(user_accessible_group_ids)),
+                        Source.group_id.in_(user_accessible_group_ids),
+                    )
+                )
             )
 
         if sourceID:
@@ -576,7 +586,6 @@ class SourceHandler(BaseHandler):
                     if sort_order == "asc"
                     else [Obj.ra.desc().nullslast()]
                 )
-                print(sort_by, sort_order)
             elif sort_by == "dec":
                 order_by = (
                     [Obj.dec.nullslast()]

--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -26,7 +26,6 @@ from ...models import (
     Source,
     Token,
     Group,
-    GroupPhotometry,
     FollowupRequest,
     ClassicalAssignment,
     ObservingRun,
@@ -662,13 +661,10 @@ class SourceHandler(BaseHandler):
                 groups_query = (
                     DBSession()
                     .query(Group)
-                    .join(GroupPhotometry)
-                    .join(Photometry)
                     .join(Source)
-                    .join(Obj)
-                    .filter(Source.obj_id == source_list[-1]["id"])
                     .filter(
-                        Photometry.groups.any(Group.id.in_(user_accessible_group_ids))
+                        Source.obj_id == source_list[-1]["id"],
+                        Group.id.in_(user_accessible_group_ids),
                     )
                 )
                 groups_query = apply_active_or_requested_filtering(


### PR DESCRIPTION
This PR changes `SourceHandler.get` query filtering to filter on objects with at least one photometry data point viewable to user, rather than filtering on which groups a source is saved to. This accords with the current access control approach for fetching individual sources.

Closes #1373 
Closes https://github.com/fritz-marshal/fritz-beta-feedback/issues/42 