### PR TITLE
Track whether a telescope is space based or ground based 

### DIFF
--- a/alembic/versions/2a17ca9d5438_add_fixed_location_col.py
+++ b/alembic/versions/2a17ca9d5438_add_fixed_location_col.py
@@ -1,4 +1,4 @@
-"""add space-based col
+"""add fixed-location column
 
 Revision ID: 2a17ca9d5438
 Revises: fbf89710dead
@@ -19,9 +19,11 @@ depends_on = None
 def upgrade():
     op.add_column(
         'telescopes',
-        sa.Column('space_based', sa.Boolean(), server_default='false', nullable=False),
+        sa.Column(
+            'fixed_location', sa.Boolean(), server_default='true', nullable=False
+        ),
     )
 
 
 def downgrade():
-    op.drop_column('telescopes', 'space_based')
+    op.drop_column('telescopes', 'fixed_location')

--- a/alembic/versions/2a17ca9d5438_add_space_based_col.py
+++ b/alembic/versions/2a17ca9d5438_add_space_based_col.py
@@ -1,0 +1,27 @@
+"""add space-based col
+
+Revision ID: 2a17ca9d5438
+Revises: fbf89710dead
+Create Date: 2020-11-17 14:28:10.158404
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '2a17ca9d5438'
+down_revision = 'fbf89710dead'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        'telescopes',
+        sa.Column('space_based', sa.Boolean(), server_default='false', nullable=False),
+    )
+
+
+def downgrade():
+    op.drop_column('telescopes', 'space_based')

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -1255,6 +1255,10 @@ class Telescope(Base):
         sa.Boolean, default=False, nullable=False, doc="Is this telescope robotic?"
     )
 
+    space_based = sa.Column(
+        sa.Boolean, nullable=False, default=False, doc="Is this telescope space-based?"
+    )
+
     weather = sa.Column(JSONB, nullable=True, doc='Latest weather information')
     weather_retrieved_at = sa.Column(
         sa.DateTime, nullable=True, doc="When was the weather last retrieved?"

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -1256,7 +1256,10 @@ class Telescope(Base):
     )
 
     space_based = sa.Column(
-        sa.Boolean, nullable=False, default=False, doc="Is this telescope space-based?"
+        sa.Boolean,
+        nullable=False,
+        server_default='false',
+        doc="Is this telescope space-based?",
     )
 
     weather = sa.Column(JSONB, nullable=True, doc='Latest weather information')

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -1255,11 +1255,11 @@ class Telescope(Base):
         sa.Boolean, default=False, nullable=False, doc="Is this telescope robotic?"
     )
 
-    space_based = sa.Column(
+    fixed_location = sa.Column(
         sa.Boolean,
         nullable=False,
-        server_default='false',
-        doc="Is this telescope space-based?",
+        server_default='true',
+        doc="Does this telescope have a fixed location (lon, lat, elev)?",
     )
 
     weather = sa.Column(JSONB, nullable=True, doc='Latest weather information')

--- a/skyportal/tests/conftest.py
+++ b/skyportal/tests/conftest.py
@@ -285,6 +285,19 @@ def ztf_camera():
 
 
 @pytest.fixture()
+def hst():
+    return TelescopeFactory(
+        name=f'Hubble Space Telescope_{uuid.uuid4()}',
+        nickname=f'HST_{uuid.uuid4()}',
+        lat=0,
+        lon=0,
+        elevation=0,
+        diameter=2.0,
+        space_based=True,
+    )
+
+
+@pytest.fixture()
 def keck1_telescope():
     observer = astroplan.Observer.at_site('Keck')
     return TelescopeFactory(

--- a/skyportal/tests/conftest.py
+++ b/skyportal/tests/conftest.py
@@ -293,7 +293,7 @@ def hst():
         lon=0,
         elevation=0,
         diameter=2.0,
-        space_based=True,
+        fixed_location=False,
     )
 
 

--- a/skyportal/tests/frontend/test_observability.py
+++ b/skyportal/tests/frontend/test_observability.py
@@ -1,0 +1,7 @@
+def test_space_based_filtering(  # noqa: E302
+    driver, view_only_user, hst, public_source, keck1_telescope
+):
+    driver.get(f'/become_user/{view_only_user.id}')
+    driver.get(f'/observability/{public_source.id}')
+    driver.wait_for_xpath(f'//*[text()="{keck1_telescope.name}"]')
+    driver.wait_for_xpath_to_disappear(f'//*[text()="{hst.name}"]')

--- a/skyportal/tests/frontend/test_observability.py
+++ b/skyportal/tests/frontend/test_observability.py
@@ -1,4 +1,4 @@
-def test_space_based_filtering(  # noqa: E302
+def test_fixed_location_filtering(  # noqa: E302
     driver, view_only_user, hst, public_source, keck1_telescope
 ):
     driver.get(f'/become_user/{view_only_user.id}')

--- a/static/js/components/Observability.jsx
+++ b/static/js/components/Observability.jsx
@@ -26,7 +26,7 @@ const ObservabilityPage = ({ route }) => {
       </Typography>
       <Grid container spacing={3}>
         {telescopeList
-          .filter((telescope) => !telescope.space_based)
+          .filter((telescope) => telescope.fixed_location)
           .map((telescope) => {
             return (
               <Grid item key={telescope.id}>

--- a/static/js/components/Observability.jsx
+++ b/static/js/components/Observability.jsx
@@ -25,23 +25,25 @@ const ObservabilityPage = ({ route }) => {
         Observability of <Link to={`/source/${route.id}`}>{route.id}</Link>
       </Typography>
       <Grid container spacing={3}>
-        {telescopeList.map((telescope) => {
-          return (
-            <Grid item key={telescope.id}>
-              <Paper>
-                <div className={classes.inner}>
-                  <Typography variant="h6">{telescope.name}</Typography>
-                  <Suspense fallback={<div>Loading plot...</div>}>
-                    <AirMassPlotWithEphemURL
-                      dataUrl={`/api/internal/plot/airmass/objtel/${route.id}/${telescope.id}`}
-                      ephemerisUrl={`/api/internal/ephemeris/${telescope.id}`}
-                    />
-                  </Suspense>
-                </div>
-              </Paper>
-            </Grid>
-          );
-        })}
+        {telescopeList
+          .filter((telescope) => !telescope.space_based)
+          .map((telescope) => {
+            return (
+              <Grid item key={telescope.id}>
+                <Paper>
+                  <div className={classes.inner}>
+                    <Typography variant="h6">{telescope.name}</Typography>
+                    <Suspense fallback={<div>Loading plot...</div>}>
+                      <AirMassPlotWithEphemURL
+                        dataUrl={`/api/internal/plot/airmass/objtel/${route.id}/${telescope.id}`}
+                        ephemerisUrl={`/api/internal/ephemeris/${telescope.id}`}
+                      />
+                    </Suspense>
+                  </div>
+                </Paper>
+              </Grid>
+            );
+          })}
       </Grid>
     </div>
   );


### PR DESCRIPTION
This PR keeps track of whether a given telescope is space based or ground based. If it is space based, it does not show the telescope's airmass plot on the observability page, partially addressing https://github.com/fritz-marshal/fritz-beta-feedback/issues/29.