### PR TITLE
Re-skin info section in CandidateList

### DIFF
--- a/skyportal/tests/frontend/test_scanning_page.py
+++ b/skyportal/tests/frontend/test_scanning_page.py
@@ -52,8 +52,8 @@ def test_candidate_group_filtering(
     driver.scroll_to_element_and_click(group_checkbox)
     submit_button = driver.wait_for_xpath('//span[text()="Search"]')
     driver.scroll_to_element_and_click(submit_button)
-    for i in range(5):
-        driver.wait_for_xpath(f'//a[text()="{candidate_id}_{i}"]')
+    for i in range(5):  # data-testid
+        driver.wait_for_xpath(f'//a[@data-testid="{candidate_id}_{i}"]')
     driver.scroll_to_element_and_click(group_checkbox)
     driver.click_xpath(
         f'//*[@data-testid="filteringFormGroupCheckbox-{new_group_id}"]',
@@ -61,7 +61,7 @@ def test_candidate_group_filtering(
     )
     driver.scroll_to_element_and_click(submit_button)
     for i in range(5):
-        driver.wait_for_xpath_to_disappear(f'//a[text()="{candidate_id}_{i}"]')
+        driver.wait_for_xpath_to_disappear(f'//a[@data-testid="{candidate_id}_{i}"]')
 
 
 @pytest.mark.flaky(reruns=2)
@@ -121,11 +121,11 @@ def test_candidate_unsaved_only_filtering(
     submit_button = driver.wait_for_xpath('//span[text()="Search"]')
     driver.scroll_to_element_and_click(submit_button)
     for i in range(5):
-        driver.wait_for_xpath_to_disappear(f'//a[text()="{candidate_id}_{i}"]')
+        driver.wait_for_xpath_to_disappear(f'//a[@data-testid="{candidate_id}_{i}"]')
     driver.scroll_to_element_and_click(unsaved_only_checkbox)
     driver.scroll_to_element_and_click(submit_button)
     for i in range(5):
-        driver.wait_for_xpath(f'//a[text()="{candidate_id}_{i}"]')
+        driver.wait_for_xpath(f'//a[@data-testid="{candidate_id}_{i}"]')
 
 
 @pytest.mark.flaky(reruns=2)
@@ -191,13 +191,15 @@ def test_candidate_date_filtering(
     submit_button = driver.wait_for_xpath_to_be_clickable('//span[text()="Search"]')
     driver.scroll_to_element_and_click(submit_button)
     for i in range(5):
-        driver.wait_for_xpath_to_disappear(f'//a[text()="{candidate_id}_{i}"]', 10)
+        driver.wait_for_xpath_to_disappear(
+            f'//a[@data-testid="{candidate_id}_{i}"]', 10
+        )
     end_date_input.clear()
     end_date_input.send_keys("209012120000")
     submit_button = driver.wait_for_xpath_to_be_clickable('//span[text()="Search"]')
     driver.scroll_to_element_and_click(submit_button)
     for i in range(5):
-        driver.wait_for_xpath(f'//a[text()="{candidate_id}_{i}"]', 10)
+        driver.wait_for_xpath(f'//a[@data-testid="{candidate_id}_{i}"]', 10)
 
 
 @pytest.mark.flaky(reruns=2)
@@ -211,7 +213,7 @@ def test_save_candidate_quick_save(
         wait_clickable=False,
     )
     driver.click_xpath('//span[text()="Search"]', wait_clickable=False)
-    driver.wait_for_xpath(f'//a[text()="{public_candidate.id}"]')
+    driver.wait_for_xpath(f'//a[@data-testid="{public_candidate.id}"]')
     save_button = driver.wait_for_xpath(
         f'//button[@name="initialSaveCandidateButton{public_candidate.id}"]'
     )
@@ -233,7 +235,7 @@ def test_save_candidate_select_groups(
         wait_clickable=False,
     )
     driver.click_xpath('//span[text()="Search"]')
-    driver.wait_for_xpath(f'//a[text()="{public_candidate.id}"]')
+    driver.wait_for_xpath(f'//a[@data-testid="{public_candidate.id}"]')
     carat = driver.wait_for_xpath(
         f'//button[@name="saveCandidateButtonDropDownArrow{public_candidate.id}"]'
     )
@@ -270,7 +272,7 @@ def test_save_candidate_no_groups_error_message(
         wait_clickable=False,
     )
     driver.click_xpath('//span[text()="Search"]')
-    driver.wait_for_xpath(f'//a[text()="{public_candidate.id}"]')
+    driver.wait_for_xpath(f'//a[@data-testid="{public_candidate.id}"]')
     carat = driver.wait_for_xpath_to_be_clickable(
         f'//button[@name="saveCandidateButtonDropDownArrow{public_candidate.id}"]'
     )
@@ -337,7 +339,7 @@ def test_submit_annotations_sorting(
         wait_clickable=False,
     )
     driver.click_xpath('//span[text()="Search"]')
-    driver.wait_for_xpath(f'//a[text()="{public_candidate.id}"]')
+    driver.wait_for_xpath(f'//a[@data-testid="{public_candidate.id}"]')
 
     driver.click_xpath(f"//p[text()='numeric_field: 1.0000']")
     # Check to see that selected annotation appears in info column
@@ -402,7 +404,7 @@ def test_submit_annotations_filtering(
         wait_clickable=False,
     )
     driver.click_xpath('//span[text()="Search"]')
-    driver.wait_for_xpath(f'//a[text()="{public_candidate.id}"]')
+    driver.wait_for_xpath(f'//a[@data-testid="{public_candidate.id}"]')
 
     # scroll to top of page so dialog doesn't get cut off
     element = driver.wait_for_xpath("//button[@data-testid='Filter Table-iconButton']")
@@ -429,6 +431,6 @@ def test_submit_annotations_filtering(
 
     # Check that results come back as expected
     # The first candidate should exist
-    driver.wait_for_xpath(f'//a[text()="{public_candidate.id}"]')
+    driver.wait_for_xpath(f'//a[@data-testid="{public_candidate.id}"]')
     # The second candidate should not exist
-    driver.wait_for_xpath_to_disappear(f'//a[text()="{public_candidate2.id}"]')
+    driver.wait_for_xpath_to_disappear(f'//a[@data-testid="{public_candidate2.id}"]')

--- a/static/js/components/CandidateList.jsx
+++ b/static/js/components/CandidateList.jsx
@@ -458,6 +458,7 @@ const CandidateList = () => {
           <a
             href={`/source/${candidateObj.id}`}
             target="_blank"
+            data-testid={candidateObj.id}
             rel="noreferrer"
           >
             <Button

--- a/static/js/components/CandidateList.jsx
+++ b/static/js/components/CandidateList.jsx
@@ -1,6 +1,5 @@
 import React, { useEffect, Suspense, useState } from "react";
 import { useSelector, useDispatch } from "react-redux";
-import { useHistory } from "react-router-dom";
 import PropTypes from "prop-types";
 
 import Paper from "@material-ui/core/Paper";
@@ -115,6 +114,11 @@ const useStyles = makeStyles((theme) => ({
     display: "flex",
     flexFlow: "row wrap",
     alignItems: "center",
+  },
+  idButton: {
+    // color: theme.palette.primary.main,
+    textTransform: "none",
+    marginBottom: theme.spacing(1),
   },
 }));
 
@@ -256,7 +260,6 @@ CustomSortToolbar.defaultProps = {
 };
 
 const CandidateList = () => {
-  const history = useHistory();
   const [queryInProgress, setQueryInProgress] = useState(false);
   const [rowsPerPage, setRowsPerPage] = useState(defaultNumPerPage);
   const [filterGroups, setFilterGroups] = useState([]);
@@ -452,31 +455,26 @@ const CandidateList = () => {
     return (
       <div className={classes.info}>
         <span className={classes.itemPaddingBottom}>
-          <b>ID:</b>&nbsp;
           <a
             href={`/source/${candidateObj.id}`}
             target="_blank"
             rel="noreferrer"
           >
-            {candidateObj.id}&nbsp;
-            <OpenInNewIcon fontSize="inherit" />
+            <Button
+              variant="contained"
+              size="small"
+              color="primary"
+              className={classes.idButton}
+            >
+              {candidateObj.id}&nbsp;
+              <OpenInNewIcon fontSize="inherit" />
+            </Button>
           </a>
         </span>
-        <br />
         {candidateObj.is_source ? (
           <div>
             <div className={classes.itemPaddingBottom}>
-              <Chip
-                size="small"
-                label="Previously Saved"
-                clickable
-                onClick={() => history.push(`/source/${candidateObj.id}`)}
-                onDelete={() =>
-                  window.open(`/source/${candidateObj.id}`, "_blank")
-                }
-                deleteIcon={<OpenInNewIcon />}
-                color="primary"
-              />
+              <Chip size="small" label="Previously Saved" color="primary" />
             </div>
             <div className={classes.saveCandidateButton}>
               <EditSourceGroups
@@ -551,7 +549,7 @@ const CandidateList = () => {
         {candidateObj.classifications && recentClassification && (
           <div className={classes.infoItem}>
             <b>Classification: </b>
-            <span>{recentClassification}</span>
+            <Chip size="small" label={recentClassification} color="primary" />
           </div>
         )}
         {selectedAnnotationSortOptions !== null &&

--- a/static/js/components/SourceDesktop.jsx
+++ b/static/js/components/SourceDesktop.jsx
@@ -182,7 +182,7 @@ const SourceDesktop = ({ source }) => {
             </>
           )}
           {source.redshift != null && <>&nbsp;|&nbsp;</>}
-          Finding Chart:&nbsp;
+          <b>Finding Chart:&nbsp;</b>
           <Button
             href={`/api/sources/${source.id}/finder`}
             download="finder-chart-pdf"

--- a/static/js/components/SourceMobile.jsx
+++ b/static/js/components/SourceMobile.jsx
@@ -211,7 +211,7 @@ const SourceMobile = ({ source }) => {
                 </>
               )}
               {source.redshift != null && <>&nbsp;|&nbsp;</>}
-              Finding Chart:&nbsp;
+              <b>Finding Chart:&nbsp;</b>
               <Button
                 href={`/api/sources/${source.id}/finder`}
                 download="finder-chart-pdf"


### PR DESCRIPTION
Proposed re-skin:
- Focus user's attention on 1) object ID that when clicked always opens in a new tab 2) if it's saved 3) if it's classified:
![image](https://user-images.githubusercontent.com/7557205/99605402-76e14f80-29bc-11eb-8b29-429b462ce656.png)

That's how it looks like now:
![image](https://user-images.githubusercontent.com/7557205/99605328-51544600-29bc-11eb-9de9-7d1f706103e1.png)
