### PR TITLE
Limit source assignment to upcoming observing runs

### DIFF
--- a/skyportal/handlers/api/observingrun.py
+++ b/skyportal/handlers/api/observingrun.py
@@ -162,7 +162,14 @@ class ObservingRunHandler(BaseHandler):
             return self.success(data=data)
 
         runs = ObservingRun.query.order_by(ObservingRun.calendar_date.asc()).all()
-        return self.success(data=runs)
+        runs_list = []
+        for run in runs:
+            runs_list.append(run.to_dict())
+            runs_list[-1]["run_end_utc"] = run.instrument.telescope.next_sunrise(
+                run.calendar_noon
+            ).isot
+
+        return self.success(data=runs_list)
 
     @permissions(["Upload data"])
     def put(self, run_id):

--- a/static/js/components/AssignmentForm.jsx
+++ b/static/js/components/AssignmentForm.jsx
@@ -72,13 +72,18 @@ const AssignmentForm = ({ obj_id, observingRunList }) => {
   }));
   const classes = useStyles();
 
-  if (observingRunList.length === 0) {
+  const upcomingObservingRuns = observingRunList.filter((run) =>
+    dayjs().isBefore(dayjs(run.run_end_utc))
+  );
+
+  if (upcomingObservingRuns.length === 0) {
     return <b>No upcoming observing runs to assign target to...</b>;
   }
 
   const initialFormState = {
     comment: "",
-    run_id: observingRunList.length > 0 ? observingRunList[0].id : null,
+    run_id:
+      upcomingObservingRuns.length > 0 ? upcomingObservingRuns[0].id : null,
     priority: "1",
     obj_id,
   };
@@ -108,10 +113,12 @@ const AssignmentForm = ({ obj_id, observingRunList }) => {
               control={control}
               rules={{ required: true }}
               defaultValue={
-                observingRunList.length > 0 ? observingRunList[0].id : null
+                upcomingObservingRuns.length > 0
+                  ? upcomingObservingRuns[0].id
+                  : null
               }
             >
-              {observingRunList.map((observingRun) => (
+              {upcomingObservingRuns.map((observingRun) => (
                 <MenuItem
                   value={observingRun.id}
                   key={observingRun.id.toString()}


### PR DESCRIPTION
Addresses [Beta Feedback Issue #39](https://github.com/fritz-marshal/fritz-beta-feedback/issues/39).

On the source page, the options for "Assign Target to Observing Run" are now limited to observing runs whose end (the next sunrise after the run's calendar date) is after the current time. 