### PR TITLE
Further improve normalization of spectra on spectroscopy plot

### DIFF
--- a/skyportal/handlers/api/observingrun.py
+++ b/skyportal/handlers/api/observingrun.py
@@ -1,3 +1,4 @@
+import numpy as np
 from sqlalchemy.orm import joinedload
 from marshmallow.exceptions import ValidationError
 from baselayer.app.access import permissions, auth_or_token
@@ -156,8 +157,8 @@ class ObservingRunHandler(BaseHandler):
                 set_times = run.set_time(targets).isot
 
                 for d, rt, st in zip(data["assignments"], rise_times, set_times):
-                    d["rise_time_utc"] = rt
-                    d["set_time_utc"] = st
+                    d["rise_time_utc"] = rt if rt is not np.ma.masked else ''
+                    d["set_time_utc"] = st if st is not np.ma.masked else ''
 
             return self.success(data=data)
 

--- a/skyportal/plot.py
+++ b/skyportal/plot.py
@@ -719,16 +719,8 @@ def spectroscopy_plot(obj_id, spec_id=None):
     data = []
     for i, s in enumerate(spectra):
 
-        # normalize spectra to a common average flux per resolving
-        # element of 1 (facilitates easy visual comparison)
-        normfac = np.sum(np.gradient(s.wavelengths) * s.fluxes) / len(s.fluxes)
-
-        if not (np.isfinite(normfac) and normfac > 0):
-            # otherwise normalize the value at the median wavelength to 1
-            median_wave_index = np.argmin(
-                np.abs(s.wavelengths - np.median(s.wavelengths))
-            )
-            normfac = s.fluxes[median_wave_index]
+        # normalize spectra to a median flux of 1 for easy comparison
+        normfac = np.median(s.fluxes)
 
         df = pd.DataFrame(
             {


### PR DESCRIPTION
<img width="473" alt="Screen Shot 2020-11-19 at 3 36 46 PM" src="https://user-images.githubusercontent.com/2769632/99737403-11a16300-2a7d-11eb-8c00-08f90bf91787.png">

The current normalization scheme seems to result in gaps between spectra that should all be more or less on top of each other. This PR uses a much more stable normalization scheme, normalizing all spectra to a median flux of 1, to fix this issue. 
