### PR TITLE
Fix permissions on spectroscopy plot 

### DIFF
--- a/skyportal/handlers/api/internal/plot.py
+++ b/skyportal/handlers/api/internal/plot.py
@@ -35,7 +35,7 @@ class PlotSpectroscopyHandler(BaseHandler):
     def get(self, obj_id):
         spec_id = self.get_query_argument("spectrumID", None)
         docs_json, render_items, custom_model_js = plot.spectroscopy_plot(
-            obj_id, spec_id
+            obj_id, self.associated_user_object, spec_id
         )
         if docs_json is None:
             self.success(data={'docs_json': None, 'url': self.request.path})

--- a/skyportal/handlers/api/observingrun.py
+++ b/skyportal/handlers/api/observingrun.py
@@ -1,3 +1,4 @@
+import numpy as np
 from sqlalchemy.orm import joinedload
 from marshmallow.exceptions import ValidationError
 from baselayer.app.access import permissions, auth_or_token
@@ -156,8 +157,8 @@ class ObservingRunHandler(BaseHandler):
                 set_times = run.set_time(targets).isot
 
                 for d, rt, st in zip(data["assignments"], rise_times, set_times):
-                    d["rise_time_utc"] = rt
-                    d["set_time_utc"] = st
+                    d["rise_time_utc"] = rt if rt is not np.ma.masked else ''
+                    d["set_time_utc"] = st if st is not np.ma.masked else ''
 
             return self.success(data=data)
 

--- a/skyportal/plot.py
+++ b/skyportal/plot.py
@@ -719,7 +719,8 @@ def spectroscopy_plot(obj_id, user, spec_id=None):
             Spectrum.obj_id == obj_id,
             GroupSpectrum.group_id.in_([g.id for g in user.accessible_groups]),
         )
-    )
+    ).all()
+
     if spec_id is not None:
         spectra = [spec for spec in spectra if spec.id == int(spec_id)]
     if len(spectra) == 0:

--- a/skyportal/tests/fixtures.py
+++ b/skyportal/tests/fixtures.py
@@ -219,7 +219,11 @@ class ObjFactory(factory.alchemy.SQLAlchemyModelFactory):
             DBSession().add(ThumbnailFactory(obj_id=obj.id, type="new"))
             DBSession().add(ThumbnailFactory(obj_id=obj.id, type="ps1"))
             DBSession().add(CommentFactory(obj_id=obj.id, groups=passed_groups))
-        DBSession().add(SpectrumFactory(obj_id=obj.id, instrument=instruments[0]))
+        DBSession().add(
+            SpectrumFactory(
+                obj_id=obj.id, instrument=instruments[0], groups=passed_groups
+            )
+        )
         DBSession().commit()
 
 


### PR DESCRIPTION
The spectroscopy bokeh plot was not doing any ACL checking and was showing all spectra associated with an object rather than just the ones that were associated with any of the requesting user's groups. This PR fixes this by adding in an ACL check to the `spectroscopy_plot` function. 