### PR TITLE
Refactor new group user & invite new user to group components; update API to use user ID instead of username

### DIFF
--- a/data/db_demo.yaml
+++ b/data/db_demo.yaml
@@ -46,9 +46,9 @@ groups:
     =id: program_B
 
 groups/=program_A/users:
-  - username: viewonlyuser
+  - userID: =viewonlyuser
     admin: false
-  - username: fulluser
+  - userID: =fulluser
     admin: false
 
 streams/=ztf_public/users:

--- a/skyportal/handlers/api/group.py
+++ b/skyportal/handlers/api/group.py
@@ -3,7 +3,6 @@ from marshmallow.exceptions import ValidationError
 from baselayer.app.access import permissions, auth_or_token
 from baselayer.app.env import load_env
 from ..base import BaseHandler
-from .user import add_user_and_setup_groups
 from ...models import (
     DBSession,
     Filter,
@@ -372,12 +371,12 @@ class GroupUserHandler(BaseHandler):
               schema:
                 type: object
                 properties:
-                  username:
-                    type: string
+                  userID:
+                    type: integer
                   admin:
                     type: boolean
                 required:
-                  - username
+                  - userID
                   - admin
         responses:
           200:
@@ -406,42 +405,41 @@ class GroupUserHandler(BaseHandler):
 
         data = self.get_json()
 
-        username = data.pop("username", None)
-        if username is None:
-            return self.error("Username must be specified")
+        user_id = data.pop("userID", None)
+        if user_id is None:
+            return self.error("userID parameter must be specified")
+        try:
+            user_id = int(user_id)
+        except (ValueError, TypeError):
+            return self.error("Invalid userID parameter: unable to parse to integer")
 
         admin = data.pop("admin", False)
         group_id = int(group_id)
         group = Group.query.get(group_id)
         if group.single_user_group:
             return self.error("Cannot add users to single-user groups.")
-        user = User.query.filter(User.username == username.lower()).first()
+        user = User.query.get(user_id)
         if user is None:
-            user_id = add_user_and_setup_groups(
-                username=username,
-                roles=["Full user"],
-                group_ids_and_admin=[[group_id, admin]],
-            )
-        else:
-            user_id = user.id
-            # Ensure user has sufficient stream access to be added to group
-            if group.streams:
-                if not all(
-                    [stream in user.accessible_streams for stream in group.streams]
-                ):
-                    return self.error(
-                        "User does not have sufficient stream access "
-                        "to be added to this group."
-                    )
-            # Add user to group
-            gu = (
-                GroupUser.query.filter(GroupUser.group_id == group_id)
-                .filter(GroupUser.user_id == user_id)
-                .first()
-            )
-            if gu is not None:
-                return self.error("Specified user is already a member of this group.")
-            DBSession.add(GroupUser(group_id=group_id, user_id=user_id, admin=admin))
+            return self.error(f"Invalid userID parameter: {user_id}")
+
+        # Ensure user has sufficient stream access to be added to group
+	if group.streams:
+	    if not all(
+		[stream in user.accessible_streams for stream in group.streams]
+	    ):
+		return self.error(
+		    "User does not have sufficient stream access "
+		    "to be added to this group."
+		)
+        # Add user to group
+        gu = (
+            GroupUser.query.filter(GroupUser.group_id == group_id)
+            .filter(GroupUser.user_id == user_id)
+            .first()
+        )
+        if gu is not None:
+            return self.error("Specified user is already a member of this group.")
+        DBSession.add(GroupUser(group_id=group_id, user_id=user_id, admin=admin))
         DBSession().commit()
 
         self.push_all(action='skyportal/REFRESH_GROUP', payload={'group_id': group_id})

--- a/skyportal/tests/frontend/test_groups.py
+++ b/skyportal/tests/frontend/test_groups.py
@@ -1,6 +1,5 @@
 import uuid
 import pytest
-from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.action_chains import ActionChains
 from baselayer.app.env import load_env
 
@@ -61,11 +60,12 @@ def test_add_new_group_user_admin(
     driver.wait_for_xpath('//h6[text()="All Groups"]')
     el = driver.wait_for_xpath(f'//a[contains(.,"{public_group.name}")]')
     driver.execute_script("arguments[0].click();", el)
-    el_input = driver.wait_for_xpath('//input[@id="newUserEmail"]', timeout=10)
+    el_input = driver.wait_for_xpath('//input[@id="newGroupUserInput"]', timeout=10)
     el_input.clear()
     ActionChains(driver).move_to_element(el_input).click().send_keys(
         user_no_groups.username
-    ).pause(5).send_keys(Keys.ENTER).perform()
+    ).perform()
+    driver.click_xpath(f'//li[text()="{user_no_groups.username}"]')
     driver.click_xpath('//input[@type="checkbox"]')
     driver.click_xpath('//button[contains(.,"Add user")]')
     driver.wait_for_xpath(f'//a[contains(.,"{user_no_groups.username}")]')
@@ -88,11 +88,12 @@ def test_add_new_group_user_nonadmin(
     driver.wait_for_xpath('//h6[text()="All Groups"]')
     el = driver.wait_for_xpath(f'//a[contains(.,"{public_group.name}")]')
     driver.execute_script("arguments[0].click();", el)
-    el_input = driver.wait_for_xpath('//input[@id="newUserEmail"]', timeout=10)
+    el_input = driver.wait_for_xpath('//input[@id="newGroupUserInput"]', timeout=10)
     el_input.clear()
     ActionChains(driver).move_to_element(el_input).click().send_keys(
         user_no_groups.username
-    ).pause(5).send_keys(Keys.ENTER).perform()
+    ).perform()
+    driver.click_xpath(f'//li[text()="{user_no_groups.username}"]')
     driver.click_xpath('//button[contains(.,"Add user")]')
     driver.wait_for_xpath(f'//a[contains(.,"{user_no_groups.username}")]')
     assert (
@@ -103,28 +104,6 @@ def test_add_new_group_user_nonadmin(
         )
         == 0
     )
-
-
-@pytest.mark.flaky(reruns=2)
-def test_add_new_group_user_new_username(driver, super_admin_user, user, public_group):
-    new_username = str(uuid.uuid4())
-    driver.get(f'/become_user/{super_admin_user.id}')
-    driver.get('/groups')
-    driver.wait_for_xpath('//h6[text()="All Groups"]')
-    el = driver.wait_for_xpath(f'//a[contains(.,"{public_group.name}")]')
-    driver.execute_script("arguments[0].click();", el)
-    el_input = driver.wait_for_xpath('//input[@id="newUserEmail"]', timeout=10)
-    el_input.clear()
-    ActionChains(driver).move_to_element(el_input).click().send_keys(
-        new_username
-    ).pause(5).send_keys(Keys.ENTER).perform()
-    driver.click_xpath('//button[contains(.,"Add user")]')
-    if cfg["invitations.enabled"]:  # If invites are disabled, we won't see these
-        driver.click_xpath('//span[text()="Confirm"]')
-        driver.wait_for_xpath('//*[contains(., "Invitation successfully sent to")]')
-    else:
-        # If invitations are disabled, the user will be added and will appear
-        driver.wait_for_xpath(f'//a[contains(.,"{new_username}")]')
 
 
 @pytest.mark.flaky(reruns=2)
@@ -168,9 +147,9 @@ def test_delete_group(driver, super_admin_user, user, public_group):
     el = driver.wait_for_xpath(f'//a[contains(.,"{public_group.name}")]')
     driver.execute_script("arguments[0].click();", el)
     driver.scroll_to_element_and_click(
-        driver.wait_for_xpath(f'//button[contains(.,"Delete Group")]')
+        driver.wait_for_xpath('//button[contains(.,"Delete Group")]')
     )
-    driver.wait_for_xpath(f'//button[contains(.,"Confirm")]').click()
+    driver.wait_for_xpath('//button[contains(.,"Confirm")]').click()
     driver.wait_for_xpath_to_disappear(f'//a[contains(.,"{public_group.name}")]')
 
 
@@ -185,29 +164,29 @@ def test_add_stream_add_delete_filter_group(
     el = driver.wait_for_xpath(f'//a[contains(.,"{public_group.name}")]')
     driver.execute_script("arguments[0].click();", el)
     # add stream
-    driver.wait_for_xpath(f'//button[contains(.,"Add stream")]').click()
+    driver.wait_for_xpath('//button[contains(.,"Add stream")]').click()
     driver.wait_for_xpath('//input[@name="stream_id"]/..', timeout=10).click()
     driver.wait_for_xpath(f'//li[contains(.,"{public_stream.id}")]', timeout=10)
     stream = driver.switch_to.active_element
     stream.click()
-    add_stream = driver.wait_for_xpath_to_be_clickable(f'//button[@type="submit"]')
+    add_stream = driver.wait_for_xpath_to_be_clickable('//button[@type="submit"]')
     driver.execute_script("arguments[0].click();", add_stream)
 
     # add filter
     filter_name = str(uuid.uuid4())
     driver.wait_for_xpath_to_be_clickable(
-        f'//button[contains(.,"Add filter")]', timeout=10
+        '//button[contains(.,"Add filter")]', timeout=10
     )
     flt = driver.switch_to.active_element
     flt.click()
-    driver.wait_for_xpath(f'//button[contains(.,"Add filter")]').click()
+    driver.wait_for_xpath('//button[contains(.,"Add filter")]').click()
     driver.wait_for_xpath('//input[@name="filter_name"]/..', timeout=10).click()
     driver.wait_for_xpath('//input[@name="filter_name"]').send_keys(filter_name)
     driver.wait_for_xpath('//input[@name="filter_stream_id"]/..', timeout=10).click()
     driver.wait_for_xpath(f'//li[contains(.,"{public_stream.id}")]', timeout=10)
     stream = driver.switch_to.active_element
     stream.click()
-    add_filter = driver.wait_for_xpath(f'//button[@type="submit"]', timeout=10)
+    add_filter = driver.wait_for_xpath('//button[@type="submit"]', timeout=10)
     driver.execute_script("arguments[0].click();", add_filter)
     driver.wait_for_xpath(f'//span[contains(.,"{filter_name}")]', timeout=10)
     assert (

--- a/static/js/components/Group.jsx
+++ b/static/js/components/Group.jsx
@@ -46,6 +46,7 @@ import * as groupsActions from "../ducks/groups";
 import * as streamsActions from "../ducks/streams";
 import * as filterActions from "../ducks/filter";
 import NewGroupUserForm from "./NewGroupUserForm";
+import InviteNewGroupUserForm from "./InviteNewGroupUserForm";
 import AddUsersFromGroupForm from "./AddUsersFromGroupForm";
 
 const useStyles = makeStyles((theme) => ({
@@ -245,6 +246,7 @@ const Group = () => {
 
   const group = useSelector((state) => state.group);
   const currentUser = useSelector((state) => state.profile);
+  const { invitationsEnabled } = useSelector((state) => state.sysInfo);
 
   // fetch streams:
   const streams = useSelector((state) => state.streams);
@@ -435,6 +437,13 @@ const Group = () => {
               <>
                 <br />
                 <NewGroupUserForm group_id={group.id} />
+                <br />
+                {invitationsEnabled && (
+                  <>
+                    <br />
+                    <InviteNewGroupUserForm group_id={group.id} />
+                  </>
+                )}
                 <br />
                 <AddUsersFromGroupForm groupID={group.id} />
               </>

--- a/static/js/components/Group.jsx
+++ b/static/js/components/Group.jsx
@@ -134,7 +134,7 @@ const ManageUserButtons = ({ group, loadedId, user, isAdmin }) => {
         onClick={() =>
           dispatch(
             groupsActions.deleteGroupUser({
-              username: user.username,
+              userID: user.id,
               group_id: group.id,
             })
           )
@@ -306,7 +306,7 @@ const Group = () => {
 
   const isAdmin = (aUser) => {
     const currentGroupUser = group?.users?.filter(
-      (group_user) => group_user.username === aUser.username
+      (group_user) => group_user.id === aUser.id
     )[0];
     return (
       (currentGroupUser &&

--- a/static/js/components/InviteNewGroupUserForm.jsx
+++ b/static/js/components/InviteNewGroupUserForm.jsx
@@ -1,0 +1,135 @@
+import React, { useState } from "react";
+import PropTypes from "prop-types";
+import { useDispatch } from "react-redux";
+import TextField from "@material-ui/core/TextField";
+import Button from "@material-ui/core/Button";
+import Dialog from "@material-ui/core/Dialog";
+import DialogActions from "@material-ui/core/DialogActions";
+import DialogContent from "@material-ui/core/DialogContent";
+import DialogContentText from "@material-ui/core/DialogContentText";
+import DialogTitle from "@material-ui/core/DialogTitle";
+import Typography from "@material-ui/core/Typography";
+import { makeStyles } from "@material-ui/core/styles";
+
+import { showNotification } from "baselayer/components/Notifications";
+import * as invitationsActions from "../ducks/invitations";
+
+const useStyles = makeStyles(() => ({
+  heading: {
+    fontSize: "1.0625rem",
+    fontWeight: 500,
+  },
+}));
+
+const InviteNewGroupUserForm = ({ group_id }) => {
+  const dispatch = useDispatch();
+  const [formState, setFormState] = useState({
+    newUserEmail: "",
+    admin: false,
+  });
+  const [confirmDialogOpen, setConfirmDialogOpen] = React.useState(false);
+  const classes = useStyles();
+
+  const handleClickSubmit = async () => {
+    const result = await dispatch(
+      invitationsActions.inviteUser({
+        userEmail: formState.newUserEmail,
+        groupIDs: [group_id],
+        groupAdmin: [formState.admin],
+        streamIDs: null,
+      })
+    );
+    if (result.status === "success") {
+      dispatch(
+        showNotification(
+          `Invitation successfully sent to ${formState.newUserEmail}`
+        )
+      );
+      setFormState({
+        newUserEmail: "",
+        admin: false,
+      });
+    }
+  };
+
+  const toggleAdmin = (event) => {
+    setFormState({
+      ...formState,
+      admin: event.target.checked,
+    });
+  };
+
+  return (
+    <div>
+      <Typography className={classes.heading}>
+        Invite a new user to the site and add them to this group
+      </Typography>
+      <div style={{ paddingBottom: "1rem" }}>
+        <TextField
+          id="newUserEmail"
+          value={formState?.newUserEmail || ""}
+          onChange={(event) =>
+            setFormState({ ...formState, newUserEmail: event.target.value })
+          }
+          label="Enter user email"
+        />
+      </div>
+      <input
+        type="checkbox"
+        checked={formState?.admin || false}
+        onChange={toggleAdmin}
+      />
+      Group Admin &nbsp;&nbsp;
+      <Button
+        onClick={() => setConfirmDialogOpen(true)}
+        variant="contained"
+        size="small"
+        disableElevation
+      >
+        Invite new user
+      </Button>
+      <Dialog
+        open={confirmDialogOpen}
+        onClose={() => {
+          setConfirmDialogOpen(false);
+        }}
+        aria-labelledby="alert-dialog-title"
+        aria-describedby="alert-dialog-description"
+      >
+        <DialogTitle id="alert-dialog-title">
+          Invite new user and add to this group?
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText id="alert-dialog-description">
+            Click Confirm to invite specified user and grant them access to this
+            group.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            onClick={() => {
+              setConfirmDialogOpen(false);
+            }}
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={() => {
+              setConfirmDialogOpen(false);
+              handleClickSubmit();
+            }}
+            color="primary"
+            autoFocus
+          >
+            Confirm
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+};
+InviteNewGroupUserForm.propTypes = {
+  group_id: PropTypes.number.isRequired,
+};
+
+export default InviteNewGroupUserForm;

--- a/static/js/components/NewGroupUserForm.jsx
+++ b/static/js/components/NewGroupUserForm.jsx
@@ -38,8 +38,7 @@ const NewGroupUserForm = ({ group_id }) => {
   }, [dispatch, allUsers]);
 
   const handleClickSubmit = async () => {
-    let result = null;
-    result = await dispatch(
+    const result = await dispatch(
       groupsActions.addGroupUser({
         userID: formState.userID,
         admin: formState.admin,

--- a/static/js/components/NewGroupUserForm.jsx
+++ b/static/js/components/NewGroupUserForm.jsx
@@ -71,7 +71,7 @@ const NewGroupUserForm = ({ group_id }) => {
         Add an existing user to this group
       </Typography>
       <Autocomplete
-        id="newUserEmail"
+        id="newGroupUserInput"
         value={
           allUsers.filter((user) => user.id === formState.userID)[0] || null
         }

--- a/static/js/components/NewGroupUserForm.jsx
+++ b/static/js/components/NewGroupUserForm.jsx
@@ -10,6 +10,8 @@ import Typography from "@material-ui/core/Typography";
 import CircularProgress from "@material-ui/core/CircularProgress";
 import { makeStyles } from "@material-ui/core/styles";
 
+import { showNotification } from "baselayer/components/Notifications";
+
 import * as groupsActions from "../ducks/groups";
 import * as usersActions from "../ducks/users";
 
@@ -38,18 +40,22 @@ const NewGroupUserForm = ({ group_id }) => {
   }, [dispatch, allUsers]);
 
   const handleClickSubmit = async () => {
-    const result = await dispatch(
-      groupsActions.addGroupUser({
-        userID: formState.userID,
-        admin: formState.admin,
-        group_id,
-      })
-    );
-    if (result.status === "success") {
-      setFormState({
-        userID: null,
-        admin: false,
-      });
+    if (!formState.userID) {
+      dispatch(showNotification("Please select a user", "error"));
+    } else {
+      const result = await dispatch(
+        groupsActions.addGroupUser({
+          userID: formState.userID,
+          admin: formState.admin,
+          group_id,
+        })
+      );
+      if (result.status === "success") {
+        setFormState({
+          userID: null,
+          admin: false,
+        });
+      }
     }
   };
 

--- a/static/js/components/NewGroupUserForm.jsx
+++ b/static/js/components/NewGroupUserForm.jsx
@@ -6,18 +6,12 @@ import Autocomplete, {
   createFilterOptions,
 } from "@material-ui/lab/Autocomplete";
 import Button from "@material-ui/core/Button";
-import Dialog from "@material-ui/core/Dialog";
-import DialogActions from "@material-ui/core/DialogActions";
-import DialogContent from "@material-ui/core/DialogContent";
-import DialogContentText from "@material-ui/core/DialogContentText";
-import DialogTitle from "@material-ui/core/DialogTitle";
 import Typography from "@material-ui/core/Typography";
+import CircularProgress from "@material-ui/core/CircularProgress";
 import { makeStyles } from "@material-ui/core/styles";
 
-import { showNotification } from "baselayer/components/Notifications";
 import * as groupsActions from "../ducks/groups";
 import * as usersActions from "../ducks/users";
-import * as invitationsActions from "../ducks/invitations";
 
 const filter = createFilterOptions();
 
@@ -30,14 +24,11 @@ const useStyles = makeStyles(() => ({
 
 const NewGroupUserForm = ({ group_id }) => {
   const dispatch = useDispatch();
-  const { invitationsEnabled } = useSelector((state) => state.sysInfo);
   const { users: allUsers } = useSelector((state) => state.users);
   const [formState, setFormState] = useState({
-    newUserEmail: null,
+    userID: null,
     admin: false,
-    invitingNewUser: false,
   });
-  const [confirmDialogOpen, setConfirmDialogOpen] = React.useState(false);
   const classes = useStyles();
 
   useEffect(() => {
@@ -46,54 +37,20 @@ const NewGroupUserForm = ({ group_id }) => {
     }
   }, [dispatch, allUsers]);
 
-  const submitAndResetForm = async () => {
+  const handleClickSubmit = async () => {
     let result = null;
-    if (formState.invitingNewUser && invitationsEnabled) {
-      result = await dispatch(
-        invitationsActions.inviteUser({
-          userEmail: formState.newUserEmail,
-          groupIDs: [group_id],
-          groupAdmin: [formState.admin],
-          streamIDs: null,
-        })
-      );
-      if (result.status === "success") {
-        dispatch(
-          showNotification(
-            `Invitation successfully sent to ${formState.newUserEmail}`
-          )
-        );
-        setFormState({
-          newUserEmail: null,
-          admin: false,
-          invitingNewUser: false,
-        });
-      }
-    } else {
-      result = await dispatch(
-        groupsActions.addGroupUser({
-          username: formState.newUserEmail,
-          admin: formState.admin,
-          group_id,
-        })
-      );
-      if (result.status === "success") {
-        setFormState({
-          newUserEmail: null,
-          admin: false,
-          invitingNewUser: false,
-        });
-      }
-    }
-  };
-
-  const handleClickSubmit = (event) => {
-    event.preventDefault();
-    if (invitationsEnabled && formState.invitingNewUser) {
-      // If user clicks confirm, `submitAndResetForm` will be called
-      setConfirmDialogOpen(true);
-    } else {
-      submitAndResetForm();
+    result = await dispatch(
+      groupsActions.addGroupUser({
+        userID: formState.userID,
+        admin: formState.admin,
+        group_id,
+      })
+    );
+    if (result.status === "success") {
+      setFormState({
+        userID: null,
+        admin: false,
+      });
     }
   };
 
@@ -103,68 +60,39 @@ const NewGroupUserForm = ({ group_id }) => {
       admin: event.target.checked,
     });
   };
-  const allUserNames = allUsers.map((user) => user.username);
+
+  if (!allUsers?.length) {
+    return <CircularProgress />;
+  }
 
   return (
     <div>
       <Typography className={classes.heading}>
-        Add or invite a new user to this group
+        Add an existing user to this group
       </Typography>
       <Autocomplete
         id="newUserEmail"
-        value={formState.newUserEmail || ""}
+        value={
+          allUsers.filter((user) => user.id === formState.userID)[0] || null
+        }
         onChange={(event, newValue) => {
-          if (typeof newValue === "string") {
-            // The user has entered a username and hit the Enter/Return key
-            setFormState({
-              newUserEmail: newValue,
-              invitingNewUser: !allUserNames.includes(newValue),
-            });
-          } else if (newValue && newValue.inputValue) {
-            // The user has entered a new username and clicked the "Add" option
-            setFormState({
-              newUserEmail: newValue.inputValue,
-              invitingNewUser: true,
-            });
-          } else {
-            setFormState({ newUserEmail: newValue?.username });
-          }
+          setFormState({ userID: newValue?.id });
         }}
         filterOptions={(options, params) => {
           const filtered = filter(options, params);
-
-          // Suggest the creation of a new value
-          if (params.inputValue !== "") {
-            filtered.push({
-              inputValue: params.inputValue,
-              username: `Add "${params.inputValue}"`,
-            });
-          }
-
           return filtered;
         }}
         selectOnFocus
         clearOnBlur
         handleHomeEndKeys
         options={allUsers}
-        getOptionLabel={(option) => {
-          // Value selected with enter, right from the input
-          if (typeof option === "string") {
-            return option;
-          }
-          // Add "xxx" option created dynamically
-          if (option.inputValue) {
-            return option.inputValue;
-          }
-          // Regular option
-          return option.username;
-        }}
+        getOptionLabel={(option) => option.username}
         renderOption={(option) => option.username}
         style={{ width: 300, paddingBottom: 10 }}
-        freeSolo
+        defaultValue={null}
         renderInput={(params) => (
           // eslint-disable-next-line react/jsx-props-no-spreading
-          <TextField {...params} label="Enter user email" />
+          <TextField {...params} label="Username" />
         )}
       />
       <input
@@ -179,45 +107,8 @@ const NewGroupUserForm = ({ group_id }) => {
         size="small"
         disableElevation
       >
-        Add user
+        Add user to group
       </Button>
-      <Dialog
-        open={confirmDialogOpen}
-        onClose={() => {
-          setConfirmDialogOpen(false);
-        }}
-        aria-labelledby="alert-dialog-title"
-        aria-describedby="alert-dialog-description"
-      >
-        <DialogTitle id="alert-dialog-title">
-          Invite new user to this group?
-        </DialogTitle>
-        <DialogContent>
-          <DialogContentText id="alert-dialog-description">
-            Click Confirm to invite specified user and grant them access to this
-            group.
-          </DialogContentText>
-        </DialogContent>
-        <DialogActions>
-          <Button
-            onClick={() => {
-              setConfirmDialogOpen(false);
-            }}
-          >
-            Cancel
-          </Button>
-          <Button
-            onClick={() => {
-              setConfirmDialogOpen(false);
-              submitAndResetForm();
-            }}
-            color="primary"
-            autoFocus
-          >
-            Confirm
-          </Button>
-        </DialogActions>
-      </Dialog>
     </div>
   );
 };

--- a/static/js/components/UserManagement.jsx
+++ b/static/js/components/UserManagement.jsx
@@ -163,7 +163,7 @@ const UserManagement = () => {
     const promises = groupIDs.map((gid) =>
       dispatch(
         groupsActions.addGroupUser({
-          username: clickedUser.username,
+          userID: clickedUser.id,
           admin: false,
           group_id: gid,
         })

--- a/static/js/components/UserManagement.jsx
+++ b/static/js/components/UserManagement.jsx
@@ -237,9 +237,9 @@ const UserManagement = () => {
     }
   };
 
-  const handleClickRemoveUserFromGroup = async (username, group_id) => {
+  const handleClickRemoveUserFromGroup = async (userID, group_id) => {
     const result = await dispatch(
-      groupsActions.deleteGroupUser({ username, group_id })
+      groupsActions.deleteGroupUser({ userID, group_id })
     );
     if (result.status === "success") {
       dispatch(
@@ -404,7 +404,7 @@ const UserManagement = () => {
             <Chip
               label={group.name}
               onDelete={() => {
-                handleClickRemoveUserFromGroup(user.username, group.id);
+                handleClickRemoveUserFromGroup(user.id, group.id);
               }}
               key={group.id}
               id={`deleteGroupUserButton_${user.id}_${group.id}`}

--- a/static/js/ducks/groups.js
+++ b/static/js/ducks/groups.js
@@ -55,11 +55,11 @@ export const addAllUsersFromGroups = ({ toGroupID, fromGroupIDs }) =>
 export const updateGroupUser = (groupID, params) =>
   API.PATCH(`/api/groups/${groupID}/users`, UPDATE_GROUP_USER, params);
 
-export function deleteGroupUser({ username, group_id }) {
+export function deleteGroupUser({ userID, group_id }) {
   return API.DELETE(
-    `/api/groups/${group_id}/users/${username}`,
+    `/api/groups/${group_id}/users/${userID}`,
     DELETE_GROUP_USER,
-    { username, group_id }
+    { userID, group_id }
   );
 }
 

--- a/static/js/ducks/groups.js
+++ b/static/js/ducks/groups.js
@@ -39,9 +39,9 @@ export function deleteGroup(group_id) {
   return API.DELETE(`/api/groups/${group_id}`, DELETE_GROUP);
 }
 
-export function addGroupUser({ username, admin, group_id }) {
+export function addGroupUser({ userID, admin, group_id }) {
   return API.POST(`/api/groups/${group_id}/users`, ADD_GROUP_USER, {
-    username,
+    userID,
     admin,
     group_id,
   });


### PR DESCRIPTION
This PR simplifies the logic of the `NewGroupUserForm` component by splitting the disparate cases it covered into two separate components -- one for adding existing users to the group, another for inviting new users to the site (& adding them to the group). This component was previously rather confusing both from a UX & DX perspective. The API is also updated to always use user ID instead of username for adding existing users to groups.

Closes https://github.com/skyportal/skyportal/issues/924