### PR TITLE
Increase default number of processes to 2

### DIFF
--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -230,7 +230,7 @@ server:
   host: localhost
   port: 5000  # This is the public-facing port
   ssl: False  # Must be either True or False
-  processes: 1
+  processes: 2
 
   auth:
     debug_login: True


### PR DESCRIPTION
Most machines have at least 2 CPUs, including our test nodes on GitHub
Actions.