### PR TITLE
Robustify tests

### DIFF
--- a/skyportal/tests/api/test_photometry.py
+++ b/skyportal/tests/api/test_photometry.py
@@ -162,7 +162,7 @@ def test_token_user_post_put_get_photometry_data(
     assert data['status'] == 'success'
     group_ids = [g["id"] for g in data['data']['groups']]
     assert len(group_ids) == 2
-    assert group_ids[0] == public_group.id
+    assert public_group.id in group_ids
 
     # PUTing photometry that contains
     # the same first point, the second point with a different origin, and a new third point should succeed
@@ -207,11 +207,13 @@ def test_token_user_post_put_get_photometry_data(
         .first()
     )
 
-    assert group_ids == [
-        public_group.id,
-        public_group2.id,
-        token_object.created_by.single_user_group.id,
-    ]
+    assert sorted(group_ids) == sorted(
+        [
+            public_group.id,
+            public_group2.id,
+            token_object.created_by.single_user_group.id,
+        ]
+    )
 
 
 def test_post_photometry_multiple_groups(

--- a/skyportal/tests/frontend/test_source_list.py
+++ b/skyportal/tests/frontend/test_source_list.py
@@ -62,7 +62,7 @@ def test_add_sources_two_groups(
         f"//*[text()[contains(., '{t1.strftime('%Y-%m-%dT%H:%M')}')]]"
     )
     saved_group1 = parser.parse(saved_at_element.text + " UTC")
-    assert abs(saved_group1 - t1) < timedelta(seconds=2)
+    assert abs(saved_group1 - t1) < timedelta(seconds=30)
 
     # check the redshift shows up
     driver.wait_for_xpath(f"//*[text()[contains(., '{'0.153'}')]]")


### PR DESCRIPTION
This PR updates the following: 
- Robustify  photometry API test that depended on response data ordering
- Increase maximum time delta for request that occasionally takes longer than previously-allotted time