### PR TITLE
Stop overwriting source counts prefs upon app reload

### DIFF
--- a/skyportal/handlers/api/internal/source_counts.py
+++ b/skyportal/handlers/api/internal/source_counts.py
@@ -28,5 +28,5 @@ class SourceCountHandler(BaseHandler):
             .filter(Source.created_at >= cutoff_day)
         )
         result = q.first()[0]
-        data = {"count": result, "since_days_ago": since_days_ago}
+        data = {"count": result, "sinceDaysAgo": since_days_ago}
         return self.success(data=data)

--- a/static/js/components/SourceCounts.jsx
+++ b/static/js/components/SourceCounts.jsx
@@ -1,5 +1,5 @@
-import React, { useEffect } from "react";
-import { useSelector, useDispatch } from "react-redux";
+import React from "react";
+import { useSelector } from "react-redux";
 import PropTypes from "prop-types";
 import { CountUp } from "use-count-up";
 
@@ -28,25 +28,15 @@ const useStyles = makeStyles(() => ({
 
 const SourceCounts = ({ classes, sinceDaysAgo }) => {
   const styles = useStyles();
-  const sourceCounts = useSelector((state) => state.sourceCounts.sourceCounts);
+  const sourceCounts = useSelector((state) => state.sourceCounts?.sourceCounts);
   const userPrefs = useSelector(
     (state) => state.profile.preferences.sourceCounts
   );
-  const dispatch = useDispatch();
 
   const defaultPrefs = {
     sinceDaysAgo: sinceDaysAgo ? sinceDaysAgo.toString() : "",
   };
   const sourceCountPrefs = userPrefs || defaultPrefs;
-
-  useEffect(() => {
-    // If user prefs is blank, update to app default
-    if (!userPrefs) {
-      dispatch(
-        profileActions.updateUserPreferences({ sourceCounts: defaultPrefs })
-      );
-    }
-  }, [userPrefs, dispatch]);
 
   return (
     <Paper
@@ -79,7 +69,7 @@ const SourceCounts = ({ classes, sinceDaysAgo }) => {
           </Typography>
           <Typography align="center" variant="body1">
             New Sources <br />
-            <i>Last {sourceCounts?.since_days_ago} days</i>
+            <i>Last {sourceCounts?.sinceDaysAgo} days</i>
           </Typography>
         </div>
       </div>

--- a/static/js/ducks/sourceCounts.js
+++ b/static/js/ducks/sourceCounts.js
@@ -16,7 +16,7 @@ messageHandler.add((actionType, payload, dispatch) => {
   }
 });
 
-const reducer = (state = { sourceViews: [] }, action) => {
+const reducer = (state = null, action) => {
   switch (action.type) {
     case FETCH_SOURCE_COUNTS_OK: {
       const sourceCounts = action.data;


### PR DESCRIPTION
Fix #1292 

Also just cleans up the `sourceCounts` redux store slightly (`since_days_ago` to `sinceDaysAgo` and setting initial to `null`).