### PR TITLE
Allow custom version tags

### DIFF
--- a/skyportal/__init__.py
+++ b/skyportal/__init__.py
@@ -27,5 +27,8 @@ if 'dev' in __version__:
                 .split()
             )
 
-            __version__ = __version__.split('+git', 1)[0]
+            __version__ = '+'.join(
+                [tag for tag in __version__.split('+')
+                 if not tag.startswith('git')]
+            )
             __version__ += f'+git{git_date}.{git_hash}'


### PR DESCRIPTION
If the SkyPortal version was modified to be, say,
"skyportal+myapp.123+git20100110.abcde", then we will only replace the
git tag, not the myapp tag.