### PR TITLE
add pull request review reminder to GA

### DIFF
--- a/.github/workflows/remind.yaml
+++ b/.github/workflows/remind.yaml
@@ -3,7 +3,8 @@ name: PRs reviews reminder
 on:
   schedule:
     # Every weekday every 2 hours during working hours, send notification
-    - cron: "0 8-17/2 * * 1-5"
+    - cron: "0 17-23/2 * * 1-5"
+    - cron: "0 1 * * 2-6" # 5pm notification
 
 jobs:
   pr-reviews-reminder:

--- a/.github/workflows/remind.yaml
+++ b/.github/workflows/remind.yaml
@@ -1,0 +1,19 @@
+name: PRs reviews reminder
+
+on:
+  schedule:
+    # Every weekday every 2 hours during working hours, send notification
+    - cron: "0 8-17/2 * * 1-5"
+
+jobs:
+  pr-reviews-reminder:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: davideviolante/pr-reviews-reminder-action@v1.3.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          webhook-url: ${{ secrets.WEBHOOK_URL }}
+          provider: "slack"
+          channel: ${{ secrets.SLACK_CHANNEL }} # Optional, eg: #general
+          github-provider-map: ${{ secrets.PROVIDER_MAP }}

--- a/.github/workflows/remind.yaml
+++ b/.github/workflows/remind.yaml
@@ -13,7 +13,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          webhook-url: ${{ secrets.WEBHOOK_URL }}
+          webhook-url: ${{ secrets.PR_REMINDER_WEBHOOK_URL }}
           provider: "slack"
-          channel: ${{ secrets.SLACK_CHANNEL }} # Optional, eg: #general
-          github-provider-map: ${{ secrets.PROVIDER_MAP }}
+          channel: ${{ secrets.PR_REMINDER_SLACK_CHANNEL }} # Optional, eg: #general
+          github-provider-map: ${{ secrets.PR_REMINDER_PROVIDER_MAP }}


### PR DESCRIPTION
During the iteration meeting today, we had 44 issues/PRs in the Review/QA state on ZenHub, so we discussed PRs getting lost in the shuffle and thought about ways to keep PRs and issues from falling through the cracks. @profjsb suggested a reminder via github actions for folks to review open PRs. This PR adds this action to the repo. 

This PR adds a GA cron task that sends out a reminder every two hours during working hours M-F to review open PRs. I have configured it to send to the #skyportal-related channel, tag the appropriate reviewers on slack and for now to only track reviews on this repo (skyportal/skyportal).
