### PR TITLE
Hotfix websocket target for frontend

### DIFF
--- a/skyportal/handlers/api/followup_request.py
+++ b/skyportal/handlers/api/followup_request.py
@@ -398,7 +398,7 @@ class FollowupRequestHandler(BaseHandler):
             DBSession().commit()
             self.push_all(
                 action="skyportal/REFRESH_SOURCE",
-                payload={"obj_id": followup_request.obj.internal_key},
+                payload={"obj_key": followup_request.obj.internal_key},
             )
 
         return self.success(data={"id": followup_request.id})

--- a/skyportal/handlers/api/followup_request.py
+++ b/skyportal/handlers/api/followup_request.py
@@ -398,7 +398,7 @@ class FollowupRequestHandler(BaseHandler):
             DBSession().commit()
             self.push_all(
                 action="skyportal/REFRESH_SOURCE",
-                payload={"obj_id": followup_request.obj_id},
+                payload={"obj_id": followup_request.obj.internal_key},
             )
 
         return self.success(data={"id": followup_request.id})


### PR DESCRIPTION
Currently the websocket message that updates the frontend after a followup request is successfully submitted to the telescope is dispatched using the wrong key, so never gets handled by the frontend's websocket message handler. This PR fixes this issue with a simple correction to use the correct key that the frontend looks for. I have tested this locally and verifies that it produces the expected behavior.

This PR fixes the CI. 

I am not sure why this did not cause the frontend / tests to fail earlier, this line has been as is for about 3 months. I guess the websocket message dispatched a few lines earlier was arriving later before, causing the `FETCH_LOADED_SOURCE` action dispatched by the frontend to hit the backend by the time the request was already submitted and the database updated. 

I guess SP is running faster ! 