### PR TITLE
Override User.to_dict to not include preferences

### DIFF
--- a/skyportal/handlers/api/candidate.py
+++ b/skyportal/handlers/api/candidate.py
@@ -290,9 +290,6 @@ class CandidateHandler(BaseHandler):
                 key=lambda x: x["created_at"],
                 reverse=True,
             )
-            for comment in candidate_info["comments"]:
-                comment["author"] = comment["author"].to_dict()
-                del comment["author"]["preferences"]
             candidate_info["annotations"] = sorted(
                 c.get_annotations_owned_by(self.current_user), key=lambda x: x.origin,
             )
@@ -568,9 +565,6 @@ class CandidateHandler(BaseHandler):
                     key=lambda x: x["created_at"],
                     reverse=True,
                 )
-                for comment in candidate_list[-1]["comments"]:
-                    comment["author"] = comment["author"].to_dict()
-                    del comment["author"]["preferences"]
                 candidate_list[-1]["annotations"] = sorted(
                     obj.get_annotations_owned_by(self.current_user),
                     key=lambda x: x.origin,

--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -437,9 +437,6 @@ class SourceHandler(BaseHandler):
                 key=lambda x: x["created_at"],
                 reverse=True,
             )
-            for comment in source_info["comments"]:
-                comment["author"] = comment["author"].to_dict()
-                del comment["author"]["preferences"]
             source_info["annotations"] = sorted(
                 s.get_annotations_owned_by(self.current_user), key=lambda x: x.origin,
             )
@@ -647,9 +644,6 @@ class SourceHandler(BaseHandler):
                     key=lambda x: x["created_at"],
                     reverse=True,
                 )
-                for comment in source_list[-1]["comments"]:
-                    comment["author"] = comment["author"].to_dict()
-                    del comment["author"]["preferences"]
                 source_list[-1][
                     "classifications"
                 ] = source.get_classifications_owned_by(self.current_user)

--- a/skyportal/handlers/api/user.py
+++ b/skyportal/handlers/api/user.py
@@ -236,7 +236,6 @@ class UserHandler(BaseHandler):
         return_values = []
         for user in query.all():
             return_values.append(user.to_dict())
-            del return_values[-1]["preferences"]
             return_values[-1]["permissions"] = sorted(user.permissions)
             return_values[-1]["roles"] = sorted([role.id for role in user.roles])
             return_values[-1]["acls"] = sorted([acl.id for acl in user.acls])

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -92,6 +92,17 @@ def basic_user_display_info(user):
     }
 
 
+def user_to_dict(self):
+    return {
+        field: getattr(self, field)
+        for field in User.__table__.columns.keys()
+        if field != "preferences"
+    }
+
+
+User.to_dict = user_to_dict
+
+
 def is_owned_by(self, user_or_token):
     """Generic ownership logic for any `skyportal` ORM model.
 


### PR DESCRIPTION
The only place `User.preferences` is needed in the response data is in the profile handler, where it's already manually added to the response data