### PR TITLE
spectroscopy plot improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@rjsf/core": "2.4.0",
     "@rjsf/material-ui": "2.4.0",
     "autosuggest-highlight": "3.1.1",
-    "bokehjs": "0.12.9",
+    "bokehjs": "0.12.13",
     "check-dependencies": "1.1.0",
     "clsx": "1.1.1",
     "convert-css-length": "2.0.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ pandas>=0.17.0
 dask>=0.15.0
 joblib>=0.11
 seaborn>=0.10.0
-bokeh==0.12.9
+bokeh==0.12.13
 pytest-randomly>=2.1.1
 factory-boy==2.11.1
 astropy==4.0.1.post1


### PR DESCRIPTION
This PR:

* Fixes #1189 
* Fixes https://github.com/fritz-marshal/fritz/issues/111
* Fixes https://github.com/fritz-marshal/fritz-beta-feedback/issues/52
* Partially addresses https://github.com/fritz-marshal/fritz-beta-feedback/issues/12

This PR introduces a new colormap for the spectrum plot to make the spectra easier to see. It shows the spectra as step functions rather than interpolated functions. It solves the problem of legend truncation. 

The step functions required an upgrade to the bokeh minor version patch (i.e., the third number in the semantic version). This is a minor thing and involves no changes to backwards compatbility. This is separate from #1293 which upgrades the bokeh major version. 