### PR TITLE
remove magsystems from enum types

### DIFF
--- a/skyportal/enum_types.py
+++ b/skyportal/enum_types.py
@@ -56,7 +56,6 @@ followup_priorities = sa.Enum(
 )
 
 sqla_enum_types = [
-    allowed_magsystems,
     allowed_bandpasses,
     thumbnail_types,
     instrument_types,


### PR DESCRIPTION
Because they are not an Enum type used by postgres. Only by the webserver.