### PR TITLE
Fix emoji parsing for non-emoji colons in comments

### DIFF
--- a/static/js/components/CommentList.jsx
+++ b/static/js/components/CommentList.jsx
@@ -55,7 +55,9 @@ const CommentList = () => {
   comments = comments || [];
 
   const emojiSupport = (text) =>
-    text.value.replace(/:\w+:/gi, (name) => emoji.getUnicode(name));
+    text.value.replace(/:\w+:/gi, (name) =>
+      emoji.getUnicode(name) ? emoji.getUnicode(name) : name
+    );
 
   return (
     <div className={styles.comments}>


### PR DESCRIPTION
Address #957 

Comment substrings matching the emoji RegEx but not mapping to a legitimate emoji are now just let through.

@mcoughlin I think the main problem with what you were trying was that the "undefined" you were seeing printed was actually the javascript undefined property instead of a string that said "undefined" so your check wasn't working.