### PR TITLE
remove redshift parsing from comment handler

### DIFF
--- a/skyportal/handlers/api/comment.py
+++ b/skyportal/handlers/api/comment.py
@@ -4,7 +4,6 @@ from marshmallow.exceptions import ValidationError
 from baselayer.app.access import permissions, auth_or_token
 from ..base import BaseHandler
 from ...models import DBSession, Source, Comment, Group, Candidate, Filter
-from .candidate import update_redshift_history_if_relevant
 
 
 class CommentHandler(BaseHandler):
@@ -93,7 +92,7 @@ class CommentHandler(BaseHandler):
         comment_text = data.get("text")
 
         # Ensure user/token has access to parent source
-        obj = Source.get_obj_if_owned_by(obj_id, self.current_user)
+        _ = Source.get_obj_if_owned_by(obj_id, self.current_user)
         user_accessible_group_ids = [g.id for g in self.current_user.accessible_groups]
         user_accessible_filter_ids = [
             filtr.id
@@ -159,18 +158,6 @@ class CommentHandler(BaseHandler):
         )
 
         DBSession().add(comment)
-        if comment_text.startswith("z="):
-            try:
-                redshift = float(comment_text.strip().split("z=")[1])
-            except ValueError:
-                return self.error(
-                    "Invalid redshift value provided; unable to cast to float"
-                )
-            obj.redshift = redshift
-            update_redshift_history_if_relevant(
-                {"redshift": redshift}, obj, self.associated_user_object
-            )
-        DBSession().commit()
 
         self.push_all(
             action='skyportal/REFRESH_SOURCE',

--- a/skyportal/tests/api/test_comments.py
+++ b/skyportal/tests/api/test_comments.py
@@ -1,4 +1,3 @@
-import numpy.testing as npt
 from skyportal.tests import api
 
 
@@ -172,24 +171,6 @@ def test_delete_comment(comment_token, public_source):
 
     status, data = api('GET', f'comment/{comment_id}', token=comment_token)
     assert status == 400
-
-
-def test_add_redshift_comment(super_admin_token, public_source, public_group):
-    status, data = api(
-        'POST',
-        'comment',
-        data={
-            'obj_id': public_source.id,
-            'text': 'z=0.221',
-            'group_ids': [public_group.id],
-        },
-        token=super_admin_token,
-    )
-    assert status == 200
-
-    status, data = api('GET', f'sources/{public_source.id}', token=super_admin_token)
-    assert status == 200
-    npt.assert_almost_equal(data['data']['redshift'], 0.221)
 
 
 def test_problematic_put_comment_attachment_1275(


### PR DESCRIPTION
This PR deprecates parsing redshifts inside comments in favor of using the redshift frontend tool #1043