### PR TITLE
Spectra normalization

### DIFF
--- a/skyportal/handlers/api/spectrum.py
+++ b/skyportal/handlers/api/spectrum.py
@@ -490,6 +490,14 @@ class ObjSpectraHandler(BaseHandler):
             schema:
               type: string
             description: ID of the object to retrieve spectra for
+          - in: query
+            name: normalization
+            required: false
+            schema:
+              type: string
+            description: |
+              what normalization is needed for the spectra (e.g., "median").
+              If omitted, returns the original spectrum.
 
         responses:
           200:
@@ -517,15 +525,23 @@ class ObjSpectraHandler(BaseHandler):
             spec_dict["observers"] = spec.observers
             return_values.append(spec_dict)
 
-        for s in return_values:
-            norm = np.median(s["fluxes"])
-            if not (np.isfinite(norm) and norm > 0):
-                # otherwise normalize the value at the median wavelength to 1
-                median_wave_index = np.argmin(
-                    np.abs(s["wavelengths"] - np.median(s["wavelengths"]))
-                )
-                norm = s["fluxes"][median_wave_index]
+        normalization = self.get_query_argument('normalization', None)
 
-            s["fluxes"] = s["fluxes"] / norm
+        if normalization is not None:
+            if normalization == "median":
+                for s in return_values:
+                    norm = np.median(s["fluxes"])
+                    if not (np.isfinite(norm) and norm > 0):
+                        # otherwise normalize the value at the median wavelength to 1
+                        median_wave_index = np.argmin(
+                            np.abs(s["wavelengths"] - np.median(s["wavelengths"]))
+                        )
+                        norm = s["fluxes"][median_wave_index]
+
+                    s["fluxes"] = s["fluxes"] / norm
+            else:
+                return self.error(
+                    f'Invalid "normalization" value "{normalization}, use "median" or no None'
+                )
 
         return self.success(data=return_values)

--- a/skyportal/handlers/api/spectrum.py
+++ b/skyportal/handlers/api/spectrum.py
@@ -498,6 +498,8 @@ class ObjSpectraHandler(BaseHandler):
             description: |
               what normalization is needed for the spectra (e.g., "median").
               If omitted, returns the original spectrum.
+              Options for normalization are:
+              - median: normalize the flux to have median==1
 
         responses:
           200:
@@ -541,7 +543,7 @@ class ObjSpectraHandler(BaseHandler):
                     s["fluxes"] = s["fluxes"] / norm
             else:
                 return self.error(
-                    f'Invalid "normalization" value "{normalization}, use "median" or no None'
+                    f'Invalid "normalization" value "{normalization}, use "median" or None'
                 )
 
         return self.success(data=return_values)

--- a/static/js/components/SourceTable.jsx
+++ b/static/js/components/SourceTable.jsx
@@ -208,7 +208,9 @@ const SourceTable = ({
             </Grid>
             <Grid item>
               <Suspense fallback={<div>Loading spectra...</div>}>
-                <VegaSpectrum dataUrl={`/api/sources/${source.id}/spectra`} />
+                <VegaSpectrum
+                  dataUrl={`/api/sources/${source.id}/spectra?normalization=median`}
+                />
               </Suspense>
             </Grid>
             <Grid item>


### PR DESCRIPTION
The API call to get a spectrum returns, by default, the original spectrum as is. 

If you want to normalize it, add a query argument ?normalization=median

Additional normalization schemes are easy to add in the back end. 

Currently this is used in the SourceTable component, where we provide this argument to the URL given to the VegaSpectrum. 
