### PR TITLE
Customizable API docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,10 @@ doc_reqs:
 api-docs: FLAGS := $(if $(FLAGS),$(FLAGS),--config=config.yaml)
 api-docs: | doc_reqs
 	@PYTHONPATH=. python tools/openapi/build-spec.py $(FLAGS)
-	npx redoc-cli@0.9.8 bundle openapi.json --title "SkyPortal API docs" --cdn
+	npx redoc-cli@0.9.8 bundle openapi.json \
+          --title "SkyPortal API docs" \
+          --options.theme.logo.gutter 2rem \
+          --cdn
 	rm -f openapi.{yml,json}
 	mkdir -p doc/_build/html
 	mv redoc-static.html doc/openapi.html

--- a/skyportal/openapi.py
+++ b/skyportal/openapi.py
@@ -12,7 +12,7 @@ from . import schema
 api_description = pjoin(os.path.dirname(__file__), 'api_description.md')
 
 
-def spec_from_handlers(handlers, exclude_internal=True):
+def spec_from_handlers(handlers, exclude_internal=True, metadata=None):
     """Generate an OpenAPI spec from Tornado handlers.
 
     The docstrings of the various http methods of the Tornado handlers
@@ -52,11 +52,11 @@ def spec_from_handlers(handlers, exclude_internal=True):
     `spec.Error`.  All schemas in `schema` are added to the OpenAPI definition.
 
     """
-    openapi_spec = APISpec(
-        title='SkyPortal',
-        version=__version__,
-        openapi_version='3.0.2',
-        info={
+    meta = {
+        'title': 'SkyPortal',
+        'version': __version__,
+        'openapi_version': '3.0.2',
+        'info': {
             'description': open(api_description, 'r').read(),
             'x-logo': {
                 'url': 'https://raw.githubusercontent.com/skyportal/skyportal/master/static/images/skyportal_logo.png',
@@ -65,8 +65,11 @@ def spec_from_handlers(handlers, exclude_internal=True):
                 'href': 'https://skyportal.io/docs',
             },
         },
-        plugins=[MarshmallowPlugin()],
-    )
+    }
+    if metadata is not None:
+        meta.update(metadata)
+
+    openapi_spec = APISpec(**meta, plugins=[MarshmallowPlugin()],)
 
     token_scheme = {
         "type": "apiKey",

--- a/tools/openapi/build-spec.py
+++ b/tools/openapi/build-spec.py
@@ -6,10 +6,10 @@ from skyportal.app_server import skyportal_handlers
 
 spec = openapi.spec_from_handlers(baselayer_handlers + skyportal_handlers)
 
-f = open('openapi.yml', 'w')
-f.write(spec.to_yaml())
-f.close()
-f = open('openapi.json', 'w')
+with open('openapi.yml', 'w') as f:
+    f.write(spec.to_yaml())
 
-json.dump(spec.to_dict(), f)
+with open('openapi.json', 'w') as f:
+    json.dump(spec.to_dict(), f)
+
 print("OpenAPI spec written to openapi.{yml,json}")


### PR DESCRIPTION
This lets us update the Fritz API docs title and URL (using this mechanism will be a separate Fritz PR, once this PR is merged)