### PR TITLE
Change window title to viewed source name

### DIFF
--- a/static/js/components/Main.jsx.template
+++ b/static/js/components/Main.jsx.template
@@ -7,7 +7,7 @@ import PropTypes from "prop-types";
 import { Provider, useSelector } from "react-redux";
 import ReactDOM from "react-dom";
 
-import { BrowserRouter, Switch } from "react-router-dom";
+import { BrowserRouter, Switch, useLocation } from "react-router-dom";
 
 import { MuiPickersUtilsProvider } from "@material-ui/pickers";
 import { makeStyles } from "@material-ui/core/styles";
@@ -81,6 +81,11 @@ const MainContent = ({ root }) => {
     store.dispatch(hydrate());
     store.dispatch(rotateLogoActions.rotateLogo());
   }, []);
+
+  let location = useLocation();
+  useEffect(() => {
+    document.title = "{{ app.title }}";
+  }, [location]);
 
   return (
     <Theme {% if testing %} disableTransitions {% endif %}>

--- a/static/js/components/Main.jsx.template
+++ b/static/js/components/Main.jsx.template
@@ -82,7 +82,7 @@ const MainContent = ({ root }) => {
     store.dispatch(rotateLogoActions.rotateLogo());
   }, []);
 
-  let location = useLocation();
+  const location = useLocation();
   useEffect(() => {
     document.title = "{{ app.title }}";
   }, [location]);

--- a/static/js/components/Source.jsx
+++ b/static/js/components/Source.jsx
@@ -57,6 +57,7 @@ const Source = ({ route }) => {
   if (source.id === undefined) {
     return <div>Source not found</div>;
   }
+  document.title = source.id;
 
   return (
     <Paper ref={ref} elevation={1}>


### PR DESCRIPTION
By default, the window title is the app title.  Switching to a source
changes it to the source's name, and navigating away restores the app
name.

Closes https://github.com/fritz-marshal/fritz-beta-feedback/issues/71