### PR TITLE
Remove instructions on how to change cosmology

### DIFF
--- a/static/js/components/About.jsx
+++ b/static/js/components/About.jsx
@@ -188,9 +188,6 @@ const About = () => {
           <>
             <blockquote>{cosmology}</blockquote>
             <b>Reference</b>: {cosmoref}
-            <br />
-            If you&apos;d like to change the cosmology, please do so in the{" "}
-            <code>config.yaml</code> under <code>misc.cosmology</code>.
           </>
         )}
       </span>


### PR DESCRIPTION
This can go in the docs, but for most hosted instances it doesn't make sense.