### PR TITLE
GaiaQuery abstraction; push to Gaia EDR3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -39,3 +39,4 @@ twilio>=6.45.3
 jsonschema-to-openapi>=0.2.1
 responses>=0.12.0
 numba>=0.51.2
+pyvo>=1.1


### PR DESCRIPTION
Push to Gaia EDR3 (`gaiaedr3`). Also, adds an abstraction layer for Gaia queries: first try the ESA TAP+ portal via astroquery, then drop back to `gaia.aip.de` TAP.
