### PR TITLE
make demo observing runs earlier in time to avoid running into outdated IERS file exceptions

### DIFF
--- a/data/db_demo.yaml
+++ b/data/db_demo.yaml
@@ -295,13 +295,13 @@ taxonomy:
 observing_run:
   - pi: Danny Goldstein
     instrument_id: =ESI
-    calendar_date: "2021-02-16"
+    calendar_date: "2020-02-16"
     group_id: =program_A
     observers: "Danny Goldstein, Peter Nugent"
     =id: esi_run
   - pi: Danny Goldstein
     instrument_id: =LRIS
-    calendar_date: "2021-06-17"
+    calendar_date: "2020-06-17"
     group_id: =program_A
     observers: "Danny Goldstein, Peter Nugent"
     =id: lris_run


### PR DESCRIPTION
@scizen9 was running into this bug locally when trying to access source pages through the web interface  (the error was being flashed as a notification)

https://github.com/astropy/astropy/issues/8788

we found that the reason for this is that when the main IERS mirror at NASA GSFC is down, it reverts to a backup mirror which serves a file that only has IERS data until 2020-08-22, which is not sufficiently late in time to calculate ephemerides for targets on runs in the demo data set (june 2021). The main IERS file from GSFC goes out till 2022, so it worked in that case.

This PR fixes that issue by moving the dates of the demo runs back in time so that they are within the period of IERS coverage for both the main and backup files. 