### PR TITLE
Set default end date for scanning to null

### DIFF
--- a/static/js/components/FilterCandidateList.jsx
+++ b/static/js/components/FilterCandidateList.jsx
@@ -82,7 +82,7 @@ const FilterCandidateList = ({
 
   const defaultStartDate = new Date();
   defaultStartDate.setDate(defaultStartDate.getDate() - 1);
-  const defaultEndDate = new Date();
+  const defaultEndDate = null;
 
   const ITEM_HEIGHT = 48;
   const MenuProps = {
@@ -196,12 +196,13 @@ const FilterCandidateList = ({
               rules={{ validate: validateDates }}
               name="startDate"
               control={control}
+              defaultValue={defaultStartDate}
             />
             &nbsp;
             <Controller
               render={({ onChange, value }) => (
                 <KeyboardDateTimePicker
-                  value={dayjs.utc(value)}
+                  value={value ? dayjs.utc(value) : null}
                   onChange={(e, date) => onChange(dayjs.utc(date))}
                   label="End (UTC)"
                   format="YYYY/MM/DD HH:mm"
@@ -213,6 +214,7 @@ const FilterCandidateList = ({
               rules={{ validate: validateDates }}
               name="endDate"
               control={control}
+              defaultValue={defaultEndDate}
             />
           </div>
           <div>
@@ -239,9 +241,9 @@ const FilterCandidateList = ({
               Classifications
             </InputLabel>
             <Controller
+              labelId="classifications-select-label"
               render={({ onChange, value }) => (
                 <Select
-                  labelId="classifications-select-label"
                   id="classifications-select"
                   multiple
                   value={value}
@@ -290,7 +292,6 @@ const FilterCandidateList = ({
                 render={({ onChange, value }) => (
                   <TextField
                     id="minimum-redshift"
-                    labelId="classifications-select-label"
                     label="Minimum"
                     type="number"
                     value={value}
@@ -304,6 +305,7 @@ const FilterCandidateList = ({
                   />
                 )}
                 name="redshiftMinimum"
+                labelId="redshift-select-label"
                 control={control}
                 defaultValue=""
               />


### PR DESCRIPTION
- Set the default end date for scanning page to null
  - Addresses #1493 
- Address console error introduced in #1476 regarding the `labelId` property on classifications and redshift filtering.
- Address console warning about `startDate` and `endDate` not passing a defaultValue to either the Controller or the useForm

Scanning page tests now all passing locally for me.