### PR TITLE
Ensure photometry is returned in the correct order for photometry api tests 

### DIFF
--- a/skyportal/tests/api/test_photometry.py
+++ b/skyportal/tests/api/test_photometry.py
@@ -1240,6 +1240,7 @@ def test_token_user_retrieving_source_photometry_and_convert(
     assert 'mjd' in data['data'][0]
     assert 'ra_unc' in data['data'][0]
 
+    data['data'] = sorted(data['data'], key=lambda d: d['mjd'])
     mag1_ab = -2.5 * np.log10(data['data'][0]['flux']) + data['data'][0]['zp']
     magerr1_ab = 2.5 / np.log(10) * data['data'][0]['fluxerr'] / data['data'][0]['flux']
 
@@ -1256,6 +1257,7 @@ def test_token_user_retrieving_source_photometry_and_convert(
     assert status == 200
     assert data['status'] == 'success'
 
+    data['data'] = sorted(data['data'], key=lambda d: d['mjd'])
     assert np.allclose(mag1_ab, data['data'][0]['mag'])
     assert np.allclose(magerr1_ab, data['data'][0]['magerr'])
 
@@ -1268,6 +1270,7 @@ def test_token_user_retrieving_source_photometry_and_convert(
         token=view_only_token,
     )
 
+    data['data'] = sorted(data['data'], key=lambda d: d['mjd'])
     mag1_vega = -2.5 * np.log10(data['data'][0]['flux']) + data['data'][0]['zp']
     magerr1_vega = (
         2.5 / np.log(10) * data['data'][0]['fluxerr'] / data['data'][0]['flux']


### PR DESCRIPTION
Object photometry used to be returned in MJD order, an assumption that went into this test

https://github.com/skyportal/skyportal/runs/1535057564#step:13:579

However, that was removed at some point for performance reasons, so the comparisons in the failing test above were comparing photometry points of different IDs.

This PR sorts the photometry by MJD order in that test so that the correct photometry points are compared. 