### PR TITLE
Catch JSON parsing errors for comment previews

### DIFF
--- a/static/js/components/CommentAttachmentPreview.jsx
+++ b/static/js/components/CommentAttachmentPreview.jsx
@@ -139,7 +139,15 @@ const CommentAttachmentPreview = ({ filename, commentId }) => {
     fileType.toLowerCase()
   );
 
-  const jsonFile = isCached ? JSON.parse(commentAttachment.attachment) : {};
+  let jsonFile = {};
+  try {
+    jsonFile = isCached ? JSON.parse(commentAttachment.attachment) : {};
+  } catch (e) {
+    jsonFile = {
+      "JSON Preview Parsing Error": `${e.message}. Please download the file if you want to inspect it.`,
+    };
+  }
+
   if (fileType.toLowerCase() === "json" && !isCached && open) {
     dispatch(sourceActions.getCommentAttachment(commentId));
   }


### PR DESCRIPTION
Catch JSON parsing errors for comment previews and display the error message instead.

Closes #1494 

![jsonerror](https://user-images.githubusercontent.com/17696889/102094974-f3ffb900-3df0-11eb-82a2-71346eb711da.gif)
