### PR TITLE
Use Obj.get_if_readable_by to determine source view handler permissioning rather than Source.get_obj_if_readable_by

### DIFF
--- a/skyportal/handlers/api/internal/source_views.py
+++ b/skyportal/handlers/api/internal/source_views.py
@@ -71,7 +71,7 @@ class SourceViewsHandler(BaseHandler):
     @tornado.web.authenticated
     def post(self, obj_id):
         # Ensure user has access to source
-        Source.get_obj_if_readable_by(obj_id, self.current_user)
+        Obj.get_if_readable_by(obj_id, self.current_user)
         # This endpoint will only be hit by front-end, so this will never be a token
         register_source_view(
             obj_id=obj_id,

--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -424,6 +424,13 @@ class SourceHandler(BaseHandler):
                 .joinedload(Allocation.group),
             ]
 
+            s = Obj.get_if_readable_by(
+                obj_id, self.current_user, options=query_options,
+            )
+
+            if s is None:
+                return self.error("Source not found", status=404)
+
             if is_token_request:
                 # Logic determining whether to register front-end request as view lives in front-end
                 register_source_view(
@@ -431,13 +438,6 @@ class SourceHandler(BaseHandler):
                     username_or_token_id=self.current_user.id,
                     is_token=True,
                 )
-
-            s = Obj.get_if_readable_by(
-                obj_id, self.current_user, options=query_options,
-            )
-
-            if s is None:
-                return self.error("Source not found", status=404)
 
             if "ps1" not in [thumb.type for thumb in s.thumbnails]:
                 IOLoop.current().add_callback(


### PR DESCRIPTION
This PR ensures that the same permission check that is used in SourceHandler.get is used in SourceViewHandler.post, so that if a user is able to view a source page, an associated source view is registered without a permission error. Also, the source view registration for token requests is now performed after ensuring the source ID is valid.

Closes https://github.com/skyportal/skyportal/issues/1503 