### PR TITLE
Properly save state across page changes in sources table

### DIFF
--- a/skyportal/tests/frontend/test_group_sources.py
+++ b/skyportal/tests/frontend/test_group_sources.py
@@ -3,7 +3,7 @@ import pytest
 from .. import api
 
 from tdtax import taxonomy, __version__
-
+from selenium.common.exceptions import TimeoutException
 from datetime import datetime, timezone
 
 
@@ -251,6 +251,14 @@ def test_sources_sorting(
     driver.click_xpath("//button[@data-testid='sortButton']")
     driver.click_xpath("//div[@id='root_column']")
     driver.click_xpath("//li[@data-value='saved_at']", scroll_parent=True)
+    # For some reason, on only the first time a sort option is selected in the test,
+    # the click sometimes does not go through; was unable to reproduce behavior
+    # through manual clicking. For now, just retry it if this is the case
+    try:
+        driver.wait_for_xpath("//div[@id='root_column'][text()='Date Saved']")
+    except TimeoutException:
+        driver.click_xpath("//div[@id='root_column']")
+        driver.click_xpath("//li[@data-value='saved_at']", scroll_parent=True)
     driver.click_xpath("//input[@value='false']", wait_clickable=False)
     driver.click_xpath("//span[text()='Submit']")
 

--- a/skyportal/tests/frontend/test_top_sources.py
+++ b/skyportal/tests/frontend/test_top_sources.py
@@ -1,9 +1,6 @@
 import uuid
 import pytest
 import datetime
-import time
-
-from selenium.common.exceptions import TimeoutException
 
 from skyportal.models import DBSession, SourceView
 from skyportal.tests import api
@@ -48,7 +45,7 @@ def test_top_sources(driver, user, public_source, public_group, upload_data_toke
 
 
 @pytest.mark.flaky(reruns=2)
-def test_top_source_prefs(driver, user, public_source, public_group, upload_data_token):
+def test_top_source_prefs(driver, user, public_group, upload_data_token):
     # Add an old source and give it an old view
     obj_id = str(uuid.uuid4())
     status, data = api(
@@ -86,22 +83,9 @@ def test_top_source_prefs(driver, user, public_source, public_group, upload_data
     driver.wait_for_xpath(last_30_days_button)
 
     # Test that source doesn't show up in last 7 days of views
-    source_view_xpath = "//*[contains(.,'1 view(s)')]"
-    try:
-        driver.wait_for_xpath_to_disappear(source_view_xpath)
-    except TimeoutException:
-        last_30_days_button = "//button[contains(@data-testid, 'topSources_30days')]"
-        driver.wait_for_xpath(last_30_days_button)
-        # Test that source doesn't show up in last 7 days of views
-        source_view_xpath = "//*[contains(.,'1 view(s)')]"
-        time.sleep(1)
-        driver.wait_for_xpath_to_disappear(source_view_xpath)
+    source_view_xpath = f"//div[@data-testid='topSourceItem_{obj_id}']"
+    driver.wait_for_xpath_to_disappear(source_view_xpath)
 
     # Test that source view appears after changing prefs
     driver.click_xpath(last_30_days_button)
-    try:
-        driver.wait_for_xpath(source_view_xpath)
-    except TimeoutException:
-        driver.click_xpath(last_30_days_button)
-        time.sleep(1)
-        driver.wait_for_xpath(source_view_xpath)
+    driver.wait_for_xpath(source_view_xpath)

--- a/static/js/components/GroupSources.jsx
+++ b/static/js/components/GroupSources.jsx
@@ -81,15 +81,22 @@ const GroupSources = ({ route }) => {
     );
   };
 
-  const handleSavedSourcesTablePagination = (pageNumber, numPerPage) => {
+  const handleSavedSourcesTablePagination = (
+    pageNumber,
+    numPerPage,
+    sortData
+  ) => {
     setSavedSourcesRowsPerPage(numPerPage);
-    dispatch(
-      sourcesActions.fetchSavedGroupSources({
-        group_ids: [route.id],
-        pageNumber,
-        numPerPage,
-      })
-    );
+    const data = {
+      group_ids: [route.id],
+      pageNumber,
+      numPerPage,
+    };
+    if (sortData) {
+      data.sortBy = sortData.column;
+      data.sortOrder = sortData.ascending ? "asc" : "desc";
+    }
+    dispatch(sourcesActions.fetchSavedGroupSources(data));
   };
 
   const handlePendingSourcesTableSorting = (formData) => {

--- a/static/js/components/SourceList.jsx
+++ b/static/js/components/SourceList.jsx
@@ -78,7 +78,7 @@ const SourceList = () => {
     dispatch(sourcesActions.fetchSources());
   };
 
-  const handleSourceTablePagination = (pageNumber, numPerPage) => {
+  const handleSourceTablePagination = (pageNumber, numPerPage, sortData) => {
     setRowsPerPage(numPerPage);
     const data = {
       ...getValues(),
@@ -86,6 +86,10 @@ const SourceList = () => {
       numPerPage,
       totalMatches: sourcesState.totalMatches,
     };
+    if (sortData) {
+      data.sortBy = sortData.column;
+      data.sortOrder = sortData.ascending ? "asc" : "desc";
+    }
     dispatch(sourcesActions.fetchSources(data));
   };
 

--- a/static/js/components/SourceTable.jsx
+++ b/static/js/components/SourceTable.jsx
@@ -64,6 +64,17 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
+const defaultDisplayedColumns = [
+  "Source ID",
+  "RA (deg)",
+  "Dec (deg)",
+  "Redshift",
+  "Classification",
+  "Groups",
+  "Date Saved",
+  "Finder",
+];
+
 // MUI data table with pull out rows containing a summary of each source.
 // This component is used in GroupSources and SourceList.
 const SourceTable = ({
@@ -94,6 +105,9 @@ const SourceTable = ({
   const sortOpen = Boolean(sortAnchorEl);
   const sortId = sortOpen ? "sort-popover" : undefined;
   const [currentSortColumn, setCurrentSortColumn] = useState(null);
+  const [displayedColumns, setDisplayedColumns] = useState(
+    defaultDisplayedColumns
+  );
 
   // Color styling
   const userColorTheme = useSelector(
@@ -116,7 +130,19 @@ const SourceTable = ({
     switch (action) {
       case "changePage":
       case "changeRowsPerPage":
-        paginateCallback(tableState.page + 1, tableState.rowsPerPage);
+        paginateCallback(
+          tableState.page + 1,
+          tableState.rowsPerPage,
+          currentSortColumn
+        );
+        break;
+      case "viewColumnsChange":
+        // Save displayed column labels
+        setDisplayedColumns(
+          tableState.columns
+            .filter((column) => column.display === "true")
+            .map((column) => column.label)
+        );
         break;
       default:
     }
@@ -471,10 +497,12 @@ const SourceTable = ({
     const peakPoint = source.photometry
       .filter((point) => point.flux)
       .sort((a, b) => a.flux - b.flux)[0];
-    return (
+    return source.photometry.length > 0 ? (
       <Tooltip title={`${(mjdNow - peakPoint.mjd).toFixed(2)} days ago`}>
         <div>{`${flux_to_mag(peakPoint.flux, peakPoint.zp).toFixed(4)}`}</div>
       </Tooltip>
+    ) : (
+      <div>No photometry</div>
     );
   };
 
@@ -483,12 +511,14 @@ const SourceTable = ({
     const latestPoint = source.photometry
       .filter((point) => point.flux)
       .sort((a, b) => b.mjd - a.mjd)[0];
-    return (
+    return source.photometry.length > 0 ? (
       <Tooltip title={`${(mjdNow - latestPoint.mjd).toFixed(2)} days ago`}>
         <div>
           {`${flux_to_mag(latestPoint.flux, latestPoint.zp).toFixed(4)}`}
         </div>
       </Tooltip>
+    ) : (
+      <div>No photometry</div>
     );
   };
 
@@ -593,6 +623,7 @@ const SourceTable = ({
       label: "Source ID",
       options: {
         filter: true,
+        display: displayedColumns.includes("Source ID"),
         customBodyRenderLite: renderObjId,
         customHeadLabelRender: () => renderHeader("id", "Source ID"),
       },
@@ -601,7 +632,7 @@ const SourceTable = ({
       name: "Alias",
       options: {
         filter: true,
-        display: false,
+        display: displayedColumns.includes("Alias"),
         customBodyRenderLite: renderAlias,
       },
     },
@@ -610,6 +641,7 @@ const SourceTable = ({
       label: "RA (deg)",
       options: {
         filter: false,
+        display: displayedColumns.includes("RA (deg)"),
         customBodyRenderLite: renderRA,
         customHeadLabelRender: () => renderHeader("ra", "RA (deg)"),
       },
@@ -619,6 +651,7 @@ const SourceTable = ({
       label: "Dec (deg)",
       options: {
         filter: false,
+        display: displayedColumns.includes("Dec (deg)"),
         customBodyRenderLite: renderDec,
         customHeadLabelRender: () => renderHeader("dec", "Dec (deg)"),
       },
@@ -628,7 +661,7 @@ const SourceTable = ({
       label: "RA (hh:mm:ss)",
       options: {
         filter: false,
-        display: false,
+        display: displayedColumns.includes("RA (hh:mm:ss)"),
         customBodyRenderLite: renderRASex,
         customHeadLabelRender: () => renderHeader("ra", "RA (hh:mm:ss)"),
       },
@@ -638,7 +671,7 @@ const SourceTable = ({
       label: "Dec (dd:mm:ss)",
       options: {
         filter: false,
-        display: false,
+        display: displayedColumns.includes("Dec (dd:mm:ss)"),
         customBodyRenderLite: renderDecSex,
         customHeadLabelRender: () => renderHeader("dec", "Dec (dd:mm:ss)"),
       },
@@ -648,6 +681,7 @@ const SourceTable = ({
       label: "Redshift",
       options: {
         filter: false,
+        display: displayedColumns.includes("Redshift"),
         customHeadLabelRender: () => renderHeader("redshift", "Redshift"),
       },
     },
@@ -656,6 +690,7 @@ const SourceTable = ({
       label: "Classification",
       options: {
         filter: true,
+        display: displayedColumns.includes("Classification"),
         customBodyRenderLite: renderClassification,
         customHeadLabelRender: () =>
           renderHeader("classification", "Classification"),
@@ -666,6 +701,7 @@ const SourceTable = ({
       label: "Groups",
       options: {
         filter: false,
+        display: displayedColumns.includes("Groups"),
         customBodyRenderLite: renderGroups,
       },
     },
@@ -674,6 +710,7 @@ const SourceTable = ({
       label: "Date Saved",
       options: {
         filter: false,
+        display: displayedColumns.includes("Date Saved"),
         customBodyRenderLite: renderDateSaved,
         customHeadLabelRender: () => renderHeader("saved_at", "Date Saved"),
       },
@@ -682,6 +719,7 @@ const SourceTable = ({
       name: "Finder",
       options: {
         filter: false,
+        display: displayedColumns.includes("Finder"),
         customBodyRenderLite: renderFinderButton,
       },
     },
@@ -689,28 +727,28 @@ const SourceTable = ({
       name: "Spectrum?",
       options: {
         customBodyRenderLite: renderSpectrumExists,
-        display: false,
+        display: displayedColumns.includes("Spectrum?"),
       },
     },
     {
       name: "Peak Magnitude",
       options: {
         customBodyRenderLite: renderPeakMagnitude,
-        display: false,
+        display: displayedColumns.includes("Peak Magnitude"),
       },
     },
     {
       name: "Latest Magnitude",
       options: {
         customBodyRenderLite: renderLatestMagnitude,
-        display: false,
+        display: displayedColumns.includes("Latest Magnitude"),
       },
     },
     {
       name: "TNS Name",
       options: {
         customBodyRenderLite: renderTNSName,
-        display: false,
+        display: displayedColumns.includes("TNS Name"),
       },
     },
   ];


### PR DESCRIPTION
For the SourceTable.jsx component and the pages that use it (Sources and GroupSources):
- Save sorted column info across page changes (pass sort state to pagination handlers)
- Save displayed column info across component re-renders
- Properly detect and display sources that have no photometry points

Address https://github.com/fritz-marshal/fritz/issues/135

Also:
- Clean up `test_top_source_prefs` to use a `data-testid` XPATH instead of current one that was ambiguous and leading to flakiness

![sourcetablestate](https://user-images.githubusercontent.com/17696889/102144512-a0628f00-3e33-11eb-86a5-d90a61260d3d.gif)
