### PR TITLE
Fix encoding of plaintext spectrum data

### DIFF
--- a/static/js/components/ManageDataForm.jsx
+++ b/static/js/components/ManageDataForm.jsx
@@ -322,8 +322,10 @@ const ManageDataForm = ({ route }) => {
       ? spectrum.original_file_filename
       : get_filename(spectrum);
 
+    const blob = new Blob([data], { type: "text/plain" });
+
     return (
-      <IconButton href={`data:,${encodeURI(data)}`} download={filename}>
+      <IconButton href={URL.createObjectURL(blob)} download={filename}>
         <GetAppIcon />
       </IconButton>
     );


### PR DESCRIPTION
This PR fixes a bug where some spectrum files would not be properly encoded for download due to inclusion of characters that were not handled by `encodeURI`. 

The solution here casts these to blobs and then encodes those to plaintext urls using `URL.createObjectURL` as recommended by https://javascript.info/blob#blob-as-url. 

Tested this locally and it fixes the issue.