### PR TITLE
Fix broken profile test

### DIFF
--- a/skyportal/tests/frontend/test_profile.py
+++ b/skyportal/tests/frontend/test_profile.py
@@ -72,18 +72,14 @@ def test_insufficient_name_entry_in_profile(driver, user):
     driver.get(f"/become_user/{user.id}")
     driver.get("/profile")
     first_name_entry = driver.wait_for_xpath('//input[@name="firstName"]')
-    first_name = ""
     driver.scroll_to_element_and_click(first_name_entry)
-    first_name_entry.send_keys(first_name)
+    first_name_entry.clear()
     last_name_entry = driver.wait_for_xpath('//input[@name="lastName"]')
     last_name = str(uuid.uuid4())
     driver.scroll_to_element_and_click(last_name_entry)
     last_name_entry.send_keys(last_name)
 
-    update_profile_button = driver.find_element_by_xpath(
-        '//*[@id="updateProfileButton"]'
-    )
-    driver.scroll_to_element_and_click(update_profile_button)
+    driver.click_xpath('//*[@id="updateProfileButton"]')
 
     helper = driver.wait_for_xpath('//p[@id="firstName_id-helper-text"]')
     assert helper.text == "Required"


### PR DESCRIPTION
Test failure with `test_insufficient_name_entry_in_profile` was due to a fixture change - was testing empty first names in the profile form, but the user fixture was changed in #1253  to initialize users with a random first name