### PR TITLE
Make news feed categories configurable via associated WidgetPrefsDialog

### DIFF
--- a/skyportal/handlers/api/news_feed.py
+++ b/skyportal/handlers/api/news_feed.py
@@ -51,7 +51,7 @@ class NewsFeedHandler(BaseHandler):
         if 'newsFeed' in preferences and 'numItems' in preferences['newsFeed']:
             n_items = min(int(preferences['newsFeed']['numItems']), 50)
         else:
-            n_items = 5
+            n_items = 10
 
         def fetch_newest(model):
             query = model.query.filter(

--- a/skyportal/handlers/api/news_feed.py
+++ b/skyportal/handlers/api/news_feed.py
@@ -85,84 +85,98 @@ class NewsFeedHandler(BaseHandler):
 
             return newest
 
-        sources = fetch_newest(Source)
-        comments = fetch_newest(Comment)
-        classifications = fetch_newest(Classification)
-        spectra = fetch_newest(Spectrum)
-        photometry = fetch_newest(Photometry)
         news_feed_items = []
-        source_seen = set()
-        # Iterate in reverse so that we arrive at re-saved sources second
-        for s in reversed(sources):
-            if s.obj_id in source_seen:
-                message = 'Source saved to new group'
-            else:
-                message = 'New source saved'
-                source_seen.add(s.obj_id)
+        if preferences.get("newsFeed", {}).get("categories", {}).get("sources", True):
+            sources = fetch_newest(Source)
+            source_seen = set()
+            # Iterate in reverse so that we arrive at re-saved sources second
+            for s in reversed(sources):
+                if s.obj_id in source_seen:
+                    message = 'Source saved to new group'
+                else:
+                    message = 'New source saved'
+                    source_seen.add(s.obj_id)
 
-            # Prepend since we are iterating in reverse
-            news_feed_items.insert(
-                0,
-                {
-                    'type': 'source',
-                    'time': s.created_at,
-                    'message': message,
-                    'source_id': s.obj_id,
-                },
+                # Prepend since we are iterating in reverse
+                news_feed_items.insert(
+                    0,
+                    {
+                        'type': 'source',
+                        'time': s.created_at,
+                        'message': message,
+                        'source_id': s.obj_id,
+                    },
+                )
+        if preferences.get("newsFeed", {}).get("categories", {}).get("comments", True):
+            comments = fetch_newest(Comment)
+            # Add latest comments
+            news_feed_items.extend(
+                [
+                    {
+                        'type': 'comment',
+                        'time': c.created_at,
+                        'message': c.text,
+                        'source_id': c.obj_id,
+                        'author': c.author.username,
+                        'author_info': c.author_info,
+                    }
+                    for c in comments
+                ]
             )
-        # Add latest comments
-        news_feed_items.extend(
-            [
-                {
-                    'type': 'comment',
-                    'time': c.created_at,
-                    'message': c.text,
-                    'source_id': c.obj_id,
-                    'author': c.author.username,
-                    'author_info': c.author_info,
-                }
-                for c in comments
-            ]
-        )
-        # Add latest classifications
-        news_feed_items.extend(
-            [
-                {
-                    "type": "classification",
-                    "time": c.created_at,
-                    "message": f"New classification for {c.obj_id} added by {c.author.username}: {c.classification}",
-                    "source_id": c.obj_id,
-                    "author_info": basic_user_display_info(c.author),
-                }
-                for c in classifications
-            ]
-        )
-        # Add latest spectra
-        news_feed_items.extend(
-            [
-                {
-                    "type": "spectrum",
-                    "time": s.created_at,
-                    "message": f"{s.owner.first_name} {s.owner.last_name} uploaded a new spectrum taken with {s.instrument.name} for {s.obj_id}",
-                    "source_id": s.obj_id,
-                    "author_info": basic_user_display_info(s.owner),
-                }
-                for s in spectra
-            ]
-        )
-        # Add latest follow-up photometry
-        news_feed_items.extend(
-            [
-                {
-                    "type": "photometry",
-                    "time": p.created_at,
-                    "message": f"{p.owner.first_name} {p.owner.last_name} uploaded new follow-up photometry taken with {p.instrument.name} for {p.obj_id}",
-                    "source_id": p.obj_id,
-                    "author_info": basic_user_display_info(p.owner),
-                }
-                for p in photometry
-            ]
-        )
+        if (
+            preferences.get("newsFeed", {})
+            .get("categories", {})
+            .get("classifications", True)
+        ):
+            classifications = fetch_newest(Classification)
+            # Add latest classifications
+            news_feed_items.extend(
+                [
+                    {
+                        "type": "classification",
+                        "time": c.created_at,
+                        "message": f"New classification for {c.obj_id} added by {c.author.username}: {c.classification}",
+                        "source_id": c.obj_id,
+                        "author_info": basic_user_display_info(c.author),
+                    }
+                    for c in classifications
+                ]
+            )
+        if preferences.get("newsFeed", {}).get("categories", {}).get("spectra", True):
+            spectra = fetch_newest(Spectrum)
+            # Add latest spectra
+            news_feed_items.extend(
+                [
+                    {
+                        "type": "spectrum",
+                        "time": s.created_at,
+                        "message": f"{s.owner.first_name} {s.owner.last_name} uploaded a new spectrum taken with {s.instrument.name} for {s.obj_id}",
+                        "source_id": s.obj_id,
+                        "author_info": basic_user_display_info(s.owner),
+                    }
+                    for s in spectra
+                ]
+            )
+        if (
+            preferences.get("newsFeed", {})
+            .get("categories", {})
+            .get("photometry", True)
+        ):
+            photometry = fetch_newest(Photometry)
+            # Add latest follow-up photometry
+            news_feed_items.extend(
+                [
+                    {
+                        "type": "photometry",
+                        "time": p.created_at,
+                        "message": f"{p.owner.first_name} {p.owner.last_name} uploaded new follow-up photometry taken with {p.instrument.name} for {p.obj_id}",
+                        "source_id": p.obj_id,
+                        "author_info": basic_user_display_info(p.owner),
+                    }
+                    for p in photometry
+                ]
+            )
+
         news_feed_items.sort(key=lambda x: x['time'], reverse=True)
         news_feed_items = news_feed_items[:n_items]
 

--- a/skyportal/tests/frontend/test_newsfeed.py
+++ b/skyportal/tests/frontend/test_newsfeed.py
@@ -93,7 +93,7 @@ def test_news_feed_prefs_widget(
         driver.wait_for_xpath(f'//p[contains(text(),"comment_text_{i}")]')
 
     driver.click_xpath('//*[@id="newsFeedSettingsIcon"]')
-    n_items_input = driver.wait_for_xpath('//input[@id="numItems"]')
+    n_items_input = driver.wait_for_xpath('//*[@data-testid="numItems"]//input')
     n_items_input.clear()
     ActionChains(driver).click(n_items_input).send_keys("2").perform()
     driver.click_xpath('//button[contains(., "Save")]')
@@ -101,8 +101,24 @@ def test_news_feed_prefs_widget(
     driver.wait_for_xpath_to_disappear(source_added_item_xpath)
 
     driver.click_xpath('//*[@id="newsFeedSettingsIcon"]')
-    n_items_input = driver.wait_for_xpath('//input[@id="numItems"]')
+    n_items_input = driver.wait_for_xpath('//*[@data-testid="numItems"]//input')
     n_items_input.clear()
     ActionChains(driver).send_keys_to_element(n_items_input, "4").perform()
     driver.click_xpath('//button[contains(., "Save")]')
     driver.wait_for_xpath(source_added_item_xpath)
+
+    driver.click_xpath('//*[@id="newsFeedSettingsIcon"]')
+    driver.click_xpath('//*[@data-testid="categories.sources"]')
+    driver.click_xpath('//button[contains(., "Save")]')
+    for i in range(2):
+        # Source added item
+        driver.wait_for_xpath_to_disappear(
+            f'//div[contains(@class, "NewsFeed__entryContent")][.//p[text()="New source saved"]][.//a[@href="/source/{obj_id_base}_{i}"]]'
+        )
+
+    driver.click_xpath('//*[@id="newsFeedSettingsIcon"]')
+    driver.click_xpath('//*[@data-testid="categories.comments"]')
+    driver.click_xpath('//button[contains(., "Save")]')
+    for i in range(2):
+        # Comment item
+        driver.wait_for_xpath_to_disappear(f'//p[contains(text(),"comment_text_{i}")]')

--- a/static/js/components/NewsFeed.jsx
+++ b/static/js/components/NewsFeed.jsx
@@ -22,7 +22,14 @@ dayjs.extend(relativeTime);
 dayjs.extend(utc);
 
 const defaultPrefs = {
-  numItems: "5",
+  numItems: "10",
+  categories: {
+    classifications: true,
+    comments: true,
+    photometry: true,
+    sources: true,
+    spectra: true,
+  },
 };
 
 const NewsFeedItem = ({ item }) => {
@@ -134,7 +141,7 @@ const NewsFeed = ({ classes }) => {
         <DragHandleIcon className={`${classes.widgetIcon} dragHandle`} />
         <div className={classes.widgetIcon}>
           <WidgetPrefsDialog
-            formValues={newsFeedPrefs}
+            initialValues={newsFeedPrefs}
             stateBranchName="newsFeed"
             title="News Feed Preferences"
             onSubmit={profileActions.updateUserPreferences}

--- a/static/js/components/NewsFeed.jsx
+++ b/static/js/components/NewsFeed.jsx
@@ -124,6 +124,9 @@ const NewsFeed = ({ classes }) => {
   const { items } = useSelector((state) => state.newsFeed);
   const newsFeedPrefs =
     useSelector((state) => state.profile.preferences.newsFeed) || defaultPrefs;
+  if (!Object.keys(newsFeedPrefs).includes("categories")) {
+    newsFeedPrefs.categories = defaultPrefs.categories;
+  }
 
   // Color styling
   const userColorTheme = useSelector(

--- a/static/js/components/RecentSources.jsx
+++ b/static/js/components/RecentSources.jsx
@@ -217,7 +217,7 @@ const RecentSources = ({ classes }) => {
         <DragHandleIcon className={`${classes.widgetIcon} dragHandle`} />
         <div className={classes.widgetIcon}>
           <WidgetPrefsDialog
-            formValues={recentSourcesPrefs}
+            initialValues={recentSourcesPrefs}
             stateBranchName="recentSources"
             title="Recent Sources Preferences"
             onSubmit={profileActions.updateUserPreferences}

--- a/static/js/components/SourceCounts.jsx
+++ b/static/js/components/SourceCounts.jsx
@@ -49,7 +49,7 @@ const SourceCounts = ({ classes, sinceDaysAgo }) => {
           <DragHandleIcon className={`${classes.widgetIcon} dragHandle`} />
           <div className={classes.widgetIcon}>
             <WidgetPrefsDialog
-              formValues={sourceCountPrefs}
+              initialValues={sourceCountPrefs}
               stateBranchName="sourceCounts"
               title="Source Count Preferences"
               onSubmit={profileActions.updateUserPreferences}

--- a/static/js/components/TopSources.jsx
+++ b/static/js/components/TopSources.jsx
@@ -202,7 +202,7 @@ const TopSources = ({ classes }) => {
           <div className={classes.widgetIcon}>
             <WidgetPrefsDialog
               // Only expose num sources
-              formValues={{ maxNumSources: topSourcesPrefs.maxNumSources }}
+              initialValues={{ maxNumSources: topSourcesPrefs.maxNumSources }}
               stateBranchName="topSources"
               title="Top Sources Preferences"
               onSubmit={profileActions.updateUserPreferences}

--- a/static/js/components/UpdateProfileForm.jsx
+++ b/static/js/components/UpdateProfileForm.jsx
@@ -44,14 +44,14 @@ const UpdateProfileForm = () => {
     });
   }, [reset, profile]);
 
-  const onSubmit = async (formValues) => {
+  const onSubmit = async (initialValues) => {
     setIsSubmitting(true);
     const basicinfo = {
-      username: formValues.username,
-      first_name: formValues.firstName,
-      last_name: formValues.lastName,
-      contact_email: formValues.email,
-      contact_phone: formValues.phone,
+      username: initialValues.username,
+      first_name: initialValues.firstName,
+      last_name: initialValues.lastName,
+      contact_email: initialValues.email,
+      contact_phone: initialValues.phone,
     };
     const result = await dispatch(
       ProfileActions.updateBasicUserInfo(basicinfo)

--- a/static/js/components/WidgetPrefsDialog.jsx
+++ b/static/js/components/WidgetPrefsDialog.jsx
@@ -12,6 +12,7 @@ import { makeStyles } from "@material-ui/core/styles";
 import SaveIcon from "@material-ui/icons/Save";
 import TextField from "@material-ui/core/TextField";
 import FormControlLabel from "@material-ui/core/FormControlLabel";
+import Typography from "@material-ui/core/Typography";
 
 const useStyles = makeStyles(() => ({
   saveButton: {
@@ -77,8 +78,7 @@ const WidgetPrefsDialog = ({
               ) {
                 return (
                   <div key={key} className={classes.inputSectionDiv}>
-                    Select {key}:
-                    <br />
+                    <Typography variant="subtitle2">Select {key}:</Typography>
                     {Object.keys(initialValues[key]).map((subKey) => (
                       <FormControlLabel
                         key={subKey}

--- a/static/js/components/WidgetPrefsDialog.jsx
+++ b/static/js/components/WidgetPrefsDialog.jsx
@@ -75,9 +75,10 @@ const WidgetPrefsDialog = ({
                 return (
                   <div key={key}>
                     Select {key}:
-                    {Object.keys(initialValues[key]).map((subkey, idx) => (
+                    <br />
+                    {Object.keys(initialValues[key]).map((subKey) => (
                       <FormControlLabel
-                        key={subkey}
+                        key={subKey}
                         control={
                           <Controller
                             render={({ onChange, value }) => (
@@ -86,15 +87,15 @@ const WidgetPrefsDialog = ({
                                   onChange(event.target.checked)
                                 }
                                 checked={value}
-                                data-testid={`${subkey}[${idx}]`}
+                                data-testid={`${key}.${subKey}`}
                               />
                             )}
-                            name={`${key}.${subkey}`}
+                            name={`${key}.${subKey}`}
                             control={control}
                             defaultValue={false}
                           />
                         }
-                        label={subkey}
+                        label={subKey}
                       />
                     ))}
                   </div>

--- a/static/js/components/WidgetPrefsDialog.jsx
+++ b/static/js/components/WidgetPrefsDialog.jsx
@@ -1,14 +1,17 @@
 import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import { useDispatch } from "react-redux";
+import { useForm, Controller } from "react-hook-form";
 import Dialog from "@material-ui/core/Dialog";
 import DialogContent from "@material-ui/core/DialogContent";
 import DialogTitle from "@material-ui/core/DialogTitle";
 import SettingsIcon from "@material-ui/icons/Settings";
 import Button from "@material-ui/core/Button";
+import Checkbox from "@material-ui/core/Checkbox";
 import { makeStyles } from "@material-ui/core/styles";
 import SaveIcon from "@material-ui/icons/Save";
 import TextField from "@material-ui/core/TextField";
+import FormControlLabel from "@material-ui/core/FormControlLabel";
 
 const useStyles = makeStyles(() => ({
   saveButton: {
@@ -19,18 +22,21 @@ const useStyles = makeStyles(() => ({
 
 const WidgetPrefsDialog = ({
   title,
-  formValues,
+  initialValues,
   onSubmit,
   stateBranchName,
 }) => {
   const classes = useStyles();
   const dispatch = useDispatch();
   const [open, setOpen] = useState(false);
-  const [state, updateState] = useState({ ...formValues });
+
+  const { handleSubmit, register, errors, reset, control } = useForm(
+    initialValues
+  );
 
   useEffect(() => {
-    updateState(formValues);
-  }, [formValues]);
+    reset(initialValues);
+  }, [initialValues, reset]);
 
   const handleClickOpen = () => {
     setOpen(true);
@@ -40,15 +46,8 @@ const WidgetPrefsDialog = ({
     setOpen(false);
   };
 
-  const handleInputChange = (event) => {
-    const stateCopy = { ...state };
-    stateCopy[event.target.id] = event.target.value;
-    updateState(stateCopy);
-  };
-
-  const handleSubmit = () => {
-    const payload = {};
-    payload[stateBranchName] = state;
+  const formSubmit = (formData) => {
+    const payload = { [stateBranchName]: formData };
     dispatch(onSubmit(payload));
     setOpen(false);
   };
@@ -63,30 +62,73 @@ const WidgetPrefsDialog = ({
       <Dialog open={open} onClose={handleClose} style={{ position: "fixed" }}>
         <DialogTitle>{title}</DialogTitle>
         <DialogContent>
-          <form noValidate autoComplete="off">
-            {Object.keys(formValues).map((key) => (
-              <div key={key}>
-                <TextField
-                  id={`${key}`}
-                  size="small"
-                  label={key}
-                  value={state[key]}
-                  onChange={handleInputChange}
-                  variant="outlined"
-                />
-              </div>
-            ))}
+          <form
+            noValidate
+            autoComplete="off"
+            onSubmit={handleSubmit(formSubmit)}
+          >
+            {Object.keys(initialValues).map((key) => {
+              if (
+                typeof initialValues[key] === "object" &&
+                initialValues[key].constructor === Object
+              ) {
+                return (
+                  <div key={key}>
+                    Select {key}:
+                    {Object.keys(initialValues[key]).map((subkey, idx) => (
+                      <FormControlLabel
+                        key={subkey}
+                        control={
+                          <Controller
+                            render={({ onChange, value }) => (
+                              <Checkbox
+                                onChange={(event) =>
+                                  onChange(event.target.checked)
+                                }
+                                checked={value}
+                                data-testid={`${subkey}[${idx}]`}
+                              />
+                            )}
+                            name={`${key}.${subkey}`}
+                            control={control}
+                            defaultValue={false}
+                          />
+                        }
+                        label={subkey}
+                      />
+                    ))}
+                  </div>
+                );
+              }
+              if (typeof initialValues[key] === "string") {
+                return (
+                  <div key={key}>
+                    <TextField
+                      data-testid={key}
+                      size="small"
+                      label={key}
+                      inputRef={register({ required: true })}
+                      name={key}
+                      error={!!errors[key]}
+                      helperText={errors[key] ? "Required" : ""}
+                      variant="outlined"
+                    />
+                  </div>
+                );
+              }
+              return <div key={key} />;
+            })}
+            <div className={classes.saveButton}>
+              <Button
+                color="primary"
+                type="submit"
+                startIcon={<SaveIcon />}
+                size="large"
+              >
+                Save
+              </Button>
+            </div>
           </form>
-          <div className={classes.saveButton}>
-            <Button
-              color="primary"
-              onClick={handleSubmit}
-              startIcon={<SaveIcon />}
-              size="large"
-            >
-              Save
-            </Button>
-          </div>
         </DialogContent>
       </Dialog>
     </div>
@@ -94,7 +136,7 @@ const WidgetPrefsDialog = ({
 };
 
 WidgetPrefsDialog.propTypes = {
-  formValues: PropTypes.objectOf(PropTypes.string).isRequired,
+  initialValues: PropTypes.objectOf(PropTypes.string).isRequired,
   stateBranchName: PropTypes.string.isRequired,
   onSubmit: PropTypes.func.isRequired,
   title: PropTypes.string.isRequired,

--- a/static/js/components/WidgetPrefsDialog.jsx
+++ b/static/js/components/WidgetPrefsDialog.jsx
@@ -18,6 +18,9 @@ const useStyles = makeStyles(() => ({
     textAlign: "center",
     margin: "1rem",
   },
+  inputSectionDiv: {
+    marginBottom: "1rem",
+  },
 }));
 
 const WidgetPrefsDialog = ({
@@ -73,7 +76,7 @@ const WidgetPrefsDialog = ({
                 initialValues[key].constructor === Object
               ) {
                 return (
-                  <div key={key}>
+                  <div key={key} className={classes.inputSectionDiv}>
                     Select {key}:
                     <br />
                     {Object.keys(initialValues[key]).map((subKey) => (
@@ -103,7 +106,7 @@ const WidgetPrefsDialog = ({
               }
               if (typeof initialValues[key] === "string") {
                 return (
-                  <div key={key}>
+                  <div key={key} className={classes.inputSectionDiv}>
                     <TextField
                       data-testid={key}
                       size="small"


### PR DESCRIPTION
This PR makes the news feed categories configurable via the widget preferences dialog form, and refactors that form to accommodate both text fields and checkbox groups (represented by an object whose keys are value names, and values are `true`/`false`, corresponding to checked/unchecked). A test is added.

![configure_newsfeed_categories](https://user-images.githubusercontent.com/7230285/102672965-386bbb80-4147-11eb-92dc-95da635682c9.gif)


Closes #1518 
Closes #1519 
Partially addresses #1383 