### PR TITLE
Temporarily pin sphinx==3.3.1

### DIFF
--- a/requirements.docs.txt
+++ b/requirements.docs.txt
@@ -1,4 +1,4 @@
-sphinx
+sphinx==3.3.1
 recommonmark
 numpydoc
 sphinx-rtd-theme


### PR DESCRIPTION
A bug in 3.4.0 has been patched, but patch is not yet included in a release. https://github.com/sphinx-doc/sphinx/pull/8569  