### PR TITLE
CI: suppress doc build/deploy on forks

### DIFF
--- a/.github/workflows/build-and-deploy-docs.yaml
+++ b/.github/workflows/build-and-deploy-docs.yaml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
+    if: github.repo_owner == 'skyportal'
+
     services:
       postgres:
         image: postgres


### PR DESCRIPTION
I recently used your CI recipe for building/deploying documentation across repos [for another project](https://github.com/pygraphviz/pygraphviz/blob/master/.github/workflows/deploy-docs.yml) (thanks!)

One thing I noticed when setting this up is that, with the current configuration, I was getting failed workflow notifications whenever I pushed to master on my fork (e.g. when syncing with upstream) due to `secrets` not being set up on my fork. We didn't actually want the build+deploy job to run on forks - I found that adding the proposed line to the config is a nice way to prevent this from happening.

I'm not sure if you've experienced similar issues, but on the off chance that you have I thought I'd share our solution. Note also that if you still want the build to run and just suppress the deploy, you can add the conditional to the individual steps you want to suppress (e.g. the ssh-agent and deploy actions) rather than suppressing the whole job.

Thanks for the CI ideas and very cool project!

