### PR TITLE
Correct hybrid properties dealing with 'NaN' flux values

### DIFF
--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -591,7 +591,7 @@ class Obj(Base, ha.Point):
         detections = [
             phot.iso
             for phot in self.photometry
-            if not np.isnan(phot.snr) and phot.snr > 5
+            if phot.snr is not None and phot.snr > 5
         ]
         return max(detections) if detections else None
 
@@ -601,7 +601,7 @@ class Obj(Base, ha.Point):
         return (
             sa.select([sa.func.max(Photometry.iso)])
             .where(Photometry.obj_id == cls.id)
-            .where(Photometry.snr != 'NaN')
+            .where(Photometry.snr.isnot(None))
             .where(Photometry.snr > 5.0)
             .group_by(Photometry.obj_id)
             .label('last_detected')

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -588,7 +588,11 @@ class Obj(Base, ha.Point):
     @hybrid_property
     def last_detected(self):
         """UTC ISO date at which the object was last detected above a S/N of 5."""
-        detections = [phot.iso for phot in self.photometry if phot.snr and phot.snr > 5]
+        detections = [
+            phot.iso
+            for phot in self.photometry
+            if not np.isnan(phot.snr) and phot.snr > 5
+        ]
         return max(detections) if detections else None
 
     @last_detected.expression
@@ -597,6 +601,7 @@ class Obj(Base, ha.Point):
         return (
             sa.select([sa.func.max(Photometry.iso)])
             .where(Photometry.obj_id == cls.id)
+            .where(Photometry.snr != 'NaN')
             .where(Photometry.snr > 5.0)
             .group_by(Photometry.obj_id)
             .label('last_detected')
@@ -1790,7 +1795,7 @@ User.comments = relationship("Comment", back_populates="author")
 
 class Annotation(Base):
     """A sortable/searchable Annotation made by a filter or other robot,
-    with a set of data as JSON """
+    with a set of data as JSON"""
 
     __table_args__ = (UniqueConstraint('obj_id', 'origin'),)
 
@@ -2023,7 +2028,7 @@ class Photometry(Base, ha.Point):
     @hybrid_property
     def mag(self):
         """The magnitude of the photometry point in the AB system."""
-        if self.flux is not None and self.flux > 0:
+        if not np.isnan(self.flux) and self.flux > 0:
             return -2.5 * np.log10(self.flux) + PHOT_ZP
         else:
             return None
@@ -2031,7 +2036,7 @@ class Photometry(Base, ha.Point):
     @hybrid_property
     def e_mag(self):
         """The error on the magnitude of the photometry point."""
-        if self.flux is not None and self.flux > 0 and self.fluxerr > 0:
+        if not np.isnan(self.flux) and self.flux > 0 and self.fluxerr > 0:
             return (2.5 / np.log(10)) * (self.fluxerr / self.flux)
         else:
             return None
@@ -2042,7 +2047,7 @@ class Photometry(Base, ha.Point):
         return sa.case(
             [
                 (
-                    sa.and_(cls.flux != None, cls.flux > 0),  # noqa
+                    sa.and_(cls.flux != 'NaN', cls.flux > 0),  # noqa
                     -2.5 * sa.func.log(cls.flux) + PHOT_ZP,
                 )
             ],
@@ -2056,7 +2061,7 @@ class Photometry(Base, ha.Point):
             [
                 (
                     sa.and_(
-                        cls.flux != None, cls.flux > 0, cls.fluxerr > 0
+                        cls.flux != 'NaN', cls.flux > 0, cls.fluxerr > 0
                     ),  # noqa: E711
                     2.5 / sa.func.ln(10) * cls.fluxerr / cls.flux,
                 )
@@ -2083,7 +2088,11 @@ class Photometry(Base, ha.Point):
     @hybrid_property
     def snr(self):
         """Signal-to-noise ratio of this Photometry point."""
-        return self.flux / self.fluxerr if self.flux and self.fluxerr else None
+        return (
+            self.flux / self.fluxerr
+            if not np.isnan(self.flux) and not np.isnan(self.fluxerr)
+            else None
+        )
 
     @snr.expression
     def snr(self):

--- a/skyportal/tests/api/test_sources.py
+++ b/skyportal/tests/api/test_sources.py
@@ -2,6 +2,7 @@ import uuid
 import pytest
 import numpy.testing as npt
 import numpy as np
+import arrow
 from tdtax import taxonomy, __version__
 
 from skyportal.tests import api
@@ -581,3 +582,57 @@ def test_sources_filter_by_classifications(
     assert status == 200
     assert len(data["data"]["sources"]) == 1
     assert data["data"]["sources"][0]["id"] == obj_id1
+
+
+def test_object_last_detected(
+    upload_data_token, view_only_token, public_source, ztf_camera, public_group
+):
+    # Some very high mjd to make this the latest point
+    # This is not a detection though
+    status, data = api(
+        'POST',
+        'photometry',
+        data={
+            'obj_id': str(public_source.id),
+            'mjd': 99999.0,
+            'instrument_id': ztf_camera.id,
+            'mag': None,
+            'magerr': None,
+            'limiting_mag': 22.3,
+            'magsys': 'ab',
+            'filter': 'ztfg',
+            'group_ids': [public_group.id],
+        },
+        token=upload_data_token,
+    )
+    assert status == 200
+    assert data['status'] == 'success'
+
+    # A high mjd, but lower than the first point
+    # Since this is a detection, it should be returned as "last_detected"
+    status, data = api(
+        'POST',
+        'photometry',
+        data={
+            'obj_id': str(public_source.id),
+            'mjd': 90000.0,
+            'instrument_id': ztf_camera.id,
+            'flux': 12.24,
+            'fluxerr': 0.031,
+            'zp': 25.0,
+            'magsys': 'ab',
+            'filter': 'ztfg',
+            'group_ids': [public_group.id],
+        },
+        token=upload_data_token,
+    )
+    assert status == 200
+    assert data['status'] == 'success'
+
+    status, data = api("GET", f"sources/{public_source.id}", token=view_only_token)
+    assert status == 200
+    assert data["status"] == "success"
+    assert (
+        data["data"]["last_detected"]
+        == arrow.get((90000.0 - 40_587) * 86400.0).isoformat()
+    )


### PR DESCRIPTION
- The `flux` column of the `Photometry` model defines a default value of `'NaN'` and is not nullable. Thus, we should be checking for `nan` float values when looking for valid flux points instead of something like `self.flux is not None` or `if self.flux:`. For example:
![Screenshot 2021-01-04 113355](https://user-images.githubusercontent.com/17696889/103557735-a58a8b00-4e81-11eb-8739-79ab5f6744c4.png)
- Additionally, Postgres considers NaN values to be greater than all non-NaN values, while python will properly return false for all comparisons against NaN:

![Screenshot 2021-01-04 113748](https://user-images.githubusercontent.com/17696889/103557978-f8644280-4e81-11eb-851d-cb9479be3173.png)
(https://www.postgresql.org/docs/9.1/datatype-numeric.html)

This PR addresses issues stemming from these two points by using `np.isnan()` to check for NaN flux points instead of checking for `None` values in the python side of relevant hybrid properties, and using ` != 'NaN'` instead of `!= None` in the SQL expressions of the hybrid properties.
