### PR TITLE
Empty spectra in source table

### DIFF
--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -305,6 +305,13 @@ class SourceHandler(BaseHandler):
               Boolean indicating whether to include comment metadata in response.
               Defaults to false.
           - in: query
+            name: includePhotometryExists
+            nullable: true
+            schema:
+              type: boolean
+            description: |
+              Boolean indicating whether to return if a source has any photometry points. Defaults to false.
+          - in: query
             name: includeSpectrumExists
             nullable: true
             schema:
@@ -369,6 +376,9 @@ class SourceHandler(BaseHandler):
         sort_by = self.get_query_argument("sortBy", None)
         sort_order = self.get_query_argument("sortOrder", "asc")
         include_comments = self.get_query_argument("includeComments", False)
+        include_photometry_exists = self.get_query_argument(
+            "includePhotometryExists", False
+        )
         include_spectrum_exists = self.get_query_argument(
             "includeSpectrumExists", False
         )
@@ -503,6 +513,11 @@ class SourceHandler(BaseHandler):
                 source_info["photometry"] = [
                     serialize(phot, 'ab', 'flux') for phot in photometry
                 ]
+            if include_photometry_exists:
+                source_info["photometry_exists"] = (
+                    len(Obj.get_photometry_readable_by_user(obj_id, self.current_user))
+                    > 0
+                )
             if include_spectrum_exists:
                 source_info["spectrum_exists"] = (
                     len(Obj.get_spectra_readable_by(obj_id, self.current_user)) > 0
@@ -747,6 +762,15 @@ class SourceHandler(BaseHandler):
                     source_list[-1]["photometry"] = [
                         serialize(phot, 'ab', 'flux') for phot in photometry
                     ]
+                if include_photometry_exists:
+                    source_list[-1]["photometry_exists"] = (
+                        len(
+                            Obj.get_photometry_readable_by_user(
+                                source.id, self.current_user
+                            )
+                        )
+                        > 0
+                    )
                 if include_spectrum_exists:
                     source_list[-1]["spectrum_exists"] = (
                         len(Obj.get_spectra_readable_by(source.id, self.current_user))

--- a/static/js/components/GroupSources.jsx
+++ b/static/js/components/GroupSources.jsx
@@ -47,7 +47,6 @@ const GroupSources = ({ route }) => {
         group_ids: [route.id],
         pageNumber: 1,
         numPerPage: 10,
-        includeSpectrumExists: true,
       })
     );
     dispatch(
@@ -55,7 +54,6 @@ const GroupSources = ({ route }) => {
         group_ids: [route.id],
         pageNumber: 1,
         numPerPage: 10,
-        includeSpectrumExists: true,
       })
     );
   }, [route.id, dispatch]);

--- a/static/js/components/GroupSources.jsx
+++ b/static/js/components/GroupSources.jsx
@@ -47,6 +47,7 @@ const GroupSources = ({ route }) => {
         group_ids: [route.id],
         pageNumber: 1,
         numPerPage: 10,
+        includeSpectrumExists: true,
       })
     );
     dispatch(
@@ -54,6 +55,7 @@ const GroupSources = ({ route }) => {
         group_ids: [route.id],
         pageNumber: 1,
         numPerPage: 10,
+        includeSpectrumExists: true,
       })
     );
   }, [route.id, dispatch]);

--- a/static/js/components/SourceTable.jsx
+++ b/static/js/components/SourceTable.jsx
@@ -235,13 +235,17 @@ const SourceTable = ({
                 <VegaPlot dataUrl={`/api/sources/${source.id}/photometry`} />
               </Suspense>
             </Grid>
-            <Grid item>
-              <Suspense fallback={<div>Loading spectra...</div>}>
-                <VegaSpectrum
-                  dataUrl={`/api/sources/${source.id}/spectra?normalization=median`}
-                />
-              </Suspense>
-            </Grid>
+
+            {source.spectrum_exists && (
+              <Grid item>
+                <Suspense fallback={<div>Loading spectra...</div>}>
+                  <VegaSpectrum
+                    dataUrl={`/api/sources/${source.id}/spectra?normalization=median`}
+                  />
+                </Suspense>
+              </Grid>
+            )}
+            {!source.spectrum_exists && "no spectra exist"}
             <Grid item>
               <div className={classes.commentListContainer}>
                 {comments.map(

--- a/static/js/components/SourceTable.jsx
+++ b/static/js/components/SourceTable.jsx
@@ -231,21 +231,25 @@ const SourceTable = ({
               useGrid={false}
             />
             <Grid item>
-              <Suspense fallback={<div>Loading plot...</div>}>
-                <VegaPlot dataUrl={`/api/sources/${source.id}/photometry`} />
-              </Suspense>
+              {source.photometry_exists && (
+                <Suspense fallback={<div>Loading plot...</div>}>
+                  <VegaPlot dataUrl={`/api/sources/${source.id}/photometry`} />
+                </Suspense>
+              )}
+              {!source.photometry_exists && (
+                <div> no photometry exists &nbsp </div>
+              )}
             </Grid>
-
-            {source.spectrum_exists && (
-              <Grid item>
+            <Grid item>
+              {source.spectrum_exists && (
                 <Suspense fallback={<div>Loading spectra...</div>}>
                   <VegaSpectrum
                     dataUrl={`/api/sources/${source.id}/spectra?normalization=median`}
                   />
                 </Suspense>
-              </Grid>
-            )}
-            {!source.spectrum_exists && "no spectra exist"}
+              )}
+              {!source.spectrum_exists && <div> no spectra exist &nbsp </div>}
+            </Grid>
             <Grid item>
               <div className={classes.commentListContainer}>
                 {comments.map(

--- a/static/js/components/SourceTable.jsx
+++ b/static/js/components/SourceTable.jsx
@@ -236,9 +236,7 @@ const SourceTable = ({
                   <VegaPlot dataUrl={`/api/sources/${source.id}/photometry`} />
                 </Suspense>
               )}
-              {!source.photometry_exists && (
-                <div> no photometry exists &nbsp </div>
-              )}
+              {!source.photometry_exists && <div> no photometry exists </div>}
             </Grid>
             <Grid item>
               {source.spectrum_exists && (
@@ -248,7 +246,7 @@ const SourceTable = ({
                   />
                 </Suspense>
               )}
-              {!source.spectrum_exists && <div> no spectra exist &nbsp </div>}
+              {!source.spectrum_exists && <div> no spectra exist </div>}
             </Grid>
             <Grid item>
               <div className={classes.commentListContainer}>

--- a/static/js/components/VegaSpectrum.jsx
+++ b/static/js/components/VegaSpectrum.jsx
@@ -8,7 +8,7 @@ const spec = (url) => ({
     url,
     format: {
       type: "json",
-      property: "data", // where on the JSON does the data live
+      property: "data.spectra", // where on the JSON does the data live
     },
   },
   transform: [

--- a/static/js/ducks/sources.js
+++ b/static/js/ducks/sources.js
@@ -23,12 +23,15 @@ const addFilterParamDefaults = (filterParams) => {
 
 export function fetchSources(filterParams = {}) {
   addFilterParamDefaults(filterParams);
+  filterParams.includePhotometryExists = true;
+  filterParams.includeSpectrumExists = true;
   return API.GET("/api/sources", FETCH_SOURCES, filterParams);
 }
 
 export function fetchSavedGroupSources(filterParams = {}) {
   addFilterParamDefaults(filterParams);
   filterParams.includePhotometry = true;
+  filterParams.includePhotometryExists = true;
   filterParams.includeSpectrumExists = true;
   return API.GET("/api/sources", FETCH_SAVED_GROUP_SOURCES, filterParams);
 }
@@ -37,6 +40,7 @@ export function fetchPendingGroupSources(filterParams = {}) {
   addFilterParamDefaults(filterParams);
   filterParams.pendingOnly = true;
   filterParams.includePhotometry = true;
+  filterParams.includePhotometryExists = true;
   filterParams.includeSpectrumExists = true;
   return API.GET("/api/sources", FETCH_PENDING_GROUP_SOURCES, filterParams);
 }


### PR DESCRIPTION
This PR fixes a few issues with plotting on the source tables (group sources and source list):
- empty photometry and spectra are now replaced with some text saying they're empty. 
- spectrum did not load in the VegaSpectrum because the API was changed. 

