### PR TITLE
Add support for Korean user names

### DIFF
--- a/static/js/components/UserAvatar.jsx
+++ b/static/js/components/UserAvatar.jsx
@@ -1,7 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { makeStyles } from "@material-ui/core/styles";
-
 import Avatar from "@material-ui/core/Avatar";
 
 const useStyles = makeStyles((theme) => ({
@@ -22,6 +21,22 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
+// Return true if all characters in a string are Korean characters
+export const isAllKoreanCharacters = (str) => {
+  return str.match(
+    /^([\uac00-\ud7af]|[\u1100-\u11ff]|[\u3130-\u318f]|[\ua960-\ua97f]|[\ud7b0-\ud7ff])+$/g
+  );
+};
+
+const getInitials = (firstName, lastName) => {
+  // Korean names are almost always <=2 characters; last names are written first,
+  // so using the full first name is a more natural "initials" than (firstName[0], lastName[0])
+  if (isAllKoreanCharacters(firstName)) {
+    return firstName;
+  }
+  return `${firstName?.charAt(0)}${lastName?.charAt(0)}`;
+};
+
 const UserAvatar = ({ size, firstName, lastName, username, gravatarUrl }) => {
   // use the hash of the username (which is in the gravatarUrl) to
   // select a unique color for this user
@@ -40,7 +55,7 @@ const UserAvatar = ({ size, firstName, lastName, username, gravatarUrl }) => {
   const backUpLetters =
     firstName === null
       ? username.slice(0, 2)
-      : `${firstName?.charAt(0)}${lastName?.charAt(0)}`;
+      : getInitials(firstName, lastName);
 
   const props = { size, usercolor, backUpLetters };
   const classes = useStyles(props);

--- a/static/js/components/UserProfileInfo.jsx
+++ b/static/js/components/UserProfileInfo.jsx
@@ -7,7 +7,7 @@ import Typography from "@material-ui/core/Typography";
 import Box from "@material-ui/core/Box";
 import PropTypes from "prop-types";
 
-import UserAvatar from "./UserAvatar";
+import UserAvatar, { isAllKoreanCharacters } from "./UserAvatar";
 
 export const UserContactInfo = ({ user }) => {
   let contact_string = "";
@@ -42,6 +42,14 @@ UserContactInfo.propTypes = {
   }).isRequired,
 };
 
+const getUserRealName = (firstName, lastName) => {
+  // Korean names are generally written in last->first name order with no space in between
+  if (isAllKoreanCharacters(firstName) && isAllKoreanCharacters(lastName)) {
+    return `${lastName}${firstName}`;
+  }
+  return `${firstName} ${lastName}`;
+};
+
 const UserProfileInfo = () => {
   const profile = useSelector((state) => state.profile);
 
@@ -72,7 +80,8 @@ const UserProfileInfo = () => {
                 : "visible",
             }}
           >
-            {profile.first_name} {profile.last_name}
+            {(profile.first_name || profile.last_name) &&
+              getUserRealName(profile.first_name, profile.last_name)}
           </h2>
         </div>
         &nbsp;


### PR DESCRIPTION
Update the user avatar and profile page name display to properly format Korean names. Korean names are generally written in last name, first name order with no space in between; a more natural (to a Korean speaker) set of initials for a Korean name would just be the full first name as first names are almost always <=2 characters in length and seeing first name -> last name order of the characters is strange (given the short length of names I don't think I've actually seen Koreans use "initials" in the manner of English names at all). 

Addresses #1567 

![Screenshot 2021-01-07 182925](https://user-images.githubusercontent.com/17696889/103956916-83aa3600-5117-11eb-8670-5a2953313103.png)
