### PR TITLE
group by origin (if exists) in photometry plot

### DIFF
--- a/skyportal/plot.py
+++ b/skyportal/plot.py
@@ -185,7 +185,15 @@ def photometry_plot(obj_id, user, width=600, height=300):
         return None, None, None
 
     data['color'] = [get_color(f) for f in data['filter']]
-    data['label'] = [f'{i}/{f}' for i, f in zip(data['instrument'], data['filter'])]
+
+    labels = []
+    for i, datarow in data.iterrows():
+        label = f'{datarow["instrument"]}/{datarow["filter"]}'
+        if datarow['origin'] is not None:
+            label += f'/{datarow["origin"]}'
+        labels.append(label)
+
+    data['label'] = labels
     data['zp'] = PHOT_ZP
     data['magsys'] = 'ab'
     data['alpha'] = 1.0


### PR DESCRIPTION
Adds an origin label to the photometry plot legend so people can see what pipeline  produced a particular photometry point 