### PR TITLE
increase range of redshift slider

### DIFF
--- a/skyportal/plot.py
+++ b/skyportal/plot.py
@@ -824,7 +824,7 @@ def spectroscopy_plot(obj_id, user, spec_id=None, width=600, height=300):
     z_slider = Slider(
         value=obj.redshift if obj.redshift is not None else 0.0,
         start=0.0,
-        end=1.0,
+        end=2.0,
         step=0.001,
         show_value=False,
         format="0[.]000",


### PR DESCRIPTION
From 1 to 2 to address this request from @agoobar:

> The spectroscopy redshift slider/lines seem to stop at z=1. Can this please be expanded? 
