### PR TITLE
Pin sphinx to 3.4.3, skipping over broken release

### DIFF
--- a/requirements.docs.txt
+++ b/requirements.docs.txt
@@ -1,4 +1,4 @@
-sphinx==3.3.1
+sphinx==3.4.3
 recommonmark
 numpydoc
 sphinx-rtd-theme


### PR DESCRIPTION
Closes https://github.com/skyportal/skyportal/issues/1528 