### PR TITLE
Fix conditional for CI doc deploy

### DIFF
--- a/.github/workflows/build-and-deploy-docs.yaml
+++ b/.github/workflows/build-and-deploy-docs.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
-    if: github.repo_owner == 'skyportal'
+    if: github.repository_owner == 'skyportal'
 
     services:
       postgres:


### PR DESCRIPTION
I accidentally used the wrong keyword in the doc deploy workflow in #1538 which is suppressing the doc deployment.

Reference: https://docs.github.com/en/free-pro-team@latest/actions/reference/context-and-expression-syntax-for-github-actions