### PR TITLE
Fix permissions-checking bug affecting fetching of Candidates/Sources/Objs

### DIFF
--- a/skyportal/handlers/api/comment.py
+++ b/skyportal/handlers/api/comment.py
@@ -3,7 +3,7 @@ from distutils.util import strtobool
 from marshmallow.exceptions import ValidationError
 from baselayer.app.access import permissions, auth_or_token
 from ..base import BaseHandler
-from ...models import DBSession, Source, Comment, Group, Candidate, Filter
+from ...models import DBSession, Source, Comment, Group, Candidate, Filter, Obj
 
 
 class CommentHandler(BaseHandler):
@@ -95,8 +95,8 @@ class CommentHandler(BaseHandler):
             return self.error("Missing required field `obj_id`")
         comment_text = data.get("text")
 
-        # Ensure user/token has access to parent source
-        _ = Source.get_obj_if_readable_by(obj_id, self.current_user)
+        # Ensure user/token has access to associated Obj
+        _ = Obj.get_if_readable_by(obj_id, self.current_user)
         user_accessible_group_ids = [g.id for g in self.current_user.accessible_groups]
         user_accessible_filter_ids = [
             filtr.id

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -1154,7 +1154,7 @@ def get_source_if_readable_by(obj_id, user_or_token, options=[]):
        The requested Obj.
     """
 
-    if Source.query.filter(Source.obj_id == obj_id).first() is None:
+    if Obj.query.get(obj_id) is None:
         return None
     user_group_ids = [g.id for g in user_or_token.accessible_groups]
     s = (


### PR DESCRIPTION
This fixes a critical bug affecting the fetching of Objs/Candidates.

The docstring for (`Source.get_obj_if_readable_by`) `get_source_if_readable_by` (which `Obj.get_if_readable_by` calls) states that it should  
> Return an Obj from the database if the Obj is a Source in at least
    one of the requesting User or Token owner's accessible Groups. If the Obj is not a
    Source in one of the User or Token owner's accessible Groups, raise an AccessError.
    If the Obj does not exist, return `None`.

This fix brings the actual functionality in line with what is expected and what is stated in the docstring.

Closes #1535 