### PR TITLE
Avoid navigating away from page in SourceTable

### DIFF
--- a/static/js/components/SourceTable.jsx
+++ b/static/js/components/SourceTable.jsx
@@ -1,6 +1,7 @@
 import React, { Suspense, useState } from "react";
 import PropTypes from "prop-types";
 import { useSelector, useDispatch } from "react-redux";
+import { Link, useHistory } from "react-router-dom";
 
 import TableCell from "@material-ui/core/TableCell";
 import TableRow from "@material-ui/core/TableRow";
@@ -8,7 +9,6 @@ import IconButton from "@material-ui/core/IconButton";
 import Button from "@material-ui/core/Button";
 import Grid from "@material-ui/core/Grid";
 import Chip from "@material-ui/core/Chip";
-import Link from "@material-ui/core/Link";
 import PictureAsPdfIcon from "@material-ui/icons/PictureAsPdf";
 import MUIDataTable from "mui-datatables";
 import {
@@ -314,13 +314,13 @@ const SourceTable = ({
   const renderObjId = (dataIndex) => {
     const objid = sources[dataIndex].id;
     return (
-      <a
-        href={`/source/${objid}`}
+      <Link
+        to={`/source/${objid}`}
         key={`${objid}_objid`}
         data-testid={`${objid}`}
       >
         {objid}
-      </a>
+      </Link>
     );
   };
 
@@ -328,9 +328,9 @@ const SourceTable = ({
     const { id: objid, alias } = sources[dataIndex];
 
     return (
-      <a href={`/source/${objid}`} key={`${objid}_alias`}>
+      <Link to={`/source/${objid}`} key={`${objid}_alias`}>
         {alias}
-      </a>
+      </Link>
     );
   };
 
@@ -360,11 +360,9 @@ const SourceTable = ({
   // helper function to get the classifications
   const getClassifications = (source) => {
     if (groupID !== undefined) {
-      return source.classifications.filter((cls) => {
-        return cls.groups.find((g) => {
-          return g.id === groupID;
-        });
-      });
+      return source.classifications.filter((cls) =>
+        cls.groups.find((g) => g.id === groupID)
+      );
     }
     return source.classifications;
   };
@@ -384,9 +382,9 @@ const SourceTable = ({
   };
 
   // helper function to get the source groups
-  const getGroups = (source) => {
-    return source.groups.filter((group) => group.active);
-  };
+  const getGroups = (source) => source.groups.filter((group) => group.active);
+
+  const history = useHistory();
 
   // This is just passed to MUI datatables options -- not meant to be instantiated directly.
   const renderGroups = (dataIndex) => {
@@ -400,6 +398,7 @@ const SourceTable = ({
               key={group.id}
               size="small"
               className={classes.chip}
+              onClick={() => history.push(`/group/${group.id}`)}
             />
             <br />
           </div>
@@ -411,16 +410,10 @@ const SourceTable = ({
   // helper function to get the source saved_at date
   const getDate = (source) => {
     if (groupID !== undefined) {
-      const group = source.groups.find((g) => {
-        return g.id === groupID;
-      });
+      const group = source.groups.find((g) => g.id === groupID);
       return group?.saved_at;
     }
-    const dates = source.groups
-      .map((g) => {
-        return g.saved_at;
-      })
-      .sort();
+    const dates = source.groups.map((g) => g.saved_at).sort();
     return dates[dates.length - 1];
   };
 
@@ -439,9 +432,9 @@ const SourceTable = ({
     const source = sources[dataIndex];
     return (
       <IconButton size="small" key={`${source.id}_actions`}>
-        <Link href={`/api/sources/${source.id}/finder`}>
+        <a href={`/api/sources/${source.id}/finder`}>
           <PictureAsPdfIcon />
-        </Link>
+        </a>
       </IconButton>
     );
   };


### PR DESCRIPTION
This is done by replacing `<a>` elements with `<Link>` elements.

Other changes:

- Add links to group chips
- Replace MaterialUI Link with React Router Link.
- Remove extraneous returns from arrow functions to satisfy linter.