### PR TITLE
Render markdown in browser notifications text

### DIFF
--- a/skyportal/handlers/api/comment.py
+++ b/skyportal/handlers/api/comment.py
@@ -189,7 +189,7 @@ class CommentHandler(BaseHandler):
                 DBSession().add(
                     UserNotification(
                         user=user_mentioned,
-                        text=f"{self.current_user.username} mentioned you in a comment on {obj_id}",
+                        text=f"*@{self.current_user.username}* mentioned you in a comment on *{obj_id}*",
                         url=f"/source/{obj_id}",
                     )
                 )

--- a/skyportal/handlers/api/group.py
+++ b/skyportal/handlers/api/group.py
@@ -464,7 +464,7 @@ class GroupUserHandler(BaseHandler):
         DBSession().add(
             UserNotification(
                 user=user,
-                text=f"You've been added to group {group.name}",
+                text=f"You've been added to group *{group.name}*",
                 url=f"/group/{group.id}",
             )
         )
@@ -670,7 +670,7 @@ class GroupUsersFromOtherGroupsHandler(BaseHandler):
                 DBSession().add(
                     UserNotification(
                         user_id=user_id,
-                        text=f"You've been added to group {group.name}",
+                        text=f"You've been added to group *{group.name}*",
                         url=f"/group/{group.id}",
                     )
                 )

--- a/skyportal/handlers/api/group_admission_request.py
+++ b/skyportal/handlers/api/group_admission_request.py
@@ -166,7 +166,7 @@ class GroupAdmissionRequestHandler(BaseHandler):
             DBSession().add(
                 UserNotification(
                     user=group_admin,
-                    text=f"{requesting_user.username} has requested to join {group.name}",
+                    text=f"*@{requesting_user.username}* has requested to join *{group.name}*",
                     url=f"/group/{group_id}",
                 )
             )
@@ -227,7 +227,7 @@ class GroupAdmissionRequestHandler(BaseHandler):
         DBSession().add(
             UserNotification(
                 user=admission_request.user,
-                text=f"Your admission request to group {admission_request.group.name} has been {status}",
+                text=f"Your admission request to group *{admission_request.group.name}* has been *{status}*",
                 url="/groups",
             )
         )

--- a/skyportal/tests/frontend/test_notifications.py
+++ b/skyportal/tests/frontend/test_notifications.py
@@ -31,15 +31,11 @@ def test_mention_generates_notification_then_mark_read_and_delete(
 
     driver.wait_for_xpath("//span[text()='1']")
     driver.click_xpath('//*[@data-testid="notificationsButton"]')
-    driver.wait_for_xpath(
-        f'//*[text()="{user.username} mentioned you in a comment on {public_source.id}"]'
-    )
+    driver.wait_for_xpath('//*[text()=" mentioned you in a comment on "]')
     driver.click_xpath('//*[contains(@data-testid, "markReadButton")]')
     driver.wait_for_xpath_to_disappear("//span[text()='1']")
     driver.click_xpath('//*[contains(@data-testid, "deleteNotificationButton")]')
-    driver.wait_for_xpath_to_disappear(
-        f'//*[text()="{user.username} mentioned you in a comment on {public_source.id}"]'
-    )
+    driver.wait_for_xpath_to_disappear('//*[text()=" mentioned you in a comment on "]')
     driver.wait_for_xpath("//*[text()='No notifications']")
 
 
@@ -67,13 +63,9 @@ def test_group_admission_requests_notifications(
     driver.get(f"/become_user/{super_admin_user.id}")
     driver.get(f"/group/{public_group2.id}")
     driver.click_xpath('//*[@data-testid="notificationsButton"]')
-    driver.wait_for_xpath(
-        f'//*[text()="{user.username} has requested to join {public_group2.name}"]'
-    )
+    driver.wait_for_xpath(f'//*[text()=" has requested to join "]')
     driver.click_xpath('//*[@data-testid="deleteAllNotificationsButton"]')
-    driver.wait_for_xpath_to_disappear(
-        f'//*[text()="{user.username} has requested to join {public_group2.name}"]'
-    )
+    driver.wait_for_xpath_to_disappear(f'//*[text()=" has requested to join "]')
 
     filter_for_value(driver, user.username, last=True)
     driver.wait_for_xpath('//div[text()="pending"]')
@@ -84,9 +76,5 @@ def test_group_admission_requests_notifications(
     driver.get(f'/become_user/{user.id}')
     driver.get("/")
     driver.click_xpath('//*[@data-testid="notificationsButton"]')
-    driver.wait_for_xpath(
-        f'//*[text()="Your admission request to group {public_group2.name} has been accepted"]'
-    )
-    driver.wait_for_xpath(
-        f'//*[text()="You\'ve been added to group {public_group2.name}"]'
-    )
+    driver.wait_for_xpath('//em[text()="accepted"]')
+    driver.wait_for_xpath(f'//em[text()="{public_group2.name}"]')

--- a/static/js/components/Notifications.jsx
+++ b/static/js/components/Notifications.jsx
@@ -10,6 +10,7 @@ import List from "@material-ui/core/List";
 import ListItem from "@material-ui/core/ListItem";
 import Divider from "@material-ui/core/Divider";
 import Button from "@material-ui/core/Button";
+import ReactMarkdown from "react-markdown";
 
 import * as userNotificationsActions from "../ducks/userNotifications";
 
@@ -144,7 +145,10 @@ const Notifications = () => {
                     }}
                     data-testid={`notification${notification.id}`}
                   >
-                    {notification.text}
+                    <ReactMarkdown
+                      source={notification.text}
+                      escapeHtml={false}
+                    />
                   </ListItem>
                   <ListItem className={classes.centered}>
                     {!notification.viewed && (


### PR DESCRIPTION
For now, just adds italicization to source/group/user names in message text.

![image](https://user-images.githubusercontent.com/7230285/105912884-f2750380-5fe0-11eb-9636-66269dd25c65.png)

Closes https://github.com/skyportal/skyportal/issues/1618