### PR TITLE
cross hair to all thumbnails

### DIFF
--- a/static/js/components/ThumbnailList.jsx
+++ b/static/js/components/ThumbnailList.jsx
@@ -100,7 +100,7 @@ const Thumbnail = ({ ra, dec, name, url, size }) => {
             loading="lazy"
           />
         </a>
-        {(name === "dr8" || name === "ps1") && (
+        {name !== "sdss" && (
           <img
             className={classes.crosshair}
             src="/static/images/crosshairs.png"


### PR DESCRIPTION
I added the little green cross-hairs (reticle) to all thumbnails, except SDSS which already has that. 

![Screenshot from 2021-02-01 15-35-11](https://user-images.githubusercontent.com/37179063/106466071-83e1eb00-64a3-11eb-9382-a0ede674235f.png)


The old files in the demo data have a built-in cross-hairs so there's two sets in my instance of SkyPortal. I think this will go away for newer data where the thumbnails don't have anything on them. 

