### PR TITLE
handle phot ra,dec being sometimes being none in offfsets handler

### DIFF
--- a/skyportal/utils/offset.py
+++ b/skyportal/utils/offset.py
@@ -394,7 +394,11 @@ def _calculate_best_position_for_offset_stars(
     # remove observations with distances more than max_offset away
     # from the median
     try:
-        med_ra, med_dec = np.median(df["ra"]), np.median(df["dec"])
+        # use nanmedian so that med_ra, med_dec are not returned as
+        # nan when df['ra'] or df['dec'] contains `None`s (can happen
+        # when there is no position information for a photometry
+        # point)
+        med_ra, med_dec = np.nanmedian(df["ra"]), np.nanmedian(df["dec"])
     except TypeError:
         log(
             "Warning: could not find the median of the positions"
@@ -910,8 +914,7 @@ def fits_image(
     cache = Cache(cache_dir=cache_dir, max_items=cache_max_items)
 
     def get_hdu(url):
-        """Try to get HDU from cache, otherwise fetch.
-        """
+        """Try to get HDU from cache, otherwise fetch."""
         hash_name = f'{center_ra}{center_dec}{imsize}{image_source}'
         hdu_fn = cache[hash_name]
 


### PR DESCRIPTION
When a detection with null photometry coordinates  is used to calculate the best position for offset stars in https://github.com/skyportal/skyportal/blob/master/skyportal/handlers/api/source.py#L1309, the resulting `best_ra` and `best_dec`, will be `nan`. This can cause the offsets handler to fail and prevent StarList components from rendering properly. 