### PR TITLE
Fix various scanning page bugs

### DIFF
--- a/static/js/components/CandidateList.jsx
+++ b/static/js/components/CandidateList.jsx
@@ -26,6 +26,7 @@ import HelpOutlineIcon from "@material-ui/icons/HelpOutline";
 import Form from "@rjsf/material-ui";
 import MUIDataTable from "mui-datatables";
 
+import { showNotification } from "baselayer/components/Notifications";
 import * as candidatesActions from "../ducks/candidates";
 import ThumbnailList from "./ThumbnailList";
 import SaveCandidateButton from "./SaveCandidateButton";
@@ -302,12 +303,6 @@ const CandidateList = () => {
     (g) => !g.single_user_group
   );
 
-  useEffect(() => {
-    if (userAccessibleGroups?.length && filterGroups.length === 0) {
-      setFilterGroups([...userAccessibleGroups]);
-    }
-  }, [setFilterGroups, filterGroups, userAccessibleGroups]);
-
   const availableAnnotationsInfo = useSelector(
     (state) => state.candidates.annotationsInfo
   );
@@ -389,6 +384,7 @@ const CandidateList = () => {
     "value" in annotationObj
       ? `${annotationObj.key} (${annotationObj.origin}): ${annotationObj.value}`
       : `${annotationObj.key} (${annotationObj.origin}): ${annotationObj.min} - ${annotationObj.max}`;
+
   const handleFilterSubmit = async (filterListQueryString) => {
     setQueryInProgress(true);
 
@@ -426,6 +422,12 @@ const CandidateList = () => {
   };
 
   const handleFilterAdd = ({ formData }) => {
+    if (filterGroups.length === 0) {
+      dispatch(
+        showNotification("At least one program should be selected.", "warning")
+      );
+      return;
+    }
     // The key is actually a combination of `origin<>key`, so parse out the key part
     const key = formData.key.split("<>")[1];
     const annotationObj = { ...formData, key };
@@ -955,6 +957,7 @@ const CandidateList = () => {
           setQueryInProgress={setQueryInProgress}
           setFilterGroups={setFilterGroups}
           numPerPage={rowsPerPage}
+          annotationFilterList={filterListQueryStrings.join()}
         />
         <Box
           display={queryInProgress ? "block" : "none"}


### PR DESCRIPTION
- The annotation filtering form properly validates against the program selection (it was still using all accessible groups by default)
- The annotation filtering state is passed along to FilterCandidateList.jsx so that the annotation filtering is persisted when you change the date range for scanning, for example.
- Fixed bug where on initial render of the scanning page, the annotation filtering logic was unaware of the initial FilterCandidateList form values (ie default start date). 

Closes #1653 