### PR TITLE
Loosen pip requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy==1.19.5
 scipy==1.6.0
 pandas==1.2.0
-dask==2020.12.0
+dask>=2020.12,<2021.3
 joblib==1.0.0
 seaborn==0.11.1
 bokeh==2.2.3
@@ -12,7 +12,7 @@ aplpy==2.0.3
 reproject==0.7.1
 avro-python3==1.10.1
 fastavro==1.2.4
-tqdm==4.23.2
+tqdm>=4.23,<4.57
 matplotlib==3.3.3
 astroquery==0.4.1
 apispec==4.0.0


### PR DESCRIPTION
Some pinned reqs are causing trouble: https://github.com/fritz-marshal/fritz/runs/1867100185#step:6:2691 (conflict with https://github.com/cesium-ml/baselayer/blob/master/requirements.txt#L7)
Putting out this fire in this PR, but I suggest to loosen more requirements, otherwise we'll likely encounter similar problems in the future.