### PR TITLE
fix inital display of phase 'b'

### DIFF
--- a/skyportal/plot.py
+++ b/skyportal/plot.py
@@ -822,6 +822,7 @@ def photometry_plot(obj_id, user, width=600, height=300, device="browser"):
                     marker='circle',
                     fill_color='color',
                     alpha='alpha',
+                    visible=('a' in ph),
                     source=ColumnDataSource(df[df['obs']]),  # only visible data
                 )
                 # add to hover tool
@@ -846,6 +847,7 @@ def photometry_plot(obj_id, user, width=600, height=300, device="browser"):
                     ys='ys',
                     color='color',
                     alpha='alpha',
+                    visible=('a' in ph),
                     source=ColumnDataSource(
                         data=dict(
                             xs=y_err_x,


### PR DESCRIPTION
Upon startup or hard refresh, phase plot shows both phase 'a' and phase 'b' even though 'One phase' is selected.  Plot x-axis limits are correct, but phase 'b' data visible.  This PR fixes this and initially sets phase 'b' data to visible=False.