### PR TITLE
Make including group users optional in GET /api/groups/<group_id>

### DIFF
--- a/skyportal/handlers/api/group.py
+++ b/skyportal/handlers/api/group.py
@@ -143,23 +143,31 @@ class GroupHandler(BaseHandler):
             ) and group.id not in [g.id for g in self.current_user.accessible_groups]:
                 return self.error('Insufficient permissions.')
 
-            include_group_users = self.get_query_argument(
-                "includeGroupUsers", True
-            )
+            if self.get_query_argument("includeGroupUsers", "true").lower() in (
+                "f",
+                "false",
+            ):
+                include_group_users = False
+            else:
+                include_group_users = True
             # Do not include User.groups to avoid circular reference
-            users = [
-                {
-                    "id": user.id,
-                    "username": user.username,
-                    "first_name": user.first_name,
-                    "last_name": user.last_name,
-                    "contact_email": user.contact_email,
-                    "contact_phone": user.contact_phone,
-                    "oauth_uid": user.oauth_uid,
-                    "admin": has_admin_access_for_group(user, group_id),
-                }
-                for user in group.users
-            ] if include_group_users else None
+            users = (
+                [
+                    {
+                        "id": user.id,
+                        "username": user.username,
+                        "first_name": user.first_name,
+                        "last_name": user.last_name,
+                        "contact_email": user.contact_email,
+                        "contact_phone": user.contact_phone,
+                        "oauth_uid": user.oauth_uid,
+                        "admin": has_admin_access_for_group(user, group_id),
+                    }
+                    for user in group.users
+                ]
+                if include_group_users
+                else None
+            )
             group = group.to_dict()
             if users is not None:
                 group['users'] = users

--- a/skyportal/handlers/api/group.py
+++ b/skyportal/handlers/api/group.py
@@ -171,8 +171,6 @@ class GroupHandler(BaseHandler):
             group = group.to_dict()
             if users is not None:
                 group['users'] = users
-            else:
-                group.pop("users", None)
             # grab streams:
             streams = (
                 DBSession()

--- a/skyportal/tests/api/test_groups.py
+++ b/skyportal/tests/api/test_groups.py
@@ -54,6 +54,12 @@ def test_fetch_group_by_name(super_admin_token, super_admin_user):
     assert data["data"][0]["id"] == new_group_id
 
 
+def test_fetch_group_exclude_users(super_admin_token, public_group):
+    status, data = api("GET", f"groups/{public_group.id}?includeGroupUsers=False", token=super_admin_token)
+    assert data["status"] == "success"
+    assert "users" not in data["data"]
+
+
 def test_token_user_request_all_groups(super_admin_token, super_admin_user):
     group_name = str(uuid.uuid4())
     status, data = api(

--- a/skyportal/tests/api/test_groups.py
+++ b/skyportal/tests/api/test_groups.py
@@ -55,7 +55,11 @@ def test_fetch_group_by_name(super_admin_token, super_admin_user):
 
 
 def test_fetch_group_exclude_users(super_admin_token, public_group):
-    status, data = api("GET", f"groups/{public_group.id}?includeGroupUsers=False", token=super_admin_token)
+    status, data = api(
+        "GET",
+        f"groups/{public_group.id}?includeGroupUsers=False",
+        token=super_admin_token,
+    )
     assert data["status"] == "success"
     assert "users" not in data["data"]
 


### PR DESCRIPTION
Currently a GET call to `/api/groups/<group_id>` return the full list of group members with all their info, which could be hundreds of potentially unwanted entries.