### PR TITLE
added time to date in spectrum plot hover

### DIFF
--- a/skyportal/plot.py
+++ b/skyportal/plot.py
@@ -1017,7 +1017,7 @@ def spectroscopy_plot(
                 'id': s.id,
                 'telescope': s.instrument.telescope.name,
                 'instrument': s.instrument.name,
-                'date_observed': s.observed_at.date().isoformat(),
+                'date_observed': s.observed_at.isoformat(sep=' ', timespec='seconds'),
                 'pi': (
                     s.assignment.run.pi
                     if s.assignment is not None


### PR DESCRIPTION
Addresses issue [#87](https://github.com/fritz-marshal/fritz-beta-feedback/issues/87) by adding UTC time to date in spectrum plot hover.