### PR TITLE
Catch SMTP auth failure & return informative error message

### DIFF
--- a/skyportal/handlers/api/invitations.py
+++ b/skyportal/handlers/api/invitations.py
@@ -1,4 +1,5 @@
 import uuid
+import smtplib
 import python_http_client.exceptions
 from baselayer.app.access import permissions
 from baselayer.app.env import load_env
@@ -147,6 +148,11 @@ class InvitationHandler(BaseHandler):
                 "Twilio Sendgrid authorization error. Please ensure "
                 "valid Sendgrid API key is set in server environment as "
                 "per their setup docs."
+            )
+        except smtplib.SMTPAuthenticationError:
+            return self.error(
+                "SMTP authentication failed. Please ensure valid "
+                "credentials are specified in the config file."
             )
         return self.success()
 


### PR DESCRIPTION
Before, the user would see a cryptic error message. Now: 
![catch_smtp_auth_failure_notif](https://user-images.githubusercontent.com/7230285/108922842-9061eb00-75ec-11eb-8d12-d052d0308a42.png)
