### PR TITLE
Use approximate photometry table count in DB Stats page for improved performance

### DIFF
--- a/skyportal/handlers/api/db_stats.py
+++ b/skyportal/handlers/api/db_stats.py
@@ -8,7 +8,6 @@ from ...models import (
     User,
     Token,
     Group,
-    Photometry,
     Spectrum,
     CronJobRun,
 )
@@ -73,7 +72,11 @@ class StatsHandler(BaseHandler):
         data["Number of candidates"] = Candidate.query.count()
         data["Number of sources"] = Source.query.count()
         data["Number of objs"] = Obj.query.count()
-        data["Number of photometry"] = Photometry.query.count()
+        data["Number of photometry (approx)"] = list(
+            DBSession().execute(
+                "SELECT reltuples::bigint FROM pg_catalog.pg_class WHERE relname = 'photometry'"
+            )
+        )[0][0]
         data["Number of spectra"] = Spectrum.query.count()
         data["Number of groups"] = Group.query.count()
         data["Number of users"] = User.query.count()


### PR DESCRIPTION
Closes #1692 
Autovacuum is enabled by default, so we don't need to run `ANALYZE` as a cron job, as autovacuum already does that. Confirmation that we have autovacuum enabled on production:
```
fritz-1=> SHOW autovacuum;
 autovacuum               
------------              
 on                       
(1 row)                   
```