### PR TITLE
Improve styling of scroll bars for dark mode

### DIFF
--- a/static/js/components/Main.jsx.template
+++ b/static/js/components/Main.jsx.template
@@ -66,12 +66,9 @@ const useStyles = makeStyles((theme) => ({
     }),
     marginLeft: 0,
   },
-  main: {
-    fontFamily: "Roboto, sans-serif",
-  },
   websocket: {
     display: "none",
-  },
+  }
 }));
 
 const MainContent = ({ root }) => {

--- a/static/js/components/SourceQuickView.jsx
+++ b/static/js/components/SourceQuickView.jsx
@@ -64,7 +64,6 @@ const useStyles = makeStyles(() => ({
   },
   title: {
     fontSize: "1.5rem",
-    fontFamily: "Roboto, Helvetica, Arial, sans-serif",
     fontWeight: "500",
     lineHeight: "1.6",
     letterSpacing: "0.0075em",

--- a/static/js/components/SurveyLinkList.jsx
+++ b/static/js/components/SurveyLinkList.jsx
@@ -28,7 +28,6 @@ const useStyles = makeStyles(() => ({
     fontWeight: "bold",
     color: "gray",
     textDecoration: "none",
-    fontFamily: ["Roboto", "Helvetica", "Arial", "sans-serif"],
   },
 }));
 

--- a/static/js/components/Theme.jsx
+++ b/static/js/components/Theme.jsx
@@ -4,15 +4,52 @@ import PropTypes from "prop-types";
 
 import { createMuiTheme, ThemeProvider } from "@material-ui/core/styles";
 import CssBaseline from "@material-ui/core/CssBaseline";
+import grey from "@material-ui/core/colors/grey";
 
 const Theme = ({ disableTransitions, children }) => {
   const theme = useSelector((state) => state.profile.preferences.theme);
+  const dark = theme === "dark";
   const materialTheme = createMuiTheme({
     palette: {
       type: theme || "light",
-      background:
-        theme === "dark" ? { default: "#303030" } : { default: "#f0f2f5" },
+      background: dark ? { default: "#303030" } : { default: "#f0f2f5" },
     },
+    overrides: {
+      MuiCssBaseline: {
+        "@global": {
+          html: {
+            fontFamily: "Roboto, Helvetica, Arial, sans-serif",
+
+            /* Scrollbar styling */
+
+            /* Works on Firefox */
+            scrollbarWidth: "thin",
+            scrollbarColor: dark
+              ? `${grey[700]} ${grey[800]}`
+              : `${grey[400]} ${grey[100]}`,
+            overflowY: "auto",
+
+            /* Works on Chrome, Edge, and Safari */
+            "& *::-webkit-scrollbar": {
+              width: "12px",
+            },
+
+            "& *::-webkit-scrollbar-track": {
+              background: dark ? grey[800] : grey[100],
+            },
+
+            "& *::-webkit-scrollbar-thumb": {
+              backgroundColor: dark ? grey[700] : grey[400],
+              borderRadius: "20px",
+              border: dark
+                ? `3px solid ${grey[800]}`
+                : `3px solid ${grey[100]}`,
+            },
+          },
+        },
+      },
+    },
+
     // Only added during testing; removes animations, transitions, and
     // rippple effects
     ...(disableTransitions && {

--- a/static/login.css
+++ b/static/login.css
@@ -1,5 +1,5 @@
 body {
-  font-family: "Roboto", sans-serif;
+  font-family: "Roboto", Helvetica, Ariel, sans-serif;
 }
 
 .loginBox {


### PR DESCRIPTION
Also returns the font family back to Roboto, which got dropped somewhere along the line.
![2021-02-24_21:02:25](https://user-images.githubusercontent.com/45071/109106394-8c18f900-76e4-11eb-80c0-3e5fdb07a23f.png)
