### PR TITLE
Add migration for LT instruments

### DIFF
--- a/alembic/versions/3e1852612f34_add_lt_apis.py
+++ b/alembic/versions/3e1852612f34_add_lt_apis.py
@@ -1,0 +1,51 @@
+"""Add LT APIs
+
+Revision ID: 3e1852612f34
+Revises: c1354c411fab
+Create Date: 2021-02-25 19:10:55.114202
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '3e1852612f34'
+down_revision = 'c1354c411fab'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Add new Liverpool Telescope API values to the followup_apis ENUM type
+    # Logic adapted from https://medium.com/makimo-tech-blog/upgrading-postgresqls-enum-type-with-sqlalchemy-using-alembic-migration-881af1e30abe
+    with op.get_context().autocommit_block():
+        op.execute("ALTER TYPE followup_apis ADD VALUE IF NOT EXISTS 'IOOAPI'")
+        op.execute("ALTER TYPE followup_apis ADD VALUE IF NOT EXISTS 'IOIAPI'")
+        op.execute("ALTER TYPE followup_apis ADD VALUE IF NOT EXISTS 'SPRATAPI'")
+
+
+def downgrade():
+    # PostgreSQL does not support directly dropping values from ENUM types.
+    # Instead, we create a new type and replace it as the column's typing.
+
+    # Rename current ENUM so it can be replaced
+    op.execute("ALTER TYPE followup_apis RENAME TO followup_apis_old")
+
+    # Create a new type with just the SEDM
+    op.execute("CREATE TYPE followup_apis AS ENUM('SEDMAPI')")
+
+    # Delete any database rows referring to the LT instruments
+    op.execute(
+        "DELETE FROM instruments WHERE api_classname IN ('IOOAPI', 'IOIAPI', 'SPRATAPI')"
+    )
+
+    # Designate the new ENUM type as the type for instruments.api_classname
+    op.execute(
+        (
+            "ALTER TABLE instruments ALTER COLUMN api_classname TYPE followup_apis USING "
+            "api_classname::text::followup_apis"
+        )
+    )
+
+    # Drop old ENUM
+    op.execute("DROP TYPE followup_apis_old")


### PR DESCRIPTION
I discovered that there was never a migration script written for adding the Liverpool Telescope APIs to the ENUM type for `instrument.api_classname`. This PR introduced a migration for that purpose.

I guess we maybe added the values manually? Although I don't see LT instruments in the followup requests form on production either, so maybe they were never added at all? Regardless, the migration uses `IF NOT EXISTS` when adding the values so that if they were manually added already no error will be thrown when upgrading.