### PR TITLE
Update SQLAlchemy relationship cascade params in Obj.classifications

### DIFF
--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -654,7 +654,7 @@ class Obj(Base, ha.Point):
     classifications = relationship(
         'Classification',
         back_populates='obj',
-        cascade='save-update, merge, refresh-expire, expunge, delete-orphan',
+        cascade='save-update, merge, refresh-expire, expunge, delete-orphan, delete',
         passive_deletes=True,
         order_by="Classification.created_at",
         doc="Classifications of the object.",


### PR DESCRIPTION
I had been seeing SQLA warnings saying something like "`delete` is required when specifying `delete-orphan` in `cascade`", and this is the only relationship in which we specify `delete-orphan`