### PR TITLE
Allow scanning page end date to be nullified

### DIFF
--- a/static/js/components/FilterCandidateList.jsx
+++ b/static/js/components/FilterCandidateList.jsx
@@ -255,7 +255,9 @@ const FilterCandidateList = ({
               render={({ onChange, value }) => (
                 <KeyboardDateTimePicker
                   value={value ? dayjs.utc(value) : null}
-                  onChange={(e, date) => onChange(dayjs.utc(date))}
+                  onChange={(e, date) =>
+                    date ? onChange(dayjs.utc(date)) : onChange(date)
+                  }
                   label="End (UTC)"
                   format="YYYY/MM/DD HH:mm"
                   ampm={false}


### PR DESCRIPTION
On the scanning page, once an end date had been selected, it could not be cleared without being marked as invalid & preventing form submission. This PR fixes that.

Before:
![clear_end_date_not_allowed](https://user-images.githubusercontent.com/7230285/109733864-d41c9d80-7b74-11eb-9f52-d044241ae5c5.gif)


After:
![clear_end_date_allowed](https://user-images.githubusercontent.com/7230285/109733616-4f318400-7b74-11eb-9b20-b47f15fb10a4.gif)

Closes https://github.com/skyportal/skyportal/issues/1729