### PR TITLE
Add hourly cron job that counts old, unsaved candidates/objs

### DIFF
--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -289,9 +289,9 @@ external_logging:
     excluded_log_files: ["log/websocket_server.log"]
 
 cron:
-  - interval: 1440
-    script: jobs/delete_unsaved_candidates.py
-    limit: ["01:00", "02:00"]
+  # - interval: 1440
+  #   script: jobs/delete_unsaved_candidates.py
+  #   limit: ["01:00", "02:00"]
 
 twilio:
   # Twilio Sendgrid API configs

--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -289,6 +289,8 @@ external_logging:
     excluded_log_files: ["log/websocket_server.log"]
 
 cron:
+  - interval: 60
+    script: jobs/count_unsaved_candidates.py
   # - interval: 1440
   #   script: jobs/delete_unsaved_candidates.py
   #   limit: ["01:00", "02:00"]

--- a/jobs/count_unsaved_candidates.py
+++ b/jobs/count_unsaved_candidates.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+
+import datetime
+from skyportal.models import init_db, Candidate, Source, Obj, DBSession
+from baselayer.app.env import load_env
+
+
+env, cfg = load_env()
+init_db(**cfg["database"])
+
+try:
+    n_days = int(cfg["misc.days_to_keep_unsaved_candidates"])
+except ValueError:
+    raise ValueError(
+        "Invalid (non-integer) value provided for "
+        "days_to_keep_unsaved_candidates in config file."
+    )
+
+if not 1 <= n_days <= 30:
+    raise ValueError(
+        "days_to_keep_unsaved_candidates must be an integer between 1 and 30"
+    )
+
+cutoff_datetime = datetime.datetime.now() - datetime.timedelta(days=n_days)
+
+n_old_unsaved_objs = (
+    DBSession()
+    .query(Obj)
+    .filter(Obj.id.in_(DBSession.query(Candidate.obj_id)))
+    .filter(Obj.id.notin_(DBSession.query(Source.obj_id)))
+    .filter(Obj.created_at <= cutoff_datetime)
+    .count()
+)
+print(f"There are {n_old_unsaved_objs} unsaved Objs older than {n_days} days.")
+
+n_old_unsaved_cands = (
+    DBSession()
+    .query(Candidate)
+    .filter(Candidate.obj_id.notin_(DBSession.query(Source.obj_id)))
+    .filter(Candidate.passed_at <= cutoff_datetime)
+    .count()
+)
+print(f"There are {n_old_unsaved_cands} unsaved Candidates older than {n_days} days.")


### PR DESCRIPTION
For informational (results are viewable on DB Stats page) & cron service debugging purposes.