### PR TITLE
Shorten spectroscopy legend labels

### DIFF
--- a/skyportal/plot.py
+++ b/skyportal/plot.py
@@ -1190,7 +1190,7 @@ def spectroscopy_plot(
     spec_labels = []
     for k, _ in split:
         s = Spectrum.query.get(k)
-        label = f'{s.instrument.telescope.nickname}/{s.instrument.name} ({s.observed_at.date().isoformat()})'
+        label = f'{s.instrument.name} ({s.observed_at.date().strftime("%m/%d/%y")})'
         spec_labels.append(label)
 
     toggle = CheckboxWithLegendGroup(

--- a/skyportal/tests/frontend/test_upload_spectroscopy.py
+++ b/skyportal/tests/frontend/test_upload_spectroscopy.py
@@ -19,26 +19,24 @@ def test_upload_spectroscopy(
 
     driver.wait_for_xpath('//*[contains(., "application/octet-stream")]')
 
-    mjd_element = driver.wait_for_xpath(f'//*[@id="root_mjd"]')
+    mjd_element = driver.wait_for_xpath('//*[@id="root_mjd"]')
     driver.scroll_to_element_and_click(mjd_element)
     mjd_element.send_keys('51232.')
 
-    instrument_id_element_xpath = f'//*[@id="root_instrument_id"]'
+    instrument_id_element_xpath = '//*[@id="root_instrument_id"]'
     driver.click_xpath(instrument_id_element_xpath)
 
     sedm_element_xpath = f'//li[@data-value="{inst_id}"]'
     driver.click_xpath(sedm_element_xpath, scroll_parent=True)
 
-    preview_button_xpath = f'//button[contains(.,"Preview")]'
+    preview_button_xpath = '//button[contains(.,"Preview")]'
     driver.click_xpath(preview_button_xpath)
 
-    submit_button_xpath = f'//button[contains(.,"Upload Spectrum")]'
+    submit_button_xpath = '//button[contains(.,"Upload Spectrum")]'
     driver.click_xpath(submit_button_xpath)
 
     driver.wait_for_xpath('//*[contains(.,"successful")]')
 
     driver.get(f"/source/{public_source.id}")
 
-    driver.wait_for_xpath(
-        f'//*[contains(.,"{sedm.telescope.nickname}/{sedm.name}")]', 20
-    )
+    driver.wait_for_xpath(f'//*[contains(.,"{sedm.name}")]', 20)


### PR DESCRIPTION
Closes fritz-marshal/fritz-beta-feedback#13
Spectroscopy plot labels now only show the telescope name (only the instrument) and uses a more concise date formatting. Note that the telescope name is still available on the hover tool.
![image](https://user-images.githubusercontent.com/17696889/109995718-8ae75d80-7cdc-11eb-95ea-4495b1903f06.png)


One question regarding this - do we have more US users or European users? Does MM/DD/YY formatting or DD/MM/YY make more sense? 