### PR TITLE
Small fixes for the periodogram page

### DIFF
--- a/skyportal/tests/frontend/test_periodogram.py
+++ b/skyportal/tests/frontend/test_periodogram.py
@@ -1,4 +1,7 @@
+import uuid
+
 import numpy as np
+import numpy.testing as npt
 
 from baselayer.app.config import load_config
 from skyportal.tests import api
@@ -9,40 +12,66 @@ cfg = load_config()
 def test_periodogram(
     driver, user, public_source, public_group, ztf_camera, upload_data_token
 ):
-    times = np.linspace(58000, 58100, num=200)
-    mags = np.sin(times - 58000) + 15.0
-    fluxerr = np.ones_like(mags) / 10
 
+    obj_id = str(uuid.uuid4())
+    status, data = api(
+        "POST",
+        "sources",
+        data={
+            "id": obj_id,
+            "ra": 10.22,
+            "dec": -22.33,
+            "redshift": 1,
+            "transient": False,
+            "ra_dis": 2.3,
+            "group_ids": [public_group.id],
+        },
+        token=upload_data_token,
+    )
+    assert status == 200
+    assert data["data"]["id"] == obj_id
+
+    P = 2.10
+    times = np.random.uniform(57000, 57020, size=(100,))
+    noise = 0.1 * np.random.normal(size=times.shape)
+    flux = 15.0 + 1.5 * np.sin((2 * np.pi / P) * (times - 57000)) + noise
+    fluxerr = 0.1 + 0.02 * np.random.normal(size=times.shape)
+
+    data = {
+        'obj_id': obj_id,
+        'mjd': list(times),
+        'instrument_id': ztf_camera.id,
+        'flux': list(flux),
+        'fluxerr': list(fluxerr),
+        'filter': ['ztfr'] * len(flux),
+        'zp': [25.0] * len(flux),
+        'magsys': ['ab'] * len(flux),
+        'ra': 165.0,
+        'ra_unc': 0.17,
+        'dec': -30.0,
+        'dec_unc': 0.2,
+        'group_ids': [public_group.id],
+    }
     # Put in some actual photometry data first
     status, data = api(
         'POST',
         'photometry',
-        data={
-            'obj_id': str(public_source.id),
-            'mjd': list(times),
-            'instrument_id': ztf_camera.id,
-            'flux': list(mags),
-            'fluxerr': list(fluxerr),
-            'filter': 'ztfg',
-            'zp': 25.0,
-            'magsys': 'ab',
-            'ra': 165.0,
-            'ra_unc': 0.17,
-            'dec': -30.0,
-            'dec_unc': 0.2,
-            'group_ids': [public_group.id],
-        },
+        data=data,
         token=upload_data_token,
     )
     assert status == 200
     assert data['status'] == 'success'
 
     driver.get(f"/become_user/{user.id}")
-    driver.get(f"/source/{public_source.id}/periodogram")
+    driver.get(f"/source/{obj_id}/periodogram")
 
     # If the bestp id shows up then a period was found
     best_period = "//span[contains(@data-testid, 'bestp')]"
-    driver.wait_for_xpath(best_period)
+    bestp = driver.wait_for_xpath(best_period)
+
+    # did we find the right period?
+    bestp_flt = float(bestp.text)
+    npt.assert_almost_equal(bestp_flt, P, decimal=1)
 
     # Is the bottom phaseplot rendering?
     phaseplot = "//div[contains(@data-testid, 'phaseplot')]"


### PR DESCRIPTION
- Handle the case where there is not much data observed over a very long time period, producing a more robust delta_t
- Handle the case when there is only a few data points (fixes what @dmitryduev found with a single photometry point). In that case, do not render the periodogram.
- ensure that we're only doing as many as 300,000 calculations (~<5 seconds in a modern browser)
- render the new light curve after resetting parameters.