### PR TITLE
Disable submit buttons while request in process

### DIFF
--- a/static/js/components/ClassificationForm.jsx
+++ b/static/js/components/ClassificationForm.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import PropTypes from "prop-types";
 import TextField from "@material-ui/core/TextField";
@@ -61,6 +61,9 @@ const ClassificationForm = ({ obj_id, taxonomyList }) => {
   const classes = useStyles();
   const dispatch = useDispatch();
   const groups = useSelector((state) => state.groups.userAccessible);
+  const [submissionRequestInProcess, setSubmissionRequestInProcess] = useState(
+    false
+  );
   const groupIDToName = {};
   groups.forEach((g) => {
     groupIDToName[g.id] = g.name;
@@ -78,6 +81,7 @@ const ClassificationForm = ({ obj_id, taxonomyList }) => {
   const latestTaxonomyList = taxonomyList.filter((t) => t.isLatest);
 
   const handleSubmit = async ({ formData }) => {
+    setSubmissionRequestInProcess(true);
     // Get the classification without the context
     const classification = formData.classification.split(" <> ")[0];
     const data = {
@@ -90,6 +94,7 @@ const ClassificationForm = ({ obj_id, taxonomyList }) => {
       data.group_ids = formData.groupIDs.map((id) => parseInt(id, 10));
     }
     const result = await dispatch(Actions.addClassification(data));
+    setSubmissionRequestInProcess(false);
     if (result.status === "success") {
       dispatch(showNotification("Classification saved"));
     }
@@ -277,6 +282,7 @@ const ClassificationForm = ({ obj_id, taxonomyList }) => {
       uiSchema={uiSchema}
       widgets={widgets}
       onSubmit={handleSubmit}
+      disabled={submissionRequestInProcess}
     />
   );
 };

--- a/static/js/components/FavoritesButton.jsx
+++ b/static/js/components/FavoritesButton.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import PropTypes from "prop-types";
@@ -12,12 +12,17 @@ import * as Actions from "../ducks/favorites";
 
 const ButtonInclude = (sourceID, textMode) => {
   const dispatch = useDispatch();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const handleSubmit = async () => {
+    setIsSubmitting(true);
+    await dispatch(Actions.removeFromFavorites(sourceID));
+    setIsSubmitting(false);
+  };
   if (textMode) {
     return (
       <Button
-        onClick={() => {
-          dispatch(Actions.removeFromFavorites(sourceID));
-        }}
+        onClick={handleSubmit}
+        disabled={isSubmitting}
         color="default"
         variant="contained"
         data-testid={`favorites-text-include_${sourceID}`}
@@ -28,10 +33,9 @@ const ButtonInclude = (sourceID, textMode) => {
   }
   return (
     <IconButton
-      onClick={() => {
-        dispatch(Actions.removeFromFavorites(sourceID));
-      }}
+      onClick={handleSubmit}
       data-testid={`favorites-include_${sourceID}`}
+      disabled={isSubmitting}
     >
       <StarIcon />
     </IconButton>
@@ -40,12 +44,17 @@ const ButtonInclude = (sourceID, textMode) => {
 
 const ButtonExclude = (sourceID, textMode) => {
   const dispatch = useDispatch();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const handleSubmit = async () => {
+    setIsSubmitting(true);
+    await dispatch(Actions.addToFavorites(sourceID));
+    setIsSubmitting(false);
+  };
   if (textMode) {
     return (
       <Button
-        onClick={() => {
-          dispatch(Actions.addToFavorites(sourceID));
-        }}
+        onClick={handleSubmit}
+        disabled={isSubmitting}
         color="default"
         variant="contained"
         data-testid={`favorites-text-exclude_${sourceID}`}
@@ -56,10 +65,9 @@ const ButtonExclude = (sourceID, textMode) => {
   }
   return (
     <IconButton
-      onClick={() => {
-        dispatch(Actions.addToFavorites(sourceID));
-      }}
+      onClick={handleSubmit}
       data-testid={`favorites-exclude_${sourceID}`}
+      disabled={isSubmitting}
     >
       <StarBorderIcon />
     </IconButton>

--- a/static/js/components/FollowupRequestForm.jsx
+++ b/static/js/components/FollowupRequestForm.jsx
@@ -155,6 +155,7 @@ const FollowupRequestForm = ({
             ].uiSchema
           }
           onSubmit={handleSubmit}
+          disabled={isSubmitting}
         />
         {isSubmitting && (
           <div className={classes.marginTop}>


### PR DESCRIPTION
This PR disables the submit buttons for the classification form, followup request form, and favorite source star while a request is in process.

Closes #1562 