### PR TITLE
Allow group admins to manage other group members

### DIFF
--- a/skyportal/handlers/api/group.py
+++ b/skyportal/handlers/api/group.py
@@ -28,7 +28,9 @@ def has_admin_access_for_group(user, group_id):
         .first()
     )
     return len(
-        {"System admin", "Manage groups"}.intersection(set(user.permissions))
+        {"System admin", "Manage groups", "Manage_users"}.intersection(
+            set(user.permissions)
+        )
     ) > 0 or (groupuser is not None and groupuser.admin)
 
 
@@ -500,10 +502,7 @@ class GroupUserHandler(BaseHandler):
     def patch(self, group_id, *ignored_args):
         """
         ---
-        description: |
-          Update a group user's admin status.
-          Group admins can grant other group members admin status, but cannot
-          revoke it or remove members unless they have sufficient ACLs.
+        description: Update a group user's admin status
         tags:
           - groups
           - users
@@ -537,6 +536,8 @@ class GroupUserHandler(BaseHandler):
             group_id = int(group_id)
         except ValueError:
             return self.error("Invalid group ID")
+        if not has_admin_access_for_group(self.associated_user_object, group_id):
+            return self.error("Insufficient permissions.")
         user_id = data.get("userID")
         try:
             user_id = int(user_id)
@@ -554,33 +555,11 @@ class GroupUserHandler(BaseHandler):
         if data.get("admin") is None:
             return self.error("Missing required parameter: `admin`")
         admin = data.get("admin") in [True, "true", "True", "t", "T"]
-        if (
-            len(
-                set(self.current_user.permissions).intersection(
-                    {"Manage users", "Group admin", "System admin"}
-                )
-            )
-            == 0
-        ):
-            # Current user doesn't have ACL-based access; check if group admin:
-            current_groupuser = (
-                DBSession()
-                .query(GroupUser)
-                .filter(GroupUser.group_id == group_id)
-                .filter(GroupUser.user_id == self.current_user.id)
-                .first()
-            )
-            if current_groupuser is None or not current_groupuser.admin:
-                return self.error("Insufficient permissions.")
-            # Current user is  a group admin, so they can only grant admin status
-            # to other users, but not revoke it:
-            if not admin:
-                return self.error("Insufficient permissions.")
         groupuser.admin = admin
         self.finalize_transaction()
         return self.success()
 
-    @permissions(["Manage users"])
+    @auth_or_token
     def delete(self, group_id, user_id):
         """
         ---

--- a/static/js/components/GroupPageManageUserButtons.jsx
+++ b/static/js/components/GroupPageManageUserButtons.jsx
@@ -11,7 +11,7 @@ import { showNotification } from "baselayer/components/Notifications";
 import * as groupActions from "../ducks/group";
 import * as groupsActions from "../ducks/groups";
 
-const ManageUserButtons = ({ currentUser, group, loadedId, user, isAdmin }) => {
+const ManageUserButtons = ({ group, loadedId, user, isAdmin }) => {
   const dispatch = useDispatch();
 
   let numAdmins = 0;
@@ -44,13 +44,7 @@ const ManageUserButtons = ({ currentUser, group, loadedId, user, isAdmin }) => {
         onClick={() => {
           toggleUserAdmin(user);
         }}
-        disabled={
-          (isAdmin(user) && numAdmins === 1) ||
-          (isAdmin(user) &&
-            ["System admin", "Group admin", "Manage users"].filter((acl) =>
-              currentUser.permissions?.includes(acl)
-            ).length === 0)
-        }
+        disabled={isAdmin(user) && numAdmins === 1}
       >
         <span style={{ whiteSpace: "nowrap" }}>
           {isAdmin(user) ? "Revoke admin status" : "Grant admin status"}
@@ -68,12 +62,7 @@ const ManageUserButtons = ({ currentUser, group, loadedId, user, isAdmin }) => {
             })
           )
         }
-        disabled={
-          (isAdmin(user) && numAdmins === 1) ||
-          ["System admin", "Group admin", "Manage users"].filter((acl) =>
-            currentUser.permissions?.includes(acl)
-          ).length === 0
-        }
+        disabled={isAdmin(user) && numAdmins === 1}
       >
         <DeleteIcon />
       </IconButton>
@@ -93,13 +82,6 @@ ManageUserButtons.propTypes = {
     users: PropTypes.arrayOf(
       PropTypes.shape({ admin: PropTypes.bool.isRequired })
     ),
-  }).isRequired,
-  currentUser: PropTypes.shape({
-    username: PropTypes.string,
-    id: PropTypes.number,
-    first_name: PropTypes.string,
-    last_name: PropTypes.string,
-    permissions: PropTypes.arrayOf(PropTypes.string),
   }).isRequired,
 };
 

--- a/static/js/components/GroupPageManageUserButtons.jsx
+++ b/static/js/components/GroupPageManageUserButtons.jsx
@@ -11,7 +11,7 @@ import { showNotification } from "baselayer/components/Notifications";
 import * as groupActions from "../ducks/group";
 import * as groupsActions from "../ducks/groups";
 
-const ManageUserButtons = ({ group, loadedId, user, isAdmin }) => {
+const ManageUserButtons = ({ currentUser, group, loadedId, user, isAdmin }) => {
   const dispatch = useDispatch();
 
   let numAdmins = 0;
@@ -44,7 +44,13 @@ const ManageUserButtons = ({ group, loadedId, user, isAdmin }) => {
         onClick={() => {
           toggleUserAdmin(user);
         }}
-        disabled={isAdmin(user) && numAdmins === 1}
+        disabled={
+          (isAdmin(user) && numAdmins === 1) ||
+          (isAdmin(user) &&
+            ["System admin", "Group admin", "Manage users"].filter((acl) =>
+              currentUser.permissions?.includes(acl)
+            ).length === 0)
+        }
       >
         <span style={{ whiteSpace: "nowrap" }}>
           {isAdmin(user) ? "Revoke admin status" : "Grant admin status"}
@@ -62,7 +68,12 @@ const ManageUserButtons = ({ group, loadedId, user, isAdmin }) => {
             })
           )
         }
-        disabled={isAdmin(user) && numAdmins === 1}
+        disabled={
+          (isAdmin(user) && numAdmins === 1) ||
+          ["System admin", "Group admin", "Manage users"].filter((acl) =>
+            currentUser.permissions?.includes(acl)
+          ).length === 0
+        }
       >
         <DeleteIcon />
       </IconButton>
@@ -82,6 +93,13 @@ ManageUserButtons.propTypes = {
     users: PropTypes.arrayOf(
       PropTypes.shape({ admin: PropTypes.bool.isRequired })
     ),
+  }).isRequired,
+  currentUser: PropTypes.shape({
+    username: PropTypes.string,
+    id: PropTypes.number,
+    first_name: PropTypes.string,
+    last_name: PropTypes.string,
+    permissions: PropTypes.arrayOf(PropTypes.string),
   }).isRequired,
 };
 

--- a/static/js/components/GroupUsers.jsx
+++ b/static/js/components/GroupUsers.jsx
@@ -96,7 +96,7 @@ const GroupUsers = ({ group, classes, currentUser, theme, isAdmin }) => {
     return (
       <div>
         {group &&
-          currentUser.permissions?.includes("Manage users") &&
+          isAdmin(currentUser) &&
           (mobile ? (
             <div>
               <IconButton
@@ -126,6 +126,7 @@ const GroupUsers = ({ group, classes, currentUser, theme, isAdmin }) => {
                     user={user}
                     isAdmin={isAdmin}
                     group={group}
+                    currentUser={currentUser}
                   />
                 </div>
               </Popover>
@@ -136,6 +137,7 @@ const GroupUsers = ({ group, classes, currentUser, theme, isAdmin }) => {
               user={user}
               isAdmin={isAdmin}
               group={group}
+              currentUser={currentUser}
             />
           ))}
       </div>

--- a/static/js/components/GroupUsers.jsx
+++ b/static/js/components/GroupUsers.jsx
@@ -126,7 +126,6 @@ const GroupUsers = ({ group, classes, currentUser, theme, isAdmin }) => {
                     user={user}
                     isAdmin={isAdmin}
                     group={group}
-                    currentUser={currentUser}
                   />
                 </div>
               </Popover>
@@ -137,7 +136,6 @@ const GroupUsers = ({ group, classes, currentUser, theme, isAdmin }) => {
               user={user}
               isAdmin={isAdmin}
               group={group}
-              currentUser={currentUser}
             />
           ))}
       </div>


### PR DESCRIPTION
This PR updates the permissions regarding modifying group members' admin status such that any group admin (regardless of ACLs) can grant/revoke the admin status of other group members, or remove users entirely.

Closes https://github.com/fritz-marshal/fritz/issues/191