### PR TITLE
Update scanning page annotations tooltip to note known limitation

### DIFF
--- a/static/js/components/CandidateList.jsx
+++ b/static/js/components/CandidateList.jsx
@@ -759,7 +759,7 @@ const CandidateList = () => {
               Warning: applying multiple filters on annotations from different
               origins is not supported currently and will return zero results.
               For example, you cannot filter for a specific annotation value in
-              annotations from both &quot;orgin_a&quot; and &quot;origin_b&quot;
+              annotations from both &quot;origin_a&quot; and &quot;origin_b&quot;
               at the same time.
             </i>
           </Typography>

--- a/static/js/components/CandidateList.jsx
+++ b/static/js/components/CandidateList.jsx
@@ -752,6 +752,16 @@ const CandidateList = () => {
             <b>Sorting: </b> Clicking on an annotation field will display it, if
             available, in the Info column. You can then click on the sort tool
             button at the top of the table to sort on that annotation field.
+            <br />
+            <b>Filtering: </b> Filtering on annotations is available through the
+            filtering tool at the top right of the table. <br />
+            <i>
+              Warning: applying multiple filters on annotations from different
+              origins is not supported currently and will return zero results.
+              For example, you cannot filter for a specific annotation value in
+              annotations from both &quot;orgin_a&quot; and &quot;origin_b&quot;
+              at the same time.
+            </i>
           </Typography>
         </Popover>
       </MuiThemeProvider>

--- a/static/js/components/CandidateList.jsx
+++ b/static/js/components/CandidateList.jsx
@@ -746,7 +746,7 @@ const CandidateList = () => {
         >
           <Typography className={classes.typography}>
             Annotation fields are uniquely identified by the combination of
-            origin and key. That is, if two annotation values belong to a key
+            origin and key. That is, two annotation values belonging to a key
             with the same name will be considered different if they come from
             different origins. <br />
             <b>Sorting: </b> Clicking on an annotation field will display it, if
@@ -759,8 +759,8 @@ const CandidateList = () => {
               Warning: applying multiple filters on annotations from different
               origins is not supported currently and will return zero results.
               For example, you cannot filter for a specific annotation value in
-              annotations from both &quot;origin_a&quot; and &quot;origin_b&quot;
-              at the same time.
+              annotations from both &quot;origin_a&quot; and
+              &quot;origin_b&quot; at the same time.
             </i>
           </Typography>
         </Popover>


### PR DESCRIPTION
Annotation filtering on the scanning page does not support filtering across multiple annotation origins. As this doesn't seem to be a common use case, it seems fine to just make note of the limitation within the column tooltip.
Closes #1185
![image](https://user-images.githubusercontent.com/17696889/110328335-3cda9e80-7fe9-11eb-9670-7c862b4f79d4.png)
