### PR TITLE
Fix loading of user dashboard layout preferences

### DIFF
--- a/static/js/components/HomePage.jsx.template
+++ b/static/js/components/HomePage.jsx.template
@@ -75,12 +75,10 @@ const HomePage = () => {
     (state) => state.dbInfo.source_table_empty
   );
 
-  const preferredLayouts = useSelector(
-    (state) => state.profile.preferences.layouts
-  );
+  const preferences = useSelector((state) => state.profile.preferences);
 
   let currentLayouts =
-    preferredLayouts == null ? defaultLayouts : preferredLayouts;
+    preferences?.layouts == null ? defaultLayouts : preferences.layouts;
 
   const dispatch = useDispatch();
 
@@ -104,60 +102,63 @@ const HomePage = () => {
   };
 
   return (
-    <div>
-      <ResponsiveGridLayout
-        className="layout"
-        layouts={currentLayouts}
-        breakpoints={{ '{' + app.homepage_grid.breakpoints|tojson + '}' }}
-        cols={{ '{' + app.homepage_grid.cols|tojson + '}' }}
-        margin={[10, 10]}
-        onLayoutChange={LayoutChangeHandler}
-        draggableHandle=".dragHandle"
-        rowHeight={gridRowHeight}
-      >
-        {%- for widgetName, widgetProps in app.homepage_widgets.items() %}
-          {%- if not (widgetProps.show is defined and not widgetProps.show) %}
-            {%- if widgetName == "GroupList" %}
-        <div key="{{ widgetName }}">
-          <{{ widgetName }}
-            groups={groups}
-            classes={classes}
-            {%- for key, value in widgetProps.props.items() -%}
-            {%- if value is string %}
-            {{ key }}={"{{ value }}"}
-            {%- else -%}
-            {{ key }}={ {{ value }} }
+    preferences &&
+    Object.keys(preferences).length !== 0 && (
+      <div>
+        <ResponsiveGridLayout
+          className="layout"
+          layouts={currentLayouts}
+          breakpoints={{ '{' + app.homepage_grid.breakpoints|tojson + '}' }}
+          cols={{ '{' + app.homepage_grid.cols|tojson + '}' }}
+          margin={[10, 10]}
+          onLayoutChange={LayoutChangeHandler}
+          draggableHandle=".dragHandle"
+          rowHeight={gridRowHeight}
+        >
+          {%- for widgetName, widgetProps in app.homepage_widgets.items() %}
+            {%- if not (widgetProps.show is defined and not widgetProps.show) %}
+              {%- if widgetName == "GroupList" %}
+          <div key="{{ widgetName }}">
+            <{{ widgetName }}
+              groups={groups}
+              classes={classes}
+              {%- for key, value in widgetProps.props.items() -%}
+              {%- if value is string %}
+              {{ key }}={"{{ value }}"}
+              {%- else -%}
+              {{ key }}={ {{ value }} }
+              {%- endif -%}
+              {%- endfor %}
+            />
+          </div>
+              {%- else %}
+          <div key="{{ widgetName }}">
+            <{{ widgetName }}
+              classes={classes}
+              {%- if widgetProps.props is defined %}
+              {% for key, value in widgetProps.props.items() -%}
+              {%- if value is string %}
+              {{ key }}={"{{ value }}"}
+              {%- else -%}
+              {{ key }}={ {{ value }} }
+              {%- endif -%}
+              {%- endfor -%}
+              {%- endif %}
+            />
+          </div>
+              {%- endif -%}
             {%- endif -%}
-            {%- endfor %}
-          />
+          {%- endfor %}
+        </ResponsiveGridLayout>
+        <div className={classes.resetButton}>
+          <Tooltip title="Reset page layout">
+            <IconButton size="small" onClick={resetLayouts}>
+              <CachedIcon />
+            </IconButton>
+          </Tooltip>
         </div>
-            {%- else %}
-        <div key="{{ widgetName }}">
-          <{{ widgetName }}
-            classes={classes}
-            {%- if widgetProps.props is defined %}
-            {% for key, value in widgetProps.props.items() -%}
-            {%- if value is string %}
-            {{ key }}={"{{ value }}"}
-            {%- else -%}
-            {{ key }}={ {{ value }} }
-            {%- endif -%}
-            {%- endfor -%}
-            {%- endif %}
-          />
-        </div>
-            {%- endif -%}
-          {%- endif -%}
-        {%- endfor %}
-      </ResponsiveGridLayout>
-      <div className={classes.resetButton}>
-        <Tooltip title="Reset page layout">
-          <IconButton size="small" onClick={resetLayouts}>
-            <CachedIcon />
-          </IconButton>
-        </Tooltip>
       </div>
-    </div>
+    )
   );
 };
 

--- a/static/js/components/HomePage.jsx.template
+++ b/static/js/components/HomePage.jsx.template
@@ -75,10 +75,12 @@ const HomePage = () => {
     (state) => state.dbInfo.source_table_empty
   );
 
-  const preferences = useSelector((state) => state.profile.preferences);
+  const profile = useSelector((state) => state.profile);
 
   let currentLayouts =
-    preferences?.layouts == null ? defaultLayouts : preferences.layouts;
+    profile?.preferences.layouts == null
+      ? defaultLayouts
+      : profile.preferences.layouts;
 
   const dispatch = useDispatch();
 
@@ -102,8 +104,8 @@ const HomePage = () => {
   };
 
   return (
-    preferences &&
-    Object.keys(preferences).length !== 0 && (
+    profile &&
+    profile.username !== "" &&  (
       <div>
         <ResponsiveGridLayout
           className="layout"


### PR DESCRIPTION
Wait until user preferences have been fetched before rendering the home page. Before, the default layouts were being rendered first because the user preferences hadn't been fetched yet; this caused the default layouts to be automatically saved to the preferences and override what was already there.

Closes #1612 

![widgets](https://user-images.githubusercontent.com/17696889/110538236-d0979200-80f1-11eb-805e-7379b92abfc5.gif)
