### PR TITLE
Show save candidate button alongside manage groups button on scanning page when relevant

### DIFF
--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -1081,12 +1081,21 @@ class SourceHandler(BaseHandler):
         update_redshift_history_if_relevant(data, obj, self.associated_user_object)
 
         DBSession().add(obj)
-        DBSession().add_all(
-            [
-                Source(obj=obj, group=group, saved_by_id=self.associated_user_object.id)
-                for group in groups
-            ]
-        )
+        for group in groups:
+            source = (
+                Source.query.filter(Source.obj_id == obj.id)
+                .filter(Source.group_id == group.id)
+                .first()
+            )
+            if source is not None:
+                source.active = True
+                source.saved_by = self.associated_user_object
+            else:
+                DBSession().add(
+                    Source(
+                        obj=obj, group=group, saved_by_id=self.associated_user_object.id
+                    )
+                )
         self.finalize_transaction()
         if not obj_already_exists:
             obj.add_linked_thumbnails()

--- a/static/js/components/CandidateList.jsx
+++ b/static/js/components/CandidateList.jsx
@@ -623,14 +623,41 @@ const CandidateList = () => {
               label="NOT SAVED"
               className={classes.itemPaddingBottom}
             />
-            <br />
-            <div className={classes.saveCandidateButton}>
-              <SaveCandidateButton
-                candidate={candidateObj}
-                userGroups={userAccessibleGroups}
-                filterGroups={filterGroups}
-              />
-            </div>
+          </div>
+        )}
+        {Boolean(
+          !candidateObj.is_source ||
+            (candidateObj.is_source &&
+              filterGroups.filter(
+                (g) =>
+                  !candidateObj.saved_groups.map((x) => x.id).includes(g.id)
+              ).length)
+        ) && (
+          // eslint-disable-next-line react/jsx-indent
+          <div className={classes.saveCandidateButton}>
+            <SaveCandidateButton
+              candidate={candidateObj}
+              userGroups={
+                candidateObj.is_source
+                  ? userAccessibleGroups.filter(
+                      (g) =>
+                        !candidateObj.saved_groups
+                          .map((x) => x.id)
+                          .includes(g.id)
+                    )
+                  : userAccessibleGroups
+              }
+              filterGroups={
+                candidateObj.is_source
+                  ? filterGroups.filter(
+                      (g) =>
+                        !candidateObj.saved_groups
+                          .map((x) => x.id)
+                          .includes(g.id)
+                    )
+                  : filterGroups
+              }
+            />
           </div>
         )}
         {candidateObj.last_detected_at && (

--- a/static/js/components/CandidateList.jsx
+++ b/static/js/components/CandidateList.jsx
@@ -625,6 +625,7 @@ const CandidateList = () => {
             />
           </div>
         )}
+        {/* If candidate is either unsaved or is not yet saved to all groups being filtered on, show the "Save to..." button */}
         {Boolean(
           !candidateObj.is_source ||
             (candidateObj.is_source &&
@@ -638,6 +639,7 @@ const CandidateList = () => {
             <SaveCandidateButton
               candidate={candidateObj}
               userGroups={
+                // Filter out groups the candidate is already saved to
                 candidateObj.is_source
                   ? userAccessibleGroups.filter(
                       (g) =>
@@ -648,6 +650,7 @@ const CandidateList = () => {
                   : userAccessibleGroups
               }
               filterGroups={
+                // Filter out groups the candidate is already saved to
                 candidateObj.is_source
                   ? filterGroups.filter(
                       (g) =>

--- a/static/js/components/SaveCandidateButton.jsx
+++ b/static/js/components/SaveCandidateButton.jsx
@@ -82,9 +82,8 @@ const SaveCandidateButton = ({ candidate, userGroups, filterGroups }) => {
     if (result.status === "success") {
       reset();
       setDialogOpen(false);
-    } else if (result.status === "error") {
-      setIsSubmitting(false);
     }
+    setIsSubmitting(false);
   };
 
   // Split button logic (largely copied from
@@ -103,10 +102,8 @@ const SaveCandidateButton = ({ candidate, userGroups, filterGroups }) => {
         id: candidate.id,
         group_ids: filterGroups.map((g) => g.id),
       };
-      const result = await dispatch(sourceActions.saveSource(data));
-      if (result.status === "error") {
-        setIsSubmitting(false);
-      }
+      await dispatch(sourceActions.saveSource(data));
+      setIsSubmitting(false);
     } else if (selectedIndex === 1) {
       handleClickOpenDialog();
     }


### PR DESCRIPTION
This PR updates the scanning page for candidates that are already saved to at least one group in the following way: If a candidate is already saved to at least one group but is not yet saved to **all** of the groups being scanned (those groups selected in the filter form), then the "Save to ..." button is now displayed in addition to the "Manage Groups" button, with those groups the source is already saved to being filtered out of the "Save to" groups (this applies both to the default button action and the "Edit groups and Save" groups list). 

In this screenshot I was scanning all three groups (i.e. "Program A", "Program B" and "Sitewide Group" were all selected in the candidate search form). Note that those groups that the source is already saved to are filtered out of the "Save to" button groups:

![scanning_page_save_cand_buttons_2](https://user-images.githubusercontent.com/7230285/110565337-2de80f00-8103-11eb-8ff5-4bf9c6ebb9f7.gif)

