### PR TITLE
Adjust photometry plot layouts

### DIFF
--- a/skyportal/handlers/api/internal/plot.py
+++ b/skyportal/handlers/api/internal/plot.py
@@ -20,7 +20,6 @@ device_types = [
 class PlotPhotometryHandler(BaseHandler):
     @auth_or_token
     def get(self, obj_id):
-        height = self.get_query_argument("height", 300)
         width = self.get_query_argument("width", 600)
         device = self.get_query_argument("device", None)
         # Just return browser by default if not one of accepted types
@@ -29,7 +28,6 @@ class PlotPhotometryHandler(BaseHandler):
         json = plot.photometry_plot(
             obj_id,
             self.current_user,
-            height=int(height),
             width=int(width),
             device=device,
         )
@@ -40,7 +38,6 @@ class PlotPhotometryHandler(BaseHandler):
 class PlotSpectroscopyHandler(BaseHandler):
     @auth_or_token
     def get(self, obj_id):
-        height = self.get_query_argument("height", 300)
         width = self.get_query_argument("width", 600)
         device = self.get_query_argument("device", None)
         # Just return browser by default if not one of accepted types
@@ -51,7 +48,6 @@ class PlotSpectroscopyHandler(BaseHandler):
             obj_id,
             self.associated_user_object,
             spec_id,
-            height=int(height),
             width=int(width),
             device=device,
         )

--- a/skyportal/plot.py
+++ b/skyportal/plot.py
@@ -752,6 +752,8 @@ def photometry_plot(obj_id, user, width=600, device="browser"):
     height = (
         500
         if device == "browser"
+        # The 18 is the height of one row in the CheckboxWithLegendGroup
+        # (the colored box next to the checkbox, to be precise)
         else math.floor(width / aspect_ratio) + 18 * len(colors_labels) + 100
     )
 

--- a/static/js/components/SourceMobile.jsx
+++ b/static/js/components/SourceMobile.jsx
@@ -202,15 +202,7 @@ const SourceMobile = WidthProvider(
       device = isLandscape ? "tablet_landscape" : "tablet_portrait";
     }
 
-    // Browser defaults
-    const aspectRatio = isMobileOnly && isLandscape ? 2.0 : 1.5;
     const plotWidth = isBrowser ? 800 : width - 100;
-    const photPlotHeight = isBrowser
-      ? 500
-      : Math.floor(plotWidth / aspectRatio) + 150;
-    const specPlotHeight = isBrowser
-      ? 600
-      : Math.floor(plotWidth / aspectRatio) + 225;
 
     return (
       <div className={classes.source}>
@@ -416,7 +408,7 @@ const SourceMobile = WidthProvider(
                 <div className={classes.photometryContainer}>
                   <Suspense fallback={<div>Loading photometry plot...</div>}>
                     <Plot
-                      url={`/api/internal/plot/photometry/${source.id}?width=${plotWidth}&height=${photPlotHeight}&device=${device}`}
+                      url={`/api/internal/plot/photometry/${source.id}?width=${plotWidth}&device=${device}`}
                     />
                   </Suspense>
                   <div className={classes.plotButtons}>
@@ -458,7 +450,7 @@ const SourceMobile = WidthProvider(
                 <div className={classes.photometryContainer}>
                   <Suspense fallback={<div>Loading spectroscopy plot...</div>}>
                     <Plot
-                      url={`/api/internal/plot/spectroscopy/${source.id}?width=${plotWidth}&height=${specPlotHeight}&device=${device}`}
+                      url={`/api/internal/plot/spectroscopy/${source.id}?width=${plotWidth}&device=${device}`}
                     />
                   </Suspense>
                   <div className={classes.plotButtons}>


### PR DESCRIPTION
- Both photometry and spectroscopy plots now dynamically adjust height on smaller screens
  - The spectroscopy plot was actually already doing this - I just removed the height parameter being passed in and going unused.
  - The photometry plot now computes a height proportional to the number of instruments/filters as the legend is moved below the plot on smaller screens and thus will alter the needed height.
- The period tab of the photometry plot also now adjusts plot layouts for smaller screens
Closes #1753 
![plots](https://user-images.githubusercontent.com/17696889/110702559-af51a700-81c0-11eb-9d9a-c22da6e6cc33.gif)
