### PR TITLE
Allow listing git logs from multiple projects

### DIFF
--- a/skyportal/handlers/api/sysinfo.py
+++ b/skyportal/handlers/api/sysinfo.py
@@ -75,8 +75,6 @@ class SysInfoHandler(BaseHandler):
             if not (entry['description'].lower().startswith(('bump', 'pin')))
         ]
 
-        print(parsed_log)
-
         return self.success(
             data={
                 "invitationsEnabled": cfg["invitations.enabled"],

--- a/skyportal/tests/utils/test_gitlog.py
+++ b/skyportal/tests/utils/test_gitlog.py
@@ -10,26 +10,31 @@ log = '''
 
 
 def test_gitlog_parse():
-    entries = gitlog.parse_gitlog(log)
+    entries = gitlog.parse_gitlog(
+        {
+            'pr_url_base': 'https://github.com/skyportal/skyportal/pull',
+            'commit_url_base': 'https://github.com/skyportal/skyportal/commit',
+            'name': 'SP',
+            'log': log,
+        }
+    )
     e0 = entries[0]
     e1 = entries[1]
 
+    assert e0['name'] == 'SP'
     assert e0['time'] == '2020-10-06T19:38:32-07:00'
     assert e0['sha'] == 'f3542fa8'
     assert e0['email'] == 'someone@berkeley.edu'
     assert e0['description'] == 'Pass git log to frontend as parsed components'
     assert e0['pr_nr'] is None
     assert e0['pr_url'] == ''
-    assert e0['commit_url'] == (
-        f"https://github.com/skyportal/skyportal/commit/f3542fa8"
-    )
+    assert e0['commit_url'] == "https://github.com/skyportal/skyportal/commit/f3542fa8"
 
+    assert e1['name'] == 'SP'
     assert e1['time'] == '2020-10-05T14:06:20+03:00'
     assert e1['sha'] == 'a4052098f'
     assert e1['email'] == 'noreply@github.com'
     assert e1['description'] == 'Bump emoji-dictionary from 1.0.10 to 1.0.11'
     assert e1['pr_nr'] == '1040'
     assert e1['pr_url'] == 'https://github.com/skyportal/skyportal/pull/1040'
-    assert e1['commit_url'] == (
-        f"https://github.com/skyportal/skyportal/commit/a4052098f"
-    )
+    assert e1['commit_url'] == "https://github.com/skyportal/skyportal/commit/a4052098f"

--- a/skyportal/utils/gitlog.py
+++ b/skyportal/utils/gitlog.py
@@ -1,12 +1,65 @@
 import re
+import subprocess
 
 from baselayer.log import make_log
 
-
-pr_url_base = "https://github.com/skyportal/skyportal/pull"
-commit_url_base = "https://github.com/skyportal/skyportal/commit"
-
 log = make_log('gitlog')
+
+
+def get_gitlog(
+    cwd='.',
+    name=None,
+    pr_url_base='https://github.com/skyportal/skyportal/pull',
+    commit_url_base='https://github.com/skyportal/skyportal/commit',
+    N=1000,
+):
+    """Return git log for a given directory.
+
+    Parameters
+    ----------
+    cwd : str
+        Where to gather logs.
+    N : int
+        Number of log entries to return.
+    name : str
+        Name of these logs. Value is propagated into the output dictionary.
+
+    Returns
+    -------
+    dict
+        The output dictionary has the following keys:
+
+        - pr_url_base: URL at which pull requests live
+        - commit_url_base: URL at which commits live
+        - name: Name of this set of logs
+        - log: list of lines that come from::
+
+          git log --no-merges --first-parent \
+                  --pretty='format:[%cI %h %cE] %s' -1000
+
+          (assuming N=1000)
+
+    """
+    p = subprocess.run(
+        [
+            "git",
+            "--git-dir=.git",
+            "log",
+            "--no-merges",
+            "--pretty=format:[%cI %h %cE] %s",
+            "-1000",
+        ],
+        capture_output=True,
+        universal_newlines=True,
+        cwd=cwd,
+    )
+    gitlog = {
+        "name": name,
+        "pr_url_base": pr_url_base,
+        "commit_url_base": commit_url_base,
+        "log": p.stdout.splitlines(),
+    }
+    return gitlog
 
 
 def parse_gitlog(gitlog):
@@ -14,11 +67,9 @@ def parse_gitlog(gitlog):
 
     Parameters
     ----------
-    gitlog : list
-        The log should be passed in as a list of lines, obtained using::
-
-          git log --no-merges --first-parent \
-                  --pretty='format:[%cI %h %cE] %s' -1000
+    gitlog : dict
+        The log should be passed in as a dictionary that conforms to the
+        output of `get_gitlog`.
 
     Returns
     -------
@@ -28,6 +79,10 @@ def parse_gitlog(gitlog):
         `pr_nr`, `pr_url`.
 
     """
+    pr_url_base = gitlog['pr_url_base']
+    commit_url_base = gitlog['commit_url_base']
+    name = gitlog.get('name', None)
+
     timechars = '[0-9\\-:\\+]'
     timestamp_re = f'(?P<time>{timechars}+T{timechars}+)'
     sha_re = '(?P<sha>[0-9a-f]{7,12})'
@@ -37,7 +92,7 @@ def parse_gitlog(gitlog):
     log_re = f'\\[{timestamp_re} {sha_re} {email_re}\\] {pr_desc_re}{pr_nr_re}$'
 
     parsed_log = []
-    for line in gitlog:
+    for line in gitlog["log"]:
         if not line:
             continue
 
@@ -51,6 +106,7 @@ def parse_gitlog(gitlog):
         sha = log_fields['sha']
         log_fields['pr_url'] = f'{pr_url_base}/{pr_nr}' if pr_nr else ''
         log_fields['commit_url'] = f'{commit_url_base}/{sha}'
+        log_fields['name'] = name
 
         parsed_log.append(log_fields)
 

--- a/static/js/components/About.jsx
+++ b/static/js/components/About.jsx
@@ -49,6 +49,9 @@ const useStyles = makeStyles((theme) => ({
   gitlogList: {
     fontFamily: "monospace",
   },
+  gitlogName: {
+    paddingRight: "0.25rem",
+  },
   gitlogSHA: {
     color: `${theme.palette.error.main} !important`,
   },
@@ -156,8 +159,19 @@ const About = () => {
               </div>
               <ul className={classes.gitlogList}>
                 {gitlog.map(
-                  ({ time, sha, description, pr_nr, pr_url, commit_url }) => (
+                  ({
+                    name,
+                    time,
+                    sha,
+                    description,
+                    pr_nr,
+                    pr_url,
+                    commit_url,
+                  }) => (
                     <li key={sha}>
+                      {name && (
+                        <span className={classes.gitlogName}>[{name}]</span>
+                      )}
                       [{dayjs(time).format("YYYY-MM-DD")}
                       <a className={classes.gitlogSHA} href={commit_url}>
                         &nbsp;{sha}


### PR DESCRIPTION
To facilitate this, we now store git logs in JSON files, instead of as
text files.  Each JSON file contains some meta-data about the git log
(where to link PRs and commits to, what the project is called) as well
as the entries to the git log itself.

![2021-03-11_01:26:33](https://user-images.githubusercontent.com/45071/110831277-ea9ab700-824e-11eb-9cfa-56c150d8795e.png)
