### PR TITLE
catch error for bad encoding on spectrum files

### DIFF
--- a/skyportal/handlers/api/spectrum.py
+++ b/skyportal/handlers/api/spectrum.py
@@ -336,7 +336,14 @@ class ASCIIHandler:
             raise ValueError('File must be smaller than 10MB.')
 
         # pass ascii in as a file-like object
-        file = io.BytesIO(ascii.encode('ascii'))
+        try:
+            file = io.BytesIO(ascii.encode('ascii'))
+        except UnicodeEncodeError:
+            raise ValueError(
+                'Unable to parse uploaded spectrum file as ascii. '
+                'Ensure the file is not a FITS file and retry.'
+            )
+
         spec = Spectrum.from_ascii(
             file,
             obj_id=json.get('obj_id', None),

--- a/skyportal/handlers/api/spectrum.py
+++ b/skyportal/handlers/api/spectrum.py
@@ -505,7 +505,10 @@ class SpectrumASCIIFileParser(BaseHandler, ASCIIHandler):
                 schema: Error
         """
 
-        spec = self.spec_from_ascii_request(validator=SpectrumAsciiFileParseJSON)
+        try:
+            spec = self.spec_from_ascii_request(validator=SpectrumAsciiFileParseJSON)
+        except Exception as e:
+            return self.error(f'Error parsing spectrum: {e.args[0]}')
         return self.success(data=spec)
 
 


### PR DESCRIPTION
Prevents tracebacks like these from appearing in the logs

```

ERROR:tornado.application:Uncaught exception POST /api/spectrum/parse/ascii (127.0.0.1)
HTTPServerRequest(protocol='http', host='fritz.science', method='POST', uri='/api/spectrum/parse/ascii', version='HTTP/1.0', remote_ip='127.0.0.1')
Traceback (most recent call last):
  File "/skyportal_env/lib/python3.8/site-packages/tornado/web.py", line 1702, in _execute
    result = method(*self.path_args, **self.path_kwargs)
  File "/skyportal/baselayer/app/access.py", line 32, in wrapper
    return tornado.web.authenticated(method)(self, *args, **kwargs)
  File "/skyportal_env/lib/python3.8/site-packages/tornado/web.py", line 3173, in wrapper
    return method(self, *args, **kwargs)
  File "/skyportal/baselayer/app/access.py", line 51, in wrapper
    return method(self, *args, **kwargs)
  File "/skyportal/skyportal/handlers/api/spectrum.py", line 501, in post
    spec = self.spec_from_ascii_request(validator=SpectrumAsciiFileParseJSON)
  File "/skyportal/skyportal/handlers/api/spectrum.py", line 339, in spec_from_ascii_request
    file = io.BytesIO(ascii.encode('ascii'))
UnicodeEncodeError: 'ascii' codec can't encode character '\ufffd' in position 5761: ordinal not in range(128)
```