### PR TITLE
Re-introduce new photometry plot legend and make it responsive

### DIFF
--- a/skyportal/handlers/api/internal/plot.py
+++ b/skyportal/handlers/api/internal/plot.py
@@ -20,7 +20,6 @@ device_types = [
 class PlotPhotometryHandler(BaseHandler):
     @auth_or_token
     def get(self, obj_id):
-        height = self.get_query_argument("height", 300)
         width = self.get_query_argument("width", 600)
         device = self.get_query_argument("device", None)
         # Just return browser by default if not one of accepted types
@@ -29,7 +28,6 @@ class PlotPhotometryHandler(BaseHandler):
         json = plot.photometry_plot(
             obj_id,
             self.current_user,
-            height=int(height),
             width=int(width),
             device=device,
         )
@@ -40,7 +38,6 @@ class PlotPhotometryHandler(BaseHandler):
 class PlotSpectroscopyHandler(BaseHandler):
     @auth_or_token
     def get(self, obj_id):
-        height = self.get_query_argument("height", 300)
         width = self.get_query_argument("width", 600)
         device = self.get_query_argument("device", None)
         # Just return browser by default if not one of accepted types
@@ -51,7 +48,6 @@ class PlotSpectroscopyHandler(BaseHandler):
             obj_id,
             self.associated_user_object,
             spec_id,
-            height=int(height),
             width=int(width),
             device=device,
         )

--- a/skyportal/plot.py
+++ b/skyportal/plot.py
@@ -752,6 +752,8 @@ def photometry_plot(obj_id, user, width=600, device="browser"):
     height = (
         500
         if device == "browser"
+        # The 18 is the height of one row in the CheckboxWithLegendGroup
+        # (the colored box next to the checkbox, to be precise)
         else math.floor(width / aspect_ratio) + 18 * len(colors_labels) + 100
     )
 

--- a/static/js/components/SourceMobile.jsx
+++ b/static/js/components/SourceMobile.jsx
@@ -206,15 +206,7 @@ const SourceMobile = WidthProvider(
       device = isLandscape ? "tablet_landscape" : "tablet_portrait";
     }
 
-    // Browser defaults
-    const aspectRatio = isMobileOnly && isLandscape ? 2.0 : 1.5;
     const plotWidth = isBrowser ? 800 : width - 100;
-    const photPlotHeight = isBrowser
-      ? 500
-      : Math.floor(plotWidth / aspectRatio) + 150;
-    const specPlotHeight = isBrowser
-      ? 600
-      : Math.floor(plotWidth / aspectRatio) + 225;
 
     return (
       <div className={classes.source}>
@@ -420,7 +412,7 @@ const SourceMobile = WidthProvider(
                 <div className={classes.photometryContainer}>
                   <Suspense fallback={<div>Loading photometry plot...</div>}>
                     <Plot
-                      url={`/api/internal/plot/photometry/${source.id}?width=${plotWidth}&height=${photPlotHeight}&device=${device}`}
+                      url={`/api/internal/plot/photometry/${source.id}?width=${plotWidth}&device=${device}`}
                     />
                   </Suspense>
                   <div className={classes.plotButtons}>
@@ -462,7 +454,7 @@ const SourceMobile = WidthProvider(
                 <div className={classes.photometryContainer}>
                   <Suspense fallback={<div>Loading spectroscopy plot...</div>}>
                     <Plot
-                      url={`/api/internal/plot/spectroscopy/${source.id}?width=${plotWidth}&height=${specPlotHeight}&device=${device}`}
+                      url={`/api/internal/plot/spectroscopy/${source.id}?width=${plotWidth}&device=${device}`}
                     />
                   </Suspense>
                   <div className={classes.plotButtons}>

--- a/static/js/plotjs/download.js
+++ b/static/js/plotjs/download.js
@@ -43,7 +43,7 @@ function table_to_csv(source, write_header) {
 
 const filename = "objname.csv";
 let filetext = "";
-for (let i = 0; i < toggle.labels.length; i++) {
+for (let i = 0; i < n_labels; i++) {
   const write_header = i === 0;
   filetext += table_to_csv(eval(`bold${i}`), write_header);
 }

--- a/static/js/plotjs/foldphase.js
+++ b/static/js/plotjs/foldphase.js
@@ -1,12 +1,12 @@
 /* eslint-disable */
 if (numphases.active == 1) {
   /* two phases */
-  p.x_range.end = 2.1;
+  p.x_range.end = 2.01;
 } else {
-  p.x_range.end = 1.1;
+  p.x_range.end = 1.01;
 }
 const period = parseFloat(textinput.value);
-for (let i = 0; i < toggle.labels.length; i++) {
+for (let i = 0; i < n_labels; i++) {
   const folda = eval(`folda${i}`).data_source;
   const foldaerr = eval(`foldaerr${i}`).data_source;
   const foldb = eval(`foldb${i}`).data_source;
@@ -22,12 +22,4 @@ for (let i = 0; i < toggle.labels.length; i++) {
   foldaerr.change.emit();
   foldb.change.emit();
   foldberr.change.emit();
-  if (numphases.active == 1) {
-    /* two phases */
-    eval(`foldb${i}`).visible = true && toggle.active.includes(i);
-    eval(`foldberr${i}`).visible = true && toggle.active.includes(i);
-  } else {
-    eval(`foldb${i}`).visible = false;
-    eval(`foldberr${i}`).visible = false;
-  }
 }

--- a/static/js/plotjs/stackf.js
+++ b/static/js/plotjs/stackf.js
@@ -2,7 +2,7 @@
 const binsize = slider.value;
 const fluxalph = binsize === 0 ? 1.0 : 0.1;
 
-for (let i = 0; i < toggle.labels.length; i++) {
+for (let i = 0; i < n_labels; i++) {
   const fluxsource = eval(`obs${i}`).data_source;
   const binsource = eval(`bin${i}`).data_source;
 

--- a/static/js/plotjs/stackm.js
+++ b/static/js/plotjs/stackm.js
@@ -2,7 +2,7 @@
 const binsize = slider.value;
 const fluxalph = binsize === 0 ? 1.0 : 0.1;
 
-for (let i = 0; i < toggle.labels.length; i++) {
+for (let i = 0; i < n_labels; i++) {
   const fluxsource = eval(`obs${i}`).data_source;
   const binsource = eval(`bin${i}`).data_source;
 

--- a/static/js/plotjs/togglef.js
+++ b/static/js/plotjs/togglef.js
@@ -1,7 +1,0 @@
-/* eslint-disable */
-for (let i = 0; i < toggle.labels.length; i++) {
-  eval(`obs${i}`).visible = toggle.active.includes(i);
-  eval(`obserr${i}`).visible = toggle.active.includes(i);
-  eval(`bin${i}`).visible = toggle.active.includes(i);
-  eval(`binerr${i}`).visible = toggle.active.includes(i);
-}

--- a/static/js/plotjs/togglem.js
+++ b/static/js/plotjs/togglem.js
@@ -1,9 +1,0 @@
-/* eslint-disable */
-for (let i = 0; i < toggle.labels.length; i++) {
-  eval(`obs${i}`).visible = toggle.active.includes(i);
-  eval(`obserr${i}`).visible = toggle.active.includes(i);
-  eval(`bin${i}`).visible = toggle.active.includes(i);
-  eval(`binerr${i}`).visible = toggle.active.includes(i);
-  eval(`unobs${i}`).visible = toggle.active.includes(i);
-  eval(`unobsbin${i}`).visible = toggle.active.includes(i);
-}

--- a/static/js/plotjs/togglep.js
+++ b/static/js/plotjs/togglep.js
@@ -1,7 +1,0 @@
-/* eslint-disable */
-for (let i = 0; i < toggle.labels.length; i++) {
-  eval(`folda${i}`).visible = toggle.active.includes(i);
-  eval(`foldb${i}`).visible = toggle.active.includes(i);
-  eval(`foldaerr${i}`).visible = toggle.active.includes(i);
-  eval(`foldberr${i}`).visible = toggle.active.includes(i);
-}


### PR DESCRIPTION
This PR re-introduces the changes in the reverted #1758 (refactoring the legend to use the legend component instead of checkboxes to support better colors and markers), and makes adjustments to the photometry plot layouts to make it properly responsive. This includes changes previously included in the closed #1759 PR, as well as new changes necessitated by the changes in #1758.

- Both photometry and spectroscopy plots now dynamically adjust height on smaller screens
  - The spectroscopy plot was actually already doing this - I just removed the height parameter being passed in and going unused.
  - The photometry plot now computes a height proportional to the number of instruments/filters as the legend is moved below the plot on smaller screens and thus will alter the needed height.
- The period tab of the photometry plot also now adjusts plot layouts for smaller screens

Closes #1753 

## Browser
![phot_desktop](https://user-images.githubusercontent.com/17696889/111007006-d85a6f00-835b-11eb-9926-03340b637456.gif)

## Tablet (iPad)
![phot_ipad](https://user-images.githubusercontent.com/17696889/111007018-dc868c80-835b-11eb-8826-c0916e84ed18.gif)

## Mobile (iPhone 8)
![phot_iphone](https://user-images.githubusercontent.com/17696889/111007023-df817d00-835b-11eb-9615-234a5e1ea691.gif)
