### PR TITLE
Implement stream / group / user access logic and update group and stream handlers

### DIFF
--- a/data/db_demo.yaml
+++ b/data/db_demo.yaml
@@ -49,6 +49,12 @@ groups/=program_A/users:
   - userID: =fulluser
     admin: false
 
+groups/=program_B/users:
+  - userID: =viewonlyuser
+    admin: false
+  - userID: =fulluser
+    admin: false
+
 streams/=ztf_public/users:
   - user_id: =viewonlyuser
   - user_id: =fulluser

--- a/data/db_demo.yaml
+++ b/data/db_demo.yaml
@@ -49,10 +49,6 @@ groups/=program_A/users:
   - userID: =fulluser
     admin: false
 
-groups/=program_B/users:
-  - userID: =viewonlyuser
-    admin: false
-
 streams/=ztf_public/users:
   - user_id: =viewonlyuser
   - user_id: =fulluser

--- a/skyportal/handlers/api/group.py
+++ b/skyportal/handlers/api/group.py
@@ -1,18 +1,15 @@
 from sqlalchemy import or_
-from sqlalchemy.orm import joinedload
 from marshmallow.exceptions import ValidationError
-from baselayer.app.access import permissions, auth_or_token
+from baselayer.app.access import auth_or_token, AccessError
 from baselayer.app.env import load_env
 from ..base import BaseHandler
 from ...models import (
     DBSession,
-    Filter,
     Group,
     GroupStream,
     GroupUser,
     Obj,
     Source,
-    Stream,
     User,
     Token,
     UserNotification,
@@ -134,16 +131,9 @@ class GroupHandler(BaseHandler):
                   schema: Error
         """
         if group_id is not None:
-            group = Group.query.get(group_id)
-            if group is None:
-                return self.error(f"Could not load group with ID {group_id}")
-            # If not super admin or member of group
-            if (
-                not {"System admin", "Manage groups"}.intersection(
-                    set(self.associated_user_object.permissions)
-                )
-            ) and group.id not in [g.id for g in self.current_user.accessible_groups]:
-                return self.error('Insufficient permissions.')
+            group = Group.get_if_accessible_by(
+                group_id, self.current_user, raise_if_none=True, mode='read'
+            )
 
             if self.get_query_argument("includeGroupUsers", "true").lower() in (
                 "f",
@@ -152,52 +142,49 @@ class GroupHandler(BaseHandler):
                 include_group_users = False
             else:
                 include_group_users = True
+
             # Do not include User.groups to avoid circular reference
             users = (
                 [
                     {
-                        "id": user.id,
-                        "username": user.username,
-                        "first_name": user.first_name,
-                        "last_name": user.last_name,
-                        "contact_email": user.contact_email,
-                        "contact_phone": user.contact_phone,
-                        "oauth_uid": user.oauth_uid,
-                        "admin": has_admin_access_for_group(user, group_id),
+                        "id": gu.user.id,
+                        "username": gu.user.username,
+                        "first_name": gu.user.first_name,
+                        "last_name": gu.user.last_name,
+                        "contact_email": gu.user.contact_email,
+                        "contact_phone": gu.user.contact_phone,
+                        "oauth_uid": gu.user.oauth_uid,
+                        "admin": gu.admin,
                     }
-                    for user in group.users
+                    for gu in group.group_users
                 ]
                 if include_group_users
                 else None
             )
+
+            streams = group.streams
+            filters = group.filters
+
             group = group.to_dict()
             if users is not None:
                 group['users'] = users
+
             # grab streams:
-            streams = (
-                DBSession()
-                .query(Stream)
-                .join(GroupStream)
-                .filter(GroupStream.group_id == group_id)
-                .all()
-            )
             group['streams'] = streams
             # grab filters:
-            filters = (
-                DBSession().query(Filter).filter(Filter.group_id == group_id).all()
-            )
             group['filters'] = filters
 
             self.verify_and_commit()
             return self.success(data=group)
+
         group_name = self.get_query_argument("name", None)
         if group_name is not None:
-            groups = Group.query.filter(Group.name == group_name).all()
+            groups = (
+                Group.query_records_accessible_by(self.current_user)
+                .filter(Group.name == group_name)
+                .all()
+            )
             # Ensure access
-            if not all(
-                [group in self.current_user.accessible_groups for group in groups]
-            ):
-                return self.error("Insufficient permissions")
             self.verify_and_commit()
             return self.success(data=groups)
 
@@ -212,7 +199,7 @@ class GroupHandler(BaseHandler):
             [g for g in self.current_user.accessible_groups if not g.single_user_group],
             key=lambda g: g.name.lower(),
         )
-        all_groups_query = Group.query
+        all_groups_query = Group.query_records_accessible_by(self.current_user)
         if (not include_single_user_groups) or (
             isinstance(include_single_user_groups, str)
             and include_single_user_groups.lower() == "false"
@@ -277,7 +264,11 @@ class GroupHandler(BaseHandler):
             return self.error(
                 "Invalid group_admins field; unable to parse all items to int"
             )
-        group_admins = User.query.filter(User.id.in_(group_admin_ids)).all()
+        group_admins = (
+            User.query_records_accessible_by(self.current_user)
+            .filter(User.id.in_(group_admin_ids))
+            .all()
+        )
         if self.current_user not in group_admins and not isinstance(
             self.current_user, Token
         ):
@@ -289,7 +280,6 @@ class GroupHandler(BaseHandler):
             [GroupUser(group=g, user=user, admin=True) for user in group_admins]
         )
         self.verify_and_commit()
-
         return self.success(data={"id": g.id})
 
     @auth_or_token
@@ -318,33 +308,24 @@ class GroupHandler(BaseHandler):
               application/json:
                 schema: Error
         """
-        groupuser = (
-            DBSession()
-            .query(GroupUser)
-            .filter(GroupUser.group_id == group_id)
-            .filter(GroupUser.user_id == self.associated_user_object.id)
-            .first()
-        )
-        if (
-            "Manage groups" not in self.associated_user_object.permissions
-            and not groupuser.admin
-        ):
-            return self.error(
-                "Insufficient permissions. You must either be a group admin or have higher site-wide permissions."
-            )
 
         data = self.get_json()
         data['id'] = group_id
 
+        # permission check
+        _ = Group.get_if_accessible_by(
+            group_id, self.current_user, raise_if_none=True, mode='update'
+        )
         schema = Group.__schema__()
+
         try:
             schema.load(data)
         except ValidationError as e:
             return self.error(
                 'Invalid/missing parameters: ' f'{e.normalized_messages()}'
             )
-        self.verify_and_commit()
 
+        self.verify_and_commit()
         return self.success(action='skyportal/FETCH_GROUPS')
 
     @auth_or_token
@@ -366,26 +347,12 @@ class GroupHandler(BaseHandler):
               application/json:
                 schema: Success
         """
-        g = Group.query.get(group_id)
-        if g.name == cfg["misc"]["public_group_name"]:
-            return self.error("Cannot delete site-wide public group.")
-        groupuser = (
-            DBSession()
-            .query(GroupUser)
-            .filter(GroupUser.group_id == group_id)
-            .filter(GroupUser.user_id == self.associated_user_object.id)
-            .first()
+
+        g = Group.get_if_accessible_by(
+            group_id, self.current_user, raise_if_none=True, mode='delete'
         )
-        if (
-            "Manage groups" not in self.associated_user_object.permissions
-            and not groupuser.admin
-        ):
-            return self.error(
-                "Insufficient permissions. You must either be a group admin or have higher site-wide permissions."
-            )
         DBSession().delete(g)
         self.verify_and_commit()
-
         self.push_all(
             action='skyportal/REFRESH_GROUP', payload={'group_id': int(group_id)}
         )
@@ -442,8 +409,6 @@ class GroupUserHandler(BaseHandler):
                               type: boolean
                               description: Boolean indicating whether user is group admin
         """
-        if not has_admin_access_for_group(self.associated_user_object, group_id):
-            return self.error("Inadequate permissions.")
 
         data = self.get_json()
 
@@ -457,20 +422,13 @@ class GroupUserHandler(BaseHandler):
 
         admin = data.pop("admin", False)
         group_id = int(group_id)
-        group = Group.query.get(group_id)
-        if group.single_user_group:
-            return self.error("Cannot add users to single-user groups.")
-        user = User.query.get(user_id)
-        if user is None:
-            return self.error(f"Invalid userID parameter: {user_id}")
+        group = Group.get_if_accessible_by(
+            group_id, self.current_user, raise_if_none=True, mode='read'
+        )
+        user = User.get_if_accessible_by(
+            user_id, self.current_user, raise_if_none=True, mode='read'
+        )
 
-        # Ensure user has sufficient stream access to be added to group
-        if group.streams:
-            if not all([stream in user.accessible_streams for stream in group.streams]):
-                return self.error(
-                    "User does not have sufficient stream access "
-                    "to be added to this group."
-                )
         # Add user to group
         gu = (
             GroupUser.query.filter(GroupUser.group_id == group_id)
@@ -534,22 +492,23 @@ class GroupUserHandler(BaseHandler):
             group_id = int(group_id)
         except ValueError:
             return self.error("Invalid group ID")
-        if not has_admin_access_for_group(self.associated_user_object, group_id):
-            return self.error("Insufficient permissions.")
+
         user_id = data.get("userID")
         try:
             user_id = int(user_id)
         except ValueError:
             return self.error("Invalid userID parameter")
+
         groupuser = (
-            DBSession()
-            .query(GroupUser)
+            GroupUser.query_records_accessible_by(self.current_user, mode='update')
             .filter(GroupUser.group_id == group_id)
             .filter(GroupUser.user_id == user_id)
             .first()
         )
+
         if groupuser is None:
             return self.error("Specified user is not a member of specified group.")
+
         if data.get("admin") is None:
             return self.error("Missing required parameter: `admin`")
         admin = data.get("admin") in [True, "true", "True", "t", "T"]
@@ -582,21 +541,23 @@ class GroupUserHandler(BaseHandler):
               application/json:
                 schema: Success
         """
-        if not has_admin_access_for_group(self.associated_user_object, group_id):
-            return self.error("Inadequate permissions.")
 
-        group = Group.query.get(group_id)
-        if group.single_user_group:
-            return self.error("Cannot delete users from single user groups.")
         try:
             user_id = int(user_id)
         except ValueError:
             return self.error("Invalid user_id; unable to parse to integer")
-        (
-            GroupUser.query.filter(GroupUser.group_id == group_id)
+
+        gu = (
+            GroupUser.query_records_accessible_by(self.current_user, mode='delete')
+            .filter(GroupUser.group_id == group_id)
             .filter(GroupUser.user_id == user_id)
-            .delete()
+            .first()
         )
+
+        if gu is None:
+            raise AccessError("GroupUser does not exist.")
+
+        DBSession().delete(gu)
         self.verify_and_commit()
         self.push_all(
             action='skyportal/REFRESH_GROUP', payload={'group_id': int(group_id)}
@@ -643,9 +604,6 @@ class GroupUsersFromOtherGroupsHandler(BaseHandler):
         except (TypeError, ValueError):
             return self.error("Invalid group_id parameter: must be an integer")
 
-        if not has_admin_access_for_group(self.associated_user_object, group_id):
-            return self.error("Requesting user is not an admin of this group.")
-
         data = self.get_json()
 
         from_group_ids = data.get("fromGroupIDs")
@@ -656,26 +614,16 @@ class GroupUsersFromOtherGroupsHandler(BaseHandler):
                 "Improperly formatted fromGroupIDs parameter; "
                 "must be an array of integers."
             )
-        group = DBSession().query(Group).get(group_id)
-        if group is None:
-            return self.error("Invalid group_id value")
-        from_groups = (
-            DBSession().query(Group).filter(Group.id.in_(from_group_ids)).all()
+        group = Group.get_if_accessible_by(
+            group_id, self.current_user, mode="read", raise_if_none=True
         )
-        if len(from_groups) != len(set(from_group_ids)):
-            return self.error("One or more invalid IDs in fromGroupIDs parameter.")
+        from_groups = Group.get_if_accessible_by(
+            from_group_ids, self.current_user, mode='read', raise_if_none=True
+        )
+
         user_ids = set()
         for from_group in from_groups:
             for user in from_group.users:
-                # Ensure user has sufficient stream access to be added to group
-                if from_group.streams:
-                    if not all(
-                        [stream in user.streams for stream in from_group.streams]
-                    ):
-                        return self.error(
-                            "Not all users have sufficient stream access "
-                            "to be added to this group."
-                        )
                 user_ids.add(user.id)
 
         for user_id in user_ids:
@@ -706,7 +654,7 @@ class GroupUsersFromOtherGroupsHandler(BaseHandler):
 
 
 class GroupStreamHandler(BaseHandler):
-    @permissions(['System admin'])
+    @auth_or_token
     def post(self, group_id, *ignored_args):
         """
         ---
@@ -751,20 +699,8 @@ class GroupStreamHandler(BaseHandler):
         """
         data = self.get_json()
         group_id = int(group_id)
-        # group = Group.query.filter(Group.id == group_id).first()
-        group = (
-            Group.query.options(joinedload(Group.users))
-            .options(joinedload(Group.group_users))
-            .get(group_id)
-        )
-        if group is None:
-            return self.error("Specified group_id does not exist.")
         stream_id = data.get('stream_id')
-        stream = Stream.query.filter(Stream.id == stream_id).first()
-        if stream is None:
-            return self.error("Specified stream_id does not exist.")
-        # TODO ensure all current group users have access to this stream
-        # TODO do the check
+
         # Add new GroupStream
         gs = GroupStream.query.filter(
             GroupStream.group_id == group_id, GroupStream.stream_id == stream_id
@@ -778,7 +714,7 @@ class GroupStreamHandler(BaseHandler):
         self.push_all(action='skyportal/REFRESH_GROUP', payload={'group_id': group_id})
         return self.success(data={'group_id': group_id, 'stream_id': stream_id})
 
-    @permissions(['System admin'])
+    @auth_or_token
     def delete(self, group_id, stream_id):
         """
         ---
@@ -803,21 +739,21 @@ class GroupStreamHandler(BaseHandler):
               application/json:
                 schema: Success
         """
-        stream = Stream.query.filter(Stream.id == int(stream_id)).first()
-        stream_id = stream.id
-        if stream is None:
-            return self.error("Specified stream_id does not exist.")
-        else:
-            (
-                GroupStream.query.filter(GroupStream.group_id == group_id)
-                .filter(GroupStream.stream_id == stream_id)
-                .delete()
-            )
-            self.verify_and_commit()
-            self.push_all(
-                action='skyportal/REFRESH_GROUP', payload={'group_id': int(group_id)}
-            )
-            return self.success()
+        groupstreams = (
+            GroupStream.query_records_accessible_by(self.current_user)
+            .filter(GroupStream.group_id == group_id)
+            .filter(GroupStream.stream_id == stream_id)
+            .all()
+        )
+
+        for gs in groupstreams:
+            DBSession().delete(gs)
+
+        self.verify_and_commit()
+        self.push_all(
+            action='skyportal/REFRESH_GROUP', payload={'group_id': int(group_id)}
+        )
+        return self.success()
 
 
 class ObjGroupsHandler(BaseHandler):
@@ -845,22 +781,18 @@ class ObjGroupsHandler(BaseHandler):
               application/json:
                 schema: Error
         """
-        s = Obj.get_if_readable_by(obj_id, self.current_user)
+        s = Obj.get_if_accessible_by(obj_id, self.current_user)
 
         if s is None:
             return self.error("Source not found", status=404)
 
         source_info = s.to_dict()
 
-        user_accessible_group_ids = [g.id for g in self.current_user.accessible_groups]
-
         query = (
-            DBSession()
-            .query(Group)
+            Group.query_records_accessible_by(self.current_user, mode="read")
             .join(Source)
             .filter(
                 Source.obj_id == source_info["id"],
-                Group.id.in_(user_accessible_group_ids),
             )
         )
         query = query.filter(or_(Source.requested.is_(True), Source.active.is_(True)))

--- a/skyportal/handlers/api/group.py
+++ b/skyportal/handlers/api/group.py
@@ -436,7 +436,9 @@ class GroupUserHandler(BaseHandler):
             .first()
         )
         if gu is not None:
-            return self.error("Specified user is already a member of this group.")
+            return self.error(
+                f"User {user_id} is already a member of group {group_id}."
+            )
 
         DBSession().add(GroupUser(group_id=group_id, user_id=user_id, admin=admin))
         DBSession().add(
@@ -507,7 +509,7 @@ class GroupUserHandler(BaseHandler):
         )
 
         if groupuser is None:
-            return self.error("Specified user is not a member of specified group.")
+            return self.error(f"User {user_id} is not a member of group {group_id}.")
 
         if data.get("admin") is None:
             return self.error("Missing required parameter: `admin`")

--- a/skyportal/handlers/api/stream.py
+++ b/skyportal/handlers/api/stream.py
@@ -175,7 +175,7 @@ class StreamHandler(BaseHandler):
 
 
 class StreamUserHandler(BaseHandler):
-    @permissions(["Manage users"])
+    @auth_or_token
     def post(self, stream_id, *ignored_args):
         """
         ---
@@ -238,7 +238,7 @@ class StreamUserHandler(BaseHandler):
 
         return self.success(data={'stream_id': stream_id, 'user_id': user_id})
 
-    @permissions(["Manage users"])
+    @auth_or_token
     def delete(self, stream_id, user_id):
         """
         ---

--- a/skyportal/handlers/api/stream.py
+++ b/skyportal/handlers/api/stream.py
@@ -48,9 +48,9 @@ class StreamHandler(BaseHandler):
                   schema: Error
         """
         if stream_id is not None:
-            s = Stream.get_if_accessible_by(stream_id, self.current_user)
-            if s is None:
-                return self.error("Invalid stream ID.")
+            s = Stream.get_if_accessible_by(
+                stream_id, self.current_user, raise_if_none=True
+            )
             return self.success(data=s)
         streams = Stream.get_records_accessible_by(self.current_user)
         self.verify_and_commit()
@@ -169,7 +169,7 @@ class StreamHandler(BaseHandler):
                 schema: Success
         """
         stream = Stream.get_if_accessible_by(
-            stream_id, self.current_user, mode="delete"
+            stream_id, self.current_user, mode="delete", raise_if_none=True
         )
         DBSession().delete(stream)
         self.verify_and_commit()

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -3691,12 +3691,10 @@ def update_single_user_group(mapper, connection, target):
 def groupuser_update_access_logic(cls, user_or_token):
     aliased = sa.orm.aliased(cls)
     user_id = UserAccessControl.user_id_from_user_or_token(user_or_token)
-    return (
-        DBSession()
-        .query(cls)
-        .join(aliased, cls.group_id == aliased.group_id)
-        .filter(aliased.user_id == user_id, aliased.admin.is_(True))
-    )
+    query = DBSession().query(cls).join(aliased, cls.group_id == aliased.group_id)
+    if not user_or_token.is_system_admin:
+        query = query.filter(aliased.user_id == user_id, aliased.admin.is_(True))
+    return query
 
 
 GroupUser.update = CustomUserAccessControl(groupuser_update_access_logic)

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -278,14 +278,16 @@ def delete_group_access_logic(cls, user_or_token):
     """User can delete a group that is not the sitewide public group, is not
     a single user group, and that they are an admin member of."""
     user_id = UserAccessControl.user_id_from_user_or_token(user_or_token)
-    return (
+    query = (
         DBSession()
         .query(cls)
         .join(GroupUser)
         .filter(cls.name != cfg['misc']['public_group_name'])
         .filter(cls.single_user_group.is_(False))
-        .filter(GroupUser.user_id == user_id, GroupUser.admin.is_(True))
     )
+    if not user_or_token.is_system_admin:
+        query = query.filter(GroupUser.user_id == user_id, GroupUser.admin.is_(True))
+    return query
 
 
 class Group(Base):

--- a/skyportal/tests/api/test_groups.py
+++ b/skyportal/tests/api/test_groups.py
@@ -446,3 +446,133 @@ def test_non_group_admin_cannot_update_group_user_admin_status(
         token=manage_users_token,
     )
     assert status == 400
+
+
+def test_remove_self_from_group(public_group, view_only_token, user):
+    status, data = api(
+        "DELETE",
+        f"groups/{public_group.id}/users/{user.id}",
+        token=view_only_token,
+    )
+    assert status == 200
+
+
+def test_super_admin_remove_user_from_group(public_group, super_admin_token, user):
+    status, data = api(
+        "DELETE",
+        f"groups/{public_group.id}/users/{user.id}",
+        token=super_admin_token,
+    )
+    assert status == 200
+
+
+def test_group_admin_remove_user_from_group(public_group, group_admin_token, user):
+    status, data = api(
+        "DELETE",
+        f"groups/{public_group.id}/users/{user.id}",
+        token=group_admin_token,
+    )
+    assert status == 200
+
+
+def test_non_group_admin_cannot_remove_user_from_group(
+    public_group, view_only_token2, user
+):
+    status, data = api(
+        "DELETE",
+        f"groups/{public_group.id}/users/{user.id}",
+        token=view_only_token2,
+    )
+    assert status == 400
+
+
+def test_cannot_add_self_to_group(public_group2, view_only_token, user):
+    status, data = api(
+        "POST",
+        f"groups/{public_group2.id}/users",
+        data={"userID": user.id, "admin": False},
+        token=view_only_token,
+    )
+    assert status == 400
+    assert "Insufficient permissions" in data["message"]
+
+
+def test_super_admin_add_user_to_group(public_group2, super_admin_token, user):
+    status, data = api(
+        "POST",
+        f"groups/{public_group2.id}/users",
+        data={"userID": user.id, "admin": False},
+        token=super_admin_token,
+    )
+    assert status == 200
+
+
+def test_group_admin_add_user_to_group(public_group, group_admin_token, user_group2):
+    status, data = api(
+        "POST",
+        f"groups/{public_group.id}/users",
+        data={"userID": user_group2.id, "admin": False},
+        token=group_admin_token,
+    )
+    assert status == 200
+
+
+def test_non_group_admin_cannot_add_user_to_group(
+    public_group2, group_admin_token, user
+):
+    status, data = api(
+        "POST",
+        f"groups/{public_group2.id}/users",
+        data={"userID": user.id, "admin": False},
+        token=group_admin_token,
+    )
+    assert status == 400
+    assert "Insufficient permission" in data["message"]
+
+
+def test_cannot_add_stream_to_single_user_group(super_admin_token, user, public_stream):
+    single_user_group = user.single_user_group
+    assert single_user_group is not None
+    status, data = api(
+        "POST",
+        f"groups/{single_user_group.id}/streams",
+        data={"stream_id": public_stream.id},
+        token=super_admin_token,
+    )
+    assert status == 400
+    assert "Insufficient permissions" in data["message"]
+
+
+def test_cannot_add_another_user_to_single_user_group(user2, super_admin_token, user):
+    single_user_group = user2.single_user_group
+    assert single_user_group is not None
+    status, data = api(
+        "POST",
+        f"groups/{single_user_group.id}/users",
+        data={"userID": user.id, "admin": False},
+        token=super_admin_token,
+    )
+    assert status == 400
+    assert "Insufficient permissions" in data["message"]
+
+
+def test_cannot_remove_user_from_single_user_group(super_admin_token, user):
+    single_user_group = user.single_user_group
+    assert single_user_group is not None
+    status, data = api(
+        "DELETE",
+        f"groups/{single_user_group.id}/users/{user.id}",
+        token=super_admin_token,
+    )
+    assert status == 400
+
+
+def test_user_cannot_remove_self_from_single_user_group(view_only_token, user):
+    single_user_group = user.single_user_group
+    assert single_user_group is not None
+    status, data = api(
+        "DELETE",
+        f"groups/{single_user_group.id}/users/{user.id}",
+        token=view_only_token,
+    )
+    assert status == 400

--- a/skyportal/tests/api/test_groups.py
+++ b/skyportal/tests/api/test_groups.py
@@ -365,3 +365,62 @@ def test_obj_groups(public_source, public_group, super_admin_token):
     )
     assert status == 200
     assert data["data"][0]["id"] == public_group.id
+
+
+def test_add_user_to_group(public_group, user_group2, super_admin_token):
+    status, data = api(
+        "POST",
+        f"groups/{public_group.id}/users",
+        data={"userID": user_group2.id, "admin": False},
+        token=super_admin_token,
+    )
+    assert status == 200
+
+
+def test_cannot_add_user_to_group_wout_stream_access(
+    public_group_stream2, super_admin_token, user
+):
+    status, data = api(
+        "POST",
+        f"groups/{public_group_stream2.id}/users",
+        data={"userID": user.id, "admin": False},
+        token=super_admin_token,
+    )
+    assert status == 400
+    assert "Insufficient permissions" in data["message"]
+
+
+def test_cannot_delete_stream_actively_filtered(
+    public_group, public_stream, public_filter, super_admin_token
+):
+    status, data = api(
+        "DELETE",
+        f"groups/{public_group.id}/streams/{public_stream.id}",
+        token=super_admin_token,
+    )
+    assert status == 400
+    assert "Insufficient permissions" in data["message"]
+
+
+def test_delete_stream_not_actively_filtered(
+    public_group_two_streams,
+    public_group,
+    public_stream,
+    public_stream2,
+    public_filter,
+    super_admin_token,
+):
+    status, data = api(
+        "DELETE",
+        f"groups/{public_group.id}/streams/{public_stream.id}",
+        token=super_admin_token,
+    )
+    assert status == 400
+    assert "Insufficient permissions" in data["message"]
+
+    status, data = api(
+        "DELETE",
+        f"groups/{public_group_two_streams.id}/streams/{public_stream2.id}",
+        token=super_admin_token,
+    )
+    assert status == 200

--- a/skyportal/tests/api/test_groups.py
+++ b/skyportal/tests/api/test_groups.py
@@ -424,3 +424,25 @@ def test_delete_stream_not_actively_filtered(
         token=super_admin_token,
     )
     assert status == 200
+
+
+def test_update_group_user_admin_status(public_group, group_admin_token, user):
+    status, data = api(
+        "PATCH",
+        f"groups/{public_group.id}/users",
+        data={"userID": user.id, "admin": True},
+        token=group_admin_token,
+    )
+    assert status == 200
+
+
+def test_non_group_admin_cannot_update_group_user_admin_status(
+    public_group, manage_users_token, user
+):
+    status, data = api(
+        "PATCH",
+        f"groups/{public_group.id}/users",
+        data={"userID": user.id, "admin": True},
+        token=manage_users_token,
+    )
+    assert status == 400

--- a/skyportal/tests/api/test_groups.py
+++ b/skyportal/tests/api/test_groups.py
@@ -221,7 +221,6 @@ def test_add_stream_to_single_user_group_delete_stream(
         "POST", "user", data={"username": username}, token=super_admin_token
     )
     assert status == 200
-    new_user_id = data["data"]["id"]
 
     # get single-user group
     status, data = api(
@@ -245,37 +244,10 @@ def test_add_stream_to_single_user_group_delete_stream(
         data={"stream_id": public_stream.id},
         token=super_admin_token,
     )
-    assert status == 200
-    assert data["data"]["stream_id"] == public_stream.id
 
-    # check that stream is there
-    status, data = api(
-        "GET",
-        f"groups/{single_user_group['id']}",
-        token=super_admin_token,
-    )
-    assert data["data"]["streams"][0]["id"] == public_stream.id
-
-    # delete stream
-    status, data = api(
-        "DELETE",
-        f"streams/{public_stream.id}",
-        token=super_admin_token,
-    )
-    assert status == 200
-
-    # check it is deleted from group
-    status, data = api(
-        "GET",
-        f"groups/{single_user_group['id']}",
-        token=super_admin_token,
-    )
-    assert len(data["data"]["streams"]) == 0
-
-    # check user still exists
-    status, data = api("GET", f"user/{new_user_id}", token=super_admin_token)
-    assert status == 200
-    assert data["data"]["id"] == new_user_id
+    # check that you can't add a stream to a single user group
+    assert status == 400
+    assert data['status'] == 'error'
 
 
 def test_add_stream_to_group_delete_stream(
@@ -384,7 +356,7 @@ def test_cannot_delete_sitewide_public_group(super_admin_token):
 
     status, data = api("DELETE", f"groups/{group_id}", token=super_admin_token)
     assert data["status"] == "error"
-    assert data["message"] == "Cannot delete site-wide public group."
+    assert "Insufficient permissions" in data["message"]
 
 
 def test_obj_groups(public_source, public_group, super_admin_token):

--- a/skyportal/tests/api/test_streams.py
+++ b/skyportal/tests/api/test_streams.py
@@ -85,13 +85,11 @@ def test_group_admin_cannot_grant_delete_user_stream_access(
         token=group_admin_token,
     )
     assert status == 400
-    assert "Insufficient permissions" in data["message"]
 
     status, data = api(
         "DELETE", f"streams/{public_stream.id}/users/{user.id}", token=group_admin_token
     )
     assert status == 400
-    assert "Insufficient permissions" in data["message"]
 
 
 def test_user_cannot_grant_self_stream_access(view_only_token, user, public_stream2):

--- a/skyportal/tests/api/test_streams.py
+++ b/skyportal/tests/api/test_streams.py
@@ -52,3 +52,54 @@ def test_token_user_delete_stream(super_admin_token, public_stream):
     status, data = api("DELETE", f"streams/{stream_id}", token=super_admin_token)
     assert status == 200
     assert data["status"] == "success"
+
+
+def test_super_admin_grant_delete_user_stream_access(
+    super_admin_token, user, public_stream2
+):
+    status, data = api(
+        "POST",
+        f"streams/{public_stream2.id}/users",
+        data={"user_id": user.id},
+        token=super_admin_token,
+    )
+    assert status == 200
+    assert data["status"] == "success"
+
+    status, data = api(
+        "DELETE",
+        f"streams/{public_stream2.id}/users/{user.id}",
+        token=super_admin_token,
+    )
+    assert status == 200
+    assert data["status"] == "success"
+
+
+def test_group_admin_cannot_grant_delete_user_stream_access(
+    group_admin_token, user, public_stream, public_stream2
+):
+    status, data = api(
+        "POST",
+        f"streams/{public_stream2.id}/users",
+        data={"user_id": user.id},
+        token=group_admin_token,
+    )
+    assert status == 400
+    assert "Insufficient permissions" in data["message"]
+
+    status, data = api(
+        "DELETE", f"streams/{public_stream.id}/users/{user.id}", token=group_admin_token
+    )
+    assert status == 400
+    assert "Insufficient permissions" in data["message"]
+
+
+def test_user_cannot_grant_self_stream_access(view_only_token, user, public_stream2):
+    status, data = api(
+        "POST",
+        f"streams/{public_stream2.id}/users",
+        data={"user_id": user.id},
+        token=view_only_token,
+    )
+    assert status == 400
+    assert "Insufficient permissions" in data["message"]

--- a/skyportal/tests/conftest.py
+++ b/skyportal/tests/conftest.py
@@ -208,6 +208,22 @@ def public_group2(public_stream):
 
 
 @pytest.fixture()
+def public_group_stream2(public_stream2):
+    group = GroupFactory(streams=[public_stream2])
+    group_id = group.id
+    yield group
+    GroupFactory.teardown(group_id)
+
+
+@pytest.fixture()
+def public_group_two_streams(public_stream, public_stream2):
+    group = GroupFactory(streams=[public_stream, public_stream2])
+    group_id = group.id
+    yield group
+    GroupFactory.teardown(group_id)
+
+
+@pytest.fixture()
 def public_group_no_streams():
     group = GroupFactory()
     group_id = group.id

--- a/skyportal/tests/conftest.py
+++ b/skyportal/tests/conftest.py
@@ -852,6 +852,15 @@ def manage_groups_token(super_admin_user):
 
 
 @pytest.fixture()
+def group_admin_token(group_admin_user):
+    token_id = create_token(
+        ACLs=[], user_id=group_admin_user.id, name=str(uuid.uuid4())
+    )
+    yield token_id
+    delete_token(token_id)
+
+
+@pytest.fixture()
 def manage_users_token(super_admin_user):
     token_id = create_token(
         ACLs=["Manage users"],

--- a/skyportal/tests/conftest.py
+++ b/skyportal/tests/conftest.py
@@ -281,6 +281,19 @@ def public_streamuser(public_stream, user):
 
 
 @pytest.fixture()
+def public_streamuser_no_groups(public_stream, user_no_groups):
+    return (
+        DBSession()
+        .query(StreamUser)
+        .filter(
+            StreamUser.user_id == user_no_groups.id,
+            StreamUser.stream_id == public_stream.id,
+        )
+        .first()
+    )
+
+
+@pytest.fixture()
 def public_filter(public_group, public_stream):
     filter_ = FilterFactory(group=public_group, stream=public_stream)
     filter_id = filter_.id

--- a/skyportal/tests/frontend/test_groups.py
+++ b/skyportal/tests/frontend/test_groups.py
@@ -1,6 +1,7 @@
 import uuid
 import pytest
 from baselayer.app.env import load_env
+from skyportal.tests import api
 
 
 _, cfg = load_env()
@@ -150,10 +151,19 @@ def test_delete_group(driver, super_admin_user, user, public_group):
 
 
 @pytest.mark.flaky(reruns=2)
-# @pytest.mark.xfail(strict=False)
 def test_add_stream_add_delete_filter_group(
-    driver, super_admin_user, user, public_group, public_stream2
+    driver, super_admin_user, super_admin_token, public_group, public_stream2
 ):
+    status, data = api(
+        'POST',
+        f'streams/{public_stream2.id}/users',
+        data={
+            'user_id': super_admin_user.id,
+        },
+        token=super_admin_token,
+    )
+    assert status == 200
+
     driver.get(f'/become_user/{super_admin_user.id}')
     driver.get('/groups')
     driver.click_xpath('//h6[text()="All Groups"]', scroll_parent=True)
@@ -161,12 +171,11 @@ def test_add_stream_add_delete_filter_group(
         f'//div[@data-testid="All Groups-{public_group.name}"]', scroll_parent=True
     )
 
-    # add stream
+    # Add stream
     driver.click_xpath('//button[contains(.,"Add stream")]')
     driver.click_xpath('//input[@name="stream_id"]/..')
 
     driver.click_xpath(f'//li[contains(.,"{public_stream2.name}")]', scroll_parent=True)
-
     driver.click_xpath('//button[@data-testid="add-stream-dialog-submit"]')
 
     # add filter
@@ -188,3 +197,22 @@ def test_add_stream_add_delete_filter_group(
     # delete filter
     driver.click_xpath(f'//a[contains(.,"{filter_name}")]')
     driver.wait_for_xpath_to_disappear(f'//a[contains(.,"{filter_name}")]')
+
+
+def test_cannot_add_stream_group_users_cant_access(
+    driver, super_admin_user, user, public_group, public_stream2
+):
+    driver.get(f'/become_user/{super_admin_user.id}')
+    driver.get('/groups')
+    driver.click_xpath('//h6[text()="All Groups"]', scroll_parent=True)
+    driver.click_xpath(
+        f'//div[@data-testid="All Groups-{public_group.name}"]', scroll_parent=True
+    )
+
+    # Cannot add stream that group members don't have access to
+    driver.click_xpath('//button[contains(.,"Add stream")]')
+    driver.click_xpath('//input[@name="stream_id"]/..')
+
+    driver.click_xpath(f'//li[contains(.,"{public_stream2.name}")]', scroll_parent=True)
+    driver.click_xpath('//button[@data-testid="add-stream-dialog-submit"]')
+    driver.wait_for_xpath('//*[contains(.,"Insufficient permissions")]')

--- a/skyportal/tests/models/test_permissions.py
+++ b/skyportal/tests/models/test_permissions.py
@@ -1299,7 +1299,7 @@ def test_group_admin_user_update_public_groupstream(
     public_groupstream,
 ):
     accessible = public_groupstream.is_accessible_by(group_admin_user, mode="update")
-    assert accessible
+    assert not accessible  # needs system admin
 
 
 def test_group_admin_user_update_public_streamuser(

--- a/skyportal/tests/models/test_permissions.py
+++ b/skyportal/tests/models/test_permissions.py
@@ -1370,6 +1370,14 @@ def test_group_admin_user_delete_public_group(
     assert accessible
 
 
+def test_group_member_user_cannot_delete_group(
+    user,
+    public_group,
+):
+    accessible = public_group.is_accessible_by(user, mode="delete")
+    assert not accessible
+
+
 def test_group_admin_user_delete_public_groupuser(
     group_admin_user,
     public_groupuser,

--- a/skyportal/tests/models/test_permissions.py
+++ b/skyportal/tests/models/test_permissions.py
@@ -1024,11 +1024,21 @@ def test_super_admin_user_delete_public_groupstream(
     assert accessible
 
 
-def test_super_admin_user_delete_public_streamuser(
+def test_super_admin_user_delete_public_streamuser_no_access(
     super_admin_user,
     public_streamuser,
 ):
     accessible = public_streamuser.is_accessible_by(super_admin_user, mode="delete")
+    assert not accessible  # User belongs to groups that filter on stream
+
+
+def test_super_admin_user_delete_public_streamuser(
+    super_admin_user,
+    public_streamuser_no_groups,
+):
+    accessible = public_streamuser_no_groups.is_accessible_by(
+        super_admin_user, mode="delete"
+    )
     assert accessible
 
 

--- a/skyportal/tests/models/test_permissions.py
+++ b/skyportal/tests/models/test_permissions.py
@@ -279,7 +279,7 @@ def test_user_delete_public_groupuser(
     public_groupuser,
 ):
     accessible = public_groupuser.is_accessible_by(user, mode="delete")
-    assert not accessible  # needs group admin
+    assert accessible  # Any user can remove themself from group
 
 
 def test_user_delete_public_stream(


### PR DESCRIPTION
This PR makes use of the framework developed in https://github.com/cesium-ml/baselayer/pull/207/ to enforce the following rules for Group / User / Stream membership:

1. A user can only join a group if they have access to all of the group's streams. 
2. A stream can only be removed from a group if none of the Group's filters currently filter the stream.
3. A stream can only be added to a group if all of the group's members have access to the stream.
4. A group user's admin status can only be modified by group admins.
5. Only a group admin or the target user can remove a user from a group.
6. Only system admins can grant and revoke stream access to users. 
7. Only a group admin can add a user to a group.
8. Users cannot add streams to single user groups.
9. No one can remove a user from their single user group (this can only be done by an event listener).
10. No one can add a user to a single user group through the groups api. 

These rules are enforced within the context of the new permissions framework that is currently being refactored throughout the codebase. The relevant conditions above are automatically checked at the end of the transaction in which  the corresponding CRUD op is performed via the ORM.

The Stream and Group handlers are refactored using these new rules. 

This PR also fixes a bug in the demo data where users without stream=2 access were being succcessfully added to a group that required it. 

Closes https://github.com/skyportal/skyportal/issues/1368
