### PR TITLE
Add padding for non-period photometry plots

### DIFF
--- a/skyportal/plot.py
+++ b/skyportal/plot.py
@@ -1142,7 +1142,7 @@ def photometry_plot(obj_id, user, width=600, device="browser"):
         tabs = Tabs(tabs=[p2, p1, p3], width=width, height=height, sizing_mode='fixed')
     else:
         # tabs for mag, flux
-        tabs = Tabs(tabs=[p2, p1], width=width, height=height, sizing_mode='fixed')
+        tabs = Tabs(tabs=[p2, p1], width=width, height=height + 90, sizing_mode='fixed')
     return bokeh_embed.json_item(tabs)
 
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/17696889/111710986-2f12ed80-8821-11eb-8e6f-f6f1ac9a8e04.png)

Unfortunately, the Bokeh plot is plotted with some `position: absolute` styling, so it wasn't straightforward to just get the div with the buttons to get pushed down reactively. 

The overlapping button issue is only with photometry plots without the period tab. I'm not sure exactly which plot widgets the extra needed height is coming from but adding some extra height to the plot layout appears to fix the issue. I was adding similar padding for the plots with periods but my reasoning for those were the extra text fields in the period tab so not exactly sure why the similar padding is needed here but I'll investigate that more later.