### PR TITLE
Patch security vulnerabilities and data model violations revealed by test suite after enabling UACL

### DIFF
--- a/doc/permissions.md
+++ b/doc/permissions.md
@@ -56,6 +56,10 @@ class UserAccessControl:
 
 To construct a new policy, subclass `UserAccessControl` and override `query_accessible_rows`.
 
+#### Restricted
+
+Baselayer provides a [restricted](https://github.com/cesium-ml/baselayer/blob/master/app/models.py#L579) policy that grants record access only to users or tokens that have the `System admin` ACL. **Restricted records are not restricted to all users.**
+
 ### Examples
 
 The following `public` policy will grant record access to any user:

--- a/skyportal/app_server.py
+++ b/skyportal/app_server.py
@@ -2,7 +2,6 @@ import tornado.web
 
 from baselayer.app.app_server import MainPageHandler
 from baselayer.app import model_util as baselayer_model_util
-from baselayer.app.models import DBSession
 from baselayer.log import make_log
 
 from skyportal.handlers import BecomeUserHandler, LogoutHandler
@@ -271,8 +270,5 @@ def make_app(cfg, baselayer_handlers, baselayer_settings, process=None, env=None
 
     model_util.provision_public_group()
     app.openapi_spec = openapi.spec_from_handlers(handlers)
-
-    # clear any objects that remain in the session
-    DBSession.remove()
 
     return app

--- a/skyportal/app_server.py
+++ b/skyportal/app_server.py
@@ -2,6 +2,7 @@ import tornado.web
 
 from baselayer.app.app_server import MainPageHandler
 from baselayer.app import model_util as baselayer_model_util
+from baselayer.app.models import DBSession
 from baselayer.log import make_log
 
 from skyportal.handlers import BecomeUserHandler, LogoutHandler
@@ -269,7 +270,9 @@ def make_app(cfg, baselayer_handlers, baselayer_settings, process=None, env=None
         print('-' * 78)
 
     model_util.provision_public_group()
-
     app.openapi_spec = openapi.spec_from_handlers(handlers)
+
+    # clear any objects that remain in the session
+    DBSession.remove()
 
     return app

--- a/skyportal/handlers/api/candidate.py
+++ b/skyportal/handlers/api/candidate.py
@@ -302,6 +302,7 @@ class CandidateHandler(BaseHandler):
                 application/json:
                   schema: Error
         """
+
         user_accessible_group_ids = [g.id for g in self.current_user.accessible_groups]
         include_photometry = self.get_query_argument("includePhotometry", False)
         include_spectra = self.get_query_argument("includeSpectra", False)
@@ -580,6 +581,8 @@ class CandidateHandler(BaseHandler):
                     .subquery()
                 )
             else:
+                # import pdb
+                # pdb.set_trace()
                 expire_date = arrow.get(annotation_exclude_date).datetime
                 right = (
                     DBSession()

--- a/skyportal/handlers/api/candidate.py
+++ b/skyportal/handlers/api/candidate.py
@@ -309,18 +309,6 @@ class CandidateHandler(BaseHandler):
 
         if obj_id is not None:
             query_options = [joinedload(Candidate.obj).joinedload(Obj.thumbnails)]
-            if include_photometry:
-                query_options.append(
-                    joinedload(Candidate.obj)
-                    .joinedload(Obj.photometry)
-                    .joinedload(Photometry.instrument)
-                )
-            if include_spectra:
-                query_options.append(
-                    joinedload(Candidate.obj)
-                    .joinedload(Obj.spectra)
-                    .joinedload(Spectrum.instrument)
-                )
             c = Candidate.get_obj_if_readable_by(
                 obj_id,
                 self.current_user,
@@ -362,6 +350,21 @@ class CandidateHandler(BaseHandler):
                 key=lambda x: x["created_at"],
                 reverse=True,
             )
+
+            if include_photometry:
+                candidate_info['photometry'] = Photometry.get_records_accessible_by(
+                    self.current_user,
+                    mode='read',
+                    options=[joinedload(Photometry.instrument)],
+                )
+
+            if include_spectra:
+                candidate_info['spectra'] = Spectrum.get_records_accessible_by(
+                    self.current_user,
+                    mode='read',
+                    options=[joinedload(Spectrum.instrument)],
+                )
+
             candidate_info["annotations"] = sorted(
                 c.get_annotations_readable_by(self.current_user),
                 key=lambda x: x.origin,
@@ -696,8 +699,6 @@ class CandidateHandler(BaseHandler):
                 n_per_page,
                 "candidates",
                 order_by=order_by,
-                include_photometry=include_photometry,
-                include_spectra=include_spectra,
             )
         except ValueError as e:
             if "Page number out of range" in str(e):
@@ -744,6 +745,23 @@ class CandidateHandler(BaseHandler):
                     )
                 ]
                 candidate_list.append(obj.to_dict())
+
+                if include_photometry:
+                    candidate_list[-1][
+                        "photometry"
+                    ] = Photometry.get_records_accessible_by(
+                        self.current_user,
+                        mode='read',
+                        options=[joinedload(Photometry.instrument)],
+                    )
+
+                if include_spectra:
+                    candidate_list[-1]["spectra"] = Spectrum.get_records_accessible_by(
+                        self.current_user,
+                        mode='read',
+                        options=[joinedload(Spectrum.instrument)],
+                    )
+
                 candidate_list[-1]["comments"] = sorted(
                     [
                         cmt.to_dict()
@@ -940,8 +958,6 @@ def grab_query_results(
     n_items_per_page,
     items_name,
     order_by=None,
-    include_photometry=False,
-    include_spectra=False,
 ):
     # The query will return multiple rows per candidate object if it has multiple
     # annotations associated with it, with rows appearing at the end of the query
@@ -1022,12 +1038,6 @@ def grab_query_results(
 
     items = []
     query_options = [joinedload(Obj.thumbnails)]
-    if include_photometry:
-        query_options.append(
-            joinedload(Obj.photometry).joinedload(Photometry.instrument)
-        )
-    if include_spectra:
-        query_options.append(joinedload(Obj.spectra).joinedload(Spectrum.instrument))
     for item_id in page_ids:
         items.append(Obj.query.options(query_options).get(item_id))
     info[items_name] = items

--- a/skyportal/handlers/api/candidate.py
+++ b/skyportal/handlers/api/candidate.py
@@ -352,17 +352,25 @@ class CandidateHandler(BaseHandler):
             )
 
             if include_photometry:
-                candidate_info['photometry'] = Photometry.get_records_accessible_by(
-                    self.current_user,
-                    mode='read',
-                    options=[joinedload(Photometry.instrument)],
+                candidate_info['photometry'] = (
+                    Photometry.query_records_accessible_by(
+                        self.current_user,
+                        mode='read',
+                        options=[joinedload(Photometry.instrument)],
+                    )
+                    .filter(Photometry.obj_id == obj_id)
+                    .all()
                 )
 
             if include_spectra:
-                candidate_info['spectra'] = Spectrum.get_records_accessible_by(
-                    self.current_user,
-                    mode='read',
-                    options=[joinedload(Spectrum.instrument)],
+                candidate_info['spectra'] = (
+                    Spectrum.query_records_accessible_by(
+                        self.current_user,
+                        mode='read',
+                        options=[joinedload(Spectrum.instrument)],
+                    )
+                    .filter(Spectrum.obj_id == obj_id)
+                    .all()
                 )
 
             candidate_info["annotations"] = sorted(
@@ -745,19 +753,25 @@ class CandidateHandler(BaseHandler):
                 candidate_list.append(obj.to_dict())
 
                 if include_photometry:
-                    candidate_list[-1][
-                        "photometry"
-                    ] = Photometry.get_records_accessible_by(
-                        self.current_user,
-                        mode='read',
-                        options=[joinedload(Photometry.instrument)],
+                    candidate_list[-1]["photometry"] = (
+                        Photometry.query_records_accessible_by(
+                            self.current_user,
+                            mode='read',
+                            options=[joinedload(Photometry.instrument)],
+                        )
+                        .filter(Photometry.obj_id == obj.id)
+                        .all()
                     )
 
                 if include_spectra:
-                    candidate_list[-1]["spectra"] = Spectrum.get_records_accessible_by(
-                        self.current_user,
-                        mode='read',
-                        options=[joinedload(Spectrum.instrument)],
+                    candidate_list[-1]["spectra"] = (
+                        Spectrum.query_records_accessible_by(
+                            self.current_user,
+                            mode='read',
+                            options=[joinedload(Spectrum.instrument)],
+                        )
+                        .filter(Spectrum.obj_id == obj.id)
+                        .all()
                     )
 
                 candidate_list[-1]["comments"] = sorted(

--- a/skyportal/handlers/api/candidate.py
+++ b/skyportal/handlers/api/candidate.py
@@ -584,8 +584,6 @@ class CandidateHandler(BaseHandler):
                     .subquery()
                 )
             else:
-                # import pdb
-                # pdb.set_trace()
                 expire_date = arrow.get(annotation_exclude_date).datetime
                 right = (
                     DBSession()

--- a/skyportal/handlers/api/photometry.py
+++ b/skyportal/handlers/api/photometry.py
@@ -963,8 +963,8 @@ class BulkDeletePhotometryHandler(BaseHandler):
         for phot in photometry_to_delete:
             DBSession().delete(phot)
 
-        # this will raise if the user does not have access to delete any of
-        # the photometry points
+        # this will return self.error if the user does not have access
+        # to delete any of the photometry points
         self.finalize_transaction()
         return self.success(f"Deleted {n} photometry points.")
 

--- a/skyportal/handlers/api/photometry.py
+++ b/skyportal/handlers/api/photometry.py
@@ -660,7 +660,8 @@ class PhotometryHandler(BaseHandler):
         except ValidationError as e:
             return self.error(e.args[0])
 
-        self.finalize_transaction()
+        # self.finalize_transaction()
+        DBSession().commit()
         return self.success(data={'ids': ids, 'upload_id': upload_id})
 
     @permissions(['Upload data'])
@@ -774,7 +775,8 @@ class PhotometryHandler(BaseHandler):
                 id_map[df_index] = id
 
         # release the lock
-        self.finalize_transaction()
+        # self.finalize_transaction()
+        DBSession().commit()
 
         # get ids in the correct order
         ids = [id_map[pdidx] for pdidx, _ in df.iterrows()]
@@ -868,7 +870,8 @@ class PhotometryHandler(BaseHandler):
                 )
             photometry.groups = groups
 
-        self.finalize_transaction()
+        # self.finalize_transaction()
+        DBSession().commit()
         return self.success()
 
     @permissions(['Upload data'])

--- a/skyportal/handlers/api/photometry.py
+++ b/skyportal/handlers/api/photometry.py
@@ -660,7 +660,8 @@ class PhotometryHandler(BaseHandler):
         except ValidationError as e:
             return self.error(e.args[0])
 
-        DBSession().commit()
+        # DBSession().commit()
+        self.finalize_transaction()
         return self.success(data={'ids': ids, 'upload_id': upload_id})
 
     @permissions(['Upload data'])
@@ -774,7 +775,7 @@ class PhotometryHandler(BaseHandler):
                 id_map[df_index] = id
 
         # release the lock
-        DBSession().commit()
+        self.finalize_transaction()
 
         # get ids in the correct order
         ids = [id_map[pdidx] for pdidx, _ in df.iterrows()]

--- a/skyportal/handlers/api/photometry.py
+++ b/skyportal/handlers/api/photometry.py
@@ -660,7 +660,6 @@ class PhotometryHandler(BaseHandler):
         except ValidationError as e:
             return self.error(e.args[0])
 
-        # DBSession().commit()
         self.finalize_transaction()
         return self.success(data={'ids': ids, 'upload_id': upload_id})
 

--- a/skyportal/handlers/api/photometry.py
+++ b/skyportal/handlers/api/photometry.py
@@ -660,7 +660,6 @@ class PhotometryHandler(BaseHandler):
         except ValidationError as e:
             return self.error(e.args[0])
 
-        # self.finalize_transaction()
         DBSession().commit()
         return self.success(data={'ids': ids, 'upload_id': upload_id})
 
@@ -775,7 +774,6 @@ class PhotometryHandler(BaseHandler):
                 id_map[df_index] = id
 
         # release the lock
-        # self.finalize_transaction()
         DBSession().commit()
 
         # get ids in the correct order
@@ -870,8 +868,7 @@ class PhotometryHandler(BaseHandler):
                 )
             photometry.groups = groups
 
-        # self.finalize_transaction()
-        DBSession().commit()
+        self.finalize_transaction()
         return self.success()
 
     @permissions(['Upload data'])

--- a/skyportal/handlers/api/photometry.py
+++ b/skyportal/handlers/api/photometry.py
@@ -947,19 +947,26 @@ class BulkDeletePhotometryHandler(BaseHandler):
               application/json:
                 schema: Error
         """
-        # Permissions check:
-        phot_id = Photometry.query.filter(Photometry.upload_id == upload_id).first().id
-        _ = Photometry.get_if_readable_by(phot_id, self.current_user)
 
-        n_deleted = (
-            DBSession()
-            .query(Photometry)
-            .filter(Photometry.upload_id == upload_id)
-            .delete()
-        )
+        # dont check permissions here -- pull all the photometry associated with
+        # the upload, not necessarily just the photometry that is accessible
+        # to the user. if any of the photometry fails to be deleted, send back
+        # 400
+        photometry_to_delete = Photometry.query.filter(
+            Photometry.upload_id == upload_id
+        ).all()
+
+        n = len(photometry_to_delete)
+        if n == 0:
+            return self.error('Invalid bulk upload id.')
+
+        for phot in photometry_to_delete:
+            DBSession().delete(phot)
+
+        # this will raise if the user does not have access to delete any of
+        # the photometry points
         self.finalize_transaction()
-
-        return self.success(f"Deleted {n_deleted} photometry points.")
+        return self.success(f"Deleted {n} photometry points.")
 
 
 class PhotometryRangeHandler(BaseHandler):

--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -957,7 +957,7 @@ class SourceHandler(BaseHandler):
                 if include_photometry:
                     photometry = Photometry.query_records_accessible_by(
                         self.current_user
-                    ).filter(Photometry.obj_id == source.obj_id)
+                    ).filter(Photometry.obj_id == source.id)
                     source_list[-1]["photometry"] = [
                         serialize(phot, 'ab', 'flux') for phot in photometry
                     ]
@@ -965,7 +965,7 @@ class SourceHandler(BaseHandler):
                     source_list[-1]["photometry_exists"] = (
                         len(
                             Photometry.query_records_accessible_by(self.current_user)
-                            .filter(Photometry.obj_id == source.obj_id)
+                            .filter(Photometry.obj_id == source.id)
                             .all()
                         )
                         > 0
@@ -974,7 +974,7 @@ class SourceHandler(BaseHandler):
                     source_list[-1]["spectrum_exists"] = (
                         len(
                             Spectrum.query_records_accessible_by(self.current_user)
-                            .filter(Spectrum.obj_id == source.obj_id)
+                            .filter(Spectrum.obj_id == source.id)
                             .all()
                         )
                         > 0
@@ -1370,7 +1370,7 @@ class SourceOffsetsHandler(BaseHandler):
         try:
             best_ra, best_dec = _calculate_best_position_for_offset_stars(
                 Photometry.query_records_accessible_by(self.current_user)
-                .filter(Photometry.obj_id == source.obj_id)
+                .filter(Photometry.obj_id == source.id)
                 .all(),
                 fallback=(initial_pos[0], initial_pos[1]),
                 how="snr2",
@@ -1560,7 +1560,7 @@ class SourceFinderHandler(BaseHandler):
         try:
             best_ra, best_dec = _calculate_best_position_for_offset_stars(
                 Photometry.query_records_accessible_by(self.current_user)
-                .filter(Photometry.obj_id == source.obj_id)
+                .filter(Photometry.obj_id == source.id)
                 .all(),
                 fallback=(initial_pos[0], initial_pos[1]),
                 how="snr2",

--- a/skyportal/handlers/api/taxonomy.py
+++ b/skyportal/handlers/api/taxonomy.py
@@ -200,7 +200,7 @@ class TaxonomyHandler(BaseHandler):
 
         return self.success(data={'taxonomy_id': taxonomy.id})
 
-    @permissions(['Delete taxonomy'])
+    @auth_or_token
     def delete(self, taxonomy_id):
         """
         ---
@@ -219,11 +219,12 @@ class TaxonomyHandler(BaseHandler):
               application/json:
                 schema: Success
         """
-        c = Taxonomy.query.get(taxonomy_id)
-        if c is None:
-            return self.error("Invalid taxonomy ID")
 
-        Taxonomy.query.filter_by(id=taxonomy_id).delete()
+        taxonomy = Taxonomy.get_if_accessible_by(
+            taxonomy_id, self.current_user, mode='delete', raise_if_none=True
+        )
+
+        DBSession().delete(taxonomy)
         self.finalize_transaction()
 
         return self.success()

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -1957,6 +1957,13 @@ class Taxonomy(Base):
 
 
 def taxonomy_update_delete_logic(cls, user_or_token):
+    """This function generates the query for taxonomies that the current user
+    can update or delete. If the querying user doesn't have System admin or
+    Delete taxonomy acl, then no taxonomies are accessible to that user under
+    this policy . Otherwise, the only taxonomies that the user can delete are
+    those that have no associated classifications, preventing classifications
+    from getting deleted in a cascade when their parent taxonomy is deleted.
+    """
 
     if len({'Delete taxonomy', 'System admin'} & set(user_or_token.permissions)) == 0:
         # nothing accessible

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -2831,7 +2831,7 @@ GroupSpectrum.update = GroupSpectrum.delete = (
 #        return '/' + file_uri.lstrip('./')
 
 
-def updatable_from_token_with_listener_acl(cls, user_or_token):
+def updatable_by_token_with_listener_acl(cls, user_or_token):
     if user_or_token.is_admin:
         return public.query_accessible_rows(cls, user_or_token)
 
@@ -2873,7 +2873,7 @@ class FollowupRequest(Base):
             | AccessibleIfUserMatches('requester')
         )
         & read
-    ) | CustomUserAccessControl(updatable_from_token_with_listener_acl)
+    ) | CustomUserAccessControl(updatable_by_token_with_listener_acl)
 
     requester_id = sa.Column(
         sa.ForeignKey('users.id', ondelete='SET NULL'),

--- a/skyportal/plot.py
+++ b/skyportal/plot.py
@@ -1241,8 +1241,14 @@ def spectroscopy_plot(obj_id, user, spec_id=None, width=600, device="browser"):
         else "box_zoom,wheel_zoom,pan,reset"
     )
     plot_width = None if device == "browser" else width
+    if device == "mobile_portrait":
+        aspect_ratio = 1
+    elif device == "tablet_portrait":
+        aspect_ratio = 1.5
+    else:
+        aspect_ratio = 1.8
     plot = figure(
-        aspect_ratio=2.0 if device == "mobile_landscape" else 1.5,
+        aspect_ratio=aspect_ratio,
         sizing_mode='scale_both',
         width=plot_width,
         y_range=(ymin, ymax),
@@ -1253,13 +1259,19 @@ def spectroscopy_plot(obj_id, user, spec_id=None, width=600, device="browser"):
     )
     plot.add_tools(hover)
     model_dict = {}
+    legend_items = []
     for i, (key, df) in enumerate(split):
+        renderers = []
+        s = Spectrum.query.get(key)
+        label = f'{s.instrument.name} ({s.observed_at.date().strftime("%m/%d/%y")})'
         model_dict['s' + str(i)] = plot.step(
             x='wavelength',
             y='flux',
             color=color_map[key],
             source=ColumnDataSource(df),
         )
+        renderers.append(model_dict['s' + str(i)])
+        legend_items.append(LegendItem(label=label, renderers=renderers))
         model_dict['l' + str(i)] = plot.line(
             x='wavelength',
             y='flux',
@@ -1280,30 +1292,12 @@ def spectroscopy_plot(obj_id, user, spec_id=None, width=600, device="browser"):
     # TODO how to choose a good default?
     plot.y_range = Range1d(0, 1.03 * data.flux.max())
 
-    spec_labels = []
-    for k, _ in split:
-        s = Spectrum.query.get(k)
-        label = f'{s.instrument.name} ({s.observed_at.date().strftime("%m/%d/%y")})'
-        spec_labels.append(label)
+    legend_loc = "below" if "mobile" in device or "tablet" in device else "right"
+    legend_orientation = (
+        "vertical" if device in ["browser", "mobile_portrait"] else "horizontal"
+    )
 
-    toggle = CheckboxWithLegendGroup(
-        labels=spec_labels,
-        active=list(range(len(spectra))),
-        colors=[color_map[k] for k, df in split],
-        width=width // 5,
-        inline=True if "tablet" in device else False,
-    )
-    toggle.js_on_click(
-        CustomJS(
-            args={'toggle': toggle, **model_dict},
-            code="""
-          for (let i = 0; i < toggle.labels.length; i++) {
-              eval("s" + i).visible = (toggle.active.includes(i))
-              eval("l" + i).visible = (toggle.active.includes(i))
-          }
-    """,
-        ),
-    )
+    add_plot_legend(plot, legend_items, width, legend_orientation, legend_loc)
 
     slider_width = width if "mobile" in device else int(width / 2)
     z_title = Div(text="Redshift (<i>z</i>): ")
@@ -1461,12 +1455,7 @@ def spectroscopy_plot(obj_id, user, spec_id=None, width=600, device="browser"):
         z_textinput.js_on_change('value', callback)
         v_exp_textinput.js_on_change('value', callback)
 
-    row1 = (
-        column(plot, toggle)
-        if "mobile" in device or "tablet" in device
-        else row(plot, toggle)
-    )
     row2 = row(elements_groups)
     row3 = column(z, v_exp) if "mobile" in device else row(z, v_exp)
-    layout = column(row1, row2, row3, sizing_mode='scale_height', width=width)
+    layout = column(plot, row2, row3, sizing_mode='scale_height', width=width)
     return bokeh_embed.json_item(layout)

--- a/skyportal/tests/api/test_candidates.py
+++ b/skyportal/tests/api/test_candidates.py
@@ -1337,8 +1337,8 @@ def test_correct_spectra_and_photometry_returned_by_candidate(
 
     phot_ids_db = sorted([p.id for p in public_candidate.photometry])
     phot_ids_api = sorted([p['id'] for p in data['data']['photometry']])
-    assert all([id1 == id2 for id1, id2 in zip(phot_ids_db, phot_ids_api)])
+    assert phot_ids_db == phot_ids_api
 
     spec_ids_db = sorted([p.id for p in public_candidate.spectra])
     spec_ids_api = sorted([p['id'] for p in data['data']['spectra']])
-    assert all([id1 == id2 for id1, id2 in zip(spec_ids_db, spec_ids_api)])
+    assert spec_ids_db == spec_ids_api

--- a/skyportal/tests/api/test_candidates.py
+++ b/skyportal/tests/api/test_candidates.py
@@ -1319,7 +1319,7 @@ def test_candidate_list_not_saved_to_all_selected_groups(
 
 def test_correct_spectra_and_photometry_returned_by_candidate(
     public_candidate,
-    public_candidate2,  # just to add additional photometry to the DB that the API handler shouldn't return
+    public_candidate2,  # adds phot and spec that should not be returned
     view_only_token_two_groups,
 ):
 

--- a/skyportal/tests/api/test_candidates.py
+++ b/skyportal/tests/api/test_candidates.py
@@ -1315,3 +1315,30 @@ def test_candidate_list_not_saved_to_all_selected_groups(
         )
         == 0
     )
+
+
+def test_correct_spectra_and_photometry_returned_by_candidate(
+    public_candidate,
+    public_candidate2,  # just to add additional photometry to the DB that the API handler shouldn't return
+    view_only_token_two_groups,
+):
+
+    status, data = api(
+        'GET',
+        f"candidates/{public_candidate.id}?includePhotometry=t&includeSpectra=t",
+        token=view_only_token_two_groups,
+    )
+
+    assert status == 200
+    assert data['status'] == 'success'
+
+    assert len(public_candidate.photometry) == len(data['data']['photometry'])
+    assert len(public_candidate.spectra) == len(data['data']['spectra'])
+
+    phot_ids_db = sorted([p.id for p in public_candidate.photometry])
+    phot_ids_api = sorted([p['id'] for p in data['data']['photometry']])
+    assert all([id1 == id2 for id1, id2 in zip(phot_ids_db, phot_ids_api)])
+
+    spec_ids_db = sorted([p.id for p in public_candidate.spectra])
+    spec_ids_api = sorted([p['id'] for p in data['data']['spectra']])
+    assert all([id1 == id2 for id1, id2 in zip(spec_ids_db, spec_ids_api)])

--- a/skyportal/tests/api/test_sharing.py
+++ b/skyportal/tests/api/test_sharing.py
@@ -127,69 +127,6 @@ def test_sharing_photometry_with_foreign_group(
     assert data["data"]["obj_id"] == public_source.id
 
 
-def test_sharing_photometry_shares_source(
-    upload_data_token,
-    public_source,
-    public_group,
-    public_group2,
-    view_only_token_group2,
-    ztf_camera,
-):
-
-    status, data = api(
-        "GET", f"sources/{public_source.id}", token=view_only_token_group2
-    )
-    # `view_only_token only` belongs to `public_group`, but not `public_group2`
-    # so the photometry is invisible to it
-    assert status == 400
-    assert data["status"] == "error"
-    assert 'permissions' in data['message'].lower()
-
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 58000.0,
-            "instrument_id": ztf_camera.id,
-            "flux": 12.24,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-
-    photometry_id = data["data"]["ids"][0]
-    status, data = api(
-        "GET", f"photometry/{photometry_id}?format=flux", token=upload_data_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
-
-    status, data = api(
-        "POST",
-        "sharing",
-        data={"photometryIDs": [photometry_id], "groupIDs": [public_group2.id]},
-        token=upload_data_token,
-    )
-
-    assert status == 200
-    assert data['status'] == 'success'
-
-    status, data = api(
-        "GET", f"sources/{public_source.id}", token=view_only_token_group2
-    )
-    # `view_only_token only` belongs to `public_group`, but not `public_group2`
-    # so the photometry is invisible to it
-    assert status == 200
-    assert data["status"] == "success"
-
-
 def test_sharing_spectroscopy_does_not_share_source(
     upload_data_token,
     public_source,

--- a/skyportal/tests/api/test_taxonomy.py
+++ b/skyportal/tests/api/test_taxonomy.py
@@ -5,7 +5,7 @@ from skyportal.tests import api
 from tdtax import taxonomy, __version__
 
 
-def test_add_retrieve_delete_taxonomy(taxonomy_token, public_group):
+def test_add_retrieve_delete_taxonomy(taxonomy_token, public_group, super_admin_token):
     name = str(uuid.uuid4())
     status, data = api(
         'POST',

--- a/skyportal/tests/api/test_taxonomy.py
+++ b/skyportal/tests/api/test_taxonomy.py
@@ -5,7 +5,7 @@ from skyportal.tests import api
 from tdtax import taxonomy, __version__
 
 
-def test_add_retrieve_delete_taxonomy(taxonomy_token, public_group, super_admin_token):
+def test_add_retrieve_delete_taxonomy(taxonomy_token, public_group):
     name = str(uuid.uuid4())
     status, data = api(
         'POST',

--- a/skyportal/tests/api/test_telescope.py
+++ b/skyportal/tests/api/test_telescope.py
@@ -3,7 +3,7 @@ import uuid
 from skyportal.tests import api
 
 
-def test_token_user_post_get_telescope(upload_data_token):
+def test_token_user_post_get_telescope(super_admin_token):
     name = str(uuid.uuid4())
     post_data = {
         'name': name,
@@ -16,19 +16,19 @@ def test_token_user_post_get_telescope(upload_data_token):
         'robotic': True,
     }
 
-    status, data = api('POST', 'telescope', data=post_data, token=upload_data_token)
+    status, data = api('POST', 'telescope', data=post_data, token=super_admin_token)
     assert status == 200
     assert data['status'] == 'success'
 
     telescope_id = data['data']['id']
-    status, data = api('GET', f'telescope/{telescope_id}', token=upload_data_token)
+    status, data = api('GET', f'telescope/{telescope_id}', token=super_admin_token)
     assert status == 200
     assert data['status'] == 'success'
     for key in post_data:
         assert data['data'][key] == post_data[key]
 
 
-def test_fetch_telescope_by_name(upload_data_token):
+def test_fetch_telescope_by_name(super_admin_token):
     name = str(uuid.uuid4())
     post_data = {
         'name': name,
@@ -40,11 +40,11 @@ def test_fetch_telescope_by_name(upload_data_token):
         'skycam_link': 'http://www.lulin.ncu.edu.tw/wea/cur_sky.jpg',
     }
 
-    status, data = api('POST', 'telescope', data=post_data, token=upload_data_token)
+    status, data = api('POST', 'telescope', data=post_data, token=super_admin_token)
     assert status == 200
     assert data['status'] == 'success'
 
-    status, data = api('GET', f'telescope?name={name}', token=upload_data_token)
+    status, data = api('GET', f'telescope?name={name}', token=super_admin_token)
     assert status == 200
     assert data['status'] == 'success'
     assert len(data['data']) == 1
@@ -52,7 +52,7 @@ def test_fetch_telescope_by_name(upload_data_token):
         assert data['data'][0][key] == post_data[key]
 
 
-def test_token_user_update_telescope(upload_data_token, manage_sources_token):
+def test_token_user_update_telescope(super_admin_token):
     name = str(uuid.uuid4())
     status, data = api(
         'POST',
@@ -66,13 +66,13 @@ def test_token_user_update_telescope(upload_data_token, manage_sources_token):
             'diameter': 10.0,
             'robotic': True,
         },
-        token=upload_data_token,
+        token=super_admin_token,
     )
     assert status == 200
     assert data['status'] == 'success'
 
     telescope_id = data['data']['id']
-    status, data = api('GET', f'telescope/{telescope_id}', token=upload_data_token)
+    status, data = api('GET', f'telescope/{telescope_id}', token=super_admin_token)
     assert status == 200
     assert data['status'] == 'success'
     assert data['data']['diameter'] == 10.0
@@ -88,18 +88,18 @@ def test_token_user_update_telescope(upload_data_token, manage_sources_token):
             'elevation': 0.0,
             'diameter': 12.0,
         },
-        token=manage_sources_token,
+        token=super_admin_token,
     )
     assert status == 200
     assert data['status'] == 'success'
 
-    status, data = api('GET', f'telescope/{telescope_id}', token=upload_data_token)
+    status, data = api('GET', f'telescope/{telescope_id}', token=super_admin_token)
     assert status == 200
     assert data['status'] == 'success'
     assert data['data']['diameter'] == 12.0
 
 
-def test_token_user_delete_telescope(upload_data_token, manage_sources_token):
+def test_token_user_delete_telescope(super_admin_token):
     name = str(uuid.uuid4())
     status, data = api(
         'POST',
@@ -113,22 +113,20 @@ def test_token_user_delete_telescope(upload_data_token, manage_sources_token):
             'diameter': 10.0,
             'robotic': False,
         },
-        token=upload_data_token,
+        token=super_admin_token,
     )
     assert status == 200
     assert data['status'] == 'success'
 
     telescope_id = data['data']['id']
-    status, data = api('GET', f'telescope/{telescope_id}', token=upload_data_token)
+    status, data = api('GET', f'telescope/{telescope_id}', token=super_admin_token)
     assert status == 200
     assert data['status'] == 'success'
     assert data['data']['diameter'] == 10.0
 
-    status, data = api(
-        'DELETE', f'telescope/{telescope_id}', token=manage_sources_token
-    )
+    status, data = api('DELETE', f'telescope/{telescope_id}', token=super_admin_token)
     assert status == 200
     assert data['status'] == 'success'
 
-    status, data = api('GET', f'telescope/{telescope_id}', token=upload_data_token)
+    status, data = api('GET', f'telescope/{telescope_id}', token=super_admin_token)
     assert status == 400

--- a/skyportal/tests/conftest.py
+++ b/skyportal/tests/conftest.py
@@ -624,9 +624,11 @@ def public_groupuser(public_group, user):
 
 
 @pytest.fixture()
-def user2(public_group):
+def user2(public_group, public_stream):
     user = UserFactory(
-        groups=[public_group], roles=[models.Role.query.get("Full user")]
+        groups=[public_group],
+        roles=[models.Role.query.get("Full user")],
+        streams=[public_stream],
     )
     user_id = user.id
     yield user
@@ -652,9 +654,11 @@ def user_no_groups_no_streams():
 
 
 @pytest.fixture()
-def user_two_groups(public_group, public_group2):
+def user_two_groups(public_group, public_group2, public_stream):
     user = UserFactory(
-        groups=[public_group, public_group2], roles=[models.Role.query.get("Full user")]
+        groups=[public_group, public_group2],
+        roles=[models.Role.query.get("Full user")],
+        streams=[public_stream],
     )
     user_id = user.id
     yield user
@@ -662,9 +666,11 @@ def user_two_groups(public_group, public_group2):
 
 
 @pytest.fixture()
-def view_only_user(public_group):
+def view_only_user(public_group, public_stream):
     user = UserFactory(
-        groups=[public_group], roles=[models.Role.query.get("View only")]
+        groups=[public_group],
+        roles=[models.Role.query.get("View only")],
+        streams=[public_stream],
     )
     user_id = user.id
     yield user
@@ -672,9 +678,11 @@ def view_only_user(public_group):
 
 
 @pytest.fixture()
-def view_only_user2(public_group):
+def view_only_user2(public_group, public_stream):
     user = UserFactory(
-        groups=[public_group], roles=[models.Role.query.get("View only")]
+        groups=[public_group],
+        roles=[models.Role.query.get("View only")],
+        streams=[public_stream],
     )
     user_id = user.id
     yield user
@@ -702,10 +710,11 @@ def group_admin_user(public_group, public_stream):
 
 
 @pytest.fixture()
-def group_admin_user_two_groups(public_group, public_group2):
+def group_admin_user_two_groups(public_group, public_group2, public_stream):
     user = UserFactory(
         groups=[public_group, public_group2],
         roles=[models.Role.query.get("Group admin")],
+        streams=[public_stream],
     )
     user_id = user.id
     yield user
@@ -725,10 +734,11 @@ def super_admin_user(public_group, public_stream):
 
 
 @pytest.fixture()
-def super_admin_user_two_groups(public_group, public_group2):
+def super_admin_user_two_groups(public_group, public_group2, public_stream):
     user = UserFactory(
         groups=[public_group, public_group2],
         roles=[models.Role.query.get("Super admin")],
+        streams=[public_stream],
     )
     user_id = user.id
     yield user

--- a/skyportal/tests/frontend/test_weather.py
+++ b/skyportal/tests/frontend/test_weather.py
@@ -4,7 +4,7 @@ from skyportal.tests import api
 
 
 @pytest.mark.flaky(reruns=2)
-def test_weather_widget(driver, user, public_group, upload_data_token, p60_telescope):
+def test_weather_widget(driver, user, public_group, super_admin_token, p60_telescope):
     name = str(uuid.uuid4())
     post_data = {
         'name': name,
@@ -18,7 +18,7 @@ def test_weather_widget(driver, user, public_group, upload_data_token, p60_teles
         'robotic': True,
     }
 
-    status, data = api('POST', 'telescope', data=post_data, token=upload_data_token)
+    status, data = api('POST', 'telescope', data=post_data, token=super_admin_token)
     assert status == 200
     assert data['status'] == 'success'
 

--- a/skyportal/tests/models/test_permissions.py
+++ b/skyportal/tests/models/test_permissions.py
@@ -1,383 +1,446 @@
 def test_user_create_public_group(  # noqa
-    user, public_group,
+    user,
+    public_group,
 ):
     accessible = public_group.is_accessible_by(user, mode="create")
     assert accessible
 
 
 def test_user_create_public_groupuser(
-    user, public_groupuser,
+    user,
+    public_groupuser,
 ):
     accessible = public_groupuser.is_accessible_by(user, mode="create")
     assert not accessible  # needs GroupAdmin
 
 
 def test_user_create_public_stream(
-    user, public_stream,
+    user,
+    public_stream,
 ):
     accessible = public_stream.is_accessible_by(user, mode="create")
     assert not accessible  # needs system admin
 
 
 def test_user_create_public_groupstream(
-    user, public_groupstream,
+    user,
+    public_groupstream,
 ):
     accessible = public_groupstream.is_accessible_by(user, mode="create")
     assert not accessible  # needs system admin
 
 
 def test_user_create_public_streamuser(
-    user, public_streamuser,
+    user,
+    public_streamuser,
 ):
     accessible = public_streamuser.is_accessible_by(user, mode="create")
     assert not accessible  # needs system admin
 
 
 def test_user_create_public_filter(
-    user, public_filter,
+    user,
+    public_filter,
 ):
     accessible = public_filter.is_accessible_by(user, mode="create")
     assert accessible
 
 
 def test_user_create_public_candidate_object(
-    user, public_candidate_object,
+    user,
+    public_candidate_object,
 ):
     accessible = public_candidate_object.is_accessible_by(user, mode="create")
     assert accessible
 
 
 def test_user_create_public_source_object(
-    user, public_source_object,
+    user,
+    public_source_object,
 ):
     accessible = public_source_object.is_accessible_by(user, mode="create")
     assert accessible
 
 
 def test_user_create_keck1_telescope(
-    user, keck1_telescope,
+    user,
+    keck1_telescope,
 ):
     accessible = keck1_telescope.is_accessible_by(user, mode="create")
-    assert accessible
+
+    # need system admin to create telescopes
+    assert not accessible
 
 
 def test_user_create_sedm(
-    user, sedm,
+    user,
+    sedm,
 ):
     accessible = sedm.is_accessible_by(user, mode="create")
-    assert accessible
+
+    # need system admin to create instruments
+    assert not accessible
 
 
 def test_user_create_public_group_sedm_allocation(
-    user, public_group_sedm_allocation,
+    user,
+    public_group_sedm_allocation,
 ):
     accessible = public_group_sedm_allocation.is_accessible_by(user, mode="create")
     assert accessible
 
 
 def test_user_read_public_group(
-    user, public_group,
+    user,
+    public_group,
 ):
     accessible = public_group.is_accessible_by(user, mode="read")
     assert accessible
 
 
 def test_user_read_public_groupuser(
-    user, public_groupuser,
+    user,
+    public_groupuser,
 ):
     accessible = public_groupuser.is_accessible_by(user, mode="read")
     assert accessible
 
 
 def test_user_read_public_stream(
-    user, public_stream,
+    user,
+    public_stream,
 ):
     accessible = public_stream.is_accessible_by(user, mode="read")
     assert accessible
 
 
 def test_user_read_public_groupstream(
-    user, public_groupstream,
+    user,
+    public_groupstream,
 ):
     accessible = public_groupstream.is_accessible_by(user, mode="read")
     assert accessible
 
 
 def test_user_read_public_streamuser(
-    user, public_streamuser,
+    user,
+    public_streamuser,
 ):
     accessible = public_streamuser.is_accessible_by(user, mode="read")
     assert accessible
 
 
 def test_user_read_public_filter(
-    user, public_filter,
+    user,
+    public_filter,
 ):
     accessible = public_filter.is_accessible_by(user, mode="read")
     assert accessible
 
 
 def test_user_read_public_candidate_object(
-    user, public_candidate_object,
+    user,
+    public_candidate_object,
 ):
     accessible = public_candidate_object.is_accessible_by(user, mode="read")
     assert accessible
 
 
 def test_user_read_public_source_object(
-    user, public_source_object,
+    user,
+    public_source_object,
 ):
     accessible = public_source_object.is_accessible_by(user, mode="read")
     assert accessible
 
 
 def test_user_read_keck1_telescope(
-    user, keck1_telescope,
+    user,
+    keck1_telescope,
 ):
     accessible = keck1_telescope.is_accessible_by(user, mode="read")
     assert accessible
 
 
 def test_user_read_sedm(
-    user, sedm,
+    user,
+    sedm,
 ):
     accessible = sedm.is_accessible_by(user, mode="read")
     assert accessible
 
 
 def test_user_read_public_group_sedm_allocation(
-    user, public_group_sedm_allocation,
+    user,
+    public_group_sedm_allocation,
 ):
     accessible = public_group_sedm_allocation.is_accessible_by(user, mode="read")
     assert accessible
 
 
 def test_user_update_public_group(
-    user, public_group,
+    user,
+    public_group,
 ):
     accessible = public_group.is_accessible_by(user, mode="update")
     assert not accessible  # needs groupadmin
 
 
 def test_user_update_public_groupuser(
-    user, public_groupuser,
+    user,
+    public_groupuser,
 ):
     accessible = public_groupuser.is_accessible_by(user, mode="update")
     assert not accessible  # needs groupadmin
 
 
 def test_user_update_public_stream(
-    user, public_stream,
+    user,
+    public_stream,
 ):
     accessible = public_stream.is_accessible_by(user, mode="update")
     assert not accessible  # needs systemadmin
 
 
 def test_user_update_public_groupstream(
-    user, public_groupstream,
+    user,
+    public_groupstream,
 ):
     accessible = public_groupstream.is_accessible_by(user, mode="update")
     assert not accessible  # needs systemadmin
 
 
 def test_user_update_public_streamuser(
-    user, public_streamuser,
+    user,
+    public_streamuser,
 ):
     accessible = public_streamuser.is_accessible_by(user, mode="update")
     assert not accessible  # needs systemadmin
 
 
 def test_user_update_public_filter(
-    user, public_filter,
+    user,
+    public_filter,
 ):
     accessible = public_filter.is_accessible_by(user, mode="update")
     assert accessible
 
 
 def test_user_update_public_candidate_object(
-    user, public_candidate_object,
+    user,
+    public_candidate_object,
 ):
     accessible = public_candidate_object.is_accessible_by(user, mode="update")
     assert accessible
 
 
 def test_user_update_public_source_object(
-    user, public_source_object,
+    user,
+    public_source_object,
 ):
     accessible = public_source_object.is_accessible_by(user, mode="update")
     assert accessible
 
 
 def test_user_update_keck1_telescope(
-    user, keck1_telescope,
+    user,
+    keck1_telescope,
 ):
     accessible = keck1_telescope.is_accessible_by(user, mode="update")
     assert not accessible  # needs system admin
 
 
 def test_user_update_sedm(
-    user, sedm,
+    user,
+    sedm,
 ):
     accessible = sedm.is_accessible_by(user, mode="update")
     assert not accessible  # needs system admin
 
 
 def test_user_update_public_group_sedm_allocation(
-    user, public_group_sedm_allocation,
+    user,
+    public_group_sedm_allocation,
 ):
     accessible = public_group_sedm_allocation.is_accessible_by(user, mode="update")
     assert accessible
 
 
 def test_user_delete_public_group(
-    user, public_group,
+    user,
+    public_group,
 ):
     accessible = public_group.is_accessible_by(user, mode="delete")
     assert not accessible  # needs group admin
 
 
 def test_user_delete_public_groupuser(
-    user, public_groupuser,
+    user,
+    public_groupuser,
 ):
     accessible = public_groupuser.is_accessible_by(user, mode="delete")
     assert not accessible  # needs group admin
 
 
 def test_user_delete_public_stream(
-    user, public_stream,
+    user,
+    public_stream,
 ):
     accessible = public_stream.is_accessible_by(user, mode="delete")
     assert not accessible  # needs system admin
 
 
 def test_user_delete_public_groupstream(
-    user, public_groupstream,
+    user,
+    public_groupstream,
 ):
     accessible = public_groupstream.is_accessible_by(user, mode="delete")
     assert not accessible  # needs system admin
 
 
 def test_user_delete_public_streamuser(
-    user, public_streamuser,
+    user,
+    public_streamuser,
 ):
     accessible = public_streamuser.is_accessible_by(user, mode="delete")
     assert not accessible  # needs system admin
 
 
 def test_user_delete_public_filter(
-    user, public_filter,
+    user,
+    public_filter,
 ):
     accessible = public_filter.is_accessible_by(user, mode="delete")
     assert accessible  # any group member can delete a group filter for now
 
 
 def test_user_delete_public_candidate_object(
-    user, public_candidate_object,
+    user,
+    public_candidate_object,
 ):
     accessible = public_candidate_object.is_accessible_by(user, mode="delete")
     assert accessible
 
 
 def test_user_delete_public_source_object(
-    user, public_source_object,
+    user,
+    public_source_object,
 ):
     accessible = public_source_object.is_accessible_by(user, mode="delete")
     assert accessible
 
 
 def test_user_delete_keck1_telescope(
-    user, keck1_telescope,
+    user,
+    keck1_telescope,
 ):
     accessible = keck1_telescope.is_accessible_by(user, mode="delete")
     assert not accessible  # needs sysadmin
 
 
 def test_user_delete_sedm(
-    user, sedm,
+    user,
+    sedm,
 ):
     accessible = sedm.is_accessible_by(user, mode="delete")
     assert not accessible  # needs sysadmin
 
 
 def test_user_delete_public_group_sedm_allocation(
-    user, public_group_sedm_allocation,
+    user,
+    public_group_sedm_allocation,
 ):
     accessible = public_group_sedm_allocation.is_accessible_by(user, mode="delete")
     assert accessible
 
 
 def test_user_group2_create_public_group(
-    user_group2, public_group,
+    user_group2,
+    public_group,
 ):
     accessible = public_group.is_accessible_by(user_group2, mode="create")
     assert accessible
 
 
 def test_user_group2_create_public_groupuser(
-    user_group2, public_groupuser,
+    user_group2,
+    public_groupuser,
 ):
     accessible = public_groupuser.is_accessible_by(user_group2, mode="create")
     assert not accessible  # must be in the group and be a group admin
 
 
 def test_user_group2_create_public_stream(
-    user_group2, public_stream,
+    user_group2,
+    public_stream,
 ):
     accessible = public_stream.is_accessible_by(user_group2, mode="create")
     assert not accessible  # needs sys admin
 
 
 def test_user_group2_create_public_groupstream(
-    user_group2, public_groupstream,
+    user_group2,
+    public_groupstream,
 ):
     accessible = public_groupstream.is_accessible_by(user_group2, mode="create")
     assert not accessible  # needs sys admin
 
 
 def test_user_group2_create_public_streamuser(
-    user_group2, public_streamuser,
+    user_group2,
+    public_streamuser,
 ):
     accessible = public_streamuser.is_accessible_by(user_group2, mode="create")
     assert not accessible  # needs system admin
 
 
 def test_user_group2_create_public_filter(
-    user_group2, public_filter,
+    user_group2,
+    public_filter,
 ):
     accessible = public_filter.is_accessible_by(user_group2, mode="create")
     assert not accessible  # must be in the filter's group
 
 
 def test_user_group2_create_public_candidate_object(
-    user_group2, public_candidate_object,
+    user_group2,
+    public_candidate_object,
 ):
     accessible = public_candidate_object.is_accessible_by(user_group2, mode="create")
     assert not accessible  # must be in the filter's group
 
 
 def test_user_group2_create_public_source_object(
-    user_group2, public_source_object,
+    user_group2,
+    public_source_object,
 ):
     accessible = public_source_object.is_accessible_by(user_group2, mode="create")
     assert not accessible  # must be in the source's group
 
 
 def test_user_group2_create_keck1_telescope(
-    user_group2, keck1_telescope,
+    user_group2,
+    keck1_telescope,
 ):
     accessible = keck1_telescope.is_accessible_by(user_group2, mode="create")
-    assert accessible
+
+    # need system admin to create telescopes
+    assert not accessible
 
 
 def test_user_group2_create_sedm(
-    user_group2, sedm,
+    user_group2,
+    sedm,
 ):
     accessible = sedm.is_accessible_by(user_group2, mode="create")
-    assert accessible
+
+    # need system admin to create instruments
+    assert not accessible
 
 
 def test_user_group2_create_public_group_sedm_allocation(
-    user_group2, public_group_sedm_allocation,
+    user_group2,
+    public_group_sedm_allocation,
 ):
     accessible = public_group_sedm_allocation.is_accessible_by(
         user_group2, mode="create"
@@ -386,35 +449,40 @@ def test_user_group2_create_public_group_sedm_allocation(
 
 
 def test_user_group2_read_public_group(
-    user_group2, public_group,
+    user_group2,
+    public_group,
 ):
     accessible = public_group.is_accessible_by(user_group2, mode="read")
     assert accessible
 
 
 def test_user_group2_read_public_groupuser(
-    user_group2, public_groupuser,
+    user_group2,
+    public_groupuser,
 ):
     accessible = public_groupuser.is_accessible_by(user_group2, mode="read")
     assert accessible
 
 
 def test_user_group2_read_public_stream(
-    user_group2, public_stream,
+    user_group2,
+    public_stream,
 ):
     accessible = public_stream.is_accessible_by(user_group2, mode="read")
     assert accessible
 
 
 def test_user_group2_read_public_groupstream(
-    user_group2, public_groupstream,
+    user_group2,
+    public_groupstream,
 ):
     accessible = public_groupstream.is_accessible_by(user_group2, mode="read")
     assert accessible
 
 
 def test_user_group2_read_public_streamuser(
-    user_group2, public_streamuser,
+    user_group2,
+    public_streamuser,
 ):
     accessible = public_streamuser.is_accessible_by(user_group2, mode="read")
     assert accessible == public_streamuser.user.is_accessible_by(
@@ -423,119 +491,136 @@ def test_user_group2_read_public_streamuser(
 
 
 def test_user_group2_read_public_filter(
-    user_group2, public_filter,
+    user_group2,
+    public_filter,
 ):
     accessible = public_filter.is_accessible_by(user_group2, mode="read")
     assert not accessible  # must be a member of the group
 
 
 def test_user_group2_read_public_candidate_object(
-    user_group2, public_candidate_object,
+    user_group2,
+    public_candidate_object,
 ):
     accessible = public_candidate_object.is_accessible_by(user_group2, mode="read")
     assert not accessible  # must be a member of the filter's group
 
 
 def test_user_group2_read_public_source_object(
-    user_group2, public_source_object,
+    user_group2,
+    public_source_object,
 ):
     accessible = public_source_object.is_accessible_by(user_group2, mode="read")
     assert not accessible  # must be a member of the source's group
 
 
 def test_user_group2_read_keck1_telescope(
-    user_group2, keck1_telescope,
+    user_group2,
+    keck1_telescope,
 ):
     accessible = keck1_telescope.is_accessible_by(user_group2, mode="read")
     assert accessible
 
 
 def test_user_group2_read_sedm(
-    user_group2, sedm,
+    user_group2,
+    sedm,
 ):
     accessible = sedm.is_accessible_by(user_group2, mode="read")
     assert accessible
 
 
 def test_user_group2_read_public_group_sedm_allocation(
-    user_group2, public_group_sedm_allocation,
+    user_group2,
+    public_group_sedm_allocation,
 ):
     accessible = public_group_sedm_allocation.is_accessible_by(user_group2, mode="read")
     assert not accessible  # must be a member of the allocation's group
 
 
 def test_user_group2_update_public_group(
-    user_group2, public_group,
+    user_group2,
+    public_group,
 ):
     accessible = public_group.is_accessible_by(user_group2, mode="update")
     assert not accessible  # must be an admin of the group
 
 
 def test_user_group2_update_public_groupuser(
-    user_group2, public_groupuser,
+    user_group2,
+    public_groupuser,
 ):
     accessible = public_groupuser.is_accessible_by(user_group2, mode="update")
     assert not accessible  # must be an admin of the group
 
 
 def test_user_group2_update_public_stream(
-    user_group2, public_stream,
+    user_group2,
+    public_stream,
 ):
     accessible = public_stream.is_accessible_by(user_group2, mode="update")
     assert not accessible  # must be a system admin
 
 
 def test_user_group2_update_public_groupstream(
-    user_group2, public_groupstream,
+    user_group2,
+    public_groupstream,
 ):
     accessible = public_groupstream.is_accessible_by(user_group2, mode="update")
     assert not accessible  # must be a system admin
 
 
 def test_user_group2_update_public_streamuser(
-    user_group2, public_streamuser,
+    user_group2,
+    public_streamuser,
 ):
     accessible = public_streamuser.is_accessible_by(user_group2, mode="update")
     assert not accessible  # must be a system admin
 
 
 def test_user_group2_update_public_filter(
-    user_group2, public_filter,
+    user_group2,
+    public_filter,
 ):
     accessible = public_filter.is_accessible_by(user_group2, mode="update")
     assert not accessible  # must be an admin of the filter's group
 
 
 def test_user_group2_update_public_candidate_object(
-    user_group2, public_candidate_object,
+    user_group2,
+    public_candidate_object,
 ):
     accessible = public_candidate_object.is_accessible_by(user_group2, mode="update")
     assert not accessible  # must be a member of the candidate's filter's group
 
 
 def test_user_group2_update_public_source_object(
-    user_group2, public_source_object,
+    user_group2,
+    public_source_object,
 ):
     accessible = public_source_object.is_accessible_by(user_group2, mode="update")
     assert not accessible  # must be a member of the source's group
 
 
 def test_user_group2_update_keck1_telescope(
-    user_group2, keck1_telescope,
+    user_group2,
+    keck1_telescope,
 ):
     accessible = keck1_telescope.is_accessible_by(user_group2, mode="update")
     assert not accessible  # must be system admin
 
 
 def test_user_group2_update_sedm(
-    user_group2, sedm,
+    user_group2,
+    sedm,
 ):
     accessible = sedm.is_accessible_by(user_group2, mode="update")
     assert not accessible  # must be system admin
 
 
 def test_user_group2_update_public_group_sedm_allocation(
-    user_group2, public_group_sedm_allocation,
+    user_group2,
+    public_group_sedm_allocation,
 ):
     accessible = public_group_sedm_allocation.is_accessible_by(
         user_group2, mode="update"
@@ -544,77 +629,88 @@ def test_user_group2_update_public_group_sedm_allocation(
 
 
 def test_user_group2_delete_public_group(
-    user_group2, public_group,
+    user_group2,
+    public_group,
 ):
     accessible = public_group.is_accessible_by(user_group2, mode="delete")
     assert not accessible  # must be a group admin
 
 
 def test_user_group2_delete_public_groupuser(
-    user_group2, public_groupuser,
+    user_group2,
+    public_groupuser,
 ):
     accessible = public_groupuser.is_accessible_by(user_group2, mode="delete")
     assert not accessible  # must be a group admin of the target group
 
 
 def test_user_group2_delete_public_stream(
-    user_group2, public_stream,
+    user_group2,
+    public_stream,
 ):
     accessible = public_stream.is_accessible_by(user_group2, mode="delete")
     assert not accessible  # must be a system admin
 
 
 def test_user_group2_delete_public_groupstream(
-    user_group2, public_groupstream,
+    user_group2,
+    public_groupstream,
 ):
     accessible = public_groupstream.is_accessible_by(user_group2, mode="delete")
     assert not accessible  # must be a system admin
 
 
 def test_user_group2_delete_public_streamuser(
-    user_group2, public_streamuser,
+    user_group2,
+    public_streamuser,
 ):
     accessible = public_streamuser.is_accessible_by(user_group2, mode="delete")
     assert not accessible  # must be a system admin
 
 
 def test_user_group2_delete_public_filter(
-    user_group2, public_filter,
+    user_group2,
+    public_filter,
 ):
     accessible = public_filter.is_accessible_by(user_group2, mode="delete")
     assert not accessible  # must be a group member of target group
 
 
 def test_user_group2_delete_public_candidate_object(
-    user_group2, public_candidate_object,
+    user_group2,
+    public_candidate_object,
 ):
     accessible = public_candidate_object.is_accessible_by(user_group2, mode="delete")
     assert not accessible  # must be a member of target group
 
 
 def test_user_group2_delete_public_source_object(
-    user_group2, public_source_object,
+    user_group2,
+    public_source_object,
 ):
     accessible = public_source_object.is_accessible_by(user_group2, mode="delete")
     assert not accessible  # must be a member of target group
 
 
 def test_user_group2_delete_keck1_telescope(
-    user_group2, keck1_telescope,
+    user_group2,
+    keck1_telescope,
 ):
     accessible = keck1_telescope.is_accessible_by(user_group2, mode="delete")
     assert not accessible  # must be a system admin
 
 
 def test_user_group2_delete_sedm(
-    user_group2, sedm,
+    user_group2,
+    sedm,
 ):
     accessible = sedm.is_accessible_by(user_group2, mode="delete")
     assert not accessible  # must be a system admin
 
 
 def test_user_group2_delete_public_group_sedm_allocation(
-    user_group2, public_group_sedm_allocation,
+    user_group2,
+    public_group_sedm_allocation,
 ):
     accessible = public_group_sedm_allocation.is_accessible_by(
         user_group2, mode="delete"
@@ -623,49 +719,56 @@ def test_user_group2_delete_public_group_sedm_allocation(
 
 
 def test_super_admin_user_create_public_group(
-    super_admin_user, public_group,
+    super_admin_user,
+    public_group,
 ):
     accessible = public_group.is_accessible_by(super_admin_user, mode="create")
     assert accessible
 
 
 def test_super_admin_user_create_public_groupuser(
-    super_admin_user, public_groupuser,
+    super_admin_user,
+    public_groupuser,
 ):
     accessible = public_groupuser.is_accessible_by(super_admin_user, mode="create")
     assert accessible
 
 
 def test_super_admin_user_create_public_stream(
-    super_admin_user, public_stream,
+    super_admin_user,
+    public_stream,
 ):
     accessible = public_stream.is_accessible_by(super_admin_user, mode="create")
     assert accessible
 
 
 def test_super_admin_user_create_public_groupstream(
-    super_admin_user, public_groupstream,
+    super_admin_user,
+    public_groupstream,
 ):
     accessible = public_groupstream.is_accessible_by(super_admin_user, mode="create")
     assert accessible
 
 
 def test_super_admin_user_create_public_streamuser(
-    super_admin_user, public_streamuser,
+    super_admin_user,
+    public_streamuser,
 ):
     accessible = public_streamuser.is_accessible_by(super_admin_user, mode="create")
     assert accessible
 
 
 def test_super_admin_user_create_public_filter(
-    super_admin_user, public_filter,
+    super_admin_user,
+    public_filter,
 ):
     accessible = public_filter.is_accessible_by(super_admin_user, mode="create")
     assert accessible
 
 
 def test_super_admin_user_create_public_candidate_object(
-    super_admin_user, public_candidate_object,
+    super_admin_user,
+    public_candidate_object,
 ):
     accessible = public_candidate_object.is_accessible_by(
         super_admin_user, mode="create"
@@ -674,28 +777,32 @@ def test_super_admin_user_create_public_candidate_object(
 
 
 def test_super_admin_user_create_public_source_object(
-    super_admin_user, public_source_object,
+    super_admin_user,
+    public_source_object,
 ):
     accessible = public_source_object.is_accessible_by(super_admin_user, mode="create")
     assert accessible
 
 
 def test_super_admin_user_create_keck1_telescope(
-    super_admin_user, keck1_telescope,
+    super_admin_user,
+    keck1_telescope,
 ):
     accessible = keck1_telescope.is_accessible_by(super_admin_user, mode="create")
     assert accessible
 
 
 def test_super_admin_user_create_sedm(
-    super_admin_user, sedm,
+    super_admin_user,
+    sedm,
 ):
     accessible = sedm.is_accessible_by(super_admin_user, mode="create")
     assert accessible
 
 
 def test_super_admin_user_create_public_group_sedm_allocation(
-    super_admin_user, public_group_sedm_allocation,
+    super_admin_user,
+    public_group_sedm_allocation,
 ):
     accessible = public_group_sedm_allocation.is_accessible_by(
         super_admin_user, mode="create"
@@ -704,77 +811,88 @@ def test_super_admin_user_create_public_group_sedm_allocation(
 
 
 def test_super_admin_user_read_public_group(
-    super_admin_user, public_group,
+    super_admin_user,
+    public_group,
 ):
     accessible = public_group.is_accessible_by(super_admin_user, mode="read")
     assert accessible
 
 
 def test_super_admin_user_read_public_groupuser(
-    super_admin_user, public_groupuser,
+    super_admin_user,
+    public_groupuser,
 ):
     accessible = public_groupuser.is_accessible_by(super_admin_user, mode="read")
     assert accessible
 
 
 def test_super_admin_user_read_public_stream(
-    super_admin_user, public_stream,
+    super_admin_user,
+    public_stream,
 ):
     accessible = public_stream.is_accessible_by(super_admin_user, mode="read")
     assert accessible
 
 
 def test_super_admin_user_read_public_groupstream(
-    super_admin_user, public_groupstream,
+    super_admin_user,
+    public_groupstream,
 ):
     accessible = public_groupstream.is_accessible_by(super_admin_user, mode="read")
     assert accessible
 
 
 def test_super_admin_user_read_public_streamuser(
-    super_admin_user, public_streamuser,
+    super_admin_user,
+    public_streamuser,
 ):
     accessible = public_streamuser.is_accessible_by(super_admin_user, mode="read")
     assert accessible
 
 
 def test_super_admin_user_read_public_filter(
-    super_admin_user, public_filter,
+    super_admin_user,
+    public_filter,
 ):
     accessible = public_filter.is_accessible_by(super_admin_user, mode="read")
     assert accessible
 
 
 def test_super_admin_user_read_public_candidate_object(
-    super_admin_user, public_candidate_object,
+    super_admin_user,
+    public_candidate_object,
 ):
     accessible = public_candidate_object.is_accessible_by(super_admin_user, mode="read")
     assert accessible
 
 
 def test_super_admin_user_read_public_source_object(
-    super_admin_user, public_source_object,
+    super_admin_user,
+    public_source_object,
 ):
     accessible = public_source_object.is_accessible_by(super_admin_user, mode="read")
     assert accessible
 
 
 def test_super_admin_user_read_keck1_telescope(
-    super_admin_user, keck1_telescope,
+    super_admin_user,
+    keck1_telescope,
 ):
     accessible = keck1_telescope.is_accessible_by(super_admin_user, mode="read")
     assert accessible
 
 
 def test_super_admin_user_read_sedm(
-    super_admin_user, sedm,
+    super_admin_user,
+    sedm,
 ):
     accessible = sedm.is_accessible_by(super_admin_user, mode="read")
     assert accessible
 
 
 def test_super_admin_user_read_public_group_sedm_allocation(
-    super_admin_user, public_group_sedm_allocation,
+    super_admin_user,
+    public_group_sedm_allocation,
 ):
     accessible = public_group_sedm_allocation.is_accessible_by(
         super_admin_user, mode="read"
@@ -783,49 +901,56 @@ def test_super_admin_user_read_public_group_sedm_allocation(
 
 
 def test_super_admin_user_update_public_group(
-    super_admin_user, public_group,
+    super_admin_user,
+    public_group,
 ):
     accessible = public_group.is_accessible_by(super_admin_user, mode="update")
     assert accessible
 
 
 def test_super_admin_user_update_public_groupuser(
-    super_admin_user, public_groupuser,
+    super_admin_user,
+    public_groupuser,
 ):
     accessible = public_groupuser.is_accessible_by(super_admin_user, mode="update")
     assert accessible
 
 
 def test_super_admin_user_update_public_stream(
-    super_admin_user, public_stream,
+    super_admin_user,
+    public_stream,
 ):
     accessible = public_stream.is_accessible_by(super_admin_user, mode="update")
     assert accessible
 
 
 def test_super_admin_user_update_public_groupstream(
-    super_admin_user, public_groupstream,
+    super_admin_user,
+    public_groupstream,
 ):
     accessible = public_groupstream.is_accessible_by(super_admin_user, mode="update")
     assert accessible
 
 
 def test_super_admin_user_update_public_streamuser(
-    super_admin_user, public_streamuser,
+    super_admin_user,
+    public_streamuser,
 ):
     accessible = public_streamuser.is_accessible_by(super_admin_user, mode="update")
     assert accessible
 
 
 def test_super_admin_user_update_public_filter(
-    super_admin_user, public_filter,
+    super_admin_user,
+    public_filter,
 ):
     accessible = public_filter.is_accessible_by(super_admin_user, mode="update")
     assert accessible
 
 
 def test_super_admin_user_update_public_candidate_object(
-    super_admin_user, public_candidate_object,
+    super_admin_user,
+    public_candidate_object,
 ):
     accessible = public_candidate_object.is_accessible_by(
         super_admin_user, mode="update"
@@ -834,28 +959,32 @@ def test_super_admin_user_update_public_candidate_object(
 
 
 def test_super_admin_user_update_public_source_object(
-    super_admin_user, public_source_object,
+    super_admin_user,
+    public_source_object,
 ):
     accessible = public_source_object.is_accessible_by(super_admin_user, mode="update")
     assert accessible
 
 
 def test_super_admin_user_update_keck1_telescope(
-    super_admin_user, keck1_telescope,
+    super_admin_user,
+    keck1_telescope,
 ):
     accessible = keck1_telescope.is_accessible_by(super_admin_user, mode="update")
     assert accessible
 
 
 def test_super_admin_user_update_sedm(
-    super_admin_user, sedm,
+    super_admin_user,
+    sedm,
 ):
     accessible = sedm.is_accessible_by(super_admin_user, mode="update")
     assert accessible
 
 
 def test_super_admin_user_update_public_group_sedm_allocation(
-    super_admin_user, public_group_sedm_allocation,
+    super_admin_user,
+    public_group_sedm_allocation,
 ):
     accessible = public_group_sedm_allocation.is_accessible_by(
         super_admin_user, mode="update"
@@ -864,49 +993,56 @@ def test_super_admin_user_update_public_group_sedm_allocation(
 
 
 def test_super_admin_user_delete_public_group(
-    super_admin_user, public_group,
+    super_admin_user,
+    public_group,
 ):
     accessible = public_group.is_accessible_by(super_admin_user, mode="delete")
     assert accessible
 
 
 def test_super_admin_user_delete_public_groupuser(
-    super_admin_user, public_groupuser,
+    super_admin_user,
+    public_groupuser,
 ):
     accessible = public_groupuser.is_accessible_by(super_admin_user, mode="delete")
     assert accessible
 
 
 def test_super_admin_user_delete_public_stream(
-    super_admin_user, public_stream,
+    super_admin_user,
+    public_stream,
 ):
     accessible = public_stream.is_accessible_by(super_admin_user, mode="delete")
     assert accessible
 
 
 def test_super_admin_user_delete_public_groupstream(
-    super_admin_user, public_groupstream,
+    super_admin_user,
+    public_groupstream,
 ):
     accessible = public_groupstream.is_accessible_by(super_admin_user, mode="delete")
     assert accessible
 
 
 def test_super_admin_user_delete_public_streamuser(
-    super_admin_user, public_streamuser,
+    super_admin_user,
+    public_streamuser,
 ):
     accessible = public_streamuser.is_accessible_by(super_admin_user, mode="delete")
     assert accessible
 
 
 def test_super_admin_user_delete_public_filter(
-    super_admin_user, public_filter,
+    super_admin_user,
+    public_filter,
 ):
     accessible = public_filter.is_accessible_by(super_admin_user, mode="delete")
     assert accessible
 
 
 def test_super_admin_user_delete_public_candidate_object(
-    super_admin_user, public_candidate_object,
+    super_admin_user,
+    public_candidate_object,
 ):
     accessible = public_candidate_object.is_accessible_by(
         super_admin_user, mode="delete"
@@ -915,28 +1051,32 @@ def test_super_admin_user_delete_public_candidate_object(
 
 
 def test_super_admin_user_delete_public_source_object(
-    super_admin_user, public_source_object,
+    super_admin_user,
+    public_source_object,
 ):
     accessible = public_source_object.is_accessible_by(super_admin_user, mode="delete")
     assert accessible
 
 
 def test_super_admin_user_delete_keck1_telescope(
-    super_admin_user, keck1_telescope,
+    super_admin_user,
+    keck1_telescope,
 ):
     accessible = keck1_telescope.is_accessible_by(super_admin_user, mode="delete")
     assert accessible
 
 
 def test_super_admin_user_delete_sedm(
-    super_admin_user, sedm,
+    super_admin_user,
+    sedm,
 ):
     accessible = sedm.is_accessible_by(super_admin_user, mode="delete")
     assert accessible
 
 
 def test_super_admin_user_delete_public_group_sedm_allocation(
-    super_admin_user, public_group_sedm_allocation,
+    super_admin_user,
+    public_group_sedm_allocation,
 ):
     accessible = public_group_sedm_allocation.is_accessible_by(
         super_admin_user, mode="delete"
@@ -945,49 +1085,56 @@ def test_super_admin_user_delete_public_group_sedm_allocation(
 
 
 def test_group_admin_user_create_public_group(
-    group_admin_user, public_group,
+    group_admin_user,
+    public_group,
 ):
     accessible = public_group.is_accessible_by(group_admin_user, mode="create")
     assert accessible
 
 
 def test_group_admin_user_create_public_groupuser(
-    group_admin_user, public_groupuser,
+    group_admin_user,
+    public_groupuser,
 ):
     accessible = public_groupuser.is_accessible_by(group_admin_user, mode="create")
     assert accessible
 
 
 def test_group_admin_user_create_public_stream(
-    group_admin_user, public_stream,
+    group_admin_user,
+    public_stream,
 ):
     accessible = public_stream.is_accessible_by(group_admin_user, mode="create")
     assert not accessible  # must be system admin
 
 
 def test_group_admin_user_create_public_groupstream(
-    group_admin_user, public_groupstream,
+    group_admin_user,
+    public_groupstream,
 ):
     accessible = public_groupstream.is_accessible_by(group_admin_user, mode="create")
     assert accessible
 
 
 def test_group_admin_user_create_public_streamuser(
-    group_admin_user, public_streamuser,
+    group_admin_user,
+    public_streamuser,
 ):
     accessible = public_streamuser.is_accessible_by(group_admin_user, mode="create")
     assert not accessible  # must be system admin
 
 
 def test_group_admin_user_create_public_filter(
-    group_admin_user, public_filter,
+    group_admin_user,
+    public_filter,
 ):
     accessible = public_filter.is_accessible_by(group_admin_user, mode="create")
     assert accessible
 
 
 def test_group_admin_user_create_public_candidate_object(
-    group_admin_user, public_candidate_object,
+    group_admin_user,
+    public_candidate_object,
 ):
     accessible = public_candidate_object.is_accessible_by(
         group_admin_user, mode="create"
@@ -996,28 +1143,36 @@ def test_group_admin_user_create_public_candidate_object(
 
 
 def test_group_admin_user_create_public_source_object(
-    group_admin_user, public_source_object,
+    group_admin_user,
+    public_source_object,
 ):
     accessible = public_source_object.is_accessible_by(group_admin_user, mode="create")
     assert accessible
 
 
 def test_group_admin_user_create_keck1_telescope(
-    group_admin_user, keck1_telescope,
+    group_admin_user,
+    keck1_telescope,
 ):
     accessible = keck1_telescope.is_accessible_by(group_admin_user, mode="create")
-    assert accessible
+
+    # need system admin to create telescopes
+    assert not accessible
 
 
 def test_group_admin_user_create_sedm(
-    group_admin_user, sedm,
+    group_admin_user,
+    sedm,
 ):
     accessible = sedm.is_accessible_by(group_admin_user, mode="create")
-    assert accessible
+
+    # need system admin
+    assert not accessible
 
 
 def test_group_admin_user_create_public_group_sedm_allocation(
-    group_admin_user, public_group_sedm_allocation,
+    group_admin_user,
+    public_group_sedm_allocation,
 ):
     accessible = public_group_sedm_allocation.is_accessible_by(
         group_admin_user, mode="create"
@@ -1026,77 +1181,88 @@ def test_group_admin_user_create_public_group_sedm_allocation(
 
 
 def test_group_admin_user_read_public_group(
-    group_admin_user, public_group,
+    group_admin_user,
+    public_group,
 ):
     accessible = public_group.is_accessible_by(group_admin_user, mode="read")
     assert accessible
 
 
 def test_group_admin_user_read_public_groupuser(
-    group_admin_user, public_groupuser,
+    group_admin_user,
+    public_groupuser,
 ):
     accessible = public_groupuser.is_accessible_by(group_admin_user, mode="read")
     assert accessible
 
 
 def test_group_admin_user_read_public_stream(
-    group_admin_user, public_stream,
+    group_admin_user,
+    public_stream,
 ):
     accessible = public_stream.is_accessible_by(group_admin_user, mode="read")
     assert accessible
 
 
 def test_group_admin_user_read_public_groupstream(
-    group_admin_user, public_groupstream,
+    group_admin_user,
+    public_groupstream,
 ):
     accessible = public_groupstream.is_accessible_by(group_admin_user, mode="read")
     assert accessible
 
 
 def test_group_admin_user_read_public_streamuser(
-    group_admin_user, public_streamuser,
+    group_admin_user,
+    public_streamuser,
 ):
     accessible = public_streamuser.is_accessible_by(group_admin_user, mode="read")
     assert accessible
 
 
 def test_group_admin_user_read_public_filter(
-    group_admin_user, public_filter,
+    group_admin_user,
+    public_filter,
 ):
     accessible = public_filter.is_accessible_by(group_admin_user, mode="read")
     assert accessible
 
 
 def test_group_admin_user_read_public_candidate_object(
-    group_admin_user, public_candidate_object,
+    group_admin_user,
+    public_candidate_object,
 ):
     accessible = public_candidate_object.is_accessible_by(group_admin_user, mode="read")
     assert accessible
 
 
 def test_group_admin_user_read_public_source_object(
-    group_admin_user, public_source_object,
+    group_admin_user,
+    public_source_object,
 ):
     accessible = public_source_object.is_accessible_by(group_admin_user, mode="read")
     assert accessible
 
 
 def test_group_admin_user_read_keck1_telescope(
-    group_admin_user, keck1_telescope,
+    group_admin_user,
+    keck1_telescope,
 ):
     accessible = keck1_telescope.is_accessible_by(group_admin_user, mode="read")
     assert accessible
 
 
 def test_group_admin_user_read_sedm(
-    group_admin_user, sedm,
+    group_admin_user,
+    sedm,
 ):
     accessible = sedm.is_accessible_by(group_admin_user, mode="read")
     assert accessible
 
 
 def test_group_admin_user_read_public_group_sedm_allocation(
-    group_admin_user, public_group_sedm_allocation,
+    group_admin_user,
+    public_group_sedm_allocation,
 ):
     accessible = public_group_sedm_allocation.is_accessible_by(
         group_admin_user, mode="read"
@@ -1105,49 +1271,56 @@ def test_group_admin_user_read_public_group_sedm_allocation(
 
 
 def test_group_admin_user_update_public_group(
-    group_admin_user, public_group,
+    group_admin_user,
+    public_group,
 ):
     accessible = public_group.is_accessible_by(group_admin_user, mode="update")
     assert accessible
 
 
 def test_group_admin_user_update_public_groupuser(
-    group_admin_user, public_groupuser,
+    group_admin_user,
+    public_groupuser,
 ):
     accessible = public_groupuser.is_accessible_by(group_admin_user, mode="update")
     assert accessible
 
 
 def test_group_admin_user_update_public_stream(
-    group_admin_user, public_stream,
+    group_admin_user,
+    public_stream,
 ):
     accessible = public_stream.is_accessible_by(group_admin_user, mode="update")
     assert not accessible  # needs system admin
 
 
 def test_group_admin_user_update_public_groupstream(
-    group_admin_user, public_groupstream,
+    group_admin_user,
+    public_groupstream,
 ):
     accessible = public_groupstream.is_accessible_by(group_admin_user, mode="update")
     assert accessible
 
 
 def test_group_admin_user_update_public_streamuser(
-    group_admin_user, public_streamuser,
+    group_admin_user,
+    public_streamuser,
 ):
     accessible = public_streamuser.is_accessible_by(group_admin_user, mode="update")
     assert not accessible  # needs system admin
 
 
 def test_group_admin_user_update_public_filter(
-    group_admin_user, public_filter,
+    group_admin_user,
+    public_filter,
 ):
     accessible = public_filter.is_accessible_by(group_admin_user, mode="update")
     assert accessible
 
 
 def test_group_admin_user_update_public_candidate_object(
-    group_admin_user, public_candidate_object,
+    group_admin_user,
+    public_candidate_object,
 ):
     accessible = public_candidate_object.is_accessible_by(
         group_admin_user, mode="update"
@@ -1156,28 +1329,32 @@ def test_group_admin_user_update_public_candidate_object(
 
 
 def test_group_admin_user_update_public_source_object(
-    group_admin_user, public_source_object,
+    group_admin_user,
+    public_source_object,
 ):
     accessible = public_source_object.is_accessible_by(group_admin_user, mode="update")
     assert accessible
 
 
 def test_group_admin_user_update_keck1_telescope(
-    group_admin_user, keck1_telescope,
+    group_admin_user,
+    keck1_telescope,
 ):
     accessible = keck1_telescope.is_accessible_by(group_admin_user, mode="update")
     assert not accessible  # system admin
 
 
 def test_group_admin_user_update_sedm(
-    group_admin_user, sedm,
+    group_admin_user,
+    sedm,
 ):
     accessible = sedm.is_accessible_by(group_admin_user, mode="update")
     assert not accessible  # sysadmin
 
 
 def test_group_admin_user_update_public_group_sedm_allocation(
-    group_admin_user, public_group_sedm_allocation,
+    group_admin_user,
+    public_group_sedm_allocation,
 ):
     accessible = public_group_sedm_allocation.is_accessible_by(
         group_admin_user, mode="update"
@@ -1186,49 +1363,56 @@ def test_group_admin_user_update_public_group_sedm_allocation(
 
 
 def test_group_admin_user_delete_public_group(
-    group_admin_user, public_group,
+    group_admin_user,
+    public_group,
 ):
     accessible = public_group.is_accessible_by(group_admin_user, mode="delete")
     assert accessible
 
 
 def test_group_admin_user_delete_public_groupuser(
-    group_admin_user, public_groupuser,
+    group_admin_user,
+    public_groupuser,
 ):
     accessible = public_groupuser.is_accessible_by(group_admin_user, mode="delete")
     assert accessible
 
 
 def test_group_admin_user_delete_public_stream(
-    group_admin_user, public_stream,
+    group_admin_user,
+    public_stream,
 ):
     accessible = public_stream.is_accessible_by(group_admin_user, mode="delete")
     assert not accessible  # sys admin
 
 
 def test_group_admin_user_delete_public_groupstream(
-    group_admin_user, public_groupstream,
+    group_admin_user,
+    public_groupstream,
 ):
     accessible = public_groupstream.is_accessible_by(group_admin_user, mode="delete")
     assert accessible
 
 
 def test_group_admin_user_delete_public_streamuser(
-    group_admin_user, public_streamuser,
+    group_admin_user,
+    public_streamuser,
 ):
     accessible = public_streamuser.is_accessible_by(group_admin_user, mode="delete")
     assert not accessible  # sysadmin
 
 
 def test_group_admin_user_delete_public_filter(
-    group_admin_user, public_filter,
+    group_admin_user,
+    public_filter,
 ):
     accessible = public_filter.is_accessible_by(group_admin_user, mode="delete")
     assert accessible
 
 
 def test_group_admin_user_delete_public_candidate_object(
-    group_admin_user, public_candidate_object,
+    group_admin_user,
+    public_candidate_object,
 ):
     accessible = public_candidate_object.is_accessible_by(
         group_admin_user, mode="delete"
@@ -1237,28 +1421,32 @@ def test_group_admin_user_delete_public_candidate_object(
 
 
 def test_group_admin_user_delete_public_source_object(
-    group_admin_user, public_source_object,
+    group_admin_user,
+    public_source_object,
 ):
     accessible = public_source_object.is_accessible_by(group_admin_user, mode="delete")
     assert accessible
 
 
 def test_group_admin_user_delete_keck1_telescope(
-    group_admin_user, keck1_telescope,
+    group_admin_user,
+    keck1_telescope,
 ):
     accessible = keck1_telescope.is_accessible_by(group_admin_user, mode="delete")
     assert not accessible  # sysadmin
 
 
 def test_group_admin_user_delete_sedm(
-    group_admin_user, sedm,
+    group_admin_user,
+    sedm,
 ):
     accessible = sedm.is_accessible_by(group_admin_user, mode="delete")
     assert not accessible  # sysadmin
 
 
 def test_group_admin_user_delete_public_group_sedm_allocation(
-    group_admin_user, public_group_sedm_allocation,
+    group_admin_user,
+    public_group_sedm_allocation,
 ):
     accessible = public_group_sedm_allocation.is_accessible_by(
         group_admin_user, mode="delete"


### PR DESCRIPTION
Merging https://github.com/cesium-ml/baselayer/pull/207 turned on automated permission checking for create, read, and update operations after they were unintentionally disabled since https://github.com/cesium-ml/baselayer/pull/184. Enabling these automated checks revealed a series of security vulnerabilities in skyportal that allowed API access to protected user data (photometry, spectra, etc.) and protected operations on user data (delete, update, etc.). 

The fix also revealed instances in which assumptions in the test suite violated underlying assumptions about the data model. 

This PR patches many of these up. The specific issues fixed in this PR include: 

* The candidate API GET endpoint had a major spectroscopy and photometry leak, returning all spectra and photometry regardless of permissions 
* The facility listener endpoint brought protected Allocation data into the session
* The facility listener handler did not correctly enforce update permissions on followup requests
* The taxonomy handler exposed a vulnerability that allowed any user with the "Delete taxonomy" ACL to delete any taxonomy (even if they couldn't read it) and all of the classifications associated with that taxonomy. There is now logic in place that allows deletion of taxonomies by users with the Delete taxonomy ACL only if a taxonomy is shared with one of their groups and there are no associated classifications (super admins can delete any taxonomy with no classifications)
* Access control policies on telescopes and instruments allowed arbitrary record creation, rather than only by system admins
* Users could not delete themselves, and their update UACL policy did not allow them to update themselves (both of these are now fixed)
* Many users in the test suite did not have any stream associations, but could post candidates to filters that filtered streams (this will be fixed in a subsequent PR). 

Performance impact:

Master: API tests took  235.76s (0:03:55) on my local machine 
This PR: API tests took 240.27s (0:04:00) on my local machine

The difference is 2%. 