### PR TITLE
Fix test_upload_spectroscopy

### DIFF
--- a/skyportal/tests/frontend/test_upload_spectroscopy.py
+++ b/skyportal/tests/frontend/test_upload_spectroscopy.py
@@ -37,6 +37,8 @@ def test_upload_spectroscopy(
 
     driver.wait_for_xpath('//*[contains(.,"successful")]')
 
-    driver.get(f"/source/{public_source.id}")
+    # Go to "Manage Data" page to look for the spectrum, since we can't easily
+    #  look into the Bokeh <canvas> tag on the Source page.
+    driver.get(f"/manage_data/{public_source.id}")
 
     driver.wait_for_xpath(f'//*[contains(.,"{sedm.name}")]', 20)


### PR DESCRIPTION
The new legend in the spectroscopy plot goes into the plot's `<canvas>` tag so can't be probed directly with an xpath like we used to. This PR fixes `test_upload_spectroscopy` by just going to the "Manage Data" page to check for successful spectrum upload.