### PR TITLE
Control access to Photometry via Obj hybrid properties

### DIFF
--- a/skyportal/handlers/api/candidate.py
+++ b/skyportal/handlers/api/candidate.py
@@ -408,14 +408,14 @@ class CandidateHandler(BaseHandler):
                 candidate_info["classifications"] = c.get_classifications_readable_by(
                     self.current_user
                 )
-            candidate_info["last_detected_at"] = c.last_detected_at
+            candidate_info["last_detected_at"] = c.last_detected_at(self.current_user)
             candidate_info["gal_lon"] = c.gal_lon_deg
             candidate_info["gal_lat"] = c.gal_lat_deg
             candidate_info["luminosity_distance"] = c.luminosity_distance
             candidate_info["dm"] = c.dm
             candidate_info["angular_diameter_distance"] = c.angular_diameter_distance
 
-            # self.verify_and_commit()
+            self.verify_and_commit()
             return self.success(data=candidate_info)
 
         page_number = self.get_query_argument("pageNumber", None) or 1
@@ -480,6 +480,7 @@ class CandidateHandler(BaseHandler):
                 "Insufficient permissions - you must only specify "
                 "groups/filters that you have access to."
             )
+
         try:
             page = int(page_number)
         except ValueError:
@@ -793,7 +794,6 @@ class CandidateHandler(BaseHandler):
                     )
                 ]
                 candidate_list.append(obj.to_dict())
-
                 if include_photometry:
                     candidate_list[-1]["photometry"] = (
                         Photometry.query_records_accessible_by(
@@ -828,7 +828,9 @@ class CandidateHandler(BaseHandler):
                     obj.get_annotations_readable_by(self.current_user),
                     key=lambda x: x.origin,
                 )
-                candidate_list[-1]["last_detected_at"] = obj.last_detected_at
+                candidate_list[-1]["last_detected_at"] = obj.last_detected_at(
+                    self.current_user
+                )
                 candidate_list[-1]["gal_lat"] = obj.gal_lat_deg
                 candidate_list[-1]["gal_lon"] = obj.gal_lon_deg
                 candidate_list[-1]["luminosity_distance"] = obj.luminosity_distance
@@ -838,7 +840,7 @@ class CandidateHandler(BaseHandler):
                 ] = obj.angular_diameter_distance
 
         query_results["candidates"] = candidate_list
-        # self.verify_and_commit()
+        self.verify_and_commit()
         return self.success(data=query_results)
 
     @permissions(["Upload data"])

--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -626,10 +626,10 @@ class SourceHandler(BaseHandler):
                 readable_classifications_json.append(classification_dict)
 
             source_info["classifications"] = readable_classifications_json
-            source_info["last_detected_at"] = s.last_detected_at
-            source_info["last_detected_mag"] = s.last_detected_mag
-            source_info["peak_detected_at"] = s.peak_detected_at
-            source_info["peak_detected_mag"] = s.peak_detected_mag
+            source_info["last_detected_at"] = s.last_detected_at(self.current_user)
+            source_info["last_detected_mag"] = s.last_detected_mag(self.current_user)
+            source_info["peak_detected_at"] = s.peak_detected_at(self.current_user)
+            source_info["peak_detected_mag"] = s.peak_detected_mag(self.current_user)
             source_info["gal_lat"] = s.gal_lat_deg
             source_info["gal_lon"] = s.gal_lon_deg
             source_info["luminosity_distance"] = s.luminosity_distance
@@ -766,10 +766,10 @@ class SourceHandler(BaseHandler):
             q = q.filter(Obj.within(other, radius))
         if start_date:
             start_date = arrow.get(start_date.strip()).datetime
-            q = q.filter(Obj.last_detected_at >= start_date)
+            q = q.filter(Obj.last_detected_at(self.current_user) >= start_date)
         if end_date:
             end_date = arrow.get(end_date.strip()).datetime
-            q = q.filter(Obj.last_detected_at <= end_date)
+            q = q.filter(Obj.last_detected_at(self.current_user) <= end_date)
         if saved_before:
             q = q.filter(Source.saved_at <= saved_before)
         if saved_after:
@@ -813,7 +813,7 @@ class SourceHandler(BaseHandler):
                 return self.error(
                     "Invalid values for minPeakMagnitude - could not convert to float"
                 )
-            q = q.filter(Obj.peak_detected_mag >= min_peak_magnitude)
+            q = q.filter(Obj.peak_detected_mag(self.current_user) >= min_peak_magnitude)
         if max_peak_magnitude is not None:
             try:
                 max_peak_magnitude = float(max_peak_magnitude)
@@ -821,7 +821,7 @@ class SourceHandler(BaseHandler):
                 return self.error(
                     "Invalid values for maxPeakMagnitude - could not convert to float"
                 )
-            q = q.filter(Obj.peak_detected_mag <= max_peak_magnitude)
+            q = q.filter(Obj.peak_detected_mag(self.current_user) <= max_peak_magnitude)
         if min_latest_magnitude is not None:
             try:
                 min_latest_magnitude = float(min_latest_magnitude)
@@ -829,7 +829,9 @@ class SourceHandler(BaseHandler):
                 return self.error(
                     "Invalid values for minLatestMagnitude - could not convert to float"
                 )
-            q = q.filter(Obj.last_detected_mag >= min_latest_magnitude)
+            q = q.filter(
+                Obj.last_detected_mag(self.current_user) >= min_latest_magnitude
+            )
         if max_latest_magnitude is not None:
             try:
                 max_latest_magnitude = float(max_latest_magnitude)
@@ -837,7 +839,9 @@ class SourceHandler(BaseHandler):
                 return self.error(
                     "Invalid values for maxLatestMagnitude - could not convert to float"
                 )
-            q = q.filter(Obj.last_detected_mag <= max_latest_magnitude)
+            q = q.filter(
+                Obj.last_detected_mag(self.current_user) <= max_latest_magnitude
+            )
         if classifications is not None:
             if isinstance(classifications, str) and "," in classifications:
                 classifications = [c.strip() for c in classifications.split(",")]
@@ -969,10 +973,18 @@ class SourceHandler(BaseHandler):
                     source.get_annotations_readable_by(self.current_user),
                     key=lambda x: x.origin,
                 )
-                source_list[-1]["last_detected_at"] = source.last_detected_at
-                source_list[-1]["last_detected_mag"] = source.last_detected_mag
-                source_list[-1]["peak_detected_at"] = source.peak_detected_at
-                source_list[-1]["peak_detected_mag"] = source.peak_detected_mag
+                source_list[-1]["last_detected_at"] = source.last_detected_at(
+                    self.current_user
+                )
+                source_list[-1]["last_detected_mag"] = source.last_detected_mag(
+                    self.current_user
+                )
+                source_list[-1]["peak_detected_at"] = source.peak_detected_at(
+                    self.current_user
+                )
+                source_list[-1]["peak_detected_mag"] = source.peak_detected_mag(
+                    self.current_user
+                )
                 source_list[-1]["gal_lon"] = source.gal_lon_deg
                 source_list[-1]["gal_lat"] = source.gal_lat_deg
                 source_list[-1]["luminosity_distance"] = source.luminosity_distance

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -22,7 +22,7 @@ from sqlalchemy import cast, event
 from sqlalchemy.dialects import postgresql as psql
 from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.dialects.postgresql import JSONB
-from sqlalchemy.ext.hybrid import hybrid_property
+from sqlalchemy.ext.hybrid import hybrid_property, hybrid_method
 from sqlalchemy.orm import relationship, joinedload
 from sqlalchemy.schema import UniqueConstraint
 from sqlalchemy_utils import URLType, EmailType
@@ -718,99 +718,107 @@ class Obj(Base, ha.Point):
         doc="Notifications regarding the object sent out by users",
     )
 
-    @hybrid_property
-    def last_detected_at(self):
+    @hybrid_method
+    def last_detected_at(self, user):
         """UTC ISO date at which the object was last detected above a given S/N (3.0 by default)."""
         detections = [
             phot.iso
-            for phot in self.photometry
+            for phot in Photometry.query_records_accessible_by(user)
+            .filter(Photometry.obj_id == self.id)
+            .all()
             if phot.snr is not None and phot.snr > PHOT_DETECTION_THRESHOLD
         ]
         return max(detections) if detections else None
 
     @last_detected_at.expression
-    def last_detected_at(cls):
+    def last_detected_at(cls, user):
         """UTC ISO date at which the object was last detected above a given S/N (3.0 by default)."""
         return (
-            sa.select([sa.func.max(Photometry.iso)])
-            .where(Photometry.obj_id == cls.id)
-            .where(Photometry.snr.isnot(None))
-            .where(Photometry.snr > PHOT_DETECTION_THRESHOLD)
+            Photometry.query_records_accessible_by(
+                user, columns=[sa.func.max(Photometry.iso)], mode="read"
+            )
+            .filter(Photometry.obj_id == cls.id)
+            .filter(Photometry.snr.isnot(None))
+            .filter(Photometry.snr > PHOT_DETECTION_THRESHOLD)
             .label('last_detected_at')
         )
 
-    @hybrid_property
-    def last_detected_mag(self):
+    @hybrid_method
+    def last_detected_mag(self, user):
         """Magnitude at which the object was last detected above a given S/N (3.0 by default)."""
         detections = [
             (phot.iso, phot.mag)
-            for phot in self.photometry
+            for phot in Photometry.query_records_accessible_by(user)
+            .filter(Photometry.obj_id == self.id)
+            .all()
             if phot.snr is not None and phot.snr > PHOT_DETECTION_THRESHOLD
         ]
         return max(detections, key=(lambda x: x[0]))[1] if detections else None
 
     @last_detected_mag.expression
-    def last_detected_mag(cls):
+    def last_detected_mag(cls, user):
         """Magnitude at which the object was last detected above a given S/N (3.0 by default)."""
-        last_detected = (
-            sa.select([cls.id, sa.func.max(Photometry.mjd).label("max_mjd")])
-            .where(Photometry.obj_id == cls.id)
-            .where(Photometry.snr.isnot(None))
-            .where(Photometry.snr > PHOT_DETECTION_THRESHOLD)
-            .group_by(cls.id)
-            .alias()
-        )
         return (
-            sa.select([Photometry.mag])
-            .where(Photometry.obj_id == cls.id)
-            .where(Photometry.snr.isnot(None))
-            .where(Photometry.snr > PHOT_DETECTION_THRESHOLD)
-            .where(cls.id == last_detected.c.id)
-            .where(Photometry.mjd == last_detected.c.max_mjd)
+            Photometry.query_records_accessible_by(
+                user, columns=[Photometry.mag], mode="read"
+            )
+            .filter(Photometry.obj_id == cls.id)
+            .filter(Photometry.snr.isnot(None))
+            .filter(Photometry.snr > PHOT_DETECTION_THRESHOLD)
+            .order_by(Photometry.mjd.desc())
+            .limit(1)
             .label('last_detected_mag')
         )
 
-    @hybrid_property
-    def peak_detected_at(self):
+    @hybrid_method
+    def peak_detected_at(self, user):
         """UTC ISO date at which the object was detected at peak magnitude above a given S/N (3.0 by default)."""
         detections = [
             (phot.iso, phot.mag)
-            for phot in self.photometry
+            for phot in Photometry.query_records_accessible_by(user)
+            .filter(Photometry.obj_id == self.id)
+            .all()
             if phot.snr is not None and phot.snr > PHOT_DETECTION_THRESHOLD
         ]
         return max(detections, key=(lambda x: x[1]))[0] if detections else None
 
     @peak_detected_at.expression
-    def peak_detected_at(cls):
+    def peak_detected_at(cls, user):
         """UTC ISO date at which the object was detected at peak magnitude above a given S/N (3.0 by default)."""
         return (
-            sa.select([Photometry.iso])
-            .where(Photometry.obj_id == cls.id)
-            .where(Photometry.snr.isnot(None))
-            .where(Photometry.snr > PHOT_DETECTION_THRESHOLD)
+            Photometry.query_records_accessible_by(
+                user, columns=[Photometry.iso], mode="read"
+            )
+            .filter(Photometry.obj_id == cls.id)
+            .filter(Photometry.snr.isnot(None))
+            .filter(Photometry.snr > PHOT_DETECTION_THRESHOLD)
             .order_by(Photometry.mag.desc())
             .limit(1)
             .label('peak_detected_at')
         )
 
-    @hybrid_property
-    def peak_detected_mag(self):
+    @hybrid_method
+    def peak_detected_mag(self, user):
         """Peak magnitude at which the object was detected above a given S/N (3.0 by default)."""
         detections = [
             phot.mag
-            for phot in self.photometry
+            for phot in Photometry.query_records_accessible_by(user)
+            .filter(Photometry.obj_id == self.id)
+            .all()
             if phot.snr is not None and phot.snr > PHOT_DETECTION_THRESHOLD
         ]
         return max(detections) if detections else None
 
     @peak_detected_mag.expression
-    def peak_detected_mag(cls):
+    def peak_detected_mag(cls, user):
         """Peak magnitude at which the object was detected above a given S/N (3.0 by default)."""
         return (
-            sa.select([sa.func.max(Photometry.mag)])
-            .where(Photometry.obj_id == cls.id)
-            .where(Photometry.snr.isnot(None))
-            .where(Photometry.snr > PHOT_DETECTION_THRESHOLD)
+            Photometry.query_records_accessible_by(
+                user, columns=[sa.func.max(Photometry.mag)], mode="read"
+            )
+            .filter(Photometry.obj_id == cls.id)
+            .filter(Photometry.snr.isnot(None))
+            .filter(Photometry.snr > PHOT_DETECTION_THRESHOLD)
             .label('peak_detected_mag')
         )
 
@@ -2321,7 +2329,7 @@ class Photometry(ha.Point, Base):
 
     __tablename__ = 'photometry'
 
-    read = accessible_by_groups_members
+    read = accessible_by_groups_members | accessible_by_owner
     update = delete = accessible_by_owner
 
     mjd = sa.Column(sa.Float, nullable=False, doc='MJD of the observation.', index=True)
@@ -2419,6 +2427,7 @@ class Photometry(ha.Point, Base):
         'User',
         back_populates='photometry',
         foreign_keys=[owner_id],
+        passive_deletes=True,
         cascade='save-update, merge, refresh-expire, expunge',
         doc="The User who uploaded the photometry.",
     )
@@ -2532,6 +2541,7 @@ User.photometry = relationship(
     'Photometry',
     doc='Photometry uploaded by this User.',
     back_populates='owner',
+    passive_deletes=True,
     foreign_keys="Photometry.owner_id",
 )
 

--- a/skyportal/tests/api/test_candidates.py
+++ b/skyportal/tests/api/test_candidates.py
@@ -1342,3 +1342,64 @@ def test_correct_spectra_and_photometry_returned_by_candidate(
     spec_ids_db = sorted([p.id for p in public_candidate.spectra])
     spec_ids_api = sorted([p['id'] for p in data['data']['spectra']])
     assert spec_ids_db == spec_ids_api
+
+
+def test_candidates_hidden_photometry_not_leaked(
+    public_candidate,
+    ztf_camera,
+    public_group,
+    public_group2,
+    view_only_token,
+    upload_data_token_two_groups,
+):
+    obj_id = str(public_candidate.id)
+    # Post photometry to the object belonging to a different group
+    status, data = api(
+        'POST',
+        'photometry',
+        data={
+            'obj_id': obj_id,
+            'mjd': 58000.0,
+            'instrument_id': ztf_camera.id,
+            'flux': 12.24,
+            'fluxerr': 0.031,
+            'zp': 25.0,
+            'magsys': 'ab',
+            'filter': 'ztfg',
+            'group_ids': [public_group2.id],
+            'altdata': {'some_key': 'some_value'},
+        },
+        token=upload_data_token_two_groups,
+    )
+    assert status == 200
+    assert data['status'] == 'success'
+    photometry_id = data['data']['ids'][0]
+
+    # Check the photometry sent back with the candidate
+    status, data = api(
+        "GET",
+        "candidates",
+        params={"groupIDs": f"{public_group.id}", "includePhotometry": "true"},
+        token=view_only_token,
+    )
+    assert status == 200
+    assert len(data["data"]["candidates"]) == 1
+    assert data["data"]["candidates"][0]["id"] == obj_id
+    assert len(public_candidate.photometry) - 1 == len(
+        data["data"]["candidates"][0]["photometry"]
+    )
+    assert photometry_id not in map(
+        lambda x: x["id"], data["data"]["candidates"][0]["photometry"]
+    )
+
+    # Check for single GET call as well
+    status, data = api(
+        "GET",
+        f"candidates/{obj_id}",
+        params={"includePhotometry": "true"},
+        token=view_only_token,
+    )
+    assert status == 200
+    assert data["data"]["id"] == obj_id
+    assert len(public_candidate.photometry) - 1 == len(data["data"]["photometry"])
+    assert photometry_id not in map(lambda x: x["id"], data["data"]["photometry"])


### PR DESCRIPTION
This PR refactors the detection hybrid properties in the `Obj` class to hybrid methods which take in a user instance so that those are computed based on accessible Photometry rows instead of all rows. The Candidates and Sources GET handlers were updated to reflect this; this should take care of Photometry leaks in those handlers. Also added/updated some tests to check that hidden photometry data isn't reflected in returned candidates/sources.

I don't think I touched anything that you did in your #1833 PR @acrellin so we shouldn't have any merge conflicts. I also didn't uncomment the `self.verify_and_commit()` lines in the SourcesHandler, as that'll be done by that PR.

Finally, set `read = accessible_by_groups_members | accessible_by_owner` on Photometry rows to make it clear that whoever posts a photometry point can read it. This was already there logically since the owner's single user group is added to the Photometry groups automatically, but wasn't very clear from the `read = accessible_by_groups_members` definition.