### PR TITLE
Update permissions for instrument and observing run handlers

### DIFF
--- a/skyportal/handlers/api/instrument.py
+++ b/skyportal/handlers/api/instrument.py
@@ -13,9 +13,9 @@ class InstrumentHandler(BaseHandler):
 
         data = self.get_json()
         telescope_id = data.get('telescope_id')
-        telescope = Telescope.query.get(telescope_id)
-        if not telescope:
-            return self.error('Invalid telescope ID.')
+        telescope = Telescope.get_if_accessible_by(
+            telescope_id, self.current_user, raise_if_none=True, mode="read"
+        )
 
         schema = Instrument.__schema__()
         try:
@@ -74,21 +74,18 @@ class InstrumentHandler(BaseHandler):
                   schema: Error
         """
         if instrument_id is not None:
-            instrument = Instrument.query.get(int(instrument_id))
-
-            if instrument is None:
-                return self.error(
-                    f"Could not load instrument {instrument_id}",
-                    data={"instrument_id": instrument_id},
-                )
+            instrument = Instrument.get_if_accessible_by(
+                int(instrument_id), self.current_user, raise_if_none=True, mode="read"
+            )
             return self.success(data=instrument)
 
         inst_name = self.get_query_argument("name", None)
-        query = Instrument.query
+        query = Instrument.query_records_accessible_by(self.current_user, mode="read")
         if inst_name is not None:
             query = query.filter(Instrument.name == inst_name)
+        instruments = query.all()
         self.verify_and_commit()
-        return self.success(data=query.all())
+        return self.success(data=instruments)
 
     @permissions(['System admin'])
     def put(self, instrument_id):
@@ -119,6 +116,11 @@ class InstrumentHandler(BaseHandler):
         """
         data = self.get_json()
         data['id'] = int(instrument_id)
+
+        # permission check
+        _ = Instrument.get_if_accessible_by(
+            int(instrument_id), self.current_user, raise_if_none=True, mode='update'
+        )
 
         schema = Instrument.__schema__()
         try:
@@ -154,9 +156,10 @@ class InstrumentHandler(BaseHandler):
               application/json:
                 schema: Error
         """
-        DBSession().query(Instrument).filter(
-            Instrument.id == int(instrument_id)
-        ).delete()
+        instrument = Instrument.get_if_accessible_by(
+            int(instrument_id), self.current_user, raise_if_none=True, mode='update'
+        )
+        DBSession().delete(instrument)
         self.verify_and_commit()
 
         return self.success()

--- a/skyportal/handlers/api/observingrun.py
+++ b/skyportal/handlers/api/observingrun.py
@@ -151,10 +151,6 @@ class ObservingRunHandler(BaseHandler):
                     d["rise_time_utc"] = rt if rt is not np.ma.masked else ''
                     d["set_time_utc"] = st if st is not np.ma.masked else ''
 
-            # TODO: uncomment once API is refactored - this is currently commented
-            # as this handler implements some changes to persistent records that
-            # should not ever be flushed to the database
-
             self.verify_and_commit()
             return self.success(data=data)
 

--- a/skyportal/handlers/api/observingrun.py
+++ b/skyportal/handlers/api/observingrun.py
@@ -2,6 +2,7 @@ import numpy as np
 from sqlalchemy.orm import joinedload
 from marshmallow.exceptions import ValidationError
 from baselayer.app.access import permissions, auth_or_token, AccessError
+from baselayer.app.model_util import recursive_to_dict
 from ..base import BaseHandler
 from ...models import (
     DBSession,
@@ -151,11 +152,12 @@ class ObservingRunHandler(BaseHandler):
                     d["rise_time_utc"] = rt if rt is not np.ma.masked else ''
                     d["set_time_utc"] = st if st is not np.ma.masked else ''
 
+            data = recursive_to_dict(data)
             self.verify_and_commit()
             return self.success(data=data)
 
         runs = (
-            ObservingRun.query_accessible_rows(self.current_user, mode="read")
+            ObservingRun.query_records_accessible_by(self.current_user, mode="read")
             .order_by(ObservingRun.calendar_date.asc())
             .all()
         )

--- a/skyportal/tests/conftest.py
+++ b/skyportal/tests/conftest.py
@@ -581,6 +581,15 @@ def problematic_assignment(lris_run_20201118, public_ZTF20acgrjqm):
 
 
 @pytest.fixture()
+def public_assignment(red_transients_run, user, public_source):
+    assignment = ClassicalAssignmentFactory(
+        run=red_transients_run, obj=public_source, requester=user, last_modified_by=user
+    )
+    yield assignment
+    ClassicalAssignmentFactory.teardown(assignment)
+
+
+@pytest.fixture()
 def private_source():
     obj = ObjFactory(groups=[])
     yield obj


### PR DESCRIPTION
Refactor the `instrument.py` and `observingrun.py` handlers to use new permissions system. Also added a test for observing runs to make sure it doesn't leak groups nested in the run's assignments.  

@dannygoldstein There was a TODO comment about not turning on verify_and_commit here until the refactor due to "changes to persistent records that shouldn't be flushed". I wasn't sure if I followed exactly what you meant by that - let me know if there's anything more I need to do here. 