### PR TITLE
Optimize annotations_info query

### DIFF
--- a/skyportal/handlers/api/internal/annotations_info.py
+++ b/skyportal/handlers/api/internal/annotations_info.py
@@ -125,6 +125,7 @@ class AnnotationsInfoHandler(BaseHandler):
             .outerjoin(annotations, literal(True))
             .join(GroupAnnotation)
             .filter(GroupAnnotation.group_id.in_(user_accessible_group_ids))
+            .distinct()
         )
 
         # Restructure query results so that records are grouped by origin in a


### PR DESCRIPTION
Since Objs are read public, we can actually skip the candidate filter check entirely, and just check for group membership in `GroupAnnotations`. I tried using `Annotation.query_rows_accessible_by()` but it was like 2x slower than doing it manually like this, at least on the demo data (maybe because read access on annotations has  `AccessibleIfRelatedRowsAreAccessible(obj='read')` defined and public access queries are still slower than not querying it at all).  On the demo data, I'm seeing ~2ms per call with this new version compared to ~7ms on the original query. 

Also, I held off on adding `self.verify_and_commit()` to this as that will only add to the time and it is basically just double-checking the access logic which should already be correct in the main query. I figured we could see how this does on production before deciding it's fast enough to add in the verification guard. 

I think this is the fastest I can get the query for now without doing something drastically different like caching the annotation metadata for each candidate or something like that 