### PR TITLE
Flag to remove nested output from bulk source query for RCF group

### DIFF
--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -161,12 +161,12 @@ class SourceHandler(BaseHandler):
               description: |
                 Boolean indicating whether to return if a source has a spectra. Defaults to false.
             - in: query
-              name: includeNested
+              name: includeThumbnails
               nullable: true
               schema:
                 type: boolean
               description: |
-                Boolean indicating whether to return nested output. Defaults to true.
+                Boolean indicating whether to include associated thumbnails. Defaults to false.
           responses:
             200:
               content:
@@ -369,12 +369,12 @@ class SourceHandler(BaseHandler):
             description: |
               Boolean indicating whether to return if a source has a spectra. Defaults to false.
           - in: query
-            name: includeNested
+            name: removeNested
             nullable: true
             schema:
               type: boolean
             description: |
-              Boolean indicating whether to return nested output. Defaults to true.
+              Boolean indicating whether to return nested output. Defaults to false.
           - in: query
             name: classifications
             nullable: true

--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -565,7 +565,9 @@ class SourceHandler(BaseHandler):
         if obj_id is not None:
             if include_thumbnails:
                 query_options = [
-                    joinedload(Obj.followup_requests).joinedload(FollowupRequest.requester),
+                    joinedload(Obj.followup_requests).joinedload(
+                        FollowupRequest.requester
+                    ),
                     joinedload(Obj.followup_requests)
                     .joinedload(FollowupRequest.allocation)
                     .joinedload(Allocation.instrument),
@@ -578,9 +580,11 @@ class SourceHandler(BaseHandler):
                     .joinedload(FollowupRequest.allocation)
                     .joinedload(Allocation.group),
                 ]
-            else: 
+            else:
                 query_options = [
-                    joinedload(Obj.followup_requests).joinedload(FollowupRequest.requester),
+                    joinedload(Obj.followup_requests).joinedload(
+                        FollowupRequest.requester
+                    ),
                     joinedload(Obj.followup_requests)
                     .joinedload(FollowupRequest.allocation)
                     .joinedload(Allocation.instrument),
@@ -591,14 +595,13 @@ class SourceHandler(BaseHandler):
                     joinedload(Obj.followup_requests)
                     .joinedload(FollowupRequest.allocation)
                     .joinedload(Allocation.group),
-                ] 
+                ]
 
             s = Obj.get_if_readable_by(
                 obj_id,
                 self.current_user,
                 options=query_options,
             )
-
 
             if s is None:
                 return self.error("Source not found", status=404)

--- a/skyportal/tests/api/test_sources.py
+++ b/skyportal/tests/api/test_sources.py
@@ -52,6 +52,50 @@ def test_token_user_retrieving_source_with_phot(view_only_token, public_source):
     )
 
 
+def test_token_user_retrieving_source_with_thumbnails(view_only_token, public_source):
+    status, data = api(
+        "GET",
+        f"sources/{public_source.id}",
+        params={"includeThumbnails": "true"},
+        token=view_only_token,
+    )
+    assert status == 200
+    assert data["status"] == "success"
+    assert all(
+        k in data["data"]
+        for k in ["ra", "dec", "redshift", "dm", "created_at", "id", "thumbnails"]
+    )
+    status, data = api(
+        "GET",
+        f"sources/{public_source.id}",
+        params={"includeThumbnails": "false"},
+        token=view_only_token,
+    )
+    assert status == 200
+    assert data["status"] == "success"
+    assert "thumbnails" not in data["data"]
+
+
+def test_token_user_retrieving_sources_without_nested(view_only_token):
+    status, data = api(
+        "GET",
+        f"sources",
+        params={"removeNested": "true"},
+        token=view_only_token,
+    )
+    assert status == 200
+    assert data["status"] == "success"
+    assert "sources" in data["data"]
+    assert all(
+        k in data["data"]["sources"][0]
+        for k in ["ra", "dec", "redshift", "classifications", "created_at", "id"]
+    )
+    assert all(
+    	k not in data["data"]["sources"][0]
+    	for k in ["annotations", "groups"]
+    )
+
+
 def test_token_user_update_source(upload_data_token, public_source):
     status, data = api(
         "PATCH",

--- a/skyportal/tests/api/test_sources.py
+++ b/skyportal/tests/api/test_sources.py
@@ -79,7 +79,7 @@ def test_token_user_retrieving_source_with_thumbnails(view_only_token, public_so
 def test_token_user_retrieving_sources_without_nested(view_only_token):
     status, data = api(
         "GET",
-        f"sources",
+        "sources",
         params={"removeNested": "true"},
         token=view_only_token,
     )
@@ -90,10 +90,7 @@ def test_token_user_retrieving_sources_without_nested(view_only_token):
         k in data["data"]["sources"][0]
         for k in ["ra", "dec", "redshift", "classifications", "created_at", "id"]
     )
-    assert all(
-    	k not in data["data"]["sources"][0]
-    	for k in ["annotations", "groups"]
-    )
+    assert all(k not in data["data"]["sources"][0] for k in ["annotations", "groups"])
 
 
 def test_token_user_update_source(upload_data_token, public_source):
@@ -312,7 +309,9 @@ def test_starlist(upload_data_token, public_source):
     assert isinstance(data["data"]["starlist_info"][0]["ra"], float)
 
     status, data = api(
-        "GET", f"sources/{public_source.id}/offsets", token=upload_data_token,
+        "GET",
+        f"sources/{public_source.id}/offsets",
+        token=upload_data_token,
     )
     assert status == 200
     assert data["status"] == "success"
@@ -629,7 +628,9 @@ def test_source_photometry_summary_info(
     iso2 = arrow.get((pt2["mjd"] - 40_587) * 86400.0).isoformat()
 
     status, data = api(
-        "GET", f"sources/{public_source_no_data.id}", token=view_only_token,
+        "GET",
+        f"sources/{public_source_no_data.id}",
+        token=view_only_token,
     )
     assert status == 200
     assert data["status"] == "success"
@@ -1276,7 +1277,10 @@ def test_sources_filter_by_has_tns_name(
 
 
 def test_sources_filter_by_has_spectrum(
-    view_only_token, public_group, public_source, public_source_no_data,
+    view_only_token,
+    public_group,
+    public_source,
+    public_source_no_data,
 ):
     # Filter for obj 1 only, since the no data source will not have spectra
     status, data = api(


### PR DESCRIPTION
To speed up bulk source query for groups which have large number of sources (like RCF), added a flag (removeNested) to remove nested query options, annotations and groups output, and only keep classifications along with basic object data.
Also added a flag to include thumbnails (earlier they were returned be default) for single source query.