### PR TITLE
Combine count and limit/offset queries for scanning

### DIFF
--- a/skyportal/handlers/api/candidate.py
+++ b/skyportal/handlers/api/candidate.py
@@ -1078,22 +1078,23 @@ def grab_query_results(
     page_ids = map(lambda x: x[0], results)
     info["totalMatches"] = results[0][1] if len(results) > 0 else 0
 
-    if (
-        (
+    if page:
+        if (
             (
-                info["totalMatches"] < (page - 1) * n_items_per_page
-                and info["totalMatches"] % n_items_per_page != 0
+                (
+                    info["totalMatches"] < (page - 1) * n_items_per_page
+                    and info["totalMatches"] % n_items_per_page != 0
+                )
+                or (
+                    info["totalMatches"] < page * n_items_per_page
+                    and info["totalMatches"] % n_items_per_page == 0
+                )
+                and info["totalMatches"] != 0
             )
-            or (
-                info["totalMatches"] < page * n_items_per_page
-                and info["totalMatches"] % n_items_per_page == 0
-            )
-            and info["totalMatches"] != 0
-        )
-        or page <= 0
-        or (info["totalMatches"] == 0 and page != 1)
-    ):
-        raise ValueError("Page number out of range.")
+            or page <= 0
+            or (info["totalMatches"] == 0 and page != 1)
+        ):
+            raise ValueError("Page number out of range.")
 
     items = []
     query_options = [joinedload(Obj.thumbnails)]

--- a/skyportal/tests/api/test_candidates.py
+++ b/skyportal/tests/api/test_candidates.py
@@ -1406,63 +1406,63 @@ def test_candidates_hidden_photometry_not_leaked(
 
 
 def test_candidate_list_pagination(
-    view_only_token, upload_data_token, public_filter, capsys
+    view_only_token,
+    upload_data_token,
+    public_group,
+    public_filter,
 ):
-    with capsys.disabled():
-        # Upload two candidates with know passed_at order
-        obj_id1 = str(uuid.uuid4())
-        obj_id2 = str(uuid.uuid4())
-        status, data = api(
-            "POST",
-            "candidates",
-            data={
-                "id": obj_id1,
-                "ra": 234.22,
-                "dec": -22.33,
-                "redshift": 3,
-                "transient": False,
-                "ra_dis": 2.3,
-                "filter_ids": [public_filter.id],
-                "passed_at": str(datetime.datetime.utcnow()),
-            },
-            token=upload_data_token,
-        )
-        assert status == 200
-        status, data = api(
-            "POST",
-            "candidates",
-            data={
-                "id": obj_id2,
-                "ra": 234.22,
-                "dec": -22.33,
-                "redshift": 3,
-                "transient": False,
-                "ra_dis": 2.3,
-                "filter_ids": [public_filter.id],
-                "passed_at": str(
-                    datetime.datetime.utcnow() + datetime.timedelta(days=1)
-                ),
-            },
-            token=upload_data_token,
-        )
-        assert status == 200
+    # Upload two candidates with know passed_at order
+    obj_id1 = str(uuid.uuid4())
+    obj_id2 = str(uuid.uuid4())
+    status, data = api(
+        "POST",
+        "candidates",
+        data={
+            "id": obj_id1,
+            "ra": 234.22,
+            "dec": -22.33,
+            "redshift": 3,
+            "transient": False,
+            "ra_dis": 2.3,
+            "filter_ids": [public_filter.id],
+            "passed_at": str(datetime.datetime.utcnow()),
+        },
+        token=upload_data_token,
+    )
+    assert status == 200
+    status, data = api(
+        "POST",
+        "candidates",
+        data={
+            "id": obj_id2,
+            "ra": 234.22,
+            "dec": -22.33,
+            "redshift": 3,
+            "transient": False,
+            "ra_dis": 2.3,
+            "filter_ids": [public_filter.id],
+            "passed_at": str(datetime.datetime.utcnow() + datetime.timedelta(days=1)),
+        },
+        token=upload_data_token,
+    )
+    assert status == 200
 
-        # Default order is descending passed_at
-        status, data = api(
-            "GET",
-            "candidates",
-            params={"numPerPage": 1, "pageNumber": 2},
-            token=view_only_token,
-        )
-        assert status == 200
-        assert data["data"]["candidates"][0]["id"] == obj_id1
+    # Default order is descending passed_at
+    status, data = api(
+        "GET",
+        "candidates",
+        params={"numPerPage": 1, "pageNumber": 2, "groupIDs": f"{public_group.id}"},
+        token=view_only_token,
+    )
+    assert status == 200
+    assert data["data"]["candidates"][0]["id"] == obj_id1
 
-        # Invalid page
-        status, data = api(
-            "GET",
-            "candidates",
-            params={"numPerPage": 1, "pageNumber": 4},
-            token=view_only_token,
-        )
-        assert status == 400
-        assert "Page number out of range" in data["message"]
+    # Invalid page
+    status, data = api(
+        "GET",
+        "candidates",
+        params={"numPerPage": 1, "pageNumber": 4},
+        token=view_only_token,
+    )
+    assert status == 400
+    assert "Page number out of range" in data["message"]

--- a/skyportal/tests/api/test_candidates.py
+++ b/skyportal/tests/api/test_candidates.py
@@ -1403,3 +1403,66 @@ def test_candidates_hidden_photometry_not_leaked(
     assert data["data"]["id"] == obj_id
     assert len(public_candidate.photometry) - 1 == len(data["data"]["photometry"])
     assert photometry_id not in map(lambda x: x["id"], data["data"]["photometry"])
+
+
+def test_candidate_list_pagination(
+    view_only_token, upload_data_token, public_filter, capsys
+):
+    with capsys.disabled():
+        # Upload two candidates with know passed_at order
+        obj_id1 = str(uuid.uuid4())
+        obj_id2 = str(uuid.uuid4())
+        status, data = api(
+            "POST",
+            "candidates",
+            data={
+                "id": obj_id1,
+                "ra": 234.22,
+                "dec": -22.33,
+                "redshift": 3,
+                "transient": False,
+                "ra_dis": 2.3,
+                "filter_ids": [public_filter.id],
+                "passed_at": str(datetime.datetime.utcnow()),
+            },
+            token=upload_data_token,
+        )
+        assert status == 200
+        status, data = api(
+            "POST",
+            "candidates",
+            data={
+                "id": obj_id2,
+                "ra": 234.22,
+                "dec": -22.33,
+                "redshift": 3,
+                "transient": False,
+                "ra_dis": 2.3,
+                "filter_ids": [public_filter.id],
+                "passed_at": str(
+                    datetime.datetime.utcnow() + datetime.timedelta(days=1)
+                ),
+            },
+            token=upload_data_token,
+        )
+        assert status == 200
+
+        # Default order is descending passed_at
+        status, data = api(
+            "GET",
+            "candidates",
+            params={"numPerPage": 1, "pageNumber": 2},
+            token=view_only_token,
+        )
+        assert status == 200
+        assert data["data"]["candidates"][0]["id"] == obj_id1
+
+        # Invalid page
+        status, data = api(
+            "GET",
+            "candidates",
+            params={"numPerPage": 1, "pageNumber": 4},
+            token=view_only_token,
+        )
+        assert status == 400
+        assert "Page number out of range" in data["message"]


### PR DESCRIPTION
This PR adds the `count()` query for `totalMatches` in the candidates query to the main query so that they are just called once together instead of essentially calling the same query twice. The block to check for out-of-range page numbers is moved to below the main query since now we don't know the total count beforehand. Also added a test for the pagination on the candidates query.