### PR TITLE
Fix user/group/streams in demo data

### DIFF
--- a/data/db_demo.yaml
+++ b/data/db_demo.yaml
@@ -46,9 +46,11 @@ groups:
     =id: program_B
 
 groups/=program_A/users:
-  - userID: =viewonlyuser
-    admin: false
   - userID: =fulluser
+    admin: false
+
+groups/=program_B/users:
+  - userID: =viewonlyuser
     admin: false
 
 streams/=ztf_public/users:
@@ -57,8 +59,12 @@ streams/=ztf_public/users:
   - user_id: =groupadmin
   - user_id: =testadmin
 
+streams/=ztf_partnership/users:
+  - user_id: =fulluser
+  - user_id: =groupadmin
+  - user_id: =testadmin
+
 streams/=ztf_caltech/users:
-  - user_id: =viewonlyuser
   - user_id: =fulluser
   - user_id: =groupadmin
   - user_id: =testadmin


### PR DESCRIPTION
There are some discrepancies in users and stream access permissions within the current demo data. 
The following were addressed:
- Group A is marked as needing access to the `ztf_partnership` stream, but its members only have access to the `ztf_public` and `ztf_caltech` streams. Now these users have partnership stream access as well.
- `viewonlyuser` was not really special, as they were put in Group A (which requires partnership access) and given access to the Caltech stream. The user was moved to Group B (which only requires public stream access) and their access to the partnership and Caltech streams removed.