### PR TITLE
Fix candidates query ordering

### DIFF
--- a/skyportal/handlers/api/candidate.py
+++ b/skyportal/handlers/api/candidate.py
@@ -528,7 +528,7 @@ class CandidateHandler(BaseHandler):
             # Don't apply the order by just yet. Save it so we can pass it to
             # the LIMT/OFFSET helper function down the line once other query
             # params are set.
-            order_by = [Candidate.passed_at.desc().nullslast(), Obj.id]
+            order_by = [candidate_subquery.c.passed_at.desc().nullslast(), Obj.id]
 
         if saved_status in [
             "savedToAllSelected",
@@ -727,7 +727,7 @@ class CandidateHandler(BaseHandler):
             order_by = [
                 origin_sort_order.nullslast(),
                 annotation_sort_criterion,
-                Candidate.passed_at.desc().nullslast(),
+                candidate_subquery.c.passed_at.desc().nullslast(),
                 Obj.id,
             ]
 


### PR DESCRIPTION
The root of the candidates list pagination test failing sometimes was that the default ORDER BY on `Candidates.passed_at` was being done on the wrong thing. Instead of the candidates in the candidates subquery, it was trying to order on the base `Candidates` table and was again introducing the `Candidates, Obj` cross-join we saw yesterday.