### PR TITLE
Do not allow negative `fluxerr` values in photometry POST handler

### DIFF
--- a/skyportal/handlers/api/photometry.py
+++ b/skyportal/handlers/api/photometry.py
@@ -173,7 +173,10 @@ class PhotometryHandler(BaseHandler):
                 )
             else:
                 kind = 'flux'
-                if data['fluxerr'] < 0:
+                if (
+                    isinstance(data['fluxerr'], (list, tuple))
+                    and not all([fluxerr >= 0 for fluxerr in data['fluxerr']])
+                ) or (isinstance(data['fluxerr'], float) and data['fluxerr'] < 0):
                     raise ValidationError("fluxerr must be a non-negative value.")
         else:
             kind = 'mag'

--- a/skyportal/handlers/api/photometry.py
+++ b/skyportal/handlers/api/photometry.py
@@ -173,14 +173,6 @@ class PhotometryHandler(BaseHandler):
                 )
             else:
                 kind = 'flux'
-                if (
-                    isinstance(data['fluxerr'], (list, tuple))
-                    and not all([float(fluxerr) >= 0 for fluxerr in data['fluxerr']])
-                ) or (
-                    isinstance(data['fluxerr'], (float, str, int))
-                    and float(data['fluxerr']) < 0
-                ):
-                    raise ValidationError("fluxerr must be a non-negative value.")
         else:
             kind = 'mag'
 

--- a/skyportal/handlers/api/photometry.py
+++ b/skyportal/handlers/api/photometry.py
@@ -173,6 +173,8 @@ class PhotometryHandler(BaseHandler):
                 )
             else:
                 kind = 'flux'
+                if data['fluxerr'] < 0:
+                    raise ValidationError("fluxerr must be a non-negative value.")
         else:
             kind = 'mag'
 

--- a/skyportal/handlers/api/photometry.py
+++ b/skyportal/handlers/api/photometry.py
@@ -175,8 +175,11 @@ class PhotometryHandler(BaseHandler):
                 kind = 'flux'
                 if (
                     isinstance(data['fluxerr'], (list, tuple))
-                    and not all([fluxerr >= 0 for fluxerr in data['fluxerr']])
-                ) or (isinstance(data['fluxerr'], float) and data['fluxerr'] < 0):
+                    and not all([float(fluxerr) >= 0 for fluxerr in data['fluxerr']])
+                ) or (
+                    isinstance(data['fluxerr'], (float, str, int))
+                    and float(data['fluxerr']) < 0
+                ):
                     raise ValidationError("fluxerr must be a non-negative value.")
         else:
             kind = 'mag'

--- a/skyportal/schema.py
+++ b/skyportal/schema.py
@@ -45,6 +45,12 @@ _, cfg = load_env()
 PHOT_DETECTION_THRESHOLD = cfg["misc.photometry_detection_threshold_nsigma"]
 
 
+def validate_fluxerr(fluxerr):
+    if isinstance(fluxerr, (float, int, str)):
+        return float(fluxerr) >= 0
+    return all([float(el) >= 0 for el in fluxerr])
+
+
 class ApispecEnumField(EnumField):
     """See https://github.com/justanr/marshmallow_enum/issues/24#issue-335162592"""
 
@@ -324,6 +330,7 @@ class PhotFluxFlexible(_Schema, PhotBaseFlexible):
         'If a scalar, will be broadcast to all values '
         'given as lists. Null values not allowed.',
         required=True,
+        validate=validate_fluxerr,
     )
 
     zp = fields.Field(

--- a/skyportal/tests/api/test_photometry.py
+++ b/skyportal/tests/api/test_photometry.py
@@ -2300,4 +2300,25 @@ def test_cannot_post_negative_fluxerr(
     )
     assert status == 400
     assert data['status'] == 'error'
-    assert "fluxerr must be a non-negative value" in data['message']
+    assert "Invalid value" in data['message']
+
+    status, data = api(
+        'POST',
+        'photometry',
+        data={
+            'obj_id': str(public_source.id),
+            'mjd': [58000.0, 58000.4],
+            'instrument_id': ztf_camera.id,
+            'flux': [12.24, 12.43],
+            'fluxerr': [0.35, -0.031],
+            'zp': 25.0,
+            'magsys': 'ab',
+            'filter': 'ztfg',
+            'group_ids': [public_group.id],
+            'altdata': {'some_key': 'some_value'},
+        },
+        token=upload_data_token,
+    )
+    assert status == 400
+    assert data['status'] == 'error'
+    assert "Invalid value" in data['message']

--- a/skyportal/tests/api/test_photometry.py
+++ b/skyportal/tests/api/test_photometry.py
@@ -2276,3 +2276,28 @@ def test_problematic_photometry_1276(
     )
     assert status == 400
     assert data['status'] == 'error'
+
+
+def test_cannot_post_negative_fluxerr(
+    upload_data_token, public_source, public_group, ztf_camera
+):
+    status, data = api(
+        'POST',
+        'photometry',
+        data={
+            'obj_id': str(public_source.id),
+            'mjd': 58000.0,
+            'instrument_id': ztf_camera.id,
+            'flux': 12.24,
+            'fluxerr': -0.031,
+            'zp': 25.0,
+            'magsys': 'ab',
+            'filter': 'ztfg',
+            'group_ids': [public_group.id],
+            'altdata': {'some_key': 'some_value'},
+        },
+        token=upload_data_token,
+    )
+    assert status == 400
+    assert data['status'] == 'error'
+    assert "fluxerr must be a non-negative value" in data['message']


### PR DESCRIPTION
Closes https://github.com/skyportal/skyportal/issues/1861
Closes https://github.com/skyportal/skyportal/issues/1839