### PR TITLE
Fix candidates saved groups

### DIFF
--- a/skyportal/handlers/api/candidate.py
+++ b/skyportal/handlers/api/candidate.py
@@ -756,15 +756,15 @@ class CandidateHandler(BaseHandler):
             with DBSession().no_autoflush:
                 obj.is_source = (obj.id,) in matching_source_ids
                 if obj.is_source:
-                    source_subquery = Source.query_records_accessible_by(
-                        self.current_user
-                    ).subquery()
+                    source_subquery = (
+                        Source.query_records_accessible_by(self.current_user)
+                        .filter(Source.obj_id == obj.id)
+                        .filter(Source.active.is_(True))
+                        .subquery()
+                    )
                     obj.saved_groups = (
                         Group.query_records_accessible_by(self.current_user)
                         .join(source_subquery, Group.id == source_subquery.c.group_id)
-                        .filter(Source.obj_id == obj.id)
-                        .filter(Source.active.is_(True))
-                        .filter(Group.id.in_(user_accessible_group_ids))
                         .all()
                     )
                     obj.classifications = (


### PR DESCRIPTION
I think this is the cleanest and most efficient fix: limits the subquery to just the Source records we actually need
Also removes an unnecessary `.filter(Group.id.in_(user_accessible_group_ids))` since we were already doing `Group.query_accessible_records_by`