### PR TITLE
Ensure source table row is not None before accessing attrs

### DIFF
--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -1047,18 +1047,20 @@ class SourceHandler(BaseHandler):
                     source_table_row = (
                         Source.query_records_accessible_by(self.current_user)
                         .filter(
-                            Source.obj_id == source.id, Source.group_id == group["id"]
+                            Source.obj_id == source_list[-1]["id"],
+                            Source.group_id == group["id"],
                         )
                         .first()
                     )
-                    group["active"] = source_table_row.active
-                    group["requested"] = source_table_row.requested
-                    group["saved_at"] = source_table_row.saved_at
-                    group["saved_by"] = (
-                        source_table_row.saved_by.to_dict()
-                        if source_table_row.saved_by is not None
-                        else None
-                    )
+                    if source_table_row is not None:
+                        group["active"] = source_table_row.active
+                        group["requested"] = source_table_row.requested
+                        group["saved_at"] = source_table_row.saved_at
+                        group["saved_by"] = (
+                            source_table_row.saved_by.to_dict()
+                            if source_table_row.saved_by is not None
+                            else None
+                        )
                 if include_color_mag:
                     source_list[-1]["color_magnitude"] = get_color_mag(
                         source_list[-1]["annotations"]


### PR DESCRIPTION
Have been seeing a lot of 
```
Traceback (most recent call last):                                                                      
  File "/skyportal_env/lib/python3.8/site-packages/tornado/web.py", line 1702, in _execute              
    result = method(*self.path_args, **self.path_kwargs)                                                
  File "/skyportal/baselayer/app/access.py", line 32, in wrapper                                        
    return tornado.web.authenticated(method)(self, *args, **kwargs)                                     
  File "/skyportal_env/lib/python3.8/site-packages/tornado/web.py", line 3173, in wrapper               
    return method(self, *args, **kwargs)                                                                
  File "/skyportal/skyportal/handlers/api/source.py", line 1054, in get                                 
    group["active"] = source_table_row.active                                                           
AttributeError: 'NoneType' object has no attribute 'active'                                             
```
in the logs. We still need to investigate why this query is not returning any results.