### PR TITLE
Fix flaky tests associated with UnitializedDBMessage

### DIFF
--- a/skyportal/tests/frontend/test_remote.py
+++ b/skyportal/tests/frontend/test_remote.py
@@ -13,4 +13,4 @@ def test_remote(driver):
     DBSession.commit()
     driver.get("/")
     assert 'localhost' in driver.current_url
-    driver.wait_for_xpath('//div[contains(.,"Welcome to SkyPortal.")]')
+    driver.wait_for_xpath('//p[contains(.,"New Sources")]')

--- a/skyportal/tests/frontend/test_source_list.py
+++ b/skyportal/tests/frontend/test_source_list.py
@@ -17,14 +17,6 @@ def test_add_sources_two_groups(
     taxonomy_token_two_groups,
     classification_token_two_groups,
 ):
-
-    driver.get(
-        f"/become_user/{super_admin_user_two_groups.id}"
-    )  # TODO decorator/context manager?
-    assert 'localhost' in driver.current_url
-    driver.get('/sources')
-    driver.wait_for_xpath('//h6[contains(text(), "Sources")]', timeout=20)
-
     obj_id = str(uuid.uuid4())
     t1 = datetime.now(timezone.utc)
 
@@ -47,8 +39,15 @@ def test_add_sources_two_groups(
     assert status == 200
     assert data['data']['id'] == f'{obj_id}'
 
+    driver.get(
+        f"/become_user/{super_admin_user_two_groups.id}"
+    )  # TODO decorator/context manager?
+    assert 'localhost' in driver.current_url
+    driver.get('/sources')
+
     # filter on the object id
     driver.click_xpath("//button[@data-testid='Filter Table-iconButton']")
+
     obj_button = driver.wait_for_xpath("//input[@name='sourceID']")
     obj_button.clear()
     obj_button.send_keys(obj_id)

--- a/static/js/components/HomePage.jsx.template
+++ b/static/js/components/HomePage.jsx.template
@@ -22,8 +22,6 @@ import TopSources from "./TopSources";
 import SourceCounts from "./SourceCounts";
 import WeatherWidget from "./WeatherWidget";
 
-import UninitializedDBMessage from "./UninitializedDBMessage";
-
 const ResponsiveGridLayout = WidthProvider(Responsive);
 
 const useStyles = makeStyles(() => ({
@@ -71,10 +69,6 @@ const HomePage = () => {
 
   const groups = useSelector((state) => state.groups.user);
 
-  const sourceTableEmpty = useSelector(
-    (state) => state.dbInfo.source_table_empty
-  );
-
   const profile = useSelector((state) => state.profile);
 
   let currentLayouts =
@@ -83,10 +77,6 @@ const HomePage = () => {
       : profile.preferences.layouts;
 
   const dispatch = useDispatch();
-
-  if (sourceTableEmpty) {
-    return <UninitializedDBMessage />;
-  }
 
   const LayoutChangeHandler = (currentLayout, allLayouts) => {
     const prefs = {

--- a/static/js/components/WeatherWidget.jsx
+++ b/static/js/components/WeatherWidget.jsx
@@ -157,12 +157,13 @@ const WeatherWidget = ({ classes }) => {
       dispatch(weatherActions.fetchWeather());
     };
     if (
-      weather?.telescope_id !== weatherPrefs?.telescopeID ||
-      weather === undefined
+      telescopeList.length > 0 &&
+      (weather?.telescope_id !== weatherPrefs?.telescopeID ||
+        weather === undefined)
     ) {
       fetchWeatherData();
     }
-  }, [weatherPrefs, weather, dispatch]);
+  }, [weatherPrefs, weather, telescopeList, dispatch]);
 
   const handleClose = () => {
     setAnchorEl(null);


### PR DESCRIPTION
A couple of tests have failed occasionally if they are run in a certain order such that no non-fixture sources from the other tests have been inserted into the test database, due to the page showing the `UninitializedDBMessage.jsx` component instead of the expected page. 

You can see `test_weather_widget` and `test_add_sources_two_groups` failing in such a manner [here](https://github.com/skyportal/skyportal/pull/1793/checks?check_run_id=2364225192).

This PR fixes that by 
- Remove the `UninitializedDBMessage.jsx` on the Home Page. Now that we have widgets like the `SourceCounts.jsx` on the dashboard, that will appear to display correct information even on an empty database, I don't think we need to overwrite all that to show a message that says "the Sources table is empty". The message was more relevant when the dashboard was just the sources list component but that has now been moved to it's own page and all the other widgets added.
- I kept the `UninitializedDBMessage.jsx` in there on the Sources page, as that message is more directly relevant there. To fix `test_add_sources_two_groups`, I just waited until the test's sources were posted before navigating to the Sources page.
- Also made a small change to the `WeatherWidget.jsx` to not make the API call to fetch weather if it sees that there are no telescopes in the database (to avoid a cryptic "Telescope ID 1 could not be found" error on the dashboard for empty databases).

Here is what the home page looks like now on an uninitialized database, instead of the message:
![image](https://user-images.githubusercontent.com/17696889/115070339-d2a7fa00-9ec2-11eb-87cb-47966d0e6d2a.png)
