### PR TITLE
Increase default DB connection pool

### DIFF
--- a/skyportal/app_server.py
+++ b/skyportal/app_server.py
@@ -248,7 +248,11 @@ def make_app(cfg, baselayer_handlers, baselayer_settings, process=None, env=None
     )
 
     app = tornado.web.Application(handlers, **settings)
-    models.init_db(**cfg['database'], autoflush=False)
+    models.init_db(
+        **cfg['database'],
+        autoflush=False,
+        default_engine_args={'pool_size': 10, 'max_overflow': 15, 'pool_recycle': 3600},
+    )
 
     # If tables are found in the database, new tables will only be added
     # in debug mode.  In production, we leave the tables alone, since

--- a/skyportal/app_server.py
+++ b/skyportal/app_server.py
@@ -251,7 +251,7 @@ def make_app(cfg, baselayer_handlers, baselayer_settings, process=None, env=None
     models.init_db(
         **cfg['database'],
         autoflush=False,
-        default_engine_args={'pool_size': 10, 'max_overflow': 15, 'pool_recycle': 3600},
+        engine_args={'pool_size': 10, 'max_overflow': 15, 'pool_recycle': 3600},
     )
 
     # If tables are found in the database, new tables will only be added


### PR DESCRIPTION
Each app instance launches ~10 threads (found by trial and error—we haven't been able to figure out how to control the number of threads exactly).  Each thread gets 2 connections, for when that thread spins off another job such as the PS1 loader.