### PR TITLE
Address various issues when adding/editing SEDM requests

### DIFF
--- a/skyportal/facility_apis/sedm.py
+++ b/skyportal/facility_apis/sedm.py
@@ -1,7 +1,6 @@
 from . import FollowUpAPI, Listener
 from baselayer.app.env import load_env
 from datetime import datetime, timedelta
-from pytz import timezone
 import json
 import requests
 
@@ -14,11 +13,7 @@ class SEDMListener(Listener):
 
     schema = {
         'type': 'object',
-        'properties': {
-            'new_status': {
-                'type': 'string',
-            },
-        },  # noqa: E231
+        'properties': {'new_status': {'type': 'string',},},  # noqa: E231
         'required': ['new_status'],
     }
 
@@ -160,8 +155,7 @@ class SEDMAPI(FollowUpAPI):
         payload = convert_request_to_sedm(request, method_value='new')
         content = json.dumps(payload)
         r = requests.post(
-            cfg['app.sedm_endpoint'],
-            files={'jsonfile': ('jsonfile', content)},
+            cfg['app.sedm_endpoint'], files={'jsonfile': ('jsonfile', content)},
         )
 
         if r.status_code == 200:
@@ -193,8 +187,7 @@ class SEDMAPI(FollowUpAPI):
         payload = convert_request_to_sedm(request, method_value='delete')
         content = json.dumps(payload)
         r = requests.post(
-            cfg['app.sedm_endpoint'],
-            files={'jsonfile': ('jsonfile', content)},
+            cfg['app.sedm_endpoint'], files={'jsonfile': ('jsonfile', content)},
         )
 
         r.raise_for_status()
@@ -224,8 +217,7 @@ class SEDMAPI(FollowUpAPI):
         payload = convert_request_to_sedm(request, method_value='edit')
         content = json.dumps(payload)
         r = requests.post(
-            cfg['app.sedm_endpoint'],
-            files={'jsonfile': ('jsonfile', content)},
+            cfg['app.sedm_endpoint'], files={'jsonfile': ('jsonfile', content)},
         )
 
         if r.status_code == 200:
@@ -290,16 +282,14 @@ class SEDMAPI(FollowUpAPI):
             "start_date": {
                 "type": "string",
                 "format": "date",
-                "default": datetime.now(tz=timezone("US/Pacific")).date().isoformat(),
+                "default": datetime.utcnow().date().isoformat(),
                 "title": "Start Date (UT)",
             },
             "end_date": {
                 "type": "string",
                 "format": "date",
                 "title": "End Date (UT)",
-                "default": (
-                    datetime.now(tz=timezone("US/Pacific")).date() + timedelta(days=7)
-                ).isoformat(),
+                "default": (datetime.utcnow().date() + timedelta(days=7)).isoformat(),
             },
         },
         "dependencies": {"observation_type": {"oneOf": _dependencies}},

--- a/skyportal/facility_apis/sedm.py
+++ b/skyportal/facility_apis/sedm.py
@@ -1,6 +1,7 @@
 from . import FollowUpAPI, Listener
 from baselayer.app.env import load_env
 from datetime import datetime, timedelta
+from pytz import timezone
 import json
 import requests
 
@@ -13,7 +14,11 @@ class SEDMListener(Listener):
 
     schema = {
         'type': 'object',
-        'properties': {'new_status': {'type': 'string',},},  # noqa: E231
+        'properties': {
+            'new_status': {
+                'type': 'string',
+            },
+        },  # noqa: E231
         'required': ['new_status'],
     }
 
@@ -155,7 +160,8 @@ class SEDMAPI(FollowUpAPI):
         payload = convert_request_to_sedm(request, method_value='new')
         content = json.dumps(payload)
         r = requests.post(
-            cfg['app.sedm_endpoint'], files={'jsonfile': ('jsonfile', content)},
+            cfg['app.sedm_endpoint'],
+            files={'jsonfile': ('jsonfile', content)},
         )
 
         if r.status_code == 200:
@@ -187,7 +193,8 @@ class SEDMAPI(FollowUpAPI):
         payload = convert_request_to_sedm(request, method_value='delete')
         content = json.dumps(payload)
         r = requests.post(
-            cfg['app.sedm_endpoint'], files={'jsonfile': ('jsonfile', content)},
+            cfg['app.sedm_endpoint'],
+            files={'jsonfile': ('jsonfile', content)},
         )
 
         r.raise_for_status()
@@ -217,7 +224,8 @@ class SEDMAPI(FollowUpAPI):
         payload = convert_request_to_sedm(request, method_value='edit')
         content = json.dumps(payload)
         r = requests.post(
-            cfg['app.sedm_endpoint'], files={'jsonfile': ('jsonfile', content)},
+            cfg['app.sedm_endpoint'],
+            files={'jsonfile': ('jsonfile', content)},
         )
 
         if r.status_code == 200:
@@ -282,14 +290,16 @@ class SEDMAPI(FollowUpAPI):
             "start_date": {
                 "type": "string",
                 "format": "date",
-                "default": datetime.utcnow().date().isoformat(),
+                "default": datetime.now(tz=timezone("US/Pacific")).date().isoformat(),
                 "title": "Start Date (UT)",
             },
             "end_date": {
                 "type": "string",
                 "format": "date",
                 "title": "End Date (UT)",
-                "default": (datetime.utcnow().date() + timedelta(days=7)).isoformat(),
+                "default": (
+                    datetime.now(tz=timezone("US/Pacific")).date() + timedelta(days=7)
+                ).isoformat(),
             },
         },
         "dependencies": {"observation_type": {"oneOf": _dependencies}},

--- a/static/js/components/EditFollowupRequestDialog.jsx
+++ b/static/js/components/EditFollowupRequestDialog.jsx
@@ -40,6 +40,15 @@ const EditFollowupRequestDialog = ({
     handleClose();
   };
 
+  // Set default form values to current request data
+  const { formSchema } = instrumentFormParams[
+    followupRequest.allocation.instrument.id
+  ];
+
+  Object.keys(formSchema.properties).forEach((key) => {
+    formSchema.properties[key].default = followupRequest.payload[key];
+  });
+
   return (
     <span key={followupRequest.id}>
       <Button
@@ -55,10 +64,7 @@ const EditFollowupRequestDialog = ({
       <Dialog open={open} onClose={handleClose} className={classes.dialog}>
         <DialogContent>
           <Form
-            schema={
-              instrumentFormParams[followupRequest.allocation.instrument.id]
-                .formSchema
-            }
+            schema={formSchema}
             uiSchema={
               instrumentFormParams[followupRequest.allocation.instrument.id]
                 .uiSchema
@@ -90,6 +96,7 @@ EditFollowupRequestDialog.propTypes = {
     status: PropTypes.string,
     obj_id: PropTypes.string,
     id: PropTypes.number,
+    payload: PropTypes.objectOf(PropTypes.any),
   }).isRequired,
   instrumentFormParams: PropTypes.shape({
     formSchema: PropTypes.objectOf(PropTypes.any),

--- a/static/js/components/EditFollowupRequestDialog.jsx
+++ b/static/js/components/EditFollowupRequestDialog.jsx
@@ -40,12 +40,14 @@ const EditFollowupRequestDialog = ({
     handleClose();
   };
 
-  // Set default form values to current request data
+  // Since we are editing exsiting follow-up requests,
+  // it makes more sense to set default form values to current request data
   const { formSchema } = instrumentFormParams[
     followupRequest.allocation.instrument.id
   ];
-
   Object.keys(formSchema.properties).forEach((key) => {
+    // Set the form value for "key" to the value in the existing request's
+    // payload, which is the form data sent to the external follow-up API
     formSchema.properties[key].default = followupRequest.payload[key];
   });
 
@@ -53,7 +55,7 @@ const EditFollowupRequestDialog = ({
     if (
       formData.start_date &&
       formData.end_date &&
-      formData.start_date > formData.end_date
+      Date.parse(formData.start_date) > Date.parse(formData.end_date)
     ) {
       errors.start_date.addError("Start Date must come before End Date");
     }

--- a/static/js/components/EditFollowupRequestDialog.jsx
+++ b/static/js/components/EditFollowupRequestDialog.jsx
@@ -49,6 +49,18 @@ const EditFollowupRequestDialog = ({
     formSchema.properties[key].default = followupRequest.payload[key];
   });
 
+  const validate = (formData, errors) => {
+    if (
+      formData.start_date &&
+      formData.end_date &&
+      formData.start_date > formData.end_date
+    ) {
+      errors.start_date.addError("Start Date must come before End Date");
+    }
+
+    return errors;
+  };
+
   return (
     <span key={followupRequest.id}>
       <Button
@@ -70,6 +82,8 @@ const EditFollowupRequestDialog = ({
                 .uiSchema
             }
             onSubmit={handleSubmit}
+            validate={validate}
+            liveValidate
           />
         </DialogContent>
       </Dialog>

--- a/static/js/components/FollowupRequestForm.jsx
+++ b/static/js/components/FollowupRequestForm.jsx
@@ -112,6 +112,18 @@ const FollowupRequestForm = ({
     setIsSubmitting(false);
   };
 
+  const validate = (formData, errors) => {
+    if (
+      formData.start_date &&
+      formData.end_date &&
+      formData.start_date > formData.end_date
+    ) {
+      errors.start_date.addError("Start Date must come before End Date");
+    }
+
+    return errors;
+  };
+
   return (
     <div className={classes.container}>
       <InputLabel id="allocationSelectLabel">Allocation</InputLabel>
@@ -154,6 +166,8 @@ const FollowupRequestForm = ({
               allocationLookUp[selectedAllocationId].instrument_id
             ].uiSchema
           }
+          liveValidate
+          validate={validate}
           onSubmit={handleSubmit}
           disabled={isSubmitting}
         />

--- a/static/js/components/FollowupRequestLists.jsx
+++ b/static/js/components/FollowupRequestLists.jsx
@@ -208,6 +208,34 @@ const FollowupRequestLists = ({
     rowsPerPageOptions: [1, 10, 15],
   };
 
+  const keyOrder = (a, b) => {
+    // End date comes after start date
+    if (a === "end_date" && b === "start_date") {
+      return 1;
+    }
+    if (b === "end_date" && a === "start_date") {
+      return -1;
+    }
+
+    // Dates come before anything else
+    if (a === "end_date" || a === "start_date") {
+      return -1;
+    }
+    if (b === "end_date" || b === "start_date") {
+      return 1;
+    }
+
+    // Regular string comparison
+    if (a < b) {
+      return -1;
+    }
+    if (a > b) {
+      return 1;
+    }
+    // a must be equal to b
+    return 0;
+  };
+
   return (
     <div className={classes.container}>
       {Object.keys(requestsGroupedByInstId).map((instrument_id) => {
@@ -220,6 +248,8 @@ const FollowupRequestLists = ({
           });
           return r;
         }, []);
+
+        keys.sort(keyOrder);
 
         return (
           <Accordion


### PR DESCRIPTION
Closes fritz-marshal/fritz#141

This PR addresses this list of issues with the SEDM follow-up request forms per user feedback:

- [x] "End date" appears before "Start date" in the table, which is confusing. 
- [ ] When adding a new request, the default start date is often in the past.
  - Not sure about this one - the default is already set to `utcnow()`, and was unable to recreate issue locally. My only guess is that the user is in a timezone ahead of UTC, so the default date may appear to be in the past. But since we specify that the field is in UTC I think this is fine as is.
- [x] When editing a new request, the defaults for the fields are not the current values but seem to be the same defaults as when entering new values. This makes it very easily to accidentally change more than one intends to.
  - When editing an existing request, the form is populated with the current values instead of the default ones  
- [x] It is possible to edit someone else's request but not to delete it.
  - This has already been addressed by the permissions refactor
- [x] It is possible to create a group with a start date before the end date.
  - Custom validation has been added to the front-end to check for this

![sedm](https://user-images.githubusercontent.com/17696889/115434094-49503a80-a1d6-11eb-912f-a836a16e55fe.gif)
