### PR TITLE
Omit `Obj.redshift_history` and `Obj.internal_key` columns from POST API schema for related handlers

### DIFF
--- a/skyportal/handlers/api/candidate.py
+++ b/skyportal/handlers/api/candidate.py
@@ -866,7 +866,7 @@ class CandidateHandler(BaseHandler):
             application/json:
               schema:
                 allOf:
-                  - $ref: '#/components/schemas/Obj'
+                  - $ref: '#/components/schemas/ObjPost'
                   - type: object
                     properties:
                       filter_ids:

--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -1121,7 +1121,7 @@ class SourceHandler(BaseHandler):
             application/json:
               schema:
                 allOf:
-                  - $ref: '#/components/schemas/Obj'
+                  - $ref: '#/components/schemas/ObjPost'
                   - type: object
                     properties:
                       group_ids:

--- a/skyportal/schema.py
+++ b/skyportal/schema.py
@@ -167,6 +167,16 @@ def setup_schema():
                     'last_modified_by_id',
                 ],
             )
+            if schema_class_name == "Obj":
+                add_schema(
+                    f'{schema_class_name}Post',
+                    exclude=[
+                        'created_at',
+                        'redshift_history',
+                        'modified',
+                        'internal_key',
+                    ],
+                )
 
 
 class PhotBaseFlexible(object):


### PR DESCRIPTION
Closes https://github.com/skyportal/skyportal/issues/1905
Closes https://github.com/skyportal/skyportal/issues/1904