### PR TITLE
Make dashboard widgets more responsive

### DIFF
--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -170,6 +170,7 @@ app:
     # section above (as well as other grid characteristics).
     WeatherWidget:
       resizeable: true
+      minW: 2
       layouts:
         xlg: [0, 10, 4, 1]
         lg: [0, 10, 4, 1]
@@ -181,6 +182,7 @@ app:
       props:
         sinceDaysAgo: 7
       resizeable: true
+      minW: 1.5
       layouts:
         xlg: [14, 0, 2, 1]
         lg: [10, 0, 2, 1]
@@ -190,6 +192,7 @@ app:
 
     RecentSources:
       resizeable: true
+      minW: 2
       layouts:
         xlg: [0, 0, 5, 3]
         lg: [0, 0, 4, 3]
@@ -199,6 +202,7 @@ app:
 
     NewsFeed:
       resizeable: true
+      minW: 2
       layouts:
         xlg: [10, 0, 4, 3]
         lg: [7, 0, 3, 3]
@@ -208,6 +212,7 @@ app:
 
     TopSources:
       resizeable: true
+      minW: 2
       layouts:
         xlg: [5, 0, 5, 3]
         lg: [4, 3, 3, 3]
@@ -219,6 +224,7 @@ app:
       props:
         title: My Groups
       resizeable: true
+      minW: 1.5
       layouts:
         xlg: [14, 1, 2, 2]
         lg: [10, 1, 2, 2]

--- a/static/js/components/GroupList.jsx
+++ b/static/js/components/GroupList.jsx
@@ -13,7 +13,7 @@ const useStyles = makeStyles(() => ({
   listContainer: {
     overflowX: "hidden",
     overflowY: "scroll",
-    height: "95%",
+    height: "calc(95% - 1.25rem);",
   },
 }));
 

--- a/static/js/components/GroupList.jsx
+++ b/static/js/components/GroupList.jsx
@@ -15,6 +15,10 @@ const useStyles = makeStyles(() => ({
     overflowY: "scroll",
     height: "calc(95% - 1.25rem);",
   },
+  flex: {
+    display: "flex",
+    flexFlow: "column nowrap",
+  },
 }));
 
 const GroupList = ({ title, groups, classes }) => {
@@ -22,9 +26,11 @@ const GroupList = ({ title, groups, classes }) => {
 
   return (
     <Paper elevation={1} className={classes.widgetPaperFillSpace}>
-      <div className={classes.widgetPaperDiv}>
-        <DragHandleIcon className={`${classes.widgetIcon} dragHandle`} />
-        <Typography variant="h6">{title}</Typography>
+      <div className={`${classes.widgetPaperDiv} ${styles.flex}`}>
+        <div>
+          <DragHandleIcon className={`${classes.widgetIcon} dragHandle`} />
+          <Typography variant="h6">{title}</Typography>
+        </div>
         <List
           component="nav"
           aria-label="main mailbox folders"

--- a/static/js/components/HomePage.jsx.template
+++ b/static/js/components/HomePage.jsx.template
@@ -36,6 +36,8 @@ const useStyles = makeStyles(() => ({
   widgetPaperDiv: {
     padding: "1rem",
     height: "100%",
+    display: "flex",
+    flexFlow: "column nowrap",
   },
   widgetPaperFillSpace: {
     height: "100%",
@@ -51,7 +53,8 @@ const defaultLayouts = {
   {%- for breakpoint in app.homepage_grid.breakpoints.keys() %}
   {{ breakpoint }}: [
     {%- for widgetName, widgetProps in app.homepage_widgets.items() %}
-    { i: "{{ widgetName }}", x: {{ widgetProps.layouts[breakpoint][0] }}, y: {{ widgetProps.layouts[breakpoint][1] }}, w: {{ widgetProps.layouts[breakpoint][2] }}, h: {{ widgetProps.layouts[breakpoint][3] }}, isResizable: {{ widgetProps.resizeable | lower }} },
+    { i: "{{ widgetName }}", x: {{ widgetProps.layouts[breakpoint][0] }}, y: {{ widgetProps.layouts[breakpoint][1] }}, w: {{ widgetProps.layouts[breakpoint][2] }}, h: {{ widgetProps.layouts[breakpoint][3] }}, isResizable: {{ widgetProps.resizeable | lower }},
+    {%- if widgetProps.minW is defined -%} minW: {{ widgetProps.minW }} {%- endif -%}},
     {%- endfor %}
   ],
   {%- endfor %}

--- a/static/js/components/NewsFeed.jsx
+++ b/static/js/components/NewsFeed.jsx
@@ -138,17 +138,19 @@ const NewsFeed = ({ classes }) => {
   return (
     <Paper elevation={1} className={classes.widgetPaperFillSpace}>
       <div className={classes.widgetPaperDiv}>
-        <Typography variant="h6" display="inline">
-          News Feed
-        </Typography>
-        <DragHandleIcon className={`${classes.widgetIcon} dragHandle`} />
-        <div className={classes.widgetIcon}>
-          <WidgetPrefsDialog
-            initialValues={newsFeedPrefs}
-            stateBranchName="newsFeed"
-            title="News Feed Preferences"
-            onSubmit={profileActions.updateUserPreferences}
-          />
+        <div>
+          <Typography variant="h6" display="inline">
+            News Feed
+          </Typography>
+          <DragHandleIcon className={`${classes.widgetIcon} dragHandle`} />
+          <div className={classes.widgetIcon}>
+            <WidgetPrefsDialog
+              initialValues={newsFeedPrefs}
+              stateBranchName="newsFeed"
+              title="News Feed Preferences"
+              onSubmit={profileActions.updateUserPreferences}
+            />
+          </div>
         </div>
         <div className={newsFeedStyle} style={{ height: "85%" }}>
           {items.map((item) => (

--- a/static/js/components/RecentSources.jsx
+++ b/static/js/components/RecentSources.jsx
@@ -240,17 +240,19 @@ const RecentSources = ({ classes }) => {
   return (
     <Paper elevation={1} className={classes.widgetPaperFillSpace}>
       <div className={classes.widgetPaperDiv}>
-        <Typography variant="h6" display="inline">
-          Recently Saved Sources
-        </Typography>
-        <DragHandleIcon className={`${classes.widgetIcon} dragHandle`} />
-        <div className={classes.widgetIcon}>
-          <WidgetPrefsDialog
-            initialValues={recentSourcesPrefs}
-            stateBranchName="recentSources"
-            title="Recent Sources Preferences"
-            onSubmit={profileActions.updateUserPreferences}
-          />
+        <div>
+          <Typography variant="h6" display="inline">
+            Recently Saved Sources
+          </Typography>
+          <DragHandleIcon className={`${classes.widgetIcon} dragHandle`} />
+          <div className={classes.widgetIcon}>
+            <WidgetPrefsDialog
+              initialValues={recentSourcesPrefs}
+              stateBranchName="recentSources"
+              title="Recent Sources Preferences"
+              onSubmit={profileActions.updateUserPreferences}
+            />
+          </div>
         </div>
         <RecentSourcesList sources={recentSources} styles={styles} />
       </div>

--- a/static/js/components/TopSources.jsx
+++ b/static/js/components/TopSources.jsx
@@ -27,6 +27,9 @@ const useStyles = makeStyles((theme) => ({
     "& .MuiButton-label": {
       color: theme.palette.text.secondary,
     },
+    "& .MuiButtonGroup-root": {
+      flexWrap: "wrap",
+    },
   },
   sourceListContainer: {
     height: "calc(100% - 5rem)",

--- a/static/js/components/WeatherWidget.jsx
+++ b/static/js/components/WeatherWidget.jsx
@@ -31,14 +31,16 @@ const useStyles = makeStyles(() => ({
     display: "flex",
     flexDirection: "row",
     height: "60%",
+    overflow: "hidden",
+    overflowY: "scroll",
   },
   weatherBar: {
     display: "flex",
     flexDirection: "column",
-    height: "80%",
+    height: "calc(100% - 1.25rem)",
   },
   weatherLinks: {
-    align: "center",
+    padding: 0,
   },
   widgetsBar: {
     position: "fixed",
@@ -51,12 +53,20 @@ const useStyles = makeStyles(() => ({
   },
   selector: {
     position: "relative",
-    top: "-0.75rem",
     left: "0.75rem",
+    "& button": {
+      padding: 0,
+    },
   },
   description: {
     position: "relative",
     left: "0.5rem",
+  },
+  telescopeName: {
+    display: "inline-block",
+    maxHeight: "2.5rem",
+    maxWidth: "calc(100% - 5.5rem)",
+    overflowY: "hidden",
   },
 }));
 
@@ -184,7 +194,11 @@ const WeatherWidget = ({ classes }) => {
   return (
     <Paper elevation={1} className={classes.widgetPaperFillSpace}>
       <div className={classes.widgetPaperDiv}>
-        <Typography variant="h6" display="inline">
+        <Typography
+          variant="h6"
+          display="inline"
+          className={styles.telescopeName}
+        >
           {weather?.telescope_name}
         </Typography>
         <DragHandleIcon className={`${classes.widgetIcon} dragHandle`} />

--- a/static/js/components/WeatherWidget.jsx
+++ b/static/js/components/WeatherWidget.jsx
@@ -38,6 +38,7 @@ const useStyles = makeStyles(() => ({
     display: "flex",
     flexDirection: "column",
     height: "calc(100% - 1.25rem)",
+    justifyContent: "space-around",
   },
   weatherLinks: {
     padding: 0,
@@ -194,48 +195,51 @@ const WeatherWidget = ({ classes }) => {
   return (
     <Paper elevation={1} className={classes.widgetPaperFillSpace}>
       <div className={classes.widgetPaperDiv}>
-        <Typography
-          variant="h6"
-          display="inline"
-          className={styles.telescopeName}
-        >
-          {weather?.telescope_name}
-        </Typography>
-        <DragHandleIcon className={`${classes.widgetIcon} dragHandle`} />
-
-        {telescopeList && (
-          <div className={`${classes.widgetIcon} ${styles.selector}`}>
-            <IconButton
-              aria-controls="tel-list"
-              data-testid="tel-list-button"
-              aria-haspopup="true"
-              onClick={handleClickDropdownIcon}
-            >
-              <MoreVertIcon />
-            </IconButton>
-            <Menu
-              id="tel-list"
-              data-testid="tel-list"
-              anchorEl={anchorEl}
-              keepMounted
-              open={Boolean(anchorEl)}
-              onClose={handleClose}
-            >
-              {telescopeList.map((telescope) => (
-                <MenuItem
-                  data-testid={telescope.name}
-                  id={telescope.name}
-                  key={telescope.id}
-                  value={telescope.id}
-                  onClick={(event) => handleMenuItemClick(event, telescope.id)}
-                  selected={telescope.id === weatherPrefs.telescopeID}
-                >
-                  {telescope.name}
-                </MenuItem>
-              ))}
-            </Menu>
-          </div>
-        )}
+        <div>
+          <Typography
+            variant="h6"
+            display="inline"
+            className={styles.telescopeName}
+          >
+            {weather?.telescope_name}
+          </Typography>
+          <DragHandleIcon className={`${classes.widgetIcon} dragHandle`} />
+          {telescopeList && (
+            <div className={`${classes.widgetIcon} ${styles.selector}`}>
+              <IconButton
+                aria-controls="tel-list"
+                data-testid="tel-list-button"
+                aria-haspopup="true"
+                onClick={handleClickDropdownIcon}
+              >
+                <MoreVertIcon />
+              </IconButton>
+              <Menu
+                id="tel-list"
+                data-testid="tel-list"
+                anchorEl={anchorEl}
+                keepMounted
+                open={Boolean(anchorEl)}
+                onClose={handleClose}
+              >
+                {telescopeList.map((telescope) => (
+                  <MenuItem
+                    data-testid={telescope.name}
+                    id={telescope.name}
+                    key={telescope.id}
+                    value={telescope.id}
+                    onClick={(event) =>
+                      handleMenuItemClick(event, telescope.id)
+                    }
+                    selected={telescope.id === weatherPrefs.telescopeID}
+                  >
+                    {telescope.name}
+                  </MenuItem>
+                ))}
+              </Menu>
+            </div>
+          )}
+        </div>
         <WeatherView weather={weather} />
       </div>
     </Paper>

--- a/static/js/components/WeatherWidget.jsx
+++ b/static/js/components/WeatherWidget.jsx
@@ -65,7 +65,7 @@ const useStyles = makeStyles(() => ({
   },
   telescopeName: {
     display: "inline-block",
-    maxHeight: "2.5rem",
+    maxHeight: "1.75rem",
     maxWidth: "calc(100% - 5.5rem)",
     overflowY: "hidden",
   },


### PR DESCRIPTION
- Add parsing of `minW` from configs for widgets to impose reasonable minimum widths for each widget
- Bunch of CSS tweaks to make widgets more responsive otherwise, i.e. truncating long telescope names, adding scrollbars, etc.

![widgets](https://user-images.githubusercontent.com/17696889/116309693-14645a80-a777-11eb-9f2b-5aa9e139d676.gif)

Closes #1902 
