### PR TITLE
Add plot height to spectroscopy plot if legend overfills plot area

### DIFF
--- a/skyportal/plot.py
+++ b/skyportal/plot.py
@@ -1361,6 +1361,10 @@ def spectroscopy_plot(obj_id, user, spec_id=None, width=600, device="browser"):
         + legend_row_height * int(len(split) / legend_items_per_row)
         + 30  # 30 is the height of the toolbar
     )
+    # check if our legend should extend the plot height
+    plot_height_with_legend = len(spectra) * 25 + 30
+    if plot_height_with_legend > plot_height:
+        plot_height = plot_height_with_legend
 
     plot = figure(
         frame_width=frame_width,


### PR DESCRIPTION
This seems to be a very simple fix, however, we may want to force a vertical scroll bar.
Here is a screenshot for 29 spectra:
![image](https://user-images.githubusercontent.com/6845428/117083116-c6140600-acf8-11eb-8d1f-101b0dd4edc0.png)
