### PR TITLE
Optimize sources query

### DIFF
--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -1106,9 +1106,9 @@ User.listings = relationship(
 
 
 Source = join_model("sources", Group, Obj)
-Source.create = Source.read = Source.update = Source.delete = (
-    accessible_by_group_members & Source.read
-)
+Source.create = (
+    Source.read
+) = Source.update = Source.delete = accessible_by_group_members
 
 Source.__doc__ = (
     "An Obj that has been saved to a Group. Once an Obj is saved as a Source, "


### PR DESCRIPTION
This should speed up the sources page query a bit. The old definition basically had `Source.read = Source.read` so there was an unnecessary self-join in there.