### PR TITLE
Modified removeNested flag to also exclude classifications

### DIFF
--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -395,7 +395,7 @@ class SourceHandler(BaseHandler):
             schema:
               type: boolean
             description: |
-              Boolean indicating whether to remove nested output (does not apply to classifications). Defaults to false.
+              Boolean indicating whether to remove nested output. Defaults to false.
           - in: query
             name: includeThumbnails
             nullable: true
@@ -1050,23 +1050,23 @@ class SourceHandler(BaseHandler):
                         reverse=True,
                     )
 
-                readable_classifications = (
-                    Classification.query_records_accessible_by(self.current_user)
-                    .filter(Classification.obj_id == obj.id)
-                    .all()
-                )
-
-                readable_classifications_json = []
-                for classification in readable_classifications:
-                    classification_dict = classification.to_dict()
-                    classification_dict['groups'] = [
-                        g.to_dict() for g in classification.groups
-                    ]
-                    readable_classifications_json.append(classification_dict)
-
-                obj_list[-1]["classifications"] = readable_classifications_json
-
                 if not remove_nested:
+                    readable_classifications = (
+                        Classification.query_records_accessible_by(self.current_user)
+                        .filter(Classification.obj_id == obj.id)
+                        .all()
+                    )
+
+                    readable_classifications_json = []
+                    for classification in readable_classifications:
+                        classification_dict = classification.to_dict()
+                        classification_dict['groups'] = [
+                            g.to_dict() for g in classification.groups
+                        ]
+                        readable_classifications_json.append(classification_dict)
+
+                    obj_list[-1]["classifications"] = readable_classifications_json
+
                     obj_list[-1]["annotations"] = sorted(
                         Annotation.query_records_accessible_by(
                             self.current_user

--- a/skyportal/tests/api/test_sources.py
+++ b/skyportal/tests/api/test_sources.py
@@ -110,11 +110,11 @@ def test_token_user_retrieving_source_without_nested(
     assert len(data["data"]["sources"]) == 2
     assert all(
         k in data["data"]["sources"][0]
-        for k in ["ra", "dec", "redshift", "created_at", "id", "classifications"]
+        for k in ["ra", "dec", "redshift", "created_at", "id"]
     )
     assert all(
         k not in data["data"]["sources"][0]
-        for k in ["annotations", "groups", "thumbnails"]
+        for k in ["annotations", "groups", "thumbnails", "classifications"]
     )
 
 


### PR DESCRIPTION
Even with removeNested option, the multiple source query for RCF is still too slow that it times out. After discussing with Dan and Christoffer, I've modified the flag to also remove classifications from output. 