### PR TITLE
Reduce database queries in photometry PUT by stream id

### DIFF
--- a/skyportal/handlers/api/photometry.py
+++ b/skyportal/handlers/api/photometry.py
@@ -799,7 +799,7 @@ class PhotometryHandler(BaseHandler):
                 # Add new stream_photometry rows if not already present
                 duplicate_stream_ids = set(
                     StreamPhotometry.query_records_accessible_by(
-                        self.current_user, column=[StreamPhotometry.stream_id]
+                        self.current_user, columns=[StreamPhotometry.stream_id]
                     )
                     .filter(
                         StreamPhotometry.photometr_id == duplicate.id,

--- a/skyportal/handlers/api/photometry.py
+++ b/skyportal/handlers/api/photometry.py
@@ -775,11 +775,13 @@ class PhotometryHandler(BaseHandler):
             .query(values_table.c.pdidx, Photometry)
             .join(Photometry, condition)
             .options(joinedload(Photometry.groups))
+            .options(joinedload(Photometry.streams))
         )
 
         for df_index, duplicate in duplicated_photometry:
             id_map[df_index] = duplicate.id
             duplicate_group_ids = set([g.id for g in duplicate.groups])
+            duplicate_stream_ids = set([s.id for s in duplicate.streams])
 
             # posting to new groups?
             if len(set(group_ids) - duplicate_group_ids) > 0:
@@ -797,16 +799,6 @@ class PhotometryHandler(BaseHandler):
             # posting to new streams?
             if stream_ids:
                 # Add new stream_photometry rows if not already present
-                duplicate_stream_ids = set(
-                    StreamPhotometry.query_records_accessible_by(
-                        self.current_user, columns=[StreamPhotometry.stream_id]
-                    )
-                    .filter(
-                        StreamPhotometry.photometr_id == duplicate.id,
-                    )
-                    .all()
-                )
-                # select new streams
                 stream_ids_update = set(stream_ids) - duplicate_stream_ids
                 if len(stream_ids_update) > 0:
                     for id in stream_ids_update:


### PR DESCRIPTION
The current version of PUT for photometry using stream IDs makes anywhere from 1 to 3 extra database queries per duplicated photometry point compared to using group IDs.
- For group IDs, each duplicated photometry point just makes one query for the new groups to be added ([these lines](https://github.com/skyportal/skyportal/blob/390d9494e0ef63b6e58f30c7a0786829e99dc7a6/skyportal/handlers/api/photometry.py#L788-L793))
- For stream IDs, we make a call for the stream records associated with the passed-in stream IDs, and then a call to see if the `StreamPhotometry` row exists for each passed-in stream ID as well. 

This PR brings the reduces the number of database queries in the stream ID block to just one per duplicated photometry point (getting the list of streams already associated with a photometry point), which should hopefully bring the posting in line with previous performance.