### PR TITLE
Added documentation for spectroscopic lines

### DIFF
--- a/doc/advanced_usage.md
+++ b/doc/advanced_usage.md
@@ -87,3 +87,9 @@ should contain a `status==200` and a data dictionary
 with the data that was posted.
 If the posting was unsuccessful,
 the status would be 400.
+
+
+
+## Spectroscopic lines
+
+The line list implemented on Skyportal was derived using the NIST atomic database : https://www.nist.gov/pml/atomic-spectra-database, using the methods of Gal-Yam, 2019 (https://ui.adsabs.harvard.edu/abs/2019ApJ...882..102G/abstract).

--- a/doc/advanced_usage.md
+++ b/doc/advanced_usage.md
@@ -92,4 +92,4 @@ the status would be 400.
 
 ## Spectroscopic lines
 
-The line list implemented on Skyportal was derived using the NIST atomic database : https://www.nist.gov/pml/atomic-spectra-database, using the methods of Gal-Yam, 2019 (https://ui.adsabs.harvard.edu/abs/2019ApJ...882..102G/abstract).
+The line list implemented on SkyPortal was derived using the [NIST atomic database](https://www.nist.gov/pml/atomic-spectra-database), employing the methods of [Gal-Yam  2019](https://ui.adsabs.harvard.edu/abs/2019ApJ...882..102G/abstract).


### PR DESCRIPTION
I added a  short description in advanced usage for the spectroscopic lines. 

Let me know if you need more details. 

Point of information: There are some lines which were part of the default lines on skyportal before:
'Mn I’   : [12900, 13310, 13630, 13859, 15184, 15263]
'C I’     : [8335, 9093, 9406, 9658, 10693, 11330, 11754, 14543]
'Si I’    : [10585, 10827, 12032, 15888]
'S I’     : [9223, 10457, 13809, 18940, 22694]
'Ca I’   : [19453, 19753]
'Fe I’   : [11973]
'Co II’  :  [15759, 16064, 16361, 17239, 17462, 17772, 21347, 22205, 22497, 23613, 24596] 

These are all IR lines which we did not include for spectroscopic analysis. I see that they were implemented on the marshal previously. 
I would be happy to add a reference to them if you know where they are from, or for which science they are used? 

Thanks! 

