### PR TITLE
Do not reset role input field after submitting invitation

### DIFF
--- a/static/js/components/InviteNewGroupUserForm.jsx
+++ b/static/js/components/InviteNewGroupUserForm.jsx
@@ -56,7 +56,10 @@ const InviteNewGroupUserForm = ({ group_id }) => {
           `Invitation successfully sent to ${formState.newUserEmail}`
         )
       );
-      setFormState(defaultState);
+      setFormState({
+        ...defaultState,
+        role: formState.role,
+      });
     }
   };
 


### PR DESCRIPTION
Minor update to PR that just went in: Since the select is uncontrolled, when we reset the form state values, that was not reflected in the select's state, opening the door for consecutive invitations to have the wrong role. This PR avoids that.