### PR TITLE
Clean expired cache upon access

### DIFF
--- a/skyportal/tests/utils/test_cache.py
+++ b/skyportal/tests/utils/test_cache.py
@@ -62,8 +62,7 @@ def test_cache_cleanup_by_age(cache):
 
     # Let object time out of cache
     time.sleep(3)
-    # Trigger cleanup
-    cache['second'] = b'two'
+
     f = cache['first']
     assert f is None
 

--- a/skyportal/utils/cache.py
+++ b/skyportal/utils/cache.py
@@ -59,6 +59,7 @@ class Cache:
         ----------
         name : str
         """
+        self.clean_cache()
         if name is None:
             return None
 


### PR DESCRIPTION
This addresses the issue where expired cache is still accessible until a new cache item is created.