### PR TITLE
Skip source detection stats by default in GET sources

### DIFF
--- a/skyportal/tests/api/test_sources.py
+++ b/skyportal/tests/api/test_sources.py
@@ -643,7 +643,12 @@ def test_object_last_detected(
     assert status == 200
     assert data['status'] == 'success'
 
-    status, data = api("GET", f"sources/{public_source.id}", token=view_only_token)
+    status, data = api(
+        "GET",
+        f"sources/{public_source.id}",
+        params={"includeDetectionStats": "true"},
+        token=view_only_token,
+    )
     assert status == 200
     assert data["status"] == "success"
     assert (
@@ -688,6 +693,7 @@ def test_source_photometry_summary_info(
     status, data = api(
         "GET",
         f"sources/{public_source_no_data.id}",
+        params={"includeDetectionStats": "true"},
         token=view_only_token,
     )
     assert status == 200

--- a/static/js/ducks/sources.js
+++ b/static/js/ducks/sources.js
@@ -33,6 +33,7 @@ export function fetchSources(filterParams = {}) {
   filterParams.includeSpectrumExists = true;
   filterParams.includeColorMagnitude = true;
   filterParams.includeThumbnails = true;
+  filterParams.includeDetectionStats = true;
   return API.GET("/api/sources", FETCH_SOURCES, filterParams);
 }
 
@@ -42,6 +43,7 @@ export function fetchSavedGroupSources(filterParams = {}) {
   filterParams.includeSpectrumExists = true;
   filterParams.includeColorMagnitude = true;
   filterParams.includeThumbnails = true;
+  filterParams.includeDetectionStats = true;
   return API.GET("/api/sources", FETCH_SAVED_GROUP_SOURCES, filterParams);
 }
 
@@ -52,6 +54,7 @@ export function fetchPendingGroupSources(filterParams = {}) {
   filterParams.includeSpectrumExists = true;
   filterParams.includeColorMagnitude = true;
   filterParams.includeThumbnails = true;
+  filterParams.includeDetectionStats = true;
   return API.GET("/api/sources", FETCH_PENDING_GROUP_SOURCES, filterParams);
 }
 
@@ -62,6 +65,7 @@ export function fetchFavoriteSources(filterParams = {}) {
   filterParams.listName = "favorites";
   filterParams.includeColorMagnitude = true;
   filterParams.includeThumbnails = true;
+  filterParams.includeDetectionStats = true;
   return API.GET("/api/sources", FETCH_FAVORITE_SOURCES, filterParams);
 }
 


### PR DESCRIPTION
By default, don't return photometry detection statistics like `last_detected_at` and `peak_detected_at` in the GET sources call in order to avoid heavy computations. 

I kept the fields in for the front-end's sources calls since those will all be through the paginated tables and thus limited to 100 sources per page.