### PR TITLE
Open external thumbnail links in new tab

### DIFF
--- a/static/js/components/ThumbnailList.jsx
+++ b/static/js/components/ThumbnailList.jsx
@@ -100,11 +100,13 @@ const Thumbnail = ({ ra, dec, name, url, size, grayscale }) => {
     <Card className={classes.root} variant="outlined">
       <CardContent className={classes.cardTitle}>
         <Typography className={classes.title} color="textSecondary">
-          <a href={link}>{name.toUpperCase()}</a>
+          <a href={link} target="_blank" rel="noreferrer">
+            {name.toUpperCase()}
+          </a>
         </Typography>
       </CardContent>
       <div className={classes.mediaDiv}>
-        <a href={link}>
+        <a href={link} target="_blank" rel="noreferrer">
           <img
             src={url}
             alt={alt}


### PR DESCRIPTION
Per Dan Perley:

> Minor functionality suggestion: on the Candidates (scan) page, if you left click the SDSS/PS1 images, the page loads in the same window.  Once this happens there is no way to go back to where you were before - the "back" browser returns you to an empty Candidates query, so you have to re-issue the search and scan again from the beginning.  So, it would be nice if these links (and any other) opened in a new tab instead of in the same window.
