### PR TITLE
Clarify difference between query params and request body params in API docs preamble

### DIFF
--- a/skyportal/api_description.md
+++ b/skyportal/api_description.md
@@ -8,9 +8,6 @@ inside of `.tokens.yaml`.
 
 Once you have a token, you may access SkyPortal programmatically as
 follows.
-Any JSON request body parameters (all parameters listed under
-"REQUEST BODY SCHEMA: application/json" in API docs below) must be
-passed in to `requests.request` to the `json` keyword argument as below.
 
 #### Python
 

--- a/skyportal/api_description.md
+++ b/skyportal/api_description.md
@@ -8,6 +8,9 @@ inside of `.tokens.yaml`.
 
 Once you have a token, you may access SkyPortal programmatically as
 follows.
+Any JSON request body parameters (all parameters listed under
+"REQUEST BODY SCHEMA: application/json" in API docs below) must be
+passed in to `requests.request` to the `json` keyword argument as below.
 
 #### Python
 
@@ -34,7 +37,7 @@ if response.status_code in (200, 400):
 curl -s -H 'Authorization: token ea70a5f0-b321-43c6-96a1-b2de225e0339' http://localhost:5000/api/sysinfo
 ```
 
-#### Using query parameters
+#### Using query parameters (specified as "PATH PARAMETERS" in API docs below)
 
 ```python
 import requests
@@ -50,6 +53,24 @@ print(f'HTTP code: {response.status_code}, {response.reason}')
 if response.status_code in (200, 400):
     print(f'JSON response: {response.json()}')
 ```
+
+Alternatively, when using Python's `requests` library, a dictionary
+of query parameters (aka path parameters, or URL parameters) can be
+passed in via the `params` keyword argument, e.g.
+
+```python
+token = 'abc'
+params = {"includeComments": True, "includeThumbnails": False}
+response = requests.get(
+    "http://localhost:5000/api/sources",
+    params=params,
+    headers={'Authorization': f'token {token}'},
+)
+```
+
+Note well the distinction between query/path/URL parameters and request
+body parameters, how they're denoted in the docs below, and the sample
+usage of each in the examples above.
 
 ### Response
 

--- a/skyportal/api_description.md
+++ b/skyportal/api_description.md
@@ -74,11 +74,16 @@ When using Python's `requests` library, body parameters are specified
 using the `json` keyword argument:
 
 ```python
-token = 'abc'
-response = requests.put(
+token = "abc"
+response = requests.post(
     "http://localhost:5000/api/sources",
-    json={...},
-    headers={'Authorization': f'token {token}'},
+    json={
+        "id": "14gqr",
+        "ra": 353.36647,
+        "dec": 33.646149,
+        "group_ids": [52, 97],
+    },
+    headers={"Authorization": f"token {token}"},
 )
 ```
 
@@ -94,9 +99,11 @@ In the above examples, the SkyPortal server is located at
 `http://localhost:5000`. In case of success, the HTTP response is 200:
 
 ```
+
 HTTP code: 200, OK
 JSON response: {'status': 'success', 'data': {}, 'version': '0.9.dev0+git20200819.84c453a'}
-```
+
+````
 
 On failure, it is 400; the JSON response has `status="error"` with the reason
 for the failure given in `message`:
@@ -108,4 +115,4 @@ for the failure given in `message`:
   "data": {},
   "version": "0.9.1"
 }
-```
+````

--- a/skyportal/api_description.md
+++ b/skyportal/api_description.md
@@ -37,21 +37,52 @@ if response.status_code in (200, 400):
 curl -s -H 'Authorization: token ea70a5f0-b321-43c6-96a1-b2de225e0339' http://localhost:5000/api/sysinfo
 ```
 
-#### Using query parameters (specified as "PATH PARAMETERS" in API docs below)
+### Request parameters
+
+There are two ways to pass information along with a request: path and body parameters.
+
+#### Path parameters
+
+Path parameters (also called query or URL parameters) are embedded in
+the URL called. For example, you can specify `numPerPage` or
+`pageNumber` path parameters when calling `/api/candidates` as
+follows:
+
+```shell
+curl -s -H 'Authorization: token ea70a5f0-b321-43c6-96a1-b2de225e0339' \
+     http://localhost:5000/api/candidates?numPerPage=100&pageNumber=1
+```
+
+When using Python's `requests` library, a dictionary of path
+parameters can be passed in via the `params` keyword argument:
 
 ```python
-import requests
-
 token = 'ea70a5f0-b321-43c6-96a1-b2de225e0339'
 
 response = requests.get(
-    'http://localhost:5000/api/candidates?numPerPage=100&pageNumber=1',
-    headers={'Authorization': f'token {token}'}
+    "http://localhost:5000/api/sources",
+    params={"includeComments": True, includeThumbnails: False},
+    headers={'Authorization': f'token {token}'},
 )
+```
 
-print(f'HTTP code: {response.status_code}, {response.reason}')
-if response.status_code in (200, 400):
-    print(f'JSON response: {response.json()}')
+#### Body parameters
+
+Request body parameters (or simply: the body of the request)
+contains data uploaded to a specific endpoint. These are the
+parameters listed under `REQUEST BODY SCHEMA: application/json` in the
+API docs.
+
+When using Python's `requests` library, body parameters are specified
+using the `json` keyword argument:
+
+```python
+token = 'abc'
+response = requests.put(
+    "http://localhost:5000/api/sources",
+    json={...},
+    headers={'Authorization': f'token {token}'},
+)
 ```
 
 Alternatively, when using Python's `requests` library, a dictionary

--- a/skyportal/api_description.md
+++ b/skyportal/api_description.md
@@ -87,7 +87,7 @@ response = requests.put(
 
 ```
 
-Note well the distinction between query/path/URL parameters and request
+Note well the distinction between path (AKA query or URL) parameters and request
 body parameters, how they're denoted in the docs below, and the sample
 usage of each in the examples above.
 

--- a/skyportal/api_description.md
+++ b/skyportal/api_description.md
@@ -87,12 +87,6 @@ response = requests.post(
 )
 ```
 
-```
-
-Note well the distinction between path (AKA query or URL) parameters and request
-body parameters, how they're denoted in the docs below, and the sample
-usage of each in the examples above.
-
 ### Response
 
 In the above examples, the SkyPortal server is located at
@@ -103,7 +97,7 @@ In the above examples, the SkyPortal server is located at
 HTTP code: 200, OK
 JSON response: {'status': 'success', 'data': {}, 'version': '0.9.dev0+git20200819.84c453a'}
 
-````
+```
 
 On failure, it is 400; the JSON response has `status="error"` with the reason
 for the failure given in `message`:
@@ -115,4 +109,4 @@ for the failure given in `message`:
   "data": {},
   "version": "0.9.1"
 }
-````
+```

--- a/skyportal/api_description.md
+++ b/skyportal/api_description.md
@@ -61,7 +61,7 @@ token = 'ea70a5f0-b321-43c6-96a1-b2de225e0339'
 
 response = requests.get(
     "http://localhost:5000/api/sources",
-    params={"includeComments": True, includeThumbnails: False},
+    params={"includeComments": True, "includeThumbnails": False},
     headers={'Authorization': f'token {token}'},
 )
 ```

--- a/skyportal/api_description.md
+++ b/skyportal/api_description.md
@@ -85,18 +85,6 @@ response = requests.put(
 )
 ```
 
-Alternatively, when using Python's `requests` library, a dictionary
-of query parameters (aka path parameters, or URL parameters) can be
-passed in via the `params` keyword argument, e.g.
-
-```python
-token = 'abc'
-params = {"includeComments": True, "includeThumbnails": False}
-response = requests.get(
-    "http://localhost:5000/api/sources",
-    params=params,
-    headers={'Authorization': f'token {token}'},
-)
 ```
 
 Note well the distinction between query/path/URL parameters and request


### PR DESCRIPTION
Some users who are less familiar with APIs/`requests` had been getting confused.