### PR TITLE
Add saved by user to sources table

### DIFF
--- a/static/js/components/SourceTable.jsx
+++ b/static/js/components/SourceTable.jsx
@@ -666,6 +666,24 @@ const SourceTable = ({
     );
   };
 
+  const getSavedBy = (source) => {
+    // Get the user who saved the source to the specified group
+    if (groupID !== undefined) {
+      const group = source.groups.find((g) => g.id === groupID);
+      return group?.saved_by.username;
+    }
+    // Otherwise, get whoever saved it last
+    const usernames = source.groups
+      .sort((g1, g2) => (g1.saved_at < g2.saved_at ? -1 : 1))
+      .map((g) => g.saved_by.username);
+    return usernames[usernames.length - 1];
+  };
+
+  const renderSavedBy = (dataIndex) => {
+    const source = sources[dataIndex];
+    return getSavedBy(source);
+  };
+
   const handleFilterSubmit = async (formData) => {
     setQueryInProgress(true);
 
@@ -863,6 +881,18 @@ const SourceTable = ({
         sortThirdClickReset: true,
         display: displayedColumns.includes("Date Saved"),
         customBodyRenderLite: renderDateSaved,
+      },
+    },
+    {
+      name: "saved_by",
+      label: groupID ? "Saved To Group By" : "Last Saved By",
+      options: {
+        filter: false,
+        sort: false,
+        display: displayedColumns.includes(
+          groupID ? "Saved To Group By" : "Last Saved By"
+        ),
+        customBodyRenderLite: renderSavedBy,
       },
     },
     {


### PR DESCRIPTION
Per Dan Perley via beta-testing channel:

> Would it be possible to make the user ID of the person who saved the transient available as an optional column to display under table of sources in "groups"?

I figured that the username would be more informative on the UI than the user ID, so I chose to display the username of the user who saved the Obj to a specific source instead. On the Sources page, instead of `Saved To Group By`, this column is made instead into a `Last Saved By` username.

![savedby](https://user-images.githubusercontent.com/17696889/121427232-76051080-c942-11eb-8d96-6054e23db229.gif)
