### PR TITLE
Replace Bokeh star markers with inverted_triangle

### DIFF
--- a/skyportal/plot.py
+++ b/skyportal/plot.py
@@ -211,7 +211,7 @@ phot_markers = [
     "triangle",
     "square",
     "diamond",
-    "star",
+    "inverted_triangle",
     "plus",
     "cross",
     "triangle_pin",


### PR DESCRIPTION
Looks like our current version of Bokeh (2.2.3) actually doesn't support the `star` marker shapes yet, so this PR just replaces that with the `inverted_triangle` option. https://docs.bokeh.org/en/2.2.3/docs/reference/models/markers.html?highlight=marker#module-bokeh.models.markers

Error reported in beta-testing channel:
![image](https://user-images.githubusercontent.com/17696889/121524892-c3769180-c9c5-11eb-8433-6f04547eed0a.png)
