### PR TITLE
Handle null source saved_by fields

### DIFF
--- a/static/js/components/SourceTable.jsx
+++ b/static/js/components/SourceTable.jsx
@@ -748,12 +748,12 @@ const SourceTable = ({
     // Get the user who saved the source to the specified group
     if (groupID !== undefined) {
       const group = source.groups.find((g) => g.id === groupID);
-      return group?.saved_by.username;
+      return group?.saved_by?.username;
     }
     // Otherwise, get whoever saved it last
     const usernames = source.groups
       .sort((g1, g2) => (g1.saved_at < g2.saved_at ? -1 : 1))
-      .map((g) => g.saved_by.username);
+      .map((g) => g.saved_by?.username);
     return usernames[usernames.length - 1];
   };
 


### PR DESCRIPTION
Should fix this error on production:
![image](https://user-images.githubusercontent.com/17696889/121595805-a87b4000-ca0c-11eb-94d7-7037f195ddfb.png)

Not sure why there are sources with no `saved_by` info in the first place and that may be an error in itself that we should look into, but we should at least handle it gracefully.