### PR TITLE
Generate front-end notifications for selected activity on favorite sources

### DIFF
--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -3775,9 +3775,9 @@ def add_user_notifications(mapper, connection, target):
         users = (
             User.query.join(listing_subquery, User.id == listing_subquery.c.user_id)
             .filter(
-                User.preferences["favorite_sources_activity_notifications"][
-                    "comments"
-                ].is_(True)
+                User.preferences["favorite_sources_activity_notifications"]["comments"]
+                .astext.cast(sa.Boolean)
+                .is_(True)
             )
             .all()
         )

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -3790,7 +3790,7 @@ def add_user_notifications(mapper, connection, target):
                 session.add(
                     UserNotification(
                         user=user,
-                        text=f"New *{target.__class__.__name__}* on your favorite source *{target.obj_id}*",
+                        text=f"New {target.__class__.__name__.lower()} on your favorite source *{target.obj_id}*",
                         url=f"/source/{target.obj_id}",
                     )
                 )

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -3764,7 +3764,6 @@ StreamUser.delete = restricted & CustomUserAccessControl(
 @event.listens_for(Spectrum, 'after_insert')
 @event.listens_for(Comment, 'after_insert')
 def add_user_notifications(mapper, connection, target):
-
     # Add front-end user notifications
     @event.listens_for(DBSession(), "after_flush", once=True)
     def receive_after_flush(session, context):

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -3785,7 +3785,7 @@ def add_user_notifications(mapper, connection, target):
             session.add(
                 UserNotification(
                     user=user,
-                    text=f"New comment on your favorite source *{target.obj_id}*",
+                    text=f"*{target.author.username}* commented on your favorite source *{target.obj_id}*",
                     url=f"/source/{target.obj_id}",
                 )
             )

--- a/skyportal/tests/frontend/test_notifications.py
+++ b/skyportal/tests/frontend/test_notifications.py
@@ -1,4 +1,6 @@
 import pytest
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.wait import WebDriverWait
 
 from skyportal.tests import api
 from skyportal.tests.frontend.test_sources import add_comment_and_wait_for_display
@@ -81,3 +83,32 @@ def test_group_admission_requests_notifications(
     driver.click_xpath('//*[@data-testid="notificationsButton"]')
     driver.wait_for_xpath('//em[text()="accepted"]')
     driver.wait_for_xpath(f'//em[text()="{public_group2.name}"]')
+
+
+def test_comment_on_favorite_source_triggers_notification(
+    driver, user, user2, public_source
+):
+    driver.get(f'/become_user/{user.id}')
+    driver.get("/profile")
+
+    # Enable browser notifications for favorite source comments
+    driver.click_xpath('//*[@name="comments"]', wait_clickable=False)
+    checkbox_el = driver.wait_for_xpath('//*[@name="comments"]')
+    WebDriverWait(driver, 3).until(EC.element_to_be_selected(checkbox_el))
+
+    # Make public_source a favorite
+    driver.get(f"/source/{public_source.id}")
+    driver.click_xpath(f'//*[@data-testid="favorites-exclude_{public_source.id}"]')
+    driver.wait_for_xpath(f'//*[@data-testid="favorites-include_{public_source.id}"]')
+
+    # Become user2 and submit comment on source
+    driver.get(f'/become_user/{user2.id}')
+    driver.get(f"/source/{public_source.id}")
+    add_comment_and_wait_for_display(driver, "comment text")
+
+    # Check that notification was created
+    driver.get(f'/become_user/{user.id}')
+    driver.get("/")
+    driver.wait_for_xpath("//span[text()='1']")
+    driver.click_xpath('//*[@data-testid="notificationsButton"]')
+    driver.wait_for_xpath('//*[text()=" on your favorite source "]')

--- a/skyportal/tests/frontend/test_notifications.py
+++ b/skyportal/tests/frontend/test_notifications.py
@@ -111,4 +111,4 @@ def test_comment_on_favorite_source_triggers_notification(
     driver.get("/")
     driver.wait_for_xpath("//span[text()='1']")
     driver.click_xpath('//*[@data-testid="notificationsButton"]')
-    driver.wait_for_xpath('//*[text()=" on your favorite source "]')
+    driver.wait_for_xpath('//*[text()="New comment on your favorite source "]')

--- a/static/js/components/FavoriteSourcesNotificationPreferences.jsx
+++ b/static/js/components/FavoriteSourcesNotificationPreferences.jsx
@@ -25,7 +25,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const NotificationPreferences = () => {
+const FavoriteSourcesNotificationPreferences = () => {
   const classes = useStyles();
   const profile = useSelector((state) => state.profile.preferences);
   const dispatch = useDispatch();
@@ -42,7 +42,9 @@ const NotificationPreferences = () => {
 
   const prefToggled = (event) => {
     const prefs = {
-      [event.target.name]: event.target.checked,
+      favorite_sources_activity_notifications: {
+        [event.target.name]: event.target.checked,
+      },
     };
 
     dispatch(profileActions.updateUserPreferences(prefs));
@@ -52,7 +54,7 @@ const NotificationPreferences = () => {
     <div>
       <div className={classes.header}>
         <Typography variant="h6" display="inline">
-          SMS/Email Notification Preferences
+          Browser Notifications For Favorite Source Activity
         </Typography>
         <IconButton aria-label="help" size="small" onClick={handleClick}>
           <HelpOutlineIcon />
@@ -73,34 +75,53 @@ const NotificationPreferences = () => {
         }}
       >
         <Typography className={classes.typography}>
-          Enable these to receive notifications regarding sources triggered by
-          other users within your groups.
+          Enable these to receive browser notifications for the selected
+          activity types regarding sources you have starred/favorited.
         </Typography>
       </Popover>
       <FormGroup row>
         <FormControlLabel
           control={
             <Switch
-              checked={profile.allowEmailAlerts === true}
-              name="allowEmailAlerts"
+              checked={
+                profile.favorite_sources_activity_notifications?.comments ===
+                true
+              }
+              name="comments"
               onChange={prefToggled}
             />
           }
-          label="Email notifications"
+          label="New Comments"
         />
         <FormControlLabel
           control={
             <Switch
-              checked={profile.allowSMSAlerts === true}
-              name="allowSMSAlerts"
+              checked={
+                profile.favorite_sources_activity_notifications?.spectra ===
+                true
+              }
+              name="spectra"
               onChange={prefToggled}
             />
           }
-          label="SMS notifications"
+          label="New Spectra"
+        />
+        <FormControlLabel
+          control={
+            <Switch
+              checked={
+                profile.favorite_sources_activity_notifications
+                  ?.classifications === true
+              }
+              name="classifications"
+              onChange={prefToggled}
+            />
+          }
+          label="New Classifications"
         />
       </FormGroup>
     </div>
   );
 };
 
-export default NotificationPreferences;
+export default FavoriteSourcesNotificationPreferences;

--- a/static/js/components/UpdateProfileForm.jsx
+++ b/static/js/components/UpdateProfileForm.jsx
@@ -21,6 +21,7 @@ import * as ProfileActions from "../ducks/profile";
 
 import UIPreferences from "./UIPreferences";
 import NotificationPreferences from "./NotificationPreferences";
+import FavoriteSourcesNotificationPreferences from "./FavoriteSourcesNotificationPreferences";
 
 const UpdateProfileForm = () => {
   const profile = useSelector((state) => state.profile);
@@ -160,6 +161,9 @@ const UpdateProfileForm = () => {
         </CardContent>
         <CardContent>
           <NotificationPreferences />
+        </CardContent>
+        <CardContent>
+          <FavoriteSourcesNotificationPreferences />
         </CardContent>
         <CardContent>
           <UIPreferences />


### PR DESCRIPTION
This PR introduces an event listener that adds front-end user notifications (when enabled) for activity on users' favorite sources (can be configured to trigger on new comments, spectra and classifications for now -- and can be easily expanded). A generalized SQLAlchemy event listener is used for all three mappers. A new notification settings section is added to the user profile. 

The generated notifications:

![notif](https://user-images.githubusercontent.com/7230285/122281991-c11da700-ce9f-11eb-9089-81c99872d0ea.png)

On the profile page:

![prof](https://user-images.githubusercontent.com/7230285/122282007-c67af180-ce9f-11eb-8a9b-e308406d242f.png)


Closes https://github.com/skyportal/skyportal/issues/1619