### PR TITLE
Do not unnecessarily fetch favorite sources

### DIFF
--- a/skyportal/handlers/api/user_obj_list.py
+++ b/skyportal/handlers/api/user_obj_list.py
@@ -158,9 +158,11 @@ class UserObjListHandler(BaseHandler):
         DBSession().add(listing)
         self.verify_and_commit()
 
-        self.push(action='skyportal/REFRESH_FAVORITES')
-        self.push(action='skyportal/REFRESH_FAVORITE_SOURCES')
-        self.push(action='skyportal/REFRESH_REJECTED_CANDIDATES')
+        if list_name == "favorites":
+            self.push(action='skyportal/REFRESH_FAVORITES')
+            self.push(action='skyportal/REFRESH_FAVORITE_SOURCES')
+        if list_name == "rejected_candidates":
+            self.push(action='skyportal/REFRESH_REJECTED_CANDIDATES')
 
         return self.success(data={'id': listing.id})
 

--- a/skyportal/handlers/api/user_obj_list.py
+++ b/skyportal/handlers/api/user_obj_list.py
@@ -335,6 +335,8 @@ class UserObjListHandler(BaseHandler):
         if listing is None:
             return self.error("Listing does not exist.")
 
+        list_name = listing.list_name
+
         DBSession.delete(listing)
         self.verify_and_commit()
 

--- a/skyportal/handlers/api/user_obj_list.py
+++ b/skyportal/handlers/api/user_obj_list.py
@@ -246,9 +246,11 @@ class UserObjListHandler(BaseHandler):
 
         self.verify_and_commit()
 
-        self.push(action='skyportal/REFRESH_FAVORITES')
-        self.push(action='skyportal/REFRESH_FAVORITE_SOURCES')
-        self.push(action='skyportal/REFRESH_REJECTED_CANDIDATES')
+        if list_name == "favorites":
+            self.push(action='skyportal/REFRESH_FAVORITES')
+            self.push(action='skyportal/REFRESH_FAVORITE_SOURCES')
+        if list_name == "rejected_candidates":
+            self.push(action='skyportal/REFRESH_REJECTED_CANDIDATES')
 
         return self.success()
 
@@ -336,8 +338,10 @@ class UserObjListHandler(BaseHandler):
         DBSession.delete(listing)
         self.verify_and_commit()
 
-        self.push(action='skyportal/REFRESH_FAVORITES')
-        self.push(action='skyportal/REFRESH_FAVORITE_SOURCES')
-        self.push(action='skyportal/REFRESH_REJECTED_CANDIDATES')
+        if list_name == "favorites":
+            self.push(action='skyportal/REFRESH_FAVORITES')
+            self.push(action='skyportal/REFRESH_FAVORITE_SOURCES')
+        if list_name == "rejected_candidates":
+            self.push(action='skyportal/REFRESH_REJECTED_CANDIDATES')
 
         return self.success()

--- a/static/js/ducks/sources.js
+++ b/static/js/ducks/sources.js
@@ -79,7 +79,9 @@ const initialState = {
 // Websocket message handler
 messageHandler.add((actionType, payload, dispatch) => {
   if (actionType === REFRESH_FAVORITE_SOURCES) {
-    dispatch(fetchFavoriteSources());
+    if (window.location.pathname === "/favorites") {
+      dispatch(fetchFavoriteSources());
+    }
   }
 });
 


### PR DESCRIPTION
This PR addresses a potentially significant resource drain whereby any time a user updated one of their listings, their favorite sources (not just the `Listing`s, but the actual `Obj` data) were re-fetched. The issue was two-fold: the REFRESH_FAVORITE_SOURCES WS message was being pushed regardless of whether the relevant list was updated; and when the front-end received that message, it was always issuing a new (potentially expensive) request, regardless of whether the user was viewing the favorites page, where that information would be relevant.