### PR TITLE
Use float priorities for SEDM and LT followup

### DIFF
--- a/skyportal/facility_apis/lt.py
+++ b/skyportal/facility_apis/lt.py
@@ -528,9 +528,10 @@ class IOOAPI(LTAPI):
             },
             "binning": {"type": "string", "enum": ["1x1", "2x2"], "default": "1x1"},
             "priority": {
-                "type": "string",
-                "enum": ["1", "2", "3", "4", "5"],
-                "default": "1",
+                "type": "number",
+                "default": 1.0,
+                "minimum": 1,
+                "maximum": 5,
                 "title": "Priority",
             },
         },

--- a/skyportal/facility_apis/sedm.py
+++ b/skyportal/facility_apis/sedm.py
@@ -285,9 +285,10 @@ class SEDMAPI(FollowUpAPI):
                 "default": "IFU",
             },
             "priority": {
-                "type": "string",
-                "enum": ["1", "2", "3", "4", "5"],
-                "default": "1",
+                "type": "number",
+                "default": 1.0,
+                "minimum": 1,
+                "maximum": 5,
                 "title": "Priority",
             },
             "start_date": {

--- a/skyportal/tests/api/test_followup_requests.py
+++ b/skyportal/tests/api/test_followup_requests.py
@@ -8,7 +8,7 @@ def test_token_user_post_robotic_followup_request(
         'allocation_id': public_group_sedm_allocation.id,
         'obj_id': public_source.id,
         'payload': {
-            'priority': "5",
+            'priority': 5,
             'start_date': '3020-09-01',
             'end_date': '3022-09-01',
             'observation_type': 'IFU',
@@ -38,7 +38,7 @@ def test_token_user_delete_owned_followup_request(
         'allocation_id': public_group_sedm_allocation.id,
         'obj_id': public_source.id,
         'payload': {
-            'priority': "5",
+            'priority': 5,
             'start_date': '3020-09-01',
             'end_date': '3022-09-01',
             'observation_type': 'IFU',
@@ -65,7 +65,7 @@ def test_token_user_modify_owned_followup_request(
         'allocation_id': public_group_sedm_allocation.id,
         'obj_id': public_source.id,
         'payload': {
-            'priority': "5",
+            'priority': 5,
             'start_date': '3020-09-01',
             'end_date': '3022-09-01',
             'observation_type': 'IFU',
@@ -83,7 +83,7 @@ def test_token_user_modify_owned_followup_request(
         'allocation_id': public_group_sedm_allocation.id,
         'obj_id': public_source.id,
         'payload': {
-            'priority': "4",
+            'priority': 4,
             'start_date': '3020-09-01',
             'end_date': '3022-09-01',
             'observation_type': 'IFU',
@@ -111,7 +111,7 @@ def test_regular_user_delete_super_admin_followup_request(
         'allocation_id': public_group_sedm_allocation.id,
         'obj_id': public_source.id,
         'payload': {
-            'priority': "5",
+            'priority': 5,
             'start_date': '3020-09-01',
             'end_date': '3022-09-01',
             'observation_type': 'IFU',
@@ -141,7 +141,7 @@ def test_group1_user_cannot_see_group2_followup_request(
         'allocation_id': public_group2_sedm_allocation.id,
         'obj_id': public_source_group2.id,
         'payload': {
-            'priority': "5",
+            'priority': 5,
             'start_date': '3020-09-01',
             'end_date': '3022-09-01',
             'observation_type': 'IFU',


### PR DESCRIPTION
This PR converts the `priority` follow-up request form field for the SEDM and LT APIs to be a float value in the `[1, 5]` range instead of an enumerated list of strings representing the integers in that range, to allow for more granularity in the priorities.

Closes #603 