### PR TITLE
Fix issue where multi-line comments were overlapping in compact mode

### DIFF
--- a/static/js/components/CommentList.jsx
+++ b/static/js/components/CommentList.jsx
@@ -126,7 +126,7 @@ const useStyles = makeStyles(() => ({
     flexDirection: "row",
     justifyContent: "space-between",
     alignItems: "center",
-    height: "25px",
+    minHeight: "25px",
     margin: "0 15px",
     width: "100%",
   },

--- a/static/js/components/CommentListMobile.jsx
+++ b/static/js/components/CommentListMobile.jsx
@@ -138,7 +138,7 @@ const useStyles = makeStyles(() => ({
     flexDirection: "row",
     justifyContent: "space-between",
     alignItems: "center",
-    height: "25px",
+    minHeight: "25px",
     margin: "0 15px",
     width: "100%",
   },


### PR DESCRIPTION
Before:

![compact_too_tight](https://user-images.githubusercontent.com/7230285/122479204-87bc6880-cf7f-11eb-912e-a5e937f2d434.png)

With this patch:

![compact_cmts_fixed](https://user-images.githubusercontent.com/7230285/122479239-930f9400-cf7f-11eb-89ac-fe2fff19c052.png)



Closes https://github.com/skyportal/skyportal/issues/2068