### PR TITLE
Show username + first/last in tooltip for UserAvatar

### DIFF
--- a/static/js/components/NewsFeed.jsx
+++ b/static/js/components/NewsFeed.jsx
@@ -54,8 +54,7 @@ const NewsFeedItem = ({ item }) => {
           gravatarUrl={item.author_info.gravatar_url}
         />
       );
-      /* eslint-disable react/display-name */
-      entryTitle = item.author_info.username;
+      entryTitle = null;
       break;
     case "source":
       /* eslint-disable react/display-name */
@@ -87,16 +86,22 @@ const NewsFeedItem = ({ item }) => {
       className={styles.entry}
       elevation={1}
     >
-      <Tooltip
-        title={entryTitle}
-        arrow
-        placement="top-start"
-        classes={{ tooltip: styles.entryTitle }}
-      >
+      {entryTitle !== null ? (
+        <Tooltip
+          title={entryTitle}
+          arrow
+          placement="top-start"
+          classes={{ tooltip: styles.entryTitle }}
+        >
+          <div className={styles.entryAvatar}>
+            <EntryAvatar />
+          </div>
+        </Tooltip>
+      ) : (
         <div className={styles.entryAvatar}>
           <EntryAvatar />
         </div>
-      </Tooltip>
+      )}
       <div className={styles.entryContent}>
         <ReactMarkdown
           source={item.message}

--- a/static/js/components/UserAvatar.jsx
+++ b/static/js/components/UserAvatar.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { makeStyles } from "@material-ui/core/styles";
 import Avatar from "@material-ui/core/Avatar";
+import Tooltip from "@material-ui/core/Tooltip";
 
 const useStyles = makeStyles((theme) => ({
   avatar: (props) => ({
@@ -22,11 +23,10 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 // Return true if all characters in a string are Korean characters
-export const isAllKoreanCharacters = (str) => {
-  return str.match(
+export const isAllKoreanCharacters = (str) =>
+  str.match(
     /^([\uac00-\ud7af]|[\u1100-\u11ff]|[\u3130-\u318f]|[\ua960-\ua97f]|[\ud7b0-\ud7ff])+$/g
   );
-};
 
 const getInitials = (firstName, lastName) => {
   // Korean names are almost always <=2 characters; last names are written first,
@@ -60,16 +60,23 @@ const UserAvatar = ({ size, firstName, lastName, username, gravatarUrl }) => {
   const props = { size, usercolor, backUpLetters };
   const classes = useStyles(props);
 
+  let tooltipText = username;
+  if (firstName && lastName) {
+    tooltipText += ` (${firstName} ${lastName})`;
+  }
+
   return (
-    <Avatar
-      alt={backUpLetters}
-      src={`${gravatarUrl}&s=${size}`}
-      size={size}
-      classes={{
-        root: classes.avatar,
-        img: classes.avatarImg,
-      }}
-    />
+    <Tooltip title={tooltipText} arrow placement="top-start">
+      <Avatar
+        alt={backUpLetters}
+        src={`${gravatarUrl}&s=${size}`}
+        size={size}
+        classes={{
+          root: classes.avatar,
+          img: classes.avatarImg,
+        }}
+      />
+    </Tooltip>
   );
 };
 


### PR DESCRIPTION
In compact comments mode, it was not possible to see more than the comment author's initials in the avatar, which is likely not enough information to fully identify the author. This PR adds a mouseover tooltip that displays the author's username, first name and last name.

![avatar_tooltip](https://user-images.githubusercontent.com/7230285/122480948-b0922d00-cf82-11eb-837c-c433bd6116c3.png)


Closes https://github.com/skyportal/skyportal/issues/2067