### PR TITLE
Duplicate sources flag on source page

### DIFF
--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -660,11 +660,10 @@ class SourceHandler(BaseHandler):
                 .all()
             )
             point = ha.Point(ra=s.ra, dec=s.dec)
-            # Check for duplicates (within 4 arcsecs, magnitude 18 or brighter)
+            # Check for duplicates (within 4 arcsecs)
             duplicates = (
                 Obj.query_records_accessible_by(self.current_user)
                 .filter(Obj.within(point, 4 / 3600))
-                .filter(Obj.last_detected_mag(self.current_user) <= 18)
                 .filter(Obj.id != s.id)
                 .all()
             )

--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -660,11 +660,11 @@ class SourceHandler(BaseHandler):
                 .all()
             )
             point = ha.Point(ra=s.ra, dec=s.dec)
-            # Check for duplicates (within 4 arcsecs, magnitude 13 or brighter)
+            # Check for duplicates (within 4 arcsecs, magnitude 18 or brighter)
             duplicates = (
                 Obj.query_records_accessible_by(self.current_user)
                 .filter(Obj.within(point, 4 / 3600))
-                .filter(Obj.last_detected_mag(self.current_user) <= 13)
+                .filter(Obj.last_detected_mag(self.current_user) <= 18)
                 .filter(Obj.id != s.id)
                 .all()
             )

--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -659,6 +659,19 @@ class SourceHandler(BaseHandler):
                 .filter(ClassicalAssignment.obj_id == obj_id)
                 .all()
             )
+            point = ha.Point(ra=s.ra, dec=s.dec)
+            # Check for duplicates (within 4 arcsecs, magnitude 13 or brighter)
+            duplicates = (
+                Obj.query_records_accessible_by(self.current_user)
+                .filter(Obj.within(point, 4 / 3600))
+                .filter(Obj.last_detected_mag(self.current_user) <= 13)
+                .filter(Obj.id != s.id)
+                .all()
+            )
+            if len(duplicates) > 0:
+                source_info["duplicates"] = [dup.id for dup in duplicates]
+            else:
+                source_info["duplicates"] = None
 
             if is_token_request:
                 # Logic determining whether to register front-end request as view lives in front-end

--- a/skyportal/tests/api/test_sources.py
+++ b/skyportal/tests/api/test_sources.py
@@ -127,8 +127,8 @@ def test_duplicate_sources(public_group, upload_data_token, ztf_camera):
         "sources",
         data={
             "id": obj_id1,
-            "ra": 234.22,
-            "dec": -22.33,
+            "ra": 230.22,
+            "dec": -21.33,
             "redshift": 3,
             "group_ids": [public_group.id],
         },
@@ -140,8 +140,8 @@ def test_duplicate_sources(public_group, upload_data_token, ztf_camera):
         "sources",
         data={
             "id": obj_id2,
-            "ra": 234.2201,
-            "dec": -22.3305,
+            "ra": 230.2201,
+            "dec": -21.3305,
             "redshift": 3,
             "group_ids": [public_group.id],
         },

--- a/static/js/components/SourceDesktop.jsx
+++ b/static/js/components/SourceDesktop.jsx
@@ -239,6 +239,18 @@ const SourceDesktop = ({ source }) => {
               )}
             </div>
           </div>
+          {source.duplicates && (
+            <div className={classes.infoLine}>
+              <div className={classes.sourceInfo}>
+                Possible duplicate of:&nbsp;
+                {source.duplicates.map((dupID) => (
+                  <Link to={`/source/${dupID}`} role="link" key={dupID}>
+                    <Button size="small">{dupID}</Button>
+                  </Link>
+                ))}
+              </div>
+            </div>
+          )}
           <div className={`${classes.infoLine} ${classes.findingChart}`}>
             <b>Finding Chart:&nbsp;</b>
             <Button
@@ -615,6 +627,7 @@ SourceDesktop.propTypes = {
         origin: PropTypes.string,
       })
     ),
+    duplicates: PropTypes.arrayOf(PropTypes.string),
     alias: PropTypes.arrayOf(PropTypes.string),
   }).isRequired,
 };

--- a/static/js/components/SourceDesktop.jsx
+++ b/static/js/components/SourceDesktop.jsx
@@ -208,6 +208,21 @@ const SourceDesktop = ({ source }) => {
               </div>
             </div>
           </div>
+          {source.duplicates && (
+            <div className={classes.infoLine}>
+              <div className={classes.sourceInfo}>
+                <b>
+                  <font color="red">Possible duplicate of:</font>
+                </b>
+                &nbsp;
+                {source.duplicates.map((dupID) => (
+                  <Link to={`/source/${dupID}`} role="link" key={dupID}>
+                    <Button size="small">{dupID}</Button>
+                  </Link>
+                ))}
+              </div>
+            </div>
+          )}
           <div className={classes.infoLine}>
             <div className={classes.redshiftInfo}>
               <b>Redshift: &nbsp;</b>
@@ -239,18 +254,6 @@ const SourceDesktop = ({ source }) => {
               )}
             </div>
           </div>
-          {source.duplicates && (
-            <div className={classes.infoLine}>
-              <div className={classes.sourceInfo}>
-                Possible duplicate of:&nbsp;
-                {source.duplicates.map((dupID) => (
-                  <Link to={`/source/${dupID}`} role="link" key={dupID}>
-                    <Button size="small">{dupID}</Button>
-                  </Link>
-                ))}
-              </div>
-            </div>
-          )}
           <div className={`${classes.infoLine} ${classes.findingChart}`}>
             <b>Finding Chart:&nbsp;</b>
             <Button

--- a/static/js/components/SourceMobile.jsx
+++ b/static/js/components/SourceMobile.jsx
@@ -296,6 +296,18 @@ const SourceMobile = WidthProvider(
                       )}
                     </div>
                   </div>
+                  {source.duplicates && (
+                    <div className={classes.infoLine}>
+                      <div className={classes.sourceInfo}>
+                        Possible duplicate of:&nbsp;
+                        {source.duplicates.map((dupID) => (
+                          <Link to={`/source/${dupID}`} role="link" key={dupID}>
+                            <Button size="small">{dupID}</Button>
+                          </Link>
+                        ))}
+                      </div>
+                    </div>
+                  )}
                   <div
                     className={`${classes.infoLine} ${classes.findingChart}`}
                   >
@@ -665,6 +677,7 @@ SourceMobile.propTypes = {
     followup_requests: PropTypes.arrayOf(PropTypes.any),
     assignments: PropTypes.arrayOf(PropTypes.any),
     redshift_history: PropTypes.arrayOf(PropTypes.any),
+    duplicates: PropTypes.arrayOf(PropTypes.string),
     color_magnitude: PropTypes.arrayOf(
       PropTypes.shape({
         abs_mag: PropTypes.number,


### PR DESCRIPTION
This PR introduces a check for duplicates in the handler for fetching individual sources by ID. If any duplicates are found, an array of their IDs is included in the response. 

On the front-end source page, if any duplicates exist, a message appears indicating so with links to all possible duplicate sources.

![dup_red_no_italics](https://user-images.githubusercontent.com/7230285/122998131-86b17f80-d361-11eb-9bca-0515f9832474.png)


Partially addresses https://github.com/fritz-marshal/fritz/issues/178