### PR TITLE
Add origin/altdata to spectrum displays

### DIFF
--- a/data/db_demo.yaml
+++ b/data/db_demo.yaml
@@ -216,14 +216,14 @@ instrument:
     name: Sinistro
     telescope_id: =LCOGT1m
     type: imager
-    filters: ['sdssu', 'sdssg', 'sdssr', 'sdssi', 'sdssz', 'desy']
+    filters: ["sdssu", "sdssg", "sdssr", "sdssi", "sdssz", "desy"]
     api_classname: SINISTROAPI
     =id: SINISTRO
   - band: optical
     name: SPECTRAL
     telescope_id: =LCOGT2m
     type: imager
-    filters: ['sdssu', 'sdssg', 'sdssr', 'sdssi', 'sdssz', 'desy']
+    filters: ["sdssu", "sdssg", "sdssr", "sdssi", "sdssz", "desy"]
     api_classname: SPECTRALAPI
     =id: SPECTRAL
   - band: optical
@@ -236,7 +236,7 @@ instrument:
     name: MUSCAT
     telescope_id: =LCOGT2m
     type: imager
-    filters: ['sdssg', 'sdssr', 'sdssi', 'sdssz']
+    filters: ["sdssg", "sdssr", "sdssi", "sdssz"]
     api_classname: MUSCATAPI
     =id: MUSCAT
 
@@ -339,7 +339,7 @@ candidates:
     redshift: 0.001
     varstar: false
     passed_at: "2020-10-30 21:19:06.475748"
-    alias: ['ZTF21whatnow', 'ASAS-SN21zzz']
+    alias: ["ZTF21whatnow", "ASAS-SN21zzz"]
   - id: 16fil
     filter_ids:
       - =example_filter
@@ -348,7 +348,7 @@ candidates:
     redshift: 0.001
     varstar: false
     passed_at: "2020-10-30 21:13:06.475748"
-    alias: ['ZTF21whatnow', 'ASAS-SN21zzz']
+    alias: ["ZTF21whatnow", "ASAS-SN21zzz"]
   - id: ZTFe028h94k
     filter_ids:
       - =example_filter
@@ -359,7 +359,7 @@ candidates:
       simbad:
         class: RRLyr
     passed_at: "2020-10-30 11:13:06.475748"
-    alias: ['SN2020abc']
+    alias: ["SN2020abc"]
   - id: ZTFrlh6cyjh
     filter_ids:
       - =example_filter
@@ -389,7 +389,7 @@ sources:
     group_ids:
       - =public_group_id
       - =program_A
-    alias: ['ZTF21whatnow', 'ASAS-SN21zzz']
+    alias: ["ZTF21whatnow", "ASAS-SN21zzz"]
   - id: ZTFe028h94k
     ra: 229.9620403
     dec: 34.8442757
@@ -397,7 +397,7 @@ sources:
       - =public_group_id
       - =program_A
       - =program_B
-    alias: ['SN2020abc']
+    alias: ["SN2020abc"]
   - id: ZTFrlh6cyjh
     ra: 342.4596
     dec: 51.2634
@@ -608,6 +608,7 @@ spectrum:
     file: spec1.csv
     instrument_id: =ALFOSC
     observed_at: "2019-10-28T00:00:00"
+    origin: "demo_data"
     assignment_id: 1
     group_ids:
       - =program_A
@@ -616,6 +617,7 @@ spectrum:
     file: spec1.csv
     instrument_id: =ALFOSC
     observed_at: "2019-10-24T05:23:14"
+    origin: "demo_data"
     assignment_id: 1
     group_ids:
       - =program_A
@@ -624,6 +626,7 @@ spectrum:
     file: spec2.csv
     instrument_id: =ALFOSC
     observed_at: "2019-08-28T00:00:00"
+    origin: "demo_data"
     assignment_id: 2
     group_ids:
       - =program_A
@@ -632,7 +635,11 @@ spectrum:
     file: spec2.csv
     instrument_id: =ALFOSC
     observed_at: "2019-08-24T06:18:53"
+    origin: "demo_data"
     assignment_id: 2
+    altdata:
+      some_value: 1
+      some_other_value: 2
     group_ids:
       - =program_A
       - =program_B
@@ -640,6 +647,7 @@ spectrum:
     file: spec1.csv
     instrument_id: =ALFOSC
     observed_at: "2019-08-19T05:23:14"
+    origin: "demo_data"
     assignment_id: 1
     group_ids:
       - =program_A

--- a/skyportal/plot.py
+++ b/skyportal/plot.py
@@ -1,5 +1,6 @@
 import itertools
 import math
+import json
 
 import numpy as np
 import pandas as pd
@@ -317,7 +318,7 @@ def annotate_spec(plot, spectra, lower, upper):
 
 
 def add_plot_legend(plot, legend_items, width, legend_orientation, legend_loc):
-    """ Helper function to add responsive legends to a photometry plot tab """
+    """Helper function to add responsive legends to a photometry plot tab"""
     if legend_orientation == "horizontal":
         width_remaining = width - 120
         current_legend_items = []
@@ -1267,7 +1268,8 @@ def spectroscopy_plot(obj_id, user, spec_id=None, width=600, device="browser"):
         # normalize spectra to a median flux of 1 for easy comparison
         normfac = np.nanmedian(np.abs(s.fluxes))
         normfac = normfac if normfac != 0.0 else 1e-20
-
+        altdata = json.dumps(s.altdata) if s.altdata is not None else ""
+        print(s.altdata)
         df = pd.DataFrame(
             {
                 'wavelength': s.wavelengths,
@@ -1285,6 +1287,8 @@ def spectroscopy_plot(obj_id, user, spec_id=None, width=600, device="browser"):
                         else ""
                     )
                 ),
+                'origin': s.origin,
+                'altdata': altdata[:20] + "..." if len(altdata) > 20 else altdata,
             }
         )
         data.append(df)
@@ -1315,6 +1319,8 @@ def spectroscopy_plot(obj_id, user, spec_id=None, width=600, device="browser"):
             ('instrument', '@instrument'),
             ('UTC date observed', '@date_observed'),
             ('PI', '@pi'),
+            ('origin', '@origin'),
+            ('altdata', '@altdata{safe}'),
         ]
     )
     smoothed_max = np.max(smoothed_data['flux'])
@@ -1372,7 +1378,7 @@ def spectroscopy_plot(obj_id, user, spec_id=None, width=600, device="browser"):
     if device == "browser":
         plot_height_of_legend = (
             legend_row_height * int(len(split) / legend_items_per_row)
-            + 40  # 40 is height of toolbar plus legend offset
+            + 90  # 90 is height of toolbar plus legend offset
         )
 
         if plot_height_of_legend > plot_height:

--- a/skyportal/plot.py
+++ b/skyportal/plot.py
@@ -1269,7 +1269,6 @@ def spectroscopy_plot(obj_id, user, spec_id=None, width=600, device="browser"):
         normfac = np.nanmedian(np.abs(s.fluxes))
         normfac = normfac if normfac != 0.0 else 1e-20
         altdata = json.dumps(s.altdata) if s.altdata is not None else ""
-        print(s.altdata)
         df = pd.DataFrame(
             {
                 'wavelength': s.wavelengths,

--- a/static/js/components/ManageDataForm.jsx
+++ b/static/js/components/ManageDataForm.jsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import { Link } from "react-router-dom";
 import { useSelector, useDispatch } from "react-redux";
 import MUIDataTable from "mui-datatables";
-import { makeStyles } from "@material-ui/core/styles";
+import { makeStyles, useTheme } from "@material-ui/core/styles";
 import Typography from "@material-ui/core/Typography";
 import { useForm, Controller } from "react-hook-form";
 import Autocomplete from "@material-ui/lab/Autocomplete";
@@ -18,6 +18,7 @@ import DialogContent from "@material-ui/core/DialogContent";
 import TableRow from "@material-ui/core/TableRow";
 import TableCell from "@material-ui/core/TableCell";
 import Papa from "papaparse";
+import ReactJson from "react-json-view";
 
 import { showNotification } from "baselayer/components/Notifications";
 
@@ -172,6 +173,8 @@ SpectrumRow.propTypes = {
 
 const ManageDataForm = ({ route }) => {
   const classes = useStyles();
+  const theme = useTheme();
+  const darkTheme = theme.palette.type === "dark";
 
   const dispatch = useDispatch();
   const [selectedPhotRows, setSelectedPhotRows] = useState([]);
@@ -355,6 +358,51 @@ const ManageDataForm = ({ route }) => {
     );
   };
 
+  const AltdataButton = (dataIndex) => {
+    const specid = specRows[dataIndex].id;
+    const spectrum = sourceSpectra.find((spec) => spec.id === specid);
+    const [open, setOpen] = useState(false);
+    return spectrum.altdata ? (
+      <>
+        <Dialog
+          open={open}
+          aria-labelledby="simple-modal-title"
+          aria-describedby="simple-modal-description"
+          onClose={() => {
+            setOpen(false);
+          }}
+        >
+          <DialogContent>
+            <div>
+              <ReactJson
+                src={spectrum.altdata}
+                name={false}
+                theme={darkTheme ? "monokai" : "rjv-default"}
+              />
+            </div>
+          </DialogContent>
+        </Dialog>
+        <Button
+          onClick={() => {
+            setOpen(true);
+          }}
+          data-testid={`altdata-spectrum-button-${specid}`}
+          variant="contained"
+          size="small"
+        >
+          Show altdata
+        </Button>
+      </>
+    ) : (
+      <div />
+    );
+  };
+
+  const renderOrigin = (value) => {
+    const spectrum = sourceSpectra.find((spec) => spec.id === value);
+    return spectrum.origin;
+  };
+
   const specHeadCells = [
     { name: "id", label: "ID" },
     { name: "instrument", label: "Instrument" },
@@ -383,6 +431,18 @@ const ManageDataForm = ({ route }) => {
         customBodyRenderLite: makeRenderMultipleUsers("observers"),
         filter: false,
       },
+    },
+    {
+      name: "id",
+      label: "Origin",
+      options: {
+        customBodyRender: renderOrigin,
+      },
+    },
+    {
+      name: "altdata",
+      label: "Altdata",
+      options: { customBodyRenderLite: AltdataButton, filter: false },
     },
     {
       name: "delete",

--- a/static/js/components/ManageDataForm.jsx
+++ b/static/js/components/ManageDataForm.jsx
@@ -102,7 +102,8 @@ const createSpecRow = (
   groups,
   owner,
   reducers,
-  observers
+  observers,
+  origin
 ) => ({
   id,
   instrument,
@@ -111,6 +112,7 @@ const createSpecRow = (
   owner,
   reducers,
   observers,
+  origin,
 });
 
 const photHeadCells = [
@@ -250,7 +252,8 @@ const ManageDataForm = ({ route }) => {
           spec.groups.map((group) => group.name).join(", "),
           spec.owner,
           spec.reducers,
-          spec.observers
+          spec.observers,
+          spec.origin
         )
       )
     : [];
@@ -398,11 +401,6 @@ const ManageDataForm = ({ route }) => {
     );
   };
 
-  const renderOrigin = (value) => {
-    const spectrum = sourceSpectra.find((spec) => spec.id === value);
-    return spectrum.origin;
-  };
-
   const specHeadCells = [
     { name: "id", label: "ID" },
     { name: "instrument", label: "Instrument" },
@@ -433,11 +431,8 @@ const ManageDataForm = ({ route }) => {
       },
     },
     {
-      name: "id",
+      name: "origin",
       label: "Origin",
-      options: {
-        customBodyRender: renderOrigin,
-      },
     },
     {
       name: "altdata",


### PR DESCRIPTION
Display spectrum origin and altdata values in the plot tooltips and the manage data table. Interestingly, it doesn't look like anyone is actually using the origin field for spectra (I didn't see any non-null or non-empty-string values in the fritz production replica database). Maybe seeing it in the tooltip will serve as advertisement so people are aware of it.

Also tweaked the spectrum plot styling to more accurately handle longer lists of spectra.

Origin and altdata columns on the Manage Data page:
![spectra](https://user-images.githubusercontent.com/17696889/123285573-28a8a780-d4db-11eb-9eb4-947e2e7153e5.gif)

New plot tooltip additions:
![Screenshot 2021-06-24 101851](https://user-images.githubusercontent.com/17696889/123285777-5857af80-d4db-11eb-88fd-da7b91b1a180.png)

Before of having a large number of spectra (22 here):
![Screenshot 2021-06-24 092156](https://user-images.githubusercontent.com/17696889/123285732-4e35b100-d4db-11eb-99ce-9ffa45b54c82.png)
After:
![Screenshot 2021-06-24 093143](https://user-images.githubusercontent.com/17696889/123285750-5130a180-d4db-11eb-8e63-157596f8815b.png)


Closes #1797 