### PR TITLE
Unify submit button styles

### DIFF
--- a/static/js/components/AddUsersFromGroupForm.jsx
+++ b/static/js/components/AddUsersFromGroupForm.jsx
@@ -97,6 +97,7 @@ const AddUsersFromGroupForm = ({ groupID }) => {
             name="submitAddFromGroupsButton"
             data-testid="submitAddFromGroupsButton"
             size="small"
+            color="primary"
             disableElevation
           >
             Add users

--- a/static/js/components/AssignmentForm.jsx
+++ b/static/js/components/AssignmentForm.jsx
@@ -73,6 +73,9 @@ const AssignmentForm = ({ obj_id, observingRunList }) => {
     observingRunSelectItem: {
       whiteSpace: "break-spaces",
     },
+    submitButton: {
+      margin: "0.5rem",
+    },
   }));
   const classes = useStyles();
 
@@ -177,6 +180,8 @@ const AssignmentForm = ({ obj_id, observingRunList }) => {
             name="assignmentSubmitButton"
             data-testid="assignmentSubmitButton"
             variant="contained"
+            color="primary"
+            className={classes.submitButton}
           >
             Submit
           </Button>

--- a/static/js/components/NewGroupForm.jsx
+++ b/static/js/components/NewGroupForm.jsx
@@ -148,7 +148,7 @@ const NewGroupForm = () => {
           </FormControl>
         </Box>
         <Box>
-          <Button type="submit" variant="contained" size="small">
+          <Button type="submit" variant="contained" color="primary">
             Create Group
           </Button>
         </Box>

--- a/static/js/components/NewGroupUserForm.jsx
+++ b/static/js/components/NewGroupUserForm.jsx
@@ -123,6 +123,7 @@ const NewGroupUserForm = ({ group_id }) => {
         onClick={handleClickSubmit}
         variant="contained"
         size="small"
+        color="primary"
         disableElevation
       >
         Add user to group

--- a/static/js/components/SourceNotification.jsx
+++ b/static/js/components/SourceNotification.jsx
@@ -190,6 +190,7 @@ const SourceNotification = ({ sourceId }) => {
             type="submit"
             name="sendNotificationButton"
             variant="contained"
+            color="primary"
             data-testid="sendNotificationButton"
           >
             Send Notification

--- a/static/js/components/WidgetPrefsDialog.jsx
+++ b/static/js/components/WidgetPrefsDialog.jsx
@@ -16,8 +16,7 @@ import Typography from "@material-ui/core/Typography";
 
 const useStyles = makeStyles(() => ({
   saveButton: {
-    textAlign: "center",
-    margin: "1rem",
+    margin: "1rem 0",
   },
   inputSectionDiv: {
     marginBottom: "1rem",
@@ -34,9 +33,8 @@ const WidgetPrefsDialog = ({
   const dispatch = useDispatch();
   const [open, setOpen] = useState(false);
 
-  const { handleSubmit, register, errors, reset, control } = useForm(
-    initialValues
-  );
+  const { handleSubmit, register, errors, reset, control } =
+    useForm(initialValues);
 
   useEffect(() => {
     reset(initialValues);
@@ -125,9 +123,9 @@ const WidgetPrefsDialog = ({
             <div className={classes.saveButton}>
               <Button
                 color="primary"
+                variant="contained"
                 type="submit"
                 startIcon={<SaveIcon />}
-                size="large"
               >
                 Save
               </Button>


### PR DESCRIPTION
Unify the MUI button type used for submitting forms throughout the app (mostly on the Source page).

Close #916

![buttons](https://user-images.githubusercontent.com/17696889/123699778-a3e8c100-d82d-11eb-9d07-9381ac701a79.gif)
![image](https://user-images.githubusercontent.com/17696889/123699799-a9460b80-d82d-11eb-9aeb-8056ced51a0c.png)
![image](https://user-images.githubusercontent.com/17696889/123699841-b3680a00-d82d-11eb-92f2-fb482e1ab6a7.png)
![image](https://user-images.githubusercontent.com/17696889/123699855-b95deb00-d82d-11eb-826c-a1fc9d30df23.png)
