### PR TITLE
Allow filtering of observability page via user preferences

### DIFF
--- a/skyportal/tests/frontend/test_observability.py
+++ b/skyportal/tests/frontend/test_observability.py
@@ -7,3 +7,24 @@ def test_fixed_location_filtering(  # noqa: E302
     driver.wait_for_xpath_to_disappear(f'//*[text()="{hst.name}"]')
     # Make sure a plot loads
     driver.wait_for_xpath("//canvas")
+
+
+def test_user_preference_filtering(
+    driver, view_only_user, public_source, keck1_telescope, p60_telescope
+):
+    driver.get(f'/become_user/{view_only_user.id}')
+    driver.get(f'/observability/{public_source.id}')
+
+    # Both show up by default
+    driver.wait_for_xpath(f'//*[text()="{keck1_telescope.name}"]')
+    driver.wait_for_xpath(f'//*[text()="{p60_telescope.name}"]')
+
+    # Now go to preferences and set to only show p60
+    driver.get("/profile")
+    driver.click_xpath("//*[@data-testid='selectTelescopes']")
+    driver.click_xpath(f"//*[@data-testid='telescope_{p60_telescope.id}']")
+
+    # Now should only show p60
+    driver.get(f'/observability/{public_source.id}')
+    driver.wait_for_xpath_to_disappear(f'//*[text()="{keck1_telescope.name}"]')
+    driver.wait_for_xpath(f'//*[text()="{p60_telescope.name}"]')

--- a/static/js/components/Observability.jsx
+++ b/static/js/components/Observability.jsx
@@ -10,8 +10,12 @@ import { Link } from "react-router-dom";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import { AirMassPlotWithEphemURL } from "./AirmassPlot";
+import ObservabilityPreferences from "./ObservabilityPreferences";
 
-const useStyles = makeStyles({ inner: { margin: "1rem" } });
+const useStyles = makeStyles({
+  inner: { margin: "1rem" },
+  preferences: { padding: "1rem", marginTop: "1rem" },
+});
 
 dayjs.extend(utc);
 
@@ -27,6 +31,9 @@ const ObservabilityPage = ({ route }) => {
       <Typography variant="h4">
         Observability of <Link to={`/source/${route.id}`}>{route.id}</Link>
       </Typography>
+      <Paper className={classes.preferences}>
+        <ObservabilityPreferences />
+      </Paper>
       <Grid container spacing={3}>
         {telescopeList
           .filter((telescope) => telescope.fixed_location)

--- a/static/js/components/Observability.jsx
+++ b/static/js/components/Observability.jsx
@@ -17,6 +17,9 @@ dayjs.extend(utc);
 
 const ObservabilityPage = ({ route }) => {
   const { telescopeList } = useSelector((state) => state.telescopes);
+  const preferences = useSelector(
+    (state) => state.profile.preferences.observabilityTelescopes
+  );
   const classes = useStyles();
 
   return (
@@ -27,23 +30,27 @@ const ObservabilityPage = ({ route }) => {
       <Grid container spacing={3}>
         {telescopeList
           .filter((telescope) => telescope.fixed_location)
-          .map((telescope) => {
-            return (
-              <Grid item key={telescope.id}>
-                <Paper>
-                  <div className={classes.inner}>
-                    <Typography variant="h6">{telescope.name}</Typography>
-                    <Suspense fallback={<div>Loading plot...</div>}>
-                      <AirMassPlotWithEphemURL
-                        dataUrl={`/api/internal/plot/airmass/objtel/${route.id}/${telescope.id}`}
-                        ephemerisUrl={`/api/internal/ephemeris/${telescope.id}`}
-                      />
-                    </Suspense>
-                  </div>
-                </Paper>
-              </Grid>
-            );
-          })}
+          // If telescope preferences exist, filter only for those
+          .filter((telescope) =>
+            preferences && preferences.length > 0
+              ? preferences.indexOf(telescope.id) !== -1
+              : true
+          )
+          .map((telescope) => (
+            <Grid item key={telescope.id}>
+              <Paper>
+                <div className={classes.inner}>
+                  <Typography variant="h6">{telescope.name}</Typography>
+                  <Suspense fallback={<div>Loading plot...</div>}>
+                    <AirMassPlotWithEphemURL
+                      dataUrl={`/api/internal/plot/airmass/objtel/${route.id}/${telescope.id}`}
+                      ephemerisUrl={`/api/internal/ephemeris/${telescope.id}`}
+                    />
+                  </Suspense>
+                </div>
+              </Paper>
+            </Grid>
+          ))}
       </Grid>
     </div>
   );

--- a/static/js/components/ObservabilityPreferences.jsx
+++ b/static/js/components/ObservabilityPreferences.jsx
@@ -1,0 +1,154 @@
+import React, { useState } from "react";
+import { useSelector, useDispatch } from "react-redux";
+
+import { makeStyles, useTheme } from "@material-ui/core/styles";
+import Select from "@material-ui/core/Select";
+import MenuItem from "@material-ui/core/MenuItem";
+import InputLabel from "@material-ui/core/InputLabel";
+import FormControl from "@material-ui/core/FormControl";
+import Chip from "@material-ui/core/Chip";
+import Input from "@material-ui/core/Input";
+import Typography from "@material-ui/core/Typography";
+import Popover from "@material-ui/core/Popover";
+import IconButton from "@material-ui/core/IconButton";
+import HelpOutlineIcon from "@material-ui/icons/HelpOutline";
+
+import * as profileActions from "../ducks/profile";
+
+const useStyles = makeStyles((theme) => ({
+  header: {
+    display: "flex",
+    alignItems: "center",
+    "& > h6": {
+      marginRight: "0.5rem",
+    },
+  },
+  typography: {
+    padding: theme.spacing(2),
+  },
+  formControl: {
+    marginTop: theme.spacing(1),
+    minWidth: "12rem",
+  },
+  chips: {
+    display: "flex",
+    flexWrap: "wrap",
+  },
+  chip: {
+    margin: 2,
+  },
+}));
+
+const getStyles = (telescopeID, telescopeIDs = [], theme) => ({
+  fontWeight:
+    telescopeIDs.indexOf(telescopeID) === -1
+      ? theme.typography.fontWeightRegular
+      : theme.typography.fontWeightMedium,
+});
+
+const ObservabilityPreferences = () => {
+  const classes = useStyles();
+  const theme = useTheme();
+  const profile = useSelector((state) => state.profile.preferences);
+  const { telescopeList } = useSelector((state) => state.telescopes);
+
+  const dispatch = useDispatch();
+
+  //   const [telescopeIDs, setTelescopeIDs] = useState([]);
+  const [anchorEl, setAnchorEl] = useState(null);
+  const handleClick = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+  const open = Boolean(anchorEl);
+  const id = open ? "simple-popover" : undefined;
+
+  const handleChange = (event) => {
+    const prefs = {
+      observabilityTelescopes: event.target.value,
+    };
+    dispatch(profileActions.updateUserPreferences(prefs));
+  };
+
+  const telescopeIDToName = {};
+  telescopeList.forEach((telescope) => {
+    telescopeIDToName[telescope.id] = telescope.name;
+  });
+
+  return (
+    <div>
+      <div className={classes.header}>
+        <Typography variant="h6" display="inline">
+          Observability Preferences
+        </Typography>
+        <IconButton aria-label="help" size="small" onClick={handleClick}>
+          <HelpOutlineIcon />
+        </IconButton>
+      </div>
+      <Popover
+        id={id}
+        open={open}
+        anchorEl={anchorEl}
+        onClose={handleClose}
+        anchorOrigin={{
+          vertical: "top",
+          horizontal: "right",
+        }}
+        transformOrigin={{
+          vertical: "top",
+          horizontal: "left",
+        }}
+      >
+        <Typography className={classes.typography}>
+          The telescopes to display observability plots for on sources&apos;
+          observability pages. Leave blank to show all telescopes.
+        </Typography>
+      </Popover>
+      <FormControl className={classes.formControl}>
+        <InputLabel id="select-telescopes-label">Telescopes to show</InputLabel>
+        <Select
+          labelId="select-telescopes-label"
+          data-testid="selectTelescopes"
+          MenuProps={{ disableScrollLock: true }}
+          multiple
+          value={profile?.observabilityTelescopes || []}
+          onChange={handleChange}
+          input={<Input id="selectTelescopes" />}
+          renderValue={(selected) => (
+            <div className={classes.chips}>
+              {selected.map((value) => (
+                <Chip
+                  key={value}
+                  label={telescopeIDToName[value]}
+                  className={classes.chip}
+                />
+              ))}
+            </div>
+          )}
+        >
+          {telescopeList
+            .filter((telescope) => telescope.fixed_location)
+            .map((telescope) => (
+              <MenuItem
+                key={telescope.id}
+                value={telescope.id}
+                style={getStyles(
+                  telescope.name,
+                  profile?.observabilityTelescopes || [],
+                  theme
+                )}
+              >
+                <div data-testid={`telescope_${telescope.id}`}>
+                  {telescope.name}
+                </div>
+              </MenuItem>
+            ))}
+        </Select>
+      </FormControl>
+    </div>
+  );
+};
+
+export default ObservabilityPreferences;

--- a/static/js/components/ObservabilityPreferences.jsx
+++ b/static/js/components/ObservabilityPreferences.jsx
@@ -67,12 +67,15 @@ const ObservabilityPreferences = () => {
 
   const handleChange = (event) => {
     const prefs = {
-      observabilityTelescopes: event.target.value,
+      observabilityTelescopes:
+        // -1 is used for the "Clear selections" option
+        event.target.value.includes(-1) ? [] : event.target.value,
     };
     dispatch(profileActions.updateUserPreferences(prefs));
   };
 
-  const telescopeIDToName = {};
+  telescopeList.sort((a, b) => (a.name < b.name ? -1 : 1));
+  const telescopeIDToName = { "-1": "Clear selections" };
   telescopeList.forEach((telescope) => {
     telescopeIDToName[telescope.id] = telescope.name;
   });
@@ -118,18 +121,24 @@ const ObservabilityPreferences = () => {
           input={<Input id="selectTelescopes" />}
           renderValue={(selected) => (
             <div className={classes.chips}>
-              {selected.map((value) => (
-                <Chip
-                  key={value}
-                  label={telescopeIDToName[value]}
-                  className={classes.chip}
-                />
-              ))}
+              {selected
+                .sort((a, b) =>
+                  telescopeIDToName[a] < telescopeIDToName[b] ? -1 : 1
+                )
+                .map((value) => (
+                  <Chip
+                    key={value}
+                    label={telescopeIDToName[value]}
+                    className={classes.chip}
+                  />
+                ))}
             </div>
           )}
         >
-          {telescopeList
-            .filter((telescope) => telescope.fixed_location)
+          {[{ id: -1, name: "Clear selections" }]
+            .concat(
+              telescopeList.filter((telescope) => telescope.fixed_location)
+            )
             .map((telescope) => (
               <MenuItem
                 key={telescope.id}

--- a/static/js/components/UpdateProfileForm.jsx
+++ b/static/js/components/UpdateProfileForm.jsx
@@ -22,6 +22,7 @@ import * as ProfileActions from "../ducks/profile";
 import UIPreferences from "./UIPreferences";
 import NotificationPreferences from "./NotificationPreferences";
 import FavoriteSourcesNotificationPreferences from "./FavoriteSourcesNotificationPreferences";
+import ObservabilityPreferences from "./ObservabilityPreferences";
 
 const UpdateProfileForm = () => {
   const profile = useSelector((state) => state.profile);
@@ -167,6 +168,9 @@ const UpdateProfileForm = () => {
         </CardContent>
         <CardContent>
           <UIPreferences />
+        </CardContent>
+        <CardContent>
+          <ObservabilityPreferences />
         </CardContent>
       </Card>
       <Dialog


### PR DESCRIPTION
Partly addresses https://github.com/fritz-marshal/fritz-beta-feedback/issues/61

![observability](https://user-images.githubusercontent.com/17696889/124002497-cf8db780-d9a3-11eb-8ab1-7047f8120ae8.gif)

@dmitryduev Part of that issue was also a request for `the "hours over airmass 2.5" plot` from the GROWTH marshal. If you could point me to where the code for that is, I can try to port it over to SkyPortal as well.