### PR TITLE
Clean up GcnEvent routes

### DIFF
--- a/skyportal/app_server.py
+++ b/skyportal/app_server.py
@@ -83,6 +83,7 @@ from skyportal.handlers.api.internal import (
     StandardsHandler,
     NotificationHandler,
     BulkNotificationHandler,
+    RecentGcnEventsHandler,
 )
 
 from . import models, model_util, openapi
@@ -189,6 +190,7 @@ skyportal_handlers = [
     (r'/api/internal/notifications(/[0-9]+)?', NotificationHandler),
     (r'/api/internal/notifications/all', BulkNotificationHandler),
     (r'/api/internal/ps1_thumbnail', PS1ThumbnailHandler),
+    (r'/api/internal/recent_gcn_events', RecentGcnEventsHandler),
     (r'/api/.*', InvalidEndpointHandler),
     (r'/become_user(/.*)?', BecomeUserHandler),
     (r'/logout', LogoutHandler),

--- a/skyportal/handlers/api/gcn.py
+++ b/skyportal/handlers/api/gcn.py
@@ -20,8 +20,6 @@ from ...models import (
 )
 from ...utils.gcn import get_dateobs, get_tags, get_skymap, get_contour
 
-default_prefs = {'maxNumGcnEvents': 10, 'sinceDaysAgo': 3650}
-
 
 class GcnEventHandler(BaseHandler):
     @auth_or_token
@@ -159,22 +157,12 @@ class GcnEventHandler(BaseHandler):
 
             return self.success(data=data)
 
-        user_prefs = getattr(self.current_user, 'preferences', None) or {}
-        recent_events_prefs = user_prefs.get('recentGcnEvents', {})
-        recent_events_prefs = {**default_prefs, **recent_events_prefs}
-
-        max_num_events = (
-            int(recent_events_prefs['maxNumEvents'])
-            if 'maxNumEvents' in recent_events_prefs
-            else 5
-        )
-        q = (
-            GcnEvent.query_records_accessible_by(
-                self.current_user,
-                options=[joinedload(GcnEvent.localizations)],
-            )
-            .order_by(GcnEvent.dateobs.desc())
-            .limit(max_num_events)
+        q = GcnEvent.query_records_accessible_by(
+            self.current_user,
+            options=[
+                joinedload(GcnEvent.localizations),
+                joinedload(GcnEvent.gcn_notices),
+            ],
         )
 
         events = []

--- a/skyportal/handlers/api/internal/__init__.py
+++ b/skyportal/handlers/api/internal/__init__.py
@@ -16,3 +16,4 @@ from .annotations_info import AnnotationsInfoHandler
 from .ephemeris import EphemerisHandler
 from .standards import StandardsHandler
 from .notifications import NotificationHandler, BulkNotificationHandler
+from .recent_gcn_events import RecentGcnEventsHandler

--- a/skyportal/handlers/api/internal/recent_gcn_events.py
+++ b/skyportal/handlers/api/internal/recent_gcn_events.py
@@ -1,0 +1,49 @@
+from sqlalchemy.orm import joinedload
+from baselayer.app.access import auth_or_token
+from ...base import BaseHandler
+from ....models import GcnEvent
+
+default_prefs = {'maxNumGcnEvents': 10}
+
+
+class RecentGcnEventsHandler(BaseHandler):
+    @auth_or_token
+    def get(self):
+        """
+        ---
+        description: Retrieve recent GCN events
+        tags:
+          - gcnevents
+        responses:
+          200:
+            content:
+              application/json:
+                schema: GcnEventHandlerGet
+          400:
+            content:
+              application/json:
+                schema: Error
+        """
+        user_prefs = getattr(self.current_user, 'preferences', None) or {}
+        recent_events_prefs = user_prefs.get('recentGcnEvents', {})
+        recent_events_prefs = {**default_prefs, **recent_events_prefs}
+
+        max_num_events = (
+            int(recent_events_prefs['maxNumEvents'])
+            if 'maxNumEvents' in recent_events_prefs
+            else 5
+        )
+        q = (
+            GcnEvent.query_records_accessible_by(
+                self.current_user,
+                options=[joinedload(GcnEvent.localizations)],
+            )
+            .order_by(GcnEvent.dateobs.desc())
+            .limit(max_num_events)
+        )
+
+        events = []
+        for event in q.all():
+            events.append({**event.to_dict(), "tags": event.tags})
+
+        return self.success(data=events)

--- a/static/js/ducks/gcnEvents.js
+++ b/static/js/ducks/gcnEvents.js
@@ -7,7 +7,7 @@ export const FETCH_RECENT_GCNEVENTS = "skyportal/FETCH_RECENT_GCNEVENTS";
 export const FETCH_RECENT_GCNEVENTS_OK = "skyportal/FETCH_RECENT_GCNEVENTS_OK";
 
 export const fetchRecentGcnEvents = () =>
-  API.GET("/api/gcn_event", FETCH_RECENT_GCNEVENTS);
+  API.GET("/api/internal/recent_gcn_events", FETCH_RECENT_GCNEVENTS);
 
 // Websocket message handler
 messageHandler.add((actionType, payload, dispatch) => {


### PR DESCRIPTION
Move the current multiple GET logic to a `RecentGcnEventsHandler` and implement separate GET multiple logic to just fetch all events (can be expanded later to support filtering etc), bringing it more inline with how we handle sources.