### PR TITLE
Change duplicates text color

### DIFF
--- a/static/js/components/SourceDesktop.jsx
+++ b/static/js/components/SourceDesktop.jsx
@@ -219,7 +219,7 @@ const SourceDesktop = ({ source }) => {
             <div className={classes.infoLine}>
               <div className={classes.sourceInfo}>
                 <b>
-                  <font color="red">Possible duplicate of:</font>
+                  <font color="#457b9d">Possible duplicate of:</font>
                 </b>
                 &nbsp;
                 {source.duplicates.map((dupID) => (


### PR DESCRIPTION
Replaced "red" (which seems too "invasive") with "#457b9d". Compare:
![image](https://user-images.githubusercontent.com/7557205/124981232-2f124580-dfea-11eb-8cea-45c12f6c3cdc.png)
![image](https://user-images.githubusercontent.com/7557205/124981262-36395380-dfea-11eb-8f22-98f87d378297.png)
