### PR TITLE
Add test for baselayer's API rate limiting

### DIFF
--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -282,6 +282,9 @@ services:
 misc:
   days_to_keep_unsaved_candidates: 7
   minutes_to_keep_candidate_query_cache: 60
+  # Minimum interval during which 100 requests will be allowed per API token,
+  # per app instance (tokens with "System admin" ACL are not limited)
+  rate_limit_100_requests_per_n_seconds: 30
   public_group_name: "Sitewide Group"
   # Use a named cosmology from `astropy.cosmology.parameters.available` cosmologies
   # or supply the arguments for an `astropy.cosmology.FLRW` cosmological instance.

--- a/skyportal/tests/api/test_rate_limiting.py
+++ b/skyportal/tests/api/test_rate_limiting.py
@@ -1,5 +1,8 @@
 import time
+from baselayer.app.env import load_env
 from skyportal.tests import api
+
+_, cfg = load_env()
 
 
 def test_api_rate_limiting(view_only_token):
@@ -7,13 +10,24 @@ def test_api_rate_limiting(view_only_token):
     status = 200
     while status == 200:
         status, _ = api('GET', 'sysinfo', token=view_only_token)
-        n_successful_requests += 1
-    assert n_successful_requests == 100
+        if status == 200:
+            n_successful_requests += 1
+    assert (
+        100 * cfg["server"]["processes"] - 2
+        <= n_successful_requests
+        <= 100 * cfg["server"]["processes"] + 2
+    )
     status, data = api('GET', 'sysinfo', token=view_only_token)
-    assert status == 503
-    assert data["message"] == "API rate limit exceeded; please throttle your requests"
+    assert status != 200
+    assert "API rate limit exceeded; please throttle your requests" in data["message"]
 
-    time.sleep(5)
+    time.sleep(20)
 
     status, _ = api('GET', 'sysinfo', token=view_only_token)
     assert status == 200
+
+
+def test_sys_admins_not_rate_limited(super_admin_token):
+    for i in range(100 * cfg["server"]["processes"] + 5):
+        status, _ = api('GET', 'sysinfo', token=super_admin_token)
+        assert status == 200

--- a/skyportal/tests/api/test_rate_limiting.py
+++ b/skyportal/tests/api/test_rate_limiting.py
@@ -1,0 +1,19 @@
+import time
+from skyportal.tests import api
+
+
+def test_api_rate_limiting(view_only_token):
+    n_successful_requests = 0
+    status = 200
+    while status == 200:
+        status, _ = api('GET', 'sysinfo', token=view_only_token)
+        n_successful_requests += 1
+    assert n_successful_requests == 100
+    status, data = api('GET', 'sysinfo', token=view_only_token)
+    assert status == 503
+    assert data["message"] == "API rate limit exceeded; please throttle your requests"
+
+    time.sleep(5)
+
+    status, _ = api('GET', 'sysinfo', token=view_only_token)
+    assert status == 200

--- a/test_config.yaml
+++ b/test_config.yaml
@@ -17,7 +17,7 @@ misc:
   allow_nonadmins_delete_objs: True
   # Minimum interval during which 100 requests will be allowed per API token,
   # per app instance (tokens with "System admin" ACL are not limited)
-  rate_limit_100_requests_per_n_seconds: 5
+  rate_limit_100_requests_per_n_seconds: 20
 
 twilio:
   # Twilio Sendgrid API configs

--- a/test_config.yaml
+++ b/test_config.yaml
@@ -15,6 +15,9 @@ misc:
   photometry_detection_threshold_nsigma: 3.0
   minutes_to_keep_candidate_query_cache: 0.033333 # 2 seconds
   allow_nonadmins_delete_objs: True
+  # Minimum interval during which 100 requests will be allowed per API token,
+  # per app instance (tokens with "System admin" ACL are not limited)
+  rate_limit_100_requests_per_n_seconds: 5
 
 twilio:
   # Twilio Sendgrid API configs


### PR DESCRIPTION
This PR brings in baselayer's new API rate-limiting functionality, updates relevant config sections, and adds tests.
Depends on https://github.com/cesium-ml/baselayer/pull/235