### PR TITLE
Pin working requests version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -46,3 +46,4 @@ ligo.skymap==0.5.3
 healpy==1.15.0
 pygcn==1.1.0
 xmlschema==1.6.1
+requests==2.25.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,4 +46,4 @@ ligo.skymap==0.5.3
 healpy==1.15.0
 pygcn==1.1.0
 xmlschema==1.6.1
-requests==2.25.1
+requests<2.26

--- a/tools/data_loader.py
+++ b/tools/data_loader.py
@@ -172,6 +172,7 @@ if __name__ == "__main__":
                 if filename.endswith('csv'):
                     df = pd.read_csv(filename)
                     obj.pop('file')
+                    df = df.where(pd.notnull(df), None)
                     obj.update(df.to_dict(orient='list'))
                 elif filename.endswith('.png'):
                     return base64.b64encode(open(filename, 'rb').read())

--- a/tools/data_loader.py
+++ b/tools/data_loader.py
@@ -172,7 +172,6 @@ if __name__ == "__main__":
                 if filename.endswith('csv'):
                     df = pd.read_csv(filename)
                     obj.pop('file')
-                    df = df.where(pd.notnull(df), None)
                     obj.update(df.to_dict(orient='list'))
                 elif filename.endswith('.png'):
                     return base64.b64encode(open(filename, 'rb').read())


### PR DESCRIPTION
This PR attempts to fix the issue with Photometry data loading (seen in the CI) caused by the recent update to `requests`.
Specifically, we can no longer have `np.nan` values in the JSON body sent to `requests.post()`: https://github.com/psf/requests/pull/5810.

~~I tried just replacing those NaN's with `None`, and the post at least goes through without error. But I'm not sure if it's a perfect solution, as now I see some weird behavior from the photometry plot with this newly loaded data:
![image](https://user-images.githubusercontent.com/17696889/125691769-affdc425-729b-49f9-9185-c43734c7e04c.png)
Any thoughts?~~

EDIT: 
This PR just pins the `requests` version to be below the breaking-change version of 2.26.0