### PR TITLE
Reduce big phot post test size from 50k points to 40k points

### DIFF
--- a/skyportal/tests/api/test_photometry.py
+++ b/skyportal/tests/api/test_photometry.py
@@ -1446,10 +1446,10 @@ def test_token_user_big_post(
         'photometry',
         data={
             'obj_id': str(public_source.id),
-            'mjd': [58000 + i for i in range(50000)],
+            'mjd': [58000 + i for i in range(40000)],
             'instrument_id': ztf_camera.id,
-            'mag': np.random.uniform(low=18, high=22, size=50000).tolist(),
-            'magerr': np.random.uniform(low=0.1, high=0.3, size=50000).tolist(),
+            'mag': np.random.uniform(low=18, high=22, size=40000).tolist(),
+            'magerr': np.random.uniform(low=0.1, high=0.3, size=40000).tolist(),
             'limiting_mag': 22.3,
             'magsys': 'ab',
             'filter': 'ztfg',


### PR DESCRIPTION
With 50k points, the test consistently fails on CI.