### PR TITLE
Allow users with System admin or Become user ACLs to become users when not in debug mode

### DIFF
--- a/.github/workflows/test_api_and_frontend.yaml
+++ b/.github/workflows/test_api_and_frontend.yaml
@@ -147,13 +147,6 @@ jobs:
           submodules: true
           clean: false
 
-      - name: Test loading demo data
-        if: ${{ matrix.test_subset == 'api_and_utils' }}
-        run: |
-          make run &
-          sleep 10 && make load_demo_data
-          kill %1
-
       - name: Formatting and linting checks
         if: ${{ github.ref != 'refs/heads/master' && matrix.test_subset == 'api_and_utils' }}
         run: |

--- a/skyportal/handlers/become_user.py
+++ b/skyportal/handlers/become_user.py
@@ -6,12 +6,9 @@ class BecomeUserHandler(BaseHandler):
     def get(self, new_user_id=None):
         if not (
             self.cfg['server.auth.debug_login']
-            or len(
-                {'System admin', 'Become user'}.intersection(
-                    set(self.current_user.permissions)
-                )
+            or {'System admin', 'Become user'}.intersection(
+                set(self.current_user.permissions)
             )
-            > 0
         ):
             return self.error("Insufficient permissions")
 

--- a/skyportal/handlers/become_user.py
+++ b/skyportal/handlers/become_user.py
@@ -4,7 +4,7 @@ from ..models import User
 
 class BecomeUserHandler(BaseHandler):
     def get(self, new_user_id=None):
-        if (
+        if not (
             self.cfg['server.auth.debug_login']
             or len(
                 {'System admin', 'Become user'}.intersection(
@@ -13,15 +13,17 @@ class BecomeUserHandler(BaseHandler):
             )
             > 0
         ):
-            user = User.query.get(new_user_id)
-            sa = user.social_auth.first()
-            if user:
-                self.clear_cookie('user_id')
-                self.clear_cookie('user_oauth_id')
-                self.clear_cookie('auth_token')
-                self.set_secure_cookie('user_id', new_user_id.encode('ascii'))
-                if sa is not None:
-                    self.set_secure_cookie('user_oauth_id', sa.uid.encode('ascii'))
-                return self.success()
-            else:
-                return self.error('Invalid user ID.')
+            return self.error("Insufficient permissions")
+
+        user = User.query.get(new_user_id)
+        sa = user.social_auth.first()
+        if user:
+            self.clear_cookie('user_id')
+            self.clear_cookie('user_oauth_id')
+            self.clear_cookie('auth_token')
+            self.set_secure_cookie('user_id', new_user_id.encode('ascii'))
+            if sa is not None:
+                self.set_secure_cookie('user_oauth_id', sa.uid.encode('ascii'))
+            return self.success()
+        else:
+            return self.error('Invalid user ID.')

--- a/skyportal/handlers/become_user.py
+++ b/skyportal/handlers/become_user.py
@@ -1,5 +1,4 @@
 from .base import BaseHandler
-from baselayer.app.models import ACL
 from ..models import User
 
 
@@ -7,7 +6,12 @@ class BecomeUserHandler(BaseHandler):
     def get(self, new_user_id=None):
         if (
             self.cfg['server.auth.debug_login']
-            or ACL.query.get('Become user') in self.current_user.permissions
+            or len(
+                {'System admin', 'Become user'}.intersection(
+                    set(self.current_user.permissions)
+                )
+            )
+            > 0
         ):
             user = User.query.get(new_user_id)
             sa = user.social_auth.first()

--- a/skyportal/handlers/become_user.py
+++ b/skyportal/handlers/become_user.py
@@ -16,14 +16,14 @@ class BecomeUserHandler(BaseHandler):
             return self.error("Insufficient permissions")
 
         user = User.query.get(new_user_id)
-        sa = user.social_auth.first()
-        if user:
-            self.clear_cookie('user_id')
-            self.clear_cookie('user_oauth_id')
-            self.clear_cookie('auth_token')
-            self.set_secure_cookie('user_id', new_user_id.encode('ascii'))
-            if sa is not None:
-                self.set_secure_cookie('user_oauth_id', sa.uid.encode('ascii'))
-            return self.success()
-        else:
+        if user is None:
             return self.error('Invalid user ID.')
+
+        sa = user.social_auth.first()
+        self.clear_cookie('user_id')
+        self.clear_cookie('user_oauth_id')
+        self.clear_cookie('auth_token')
+        self.set_secure_cookie('user_id', new_user_id.encode('ascii'))
+        if sa is not None:
+            self.set_secure_cookie('user_oauth_id', sa.uid.encode('ascii'))
+        return self.success()

--- a/tools/data_loader.py
+++ b/tools/data_loader.py
@@ -63,7 +63,7 @@ if __name__ == "__main__":
         from skyportal.models import init_db
 
         RETRIES = 6
-        timeout = 2
+        timeout = 3
         for i in range(RETRIES):
             try:
                 print(f"Connecting to database {cfg['database']['database']}")


### PR DESCRIPTION
This fixes a bug in the logic that didn't allow a user with the "Become user" ACL to become another user when not in debug mode, and now also allows users with the "System admin" ACL to do the same.

This PR also updates the GitHub actions workflows to only test `load_demo_data` in one workflow (the model tests), and bumps the data loader timeout to 3s.