### PR TITLE
Fix spectrum comment previews

### DIFF
--- a/skyportal/app_server.py
+++ b/skyportal/app_server.py
@@ -111,13 +111,19 @@ skyportal_handlers = [
     (r'/api/candidates(/[0-9A-Za-z-_]+)/([0-9]+)', CandidateHandler),
     (r'/api/candidates(/.*)?', CandidateHandler),
     (r'/api/classification(/[0-9]+)?', ClassificationHandler),
-    (r'/api/comment', CommentHandler),
-    (r'/api/comment(/[0-9]+)/attachment', CommentAttachmentHandler),
+    (
+        r'/api/comment(/[0-9]+)/attachment(/(?:object|spectrum))?',
+        CommentAttachmentHandler,
+    ),
     # Allow the '.pdf' suffix for the attachment route, as the
     # react-file-previewer package expects URLs ending with '.pdf' to
     # load PDF files.
-    (r'/api/comment(/[0-9]+)/attachment.pdf', CommentAttachmentHandler),
-    (r'/api/comment(/[0-9]+)?(/.+)?', CommentHandler),
+    (
+        r'/api/comment(/[0-9]+)/attachment.pdf(/(?:object|spectrum))?',
+        CommentAttachmentHandler,
+    ),
+    (r'/api/comment(/[0-9]+)(/(?:object|spectrum))?', CommentHandler),
+    (r'/api/comment', CommentHandler),
     (r'/api/annotation(/[0-9]+)?', AnnotationHandler),
     (r'/api/facility', FacilityMessageHandler),
     (r'/api/filters(/.*)?', FilterHandler),

--- a/skyportal/handlers/api/comment.py
+++ b/skyportal/handlers/api/comment.py
@@ -472,6 +472,9 @@ class CommentAttachmentHandler(BaseHandler):
 
         self.verify_and_commit()
 
+        if not comment.attachment_bytes:
+            return self.error('Comment has no attachment')
+
         if download:
             self.set_header(
                 "Content-Disposition",

--- a/static/js/components/CommentAttachmentPreview.jsx
+++ b/static/js/components/CommentAttachmentPreview.jsx
@@ -112,7 +112,7 @@ export const shortenFilename = (filename) => {
   return `${filename.slice(0, 12)}...`;
 };
 
-const CommentAttachmentPreview = ({ filename, commentId }) => {
+const CommentAttachmentPreview = ({ filename, commentId, commentType }) => {
   const classes = useStyles();
   const theme = useTheme();
   const darkTheme = theme.palette.type === "dark";
@@ -154,7 +154,7 @@ const CommentAttachmentPreview = ({ filename, commentId }) => {
   }
 
   // The FilePreviewer expects a url ending with .pdf for PDF files
-  const baseUrl = `/api/comment/${commentId}/attachment`;
+  const baseUrl = `/api/comment/${commentId}/attachment/${commentType}`;
   const url = fileType === "pdf" ? `${baseUrl}.pdf` : baseUrl;
 
   return (
@@ -235,6 +235,7 @@ const CommentAttachmentPreview = ({ filename, commentId }) => {
 CommentAttachmentPreview.propTypes = {
   filename: PropTypes.string.isRequired,
   commentId: PropTypes.number.isRequired,
+  commentType: PropTypes.string.isRequired,
 };
 
 export default CommentAttachmentPreview;

--- a/static/js/components/CommentList.jsx
+++ b/static/js/components/CommentList.jsx
@@ -416,6 +416,7 @@ const CommentList = ({
                         <CommentAttachmentPreview
                           filename={attachment_name}
                           commentId={id}
+                          commentType={spectrum_id ? "spectrum" : "object"}
                         />
                       )}
                     </span>


### PR DESCRIPTION
- Modify the app routing regexps to ensure that
  `/api/comments/10/attachment/spectrum` is reachable
- Return a sensible error message if no attachment exists
- Modify CommentAttachmentPreview to fetch attachment from
  the appropriate endpoint for either object or spectrum comment

Closes #2200