### PR TITLE
On first run, check out committed version of baselayer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ help: baselayer/Makefile
 	@echo
 
 baselayer/Makefile:
-	git submodule update --init --remote
+	git submodule update --init
 
 docker-images: ## Make and upload docker images
 docker-images: docker-local


### PR DESCRIPTION
Before, we used to check out the HEAD of the baselayer repository.