### PR TITLE
Explicitly install SkyPortal dependencies for tested branch

### DIFF
--- a/.github/workflows/test_api_and_frontend.yaml
+++ b/.github/workflows/test_api_and_frontend.yaml
@@ -101,7 +101,7 @@ jobs:
           nginx -v
           firefox --version
 
-      - name: Install SkyPortal dependencies
+      - name: Install SkyPortal dependencies for master
         run: |
           export PYTHONPATH=$PYTHONPATH:$(pwd)
           make dependencies
@@ -149,6 +149,11 @@ jobs:
           fetch-depth: 0
           submodules: true
           clean: false
+
+      - name: Refresh SkyPortal dependencies for tested version
+        run: |
+          export PYTHONPATH=$PYTHONPATH:$(pwd)
+          make dependencies
 
       - name: Formatting and linting checks
         if: ${{ github.ref != 'refs/heads/master' && matrix.test_subset == 'api_and_utils' }}


### PR DESCRIPTION
This is not strictly speaking necessary: SkyPortal make commands check
dependencies on each run already.  Still, this is a useful reminder in
the GitHub Actions workflow that we are switching SkyPortal versions
and, thereby, dependencies, and may avoid confusion.