### PR TITLE
Disable slow Obj filters in Sources tables

### DIFF
--- a/static/js/components/SourceTableFilterForm.jsx
+++ b/static/js/components/SourceTableFilterForm.jsx
@@ -209,6 +209,7 @@ const SourceTableFilterForm = ({ handleFilterSubmit }) => {
             Time Last Detected (UTC)
           </Typography>
           <TextField
+            disabled
             size="small"
             label="Last Detected After"
             name="startDate"
@@ -216,6 +217,7 @@ const SourceTableFilterForm = ({ handleFilterSubmit }) => {
             placeholder="2012-08-30T00:00:00"
           />
           <TextField
+            disabled
             size="small"
             label="Last Detected Before"
             name="endDate"
@@ -319,6 +321,7 @@ const SourceTableFilterForm = ({ handleFilterSubmit }) => {
             Peak Magnitude
           </Typography>
           <TextField
+            disabled
             size="small"
             label="Min"
             name="minPeakMagnitude"
@@ -329,6 +332,7 @@ const SourceTableFilterForm = ({ handleFilterSubmit }) => {
             inputRef={register}
           />
           <TextField
+            disabled
             size="small"
             label="Max"
             name="maxPeakMagnitude"
@@ -370,6 +374,7 @@ const SourceTableFilterForm = ({ handleFilterSubmit }) => {
             Latest Magnitude
           </Typography>
           <TextField
+            disabled
             size="small"
             label="Min"
             name="minLatestMagnitude"
@@ -380,6 +385,7 @@ const SourceTableFilterForm = ({ handleFilterSubmit }) => {
             inputRef={register}
           />
           <TextField
+            disabled
             size="small"
             label="Max"
             name="maxLatestMagnitude"


### PR DESCRIPTION
This is a temporary measure to prevent potential system slowdowns. See https://github.com/fritz-marshal/fritz/issues/338 for the description and background.
I only disabled things on the frontend, didn't touch the backend. In the latter case, there are multiple places where permissions checking potentially cause tons of lookups that are slow (last_detected_at, peak_magnitude, etc.), but let's hope that our theory is right and people were only using the front-end to issue these queries.

In the meantime, we should come up with a permanent solution.