### PR TITLE
Provide explicit feedback when API fetch fails

### DIFF
--- a/static/js/API.js
+++ b/static/js/API.js
@@ -62,6 +62,8 @@ function API(endpoint, actionType, method = "GET", body = {}, otherArgs = {}) {
       return dispatch({
         type: `${actionType}_FAIL`,
         parameters,
+        status: "error",
+        message: error.message,
       });
     }
   };

--- a/static/js/ducks/candidate.js
+++ b/static/js/ducks/candidate.js
@@ -29,11 +29,10 @@ const reducer = (state = initialState, action) => {
         ...state,
         loadError: action.message,
       };
-
     case FETCH_CANDIDATE_FAIL:
       return {
         ...state,
-        loadError: "Unknown error while loading candidate",
+        loadError: `Error while loading candidate: ${action.message}`,
       };
     default:
       return state;

--- a/static/js/ducks/source.js
+++ b/static/js/ducks/source.js
@@ -198,7 +198,7 @@ const reducer = (state = { source: null, loadError: false }, action) => {
     case FETCH_LOADED_SOURCE_FAIL:
       return {
         ...state,
-        loadError: "Unknown error while loading source",
+        loadError: `Error while loading source: ${action.message}`,
       };
     case GET_COMMENT_ATTACHMENT_OK: {
       const { commentId, attachment } = action.data;


### PR DESCRIPTION
Before, when an API call failed for an unknown reason, we displayed
the error but did not try and propagate it further.  Now, the error
message is attached to the `*_FAIL` action so that it may be displayed
in a component or logged to the console.