### PR TITLE
Do not include detection stats in sources action creators; remove Peak/Latest mag cols from SourceTable

### DIFF
--- a/static/js/components/SourceTable.jsx
+++ b/static/js/components/SourceTable.jsx
@@ -27,7 +27,7 @@ import CircularProgress from "@material-ui/core/CircularProgress";
 import dayjs from "dayjs";
 import { isMobileOnly } from "react-device-detect";
 
-import { ra_to_hours, dec_to_dms, time_relative_to_local } from "../units";
+import { ra_to_hours, dec_to_dms } from "../units";
 import ThumbnailList from "./ThumbnailList";
 import UserAvatar from "./UserAvatar";
 import ShowClassification from "./ShowClassification";
@@ -722,27 +722,27 @@ const SourceTable = ({
     );
   };
 
-  const renderPeakMagnitude = (dataIndex) => {
-    const source = sources[dataIndex];
-    return source.peak_detected_mag ? (
-      <Tooltip title={time_relative_to_local(source.peak_detected_at)}>
-        <div>{`${source.peak_detected_mag.toFixed(4)}`}</div>
-      </Tooltip>
-    ) : (
-      <div>No photometry</div>
-    );
-  };
+  // const renderPeakMagnitude = (dataIndex) => {
+  //   const source = sources[dataIndex];
+  //   return source.peak_detected_mag ? (
+  //     <Tooltip title={time_relative_to_local(source.peak_detected_at)}>
+  //       <div>{`${source.peak_detected_mag.toFixed(4)}`}</div>
+  //     </Tooltip>
+  //   ) : (
+  //     <div>No photometry</div>
+  //   );
+  // };
 
-  const renderLatestMagnitude = (dataIndex) => {
-    const source = sources[dataIndex];
-    return source.last_detected_mag ? (
-      <Tooltip title={time_relative_to_local(source.last_detected_at)}>
-        <div>{`${source.last_detected_mag.toFixed(4)}`}</div>
-      </Tooltip>
-    ) : (
-      <div>No photometry</div>
-    );
-  };
+  // const renderLatestMagnitude = (dataIndex) => {
+  //   const source = sources[dataIndex];
+  //   return source.last_detected_mag ? (
+  //     <Tooltip title={time_relative_to_local(source.last_detected_at)}>
+  //       <div>{`${source.last_detected_mag.toFixed(4)}`}</div>
+  //     </Tooltip>
+  //   ) : (
+  //     <div>No photometry</div>
+  //   );
+  // };
 
   const renderTNSName = (dataIndex) => {
     const source = sources[dataIndex];
@@ -1000,24 +1000,26 @@ const SourceTable = ({
         display: displayedColumns.includes("Spectrum?"),
       },
     },
-    {
-      name: "Peak Magnitude",
-      options: {
-        filter: false,
-        sort: false,
-        customBodyRenderLite: renderPeakMagnitude,
-        display: displayedColumns.includes("Peak Magnitude"),
-      },
-    },
-    {
-      name: "Latest Magnitude",
-      options: {
-        filter: false,
-        sort: false,
-        customBodyRenderLite: renderLatestMagnitude,
-        display: displayedColumns.includes("Latest Magnitude"),
-      },
-    },
+    // Temporarily disable these two detection stats columns until we improve back-end performance
+    // {
+    //   name: "Peak Magnitude",
+    //   options: {
+    //     filter: false,
+    //     sort: false,
+    //     customBodyRenderLite: renderPeakMagnitude,
+    //     display: displayedColumns.includes("Peak Magnitude"),
+    //   },
+    // },
+    // {
+    //   name: "Latest Magnitude",
+    //   options: {
+    //     filter: false,
+    //     sort: false,
+    //     customBodyRenderLite: renderLatestMagnitude,
+    //     display: displayedColumns.includes("Latest Magnitude"),
+    //   },
+    // },
+
     {
       name: "TNS Name",
       options: {

--- a/static/js/ducks/sources.js
+++ b/static/js/ducks/sources.js
@@ -33,7 +33,7 @@ export function fetchSources(filterParams = {}) {
   filterParams.includeSpectrumExists = true;
   filterParams.includeColorMagnitude = true;
   filterParams.includeThumbnails = true;
-  filterParams.includeDetectionStats = true;
+  filterParams.includeDetectionStats = false;
   return API.GET("/api/sources", FETCH_SOURCES, filterParams);
 }
 
@@ -43,7 +43,7 @@ export function fetchSavedGroupSources(filterParams = {}) {
   filterParams.includeSpectrumExists = true;
   filterParams.includeColorMagnitude = true;
   filterParams.includeThumbnails = true;
-  filterParams.includeDetectionStats = true;
+  filterParams.includeDetectionStats = false;
   return API.GET("/api/sources", FETCH_SAVED_GROUP_SOURCES, filterParams);
 }
 
@@ -54,7 +54,7 @@ export function fetchPendingGroupSources(filterParams = {}) {
   filterParams.includeSpectrumExists = true;
   filterParams.includeColorMagnitude = true;
   filterParams.includeThumbnails = true;
-  filterParams.includeDetectionStats = true;
+  filterParams.includeDetectionStats = false;
   return API.GET("/api/sources", FETCH_PENDING_GROUP_SOURCES, filterParams);
 }
 
@@ -65,7 +65,7 @@ export function fetchFavoriteSources(filterParams = {}) {
   filterParams.listName = "favorites";
   filterParams.includeColorMagnitude = true;
   filterParams.includeThumbnails = true;
-  filterParams.includeDetectionStats = true;
+  filterParams.includeDetectionStats = false;
   return API.GET("/api/sources", FETCH_FAVORITE_SOURCES, filterParams);
 }
 


### PR DESCRIPTION
This is a temporary stopgap to address major performance issues
when fetching sources including detection statistics. We will
revert this when those inefficiencies are addressed.