### PR TITLE
Upgrade bokeh/bokehjs to 2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
     "test": "eslint --ext .jsx,.js static/js && make test"
   },
   "dependencies": {
-    "@babel/plugin-proposal-export-namespace-from": "7.14.2",
-    "@bokeh/bokehjs": "2.2.3",
+    "@bokeh/bokehjs": "2.4.0-rc.2",
     "@date-io/dayjs": "1.3.13",
     "@material-ui/core": "4.12.3",
     "@material-ui/icons": "4.11.2",
@@ -34,7 +33,6 @@
     "imports-loader": "1.2.0",
     "material-ui-phone-number": "2.2.6",
     "mathjs": "9.4.4",
-    "mobx": "6.3.0",
     "mui-datatables": "3.6.0",
     "npm-check": "5.9.2",
     "numeral": "2.0.6",
@@ -74,13 +72,16 @@
     "vega-lite": "4.17.0"
   },
   "devDependencies": {
-    "@babel/core": "7.11.5",
-    "@babel/plugin-proposal-class-properties": "7.12.1",
-    "@babel/plugin-proposal-object-rest-spread": "7.14.4",
+    "@babel/core": "7.15.5",
+    "@babel/plugin-proposal-class-properties": "7.14.5",
+    "@babel/plugin-proposal-export-namespace-from": "7.14.5",
+    "@babel/plugin-proposal-object-rest-spread": "7.15.6",
     "@babel/plugin-transform-arrow-functions": "7.14.5",
     "@babel/plugin-transform-async-to-generator": "7.14.5",
+    "@babel/plugin-proposal-optional-chaining": "7.14.5",
+    "@babel/plugin-proposal-nullish-coalescing-operator": "7.14.5",
     "@babel/polyfill": "7.12.1",
-    "@babel/preset-env": "7.11.0",
+    "@babel/preset-env": "7.15.6",
     "@babel/preset-react": "7.14.5",
     "@types/node": "15.6.1",
     "babel-eslint": "10.1.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "test": "eslint --ext .jsx,.js static/js && make test"
   },
   "dependencies": {
-    "@bokeh/bokehjs": "2.4.0-rc.2",
+    "@bokeh/bokehjs": "2.4.0",
     "@date-io/dayjs": "1.3.13",
     "@material-ui/core": "4.12.3",
     "@material-ui/icons": "4.11.2",

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pandas==1.2.5
 dask>=2020.12,<2021.10.0
 joblib==1.0.1
 seaborn==0.11.1
-bokeh==2.2.3
+bokeh==2.4.0rc2
 pytest-randomly==3.8.0
 factory-boy==3.2.0
 astropy==4.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pandas==1.2.5
 dask>=2020.12,<2021.10.0
 joblib==1.0.1
 seaborn==0.11.1
-bokeh==2.4.0rc2
+bokeh==2.4.0
 pytest-randomly==3.8.0
 factory-boy==3.2.0
 astropy==4.2.1

--- a/skyportal/tests/frontend/sources_and_followup_etc/test_followup_requests.py
+++ b/skyportal/tests/frontend/sources_and_followup_etc/test_followup_requests.py
@@ -420,32 +420,47 @@ def add_followup_request_using_frontend_and_verify_SEDM(
     )
     select_box.click()
 
-    driver.click_xpath(
-        f'//li[contains(text(), "SEDM")][contains(text(), "{public_group.name}")]',
-        scroll_parent=True,
+    driver.execute_script(
+        "arguments[0].click();",
+        driver.wait_for_xpath(
+            f'//li[contains(text(), "SEDM")][contains(text(), "{public_group.name}")]'
+        ),
     )
 
     # Click somewhere outside to remove focus from instrument select
     driver.click_xpath("//header")
 
     # mode select
-    driver.click_xpath('//div[@id="root_observation_type"]', wait_clickable=False)
+    driver.execute_script(
+        "arguments[0].click();",
+        driver.wait_for_xpath('//div[@id="root_observation_type"]'),
+    )
 
     # mix n match option
-    driver.click_xpath('''//li[@data-value="Mix 'n Match"]''')
+    driver.execute_script(
+        "arguments[0].click();",
+        driver.wait_for_xpath('''//li[@data-value="Mix 'n Match"]'''),
+    )
 
     # u band option
-    driver.click_xpath(
-        '//input[@id="root_observation_choices_0"]', wait_clickable=False
+    driver.execute_script(
+        "arguments[0].click();",
+        driver.wait_for_xpath('//input[@id="root_observation_choices_0"]'),
     )
 
     # ifu option
-    driver.click_xpath(
-        '//input[@id="root_observation_choices_4"]', wait_clickable=False
+    driver.execute_script(
+        "arguments[0].click();",
+        driver.wait_for_xpath('//input[@id="root_observation_choices_4"]'),
     )
-    driver.click_xpath(submit_button_xpath)
+    driver.execute_script(
+        "arguments[0].click();", driver.wait_for_xpath(submit_button_xpath)
+    )
 
-    driver.click_xpath("//div[@data-testid='SEDM-requests-header']")
+    driver.execute_script(
+        "arguments[0].click();",
+        driver.wait_for_xpath("//div[@data-testid='SEDM-requests-header']"),
+    )
     driver.wait_for_xpath(
         '//div[contains(@data-testid, "SEDM_followupRequestsTable")]//div[contains(., "Mix \'n Match")]'
     )

--- a/skyportal/tests/frontend/sources_and_followup_etc/test_followup_requests.py
+++ b/skyportal/tests/frontend/sources_and_followup_etc/test_followup_requests.py
@@ -420,47 +420,32 @@ def add_followup_request_using_frontend_and_verify_SEDM(
     )
     select_box.click()
 
-    driver.execute_script(
-        "arguments[0].click();",
-        driver.wait_for_xpath(
-            f'//li[contains(text(), "SEDM")][contains(text(), "{public_group.name}")]'
-        ),
+    driver.click_xpath(
+        f'//li[contains(text(), "SEDM")][contains(text(), "{public_group.name}")]',
+        scroll_parent=True,
     )
 
     # Click somewhere outside to remove focus from instrument select
     driver.click_xpath("//header")
 
     # mode select
-    driver.execute_script(
-        "arguments[0].click();",
-        driver.wait_for_xpath('//div[@id="root_observation_type"]'),
-    )
+    driver.click_xpath('//div[@id="root_observation_type"]', wait_clickable=False)
 
     # mix n match option
-    driver.execute_script(
-        "arguments[0].click();",
-        driver.wait_for_xpath('''//li[@data-value="Mix 'n Match"]'''),
-    )
+    driver.click_xpath('''//li[@data-value="Mix 'n Match"]''')
 
     # u band option
-    driver.execute_script(
-        "arguments[0].click();",
-        driver.wait_for_xpath('//input[@id="root_observation_choices_0"]'),
+    driver.click_xpath(
+        '//input[@id="root_observation_choices_0"]', wait_clickable=False
     )
 
     # ifu option
-    driver.execute_script(
-        "arguments[0].click();",
-        driver.wait_for_xpath('//input[@id="root_observation_choices_4"]'),
+    driver.click_xpath(
+        '//input[@id="root_observation_choices_4"]', wait_clickable=False
     )
-    driver.execute_script(
-        "arguments[0].click();", driver.wait_for_xpath(submit_button_xpath)
-    )
+    driver.click_xpath(submit_button_xpath)
 
-    driver.execute_script(
-        "arguments[0].click();",
-        driver.wait_for_xpath("//div[@data-testid='SEDM-requests-header']"),
-    )
+    driver.click_xpath("//div[@data-testid='SEDM-requests-header']")
     driver.wait_for_xpath(
         '//div[contains(@data-testid, "SEDM_followupRequestsTable")]//div[contains(., "Mix \'n Match")]'
     )

--- a/static/js/components/BokehModels.js
+++ b/static/js/components/BokehModels.js
@@ -3,19 +3,18 @@
 import { input, label, div, span } from "bokehjs/core/dom";
 import { includes } from "bokehjs/core/util/array";
 import * as p from "bokehjs/core/properties";
-import { bk_inline } from "bokehjs/styles/mixins";
-import { bk_input_group } from "bokehjs/styles/widgets/inputs";
+import * as inputs from "bokehjs/styles/widgets/inputs.css";
+import { InputGroupView } from "bokehjs/models/widgets/input_group";
 import {
   CheckboxGroup,
   CheckboxGroupView,
 } from "bokehjs/models/widgets/checkbox_group";
-import { InputGroupView } from "bokehjs/models/widgets/input_group";
 
 export class CheckboxWithLegendGroupView extends CheckboxGroupView {
   render() {
     InputGroupView.prototype.render.call(this);
     const group = div({
-      class: [bk_input_group, this.model.inline ? bk_inline : null],
+      class: [inputs.input_group, this.model.inline ? inputs.inline : null],
     });
     this.el.appendChild(group);
     const { active, colors, labels } = this.model;
@@ -34,16 +33,6 @@ export class CheckboxWithLegendGroupView extends CheckboxGroupView {
       const label_el = label(attrs, checkbox, span({}, labels[i]));
       group.appendChild(label_el);
     }
-  }
-
-  change_active(i) {
-    const active = new Set(this.model.active);
-    if (active.has(i)) {
-      active.delete(i);
-    } else {
-      active.add(i);
-    }
-    this.model.active = [...active].sort();
   }
 }
 // eslint-disable-next-line no-underscore-dangle

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,7 +41,11 @@ const config = {
           {
             loader: "babel-loader",
             options: {
-              plugins: ["@babel/plugin-proposal-export-namespace-from"],
+              plugins: [
+                "@babel/plugin-proposal-export-namespace-from",
+                "@babel/plugin-proposal-optional-chaining",
+                "@babel/plugin-proposal-nullish-coalescing-operator",
+              ],
             },
           },
         ],


### PR DESCRIPTION
BokehJS now uses more JS features, so added the babel plugins for:

- optional chaining (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining)
- nullish coalescing operator (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator).

Tweaked the models to be in line with the latest BokehJS (mainly usage
of `super.render()`).

<strike>Depends on https://github.com/bokeh/bokeh/issues/11616 to be resolved.</strike>