### PR TITLE
Fix faulty URL for PDF attachment previews

### DIFF
--- a/skyportal/app_server.py
+++ b/skyportal/app_server.py
@@ -119,7 +119,7 @@ skyportal_handlers = [
     # react-file-previewer package expects URLs ending with '.pdf' to
     # load PDF files.
     (
-        r'/api/comment(/[0-9]+)/attachment.pdf(/(?:object|spectrum))?',
+        r'/api/comment(/[0-9]+)/attachment(/(?:object|spectrum))?.pdf',
         CommentAttachmentHandler,
     ),
     (r'/api/comment(/[0-9]+)(/(?:object|spectrum))?', CommentHandler),


### PR DESCRIPTION
This updates the regex used for matching comment attachment preview
requests to the correct Tornado handler. This was likely broken when
the comment API was updated to include associated resource type.

Closes https://github.com/skyportal/skyportal/issues/2214