### PR TITLE
Add event listener to remove on-disk thumbnail files upon removal

### DIFF
--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -1,3 +1,4 @@
+import os
 import json
 import re
 import uuid
@@ -3152,6 +3153,12 @@ def classify_thumbnail_grayscale(mapper, connection, target):
             )
         except requests.exceptions.RequestException:
             pass
+
+
+@event.listens_for(Thumbnail, 'remove')
+def delete_thumbnail_from_disk(mapper, connection, target):
+    if target.file_uri is not None:
+        os.remove(target.file_uri)
 
 
 class ObservingRun(Base):

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -3158,13 +3158,23 @@ def classify_thumbnail_grayscale(mapper, connection, target):
             pass
 
 
-@event.listens_for(Thumbnail, 'remove')
+@event.listens_for(Thumbnail, 'after_delete')
 def delete_thumbnail_from_disk(mapper, connection, target):
     if target.file_uri is not None:
         try:
             os.remove(target.file_uri)
         except (FileNotFoundError, OSError) as e:
             log(f"Error deleting thumbnail file {target.file_uri}: {e}")
+
+
+@event.listens_for(Obj, 'before_delete')
+def delete_obj_thumbnails_from_disk(mapper, connection, target):
+    for thumb in target.thumbnails:
+        if thumb.file_uri is not None:
+            try:
+                os.remove(thumb.file_uri)
+            except (FileNotFoundError, OSError) as e:
+                log(f"Error deleting thumbnail file {thumb.file_uri}: {e}")
 
 
 class ObservingRun(Base):

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -3158,7 +3158,10 @@ def classify_thumbnail_grayscale(mapper, connection, target):
 @event.listens_for(Thumbnail, 'remove')
 def delete_thumbnail_from_disk(mapper, connection, target):
     if target.file_uri is not None:
-        os.remove(target.file_uri)
+        try:
+            os.remove(target.file_uri)
+        except (FileNotFoundError, OSError):
+            pass
 
 
 class ObservingRun(Base):

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -64,6 +64,7 @@ from baselayer.app.models import (  # noqa
     AccessibleIfRelatedRowsAreAccessible,
     CronJobRun,
 )
+from baselayer.log import make_log
 from skyportal import facility_apis
 from . import schema
 from .email_utils import send_email
@@ -90,6 +91,8 @@ cosmo = establish_cosmology(cfg)
 
 # The minimum signal-to-noise ratio to consider a photometry point as a detection
 PHOT_DETECTION_THRESHOLD = cfg["misc.photometry_detection_threshold_nsigma"]
+
+log = make_log('db_models')
 
 
 def get_app_base_url():
@@ -3160,8 +3163,8 @@ def delete_thumbnail_from_disk(mapper, connection, target):
     if target.file_uri is not None:
         try:
             os.remove(target.file_uri)
-        except (FileNotFoundError, OSError):
-            pass
+        except (FileNotFoundError, OSError) as e:
+            log(f"Error deleting thumbnail file {target.file_uri}: {e}")
 
 
 class ObservingRun(Base):

--- a/skyportal/tests/api/test_thumbnail.py
+++ b/skyportal/tests/api/test_thumbnail.py
@@ -262,3 +262,111 @@ def test_cannot_post_thumbnail_invalid_file_type(
     assert status == 400
     assert data['status'] == 'error'
     assert 'cannot identify image file' in data['message']
+
+
+def test_delete_thumbnail_deletes_file_on_disk(
+    upload_data_token, super_admin_token, public_group
+):
+
+    obj_id = str(uuid.uuid4())
+    status, data = api(
+        'POST',
+        'sources',
+        data={
+            'id': obj_id,
+            'ra': 234.22,
+            'dec': -22.33,
+            'redshift': 3,
+            'transient': False,
+            'ra_dis': 2.3,
+            'group_ids': [public_group.id],
+        },
+        token=upload_data_token,
+    )
+    assert status == 200
+    assert data['data']['id'] == obj_id
+
+    thumbnail_data = base64.b64encode(
+        open(os.path.abspath('skyportal/tests/data/14gqr_new.png'), 'rb').read()
+    )
+    ttype = 'new'
+    status, data = api(
+        'POST',
+        'thumbnail',
+        data={'obj_id': obj_id, 'data': thumbnail_data, 'ttype': ttype},
+        token=upload_data_token,
+    )
+    assert status == 200
+    assert data['status'] == 'success'
+    thumbnail_id = data['data']['id']
+    assert isinstance(thumbnail_id, int)
+
+    status, data = api('GET', f'thumbnail/{thumbnail_id}', token=upload_data_token)
+    assert status == 200
+    assert data['status'] == 'success'
+    assert data['data']['type'] == ttype
+
+    thumbnail = DBSession.query(Thumbnail).filter(Thumbnail.id == thumbnail_id).first()
+    assert thumbnail.obj_id == obj_id
+    fpath = thumbnail.file_uri
+    assert os.path.exists(fpath)
+
+    status, data = api('DELETE', f'thumbnail/{thumbnail_id}', token=super_admin_token)
+    assert status == 200
+    assert data['status'] == 'success'
+
+    assert not os.path.exists(fpath)
+
+
+def test_delete_obj_deletes_thumbnail_file_on_disk(
+    upload_data_token, super_admin_token, public_group
+):
+
+    obj_id = str(uuid.uuid4())
+    status, data = api(
+        'POST',
+        'sources',
+        data={
+            'id': obj_id,
+            'ra': 234.22,
+            'dec': -22.33,
+            'redshift': 3,
+            'transient': False,
+            'ra_dis': 2.3,
+            'group_ids': [public_group.id],
+        },
+        token=upload_data_token,
+    )
+    assert status == 200
+    assert data['data']['id'] == obj_id
+
+    thumbnail_data = base64.b64encode(
+        open(os.path.abspath('skyportal/tests/data/14gqr_new.png'), 'rb').read()
+    )
+    ttype = 'new'
+    status, data = api(
+        'POST',
+        'thumbnail',
+        data={'obj_id': obj_id, 'data': thumbnail_data, 'ttype': ttype},
+        token=upload_data_token,
+    )
+    assert status == 200
+    assert data['status'] == 'success'
+    thumbnail_id = data['data']['id']
+    assert isinstance(thumbnail_id, int)
+
+    status, data = api('GET', f'thumbnail/{thumbnail_id}', token=upload_data_token)
+    assert status == 200
+    assert data['status'] == 'success'
+    assert data['data']['type'] == ttype
+
+    thumbnail = DBSession.query(Thumbnail).filter(Thumbnail.id == thumbnail_id).first()
+    assert thumbnail.obj_id == obj_id
+    fpath = thumbnail.file_uri
+    assert os.path.exists(fpath)
+
+    status, data = api('DELETE', f'objs/{obj_id}', token=super_admin_token)
+    assert status == 200
+    assert data['status'] == 'success'
+
+    assert not os.path.exists(fpath)


### PR DESCRIPTION
This adds an event listener that deletes associated on-disk thumbnail files
upon removal of a row from the Thumbnail table. Tests are also added.

Closes https://github.com/skyportal/skyportal/issues/2279