### PR TITLE
Address edge case where status is undefined in data loader

### DIFF
--- a/tools/data_loader.py
+++ b/tools/data_loader.py
@@ -103,6 +103,7 @@ if __name__ == "__main__":
     RETRIES = 15
     timeout = 3
     admin_token = None
+    status = None
     for i in range(RETRIES):
         try:
             previous_admin_token = admin_token


### PR DESCRIPTION
This addresses the edge case where, after the maximum number of
attempts to connect to the running app instance, the `status` variable 
is referenced without being defined.

See https://github.com/skyportal/skyportal/issues/2292#issue-1010100911