### PR TITLE
Use plural nouns consistently in comments API endpoints

### DIFF
--- a/data/db_demo.yaml
+++ b/data/db_demo.yaml
@@ -414,31 +414,31 @@ sources:
       - =program_B
     alias: [""]
 
-sources/14gqr_unsaved_copy/comment:
+sources/14gqr_unsaved_copy/comments:
   - obj_id: 14gqr_unsaved_copy
     text: "No source at transient location to R>26 in LRIS imaging"
   - obj_id: 14gqr_unsaved_copy
     text: "Strong calcium lines have emerged."
 
-sources/14gqr/comment:
+sources/14gqr/comments:
   - obj_id: 14gqr
     text: "No source at transient location to R>26 in LRIS imaging"
   - obj_id: 14gqr
     text: "Strong calcium lines have emerged."
 
-sources/16fil_unsaved_copy/comment:
+sources/16fil_unsaved_copy/comments:
   - obj_id: 16fil_unsaved_copy
     text: "Dogs in the park"
   - obj_id: 16fil_unsaved_copy
     text: "Birds are not real"
 
-sources/16fil/comment:
+sources/16fil/comments:
   - obj_id: 16fil
     text: "Dogs in the park"
   - obj_id: 16fil
     text: "Birds are not real"
 
-sources/14gqr_unsaved_copy/annotation:
+sources/14gqr_unsaved_copy/annotations:
   - obj_id: 14gqr_unsaved_copy
     origin: "Program A"
     data:
@@ -458,7 +458,7 @@ sources/14gqr_unsaved_copy/annotation:
     group_ids:
       - =program_B
 
-sources/14gqr/annotation:
+sources/14gqr/annotations:
   - obj_id: 14gqr
     origin: "Program A"
     data:
@@ -487,7 +487,7 @@ sources/14gqr/annotation:
         Mag_Rp: 5.1
         A_G: 0.3
 
-sources/16fil_unsaved_copy/annotation:
+sources/16fil_unsaved_copy/annotations:
   - obj_id: 16fil_unsaved_copy
     origin: "Program A"
     data:
@@ -496,7 +496,7 @@ sources/16fil_unsaved_copy/annotation:
     group_ids:
       - =program_A
 
-sources/16fil/annotation:
+sources/16fil/annotations:
   - obj_id: 16fil
     origin: "Program A"
     data:
@@ -505,7 +505,7 @@ sources/16fil/annotation:
     group_ids:
       - =program_A
 
-sources/ZTFe028h94k/annotation:
+sources/ZTFe028h94k/annotations:
   - obj_id: ZTFe028h94k
     origin: "Program B"
     data:
@@ -519,7 +519,7 @@ sources/ZTFe028h94k/annotation:
     group_ids:
       - =program_B
 
-sources/ZTFrlh6cyjh/annotation:
+sources/ZTFrlh6cyjh/annotations:
   - obj_id: ZTFrlh6cyjh
     origin: "ZVM"
     data:

--- a/doc/advanced_usage.md
+++ b/doc/advanced_usage.md
@@ -32,7 +32,7 @@ data = {'obj_id': '2021example',
         }
 
 response = requests.post(
-      f'{url}/api/sources/2021example/annotation',
+      f'{url}/api/sources/2021example/annotations',
       header=header,
       data=json.dumps(data)
     )

--- a/doc/comment_url_migration.md
+++ b/doc/comment_url_migration.md
@@ -14,17 +14,17 @@ In the past, a comment was accessed via the endpoint
 
 In the new framework, a comment on a source must be accessed via
 the source path:
-`api/sources/<sourceID>/comment/<commentID>`
+`api/sources/<sourceID>/comments/<commentID>`
 
 This also applies to comments on spectra:
-`api/spectrum/<spectrumID>/comment/<commentID>`
+`api/spectra/<spectrumID>/comments/<commentID>`
 
 For annotations, use:
-`api/sources/<sourceID>/annotation/<annotationID>`
+`api/sources/<sourceID>/annotations/<annotationID>`
 
 In all cases, when posting a new comment/annotation,
 do not supply a commentID or annotationID at the end of the path, e.g.,
-POST to `api/sources/<sourceID>/comment`.
+POST to `api/sources/<sourceID>/comments`.
 
 Any existing scripts that use the comment or annotation
 API must be changed accordingly.

--- a/skyportal/app_server.py
+++ b/skyportal/app_server.py
@@ -170,7 +170,7 @@ skyportal_handlers = [
     (r'/api/spectra/parse/ascii', SpectrumASCIIFileParser),
     (r'/api/spectra/ascii(/[0-9]+)?', SpectrumASCIIFileHandler),
     (r'/api/spectra/range(/.*)?', SpectrumRangeHandler),
-    # DEPRECATED: To be removed in an upcoming release
+    # FIXME: TODO: Deprecated, to be removed in an upcoming release
     (r'/api/spectrum(/[0-9]+)?', SpectrumHandler),
     (r'/api/spectrum/parse/ascii', SpectrumASCIIFileParser),
     (r'/api/spectrum/ascii(/[0-9]+)?', SpectrumASCIIFileHandler),

--- a/skyportal/app_server.py
+++ b/skyportal/app_server.py
@@ -37,7 +37,6 @@ from skyportal.handlers.api import (
     ObjHandler,
     ObjPhotometryHandler,
     ObjClassificationHandler,
-    ObjAnnotationHandler,
     PhotometryRangeHandler,
     RoleHandler,
     UserRoleHandler,
@@ -143,35 +142,40 @@ skyportal_handlers = [
     (r'/api/sources(/[0-9A-Za-z-_\.\+]+)/classifications', ObjClassificationHandler),
     (r'/api/sources(/[0-9A-Za-z-_\.\+]+)/groups', ObjGroupsHandler),
     (r'/api/sources(/[0-9A-Za-z-_\.\+]+)/color_mag', ObjColorMagHandler),
-    (r'/api/(sources|spectrum)/([0-9A-Za-z-_\.\+]+)/comment', CommentHandler),
-    (r'/api/(sources|spectrum)/([0-9A-Za-z-_\.\+]+)/comment(/[0-9]+)?', CommentHandler),
+    (r'/api/(sources|spectra)/([0-9A-Za-z-_\.\+]+)/comments', CommentHandler),
+    (r'/api/(sources|spectra)/([0-9A-Za-z-_\.\+]+)/comments(/[0-9]+)?', CommentHandler),
     (
-        r'/api/(sources|spectrum)(/[0-9A-Za-z-_\.\+]+)/comment(/[0-9]+)/attachment',
+        r'/api/(sources|spectra)(/[0-9A-Za-z-_\.\+]+)/comments(/[0-9]+)/attachment',
         CommentAttachmentHandler,
     ),
     # Allow the '.pdf' suffix for the attachment route, as the
     # react-file-previewer package expects URLs ending with '.pdf' to
     # load PDF files.
     (
-        r'/api/(sources|spectrum)/([0-9A-Za-z-_\.\+]+)/comment(/[0-9]+)/attachment.pdf',
+        r'/api/(sources|spectra)/([0-9A-Za-z-_\.\+]+)/comments(/[0-9]+)/attachment.pdf',
         CommentAttachmentHandler,
     ),
     (
-        r'/api/(sources|spectrum)(/[0-9A-Za-z-_\.\+]+)/annotation',
+        r'/api/(sources|spectra)(/[0-9A-Za-z-_\.\+]+)/annotations',
         AnnotationHandler,
     ),
     (
-        r'/api/(sources|spectrum)(/[0-9A-Za-z-_\.\+]+)/annotation(/[0-9]+)?',
+        r'/api/(sources|spectra)(/[0-9A-Za-z-_\.\+]+)/annotations(/[0-9]+)?',
         AnnotationHandler,
     ),
-    (r'/api/sources(/[0-9A-Za-z-_\.\+]+)/annotations', ObjAnnotationHandler),
     (r'/api/sources(/.*)?', SourceHandler),
     (r'/api/source_notifications', SourceNotificationHandler),
     (r'/api/source_groups(/.*)?', SourceGroupsHandler),
+    (r'/api/spectra(/[0-9]+)?', SpectrumHandler),
+    (r'/api/spectra/parse/ascii', SpectrumASCIIFileParser),
+    (r'/api/spectra/ascii(/[0-9]+)?', SpectrumASCIIFileHandler),
+    (r'/api/spectra/range(/.*)?', SpectrumRangeHandler),
+    # DEPRECATED: To be removed in an upcoming release
     (r'/api/spectrum(/[0-9]+)?', SpectrumHandler),
     (r'/api/spectrum/parse/ascii', SpectrumASCIIFileParser),
     (r'/api/spectrum/ascii(/[0-9]+)?', SpectrumASCIIFileHandler),
     (r'/api/spectrum/range(/.*)?', SpectrumRangeHandler),
+    # End deprecated
     (r'/api/streams(/[0-9]+)/users(/.*)?', StreamUserHandler),
     (r'/api/streams(/[0-9]+)?', StreamHandler),
     (r'/api/db_stats', StatsHandler),

--- a/skyportal/handlers/api/__init__.py
+++ b/skyportal/handlers/api/__init__.py
@@ -3,7 +3,7 @@ from .allocation import AllocationHandler
 from .candidate import CandidateHandler
 from .classification import ClassificationHandler, ObjClassificationHandler
 from .comment import CommentHandler, CommentAttachmentHandler
-from .annotation import AnnotationHandler, ObjAnnotationHandler
+from .annotation import AnnotationHandler
 from .db_stats import StatsHandler
 from .filter import FilterHandler
 from .followup_request import FollowupRequestHandler, AssignmentHandler

--- a/skyportal/handlers/api/comment.py
+++ b/skyportal/handlers/api/comment.py
@@ -44,13 +44,13 @@ class CommentHandler(BaseHandler):
               type: string
             description: |
                What underlying data the comment is on:
-               "sources" or "spectrum".
+               "sources" or "spectra".
           - in: path
             name: resource_id
             required: true
             schema:
               type: string
-              enum: [sources, spectrum]
+              enum: [sources, spectra]
             description: |
                The ID of the source or spectrum
                that the comment is posted to.
@@ -88,7 +88,7 @@ class CommentHandler(BaseHandler):
                 return self.error('Could not find any accessible comments.', status=403)
             comment_resource_id_str = str(comment.obj_id)
 
-        elif associated_resource_type.lower() == "spectrum":
+        elif associated_resource_type.lower() == "spectra":
             try:
                 comment = CommentOnSpectrum.get_if_accessible_by(
                     comment_id, self.current_user, raise_if_none=True
@@ -130,7 +130,7 @@ class CommentHandler(BaseHandler):
             required: true
             schema:
               type: string
-              enum: [sources, spectrum]
+              enum: [sources, spectra]
             description: |
                The ID of the source or spectrum
                that the comment is posted to.
@@ -224,7 +224,7 @@ class CommentHandler(BaseHandler):
                 groups=groups,
                 bot=is_bot_request,
             )
-        elif associated_resource_type.lower() == "spectrum":
+        elif associated_resource_type.lower() == "spectra":
             spectrum_id = resource_id
             try:
                 spectrum = Spectrum.get_if_accessible_by(
@@ -293,13 +293,13 @@ class CommentHandler(BaseHandler):
               type: string
             description: |
                What underlying data the comment is on:
-               "sources" or "spectrum".
+               "sources" or "spectra".
           - in: path
             name: resource_id
             required: true
             schema:
               type: string
-              enum: [sources, spectrum]
+              enum: [sources, spectra]
             description: |
                The ID of the source or spectrum
                that the comment is posted to.
@@ -351,7 +351,7 @@ class CommentHandler(BaseHandler):
                 return self.error('Could not find any accessible comments.', status=403)
             comment_resource_id_str = str(c.obj_id)
 
-        elif associated_resource_type.lower() == "spectrum":
+        elif associated_resource_type.lower() == "spectra":
             schema = CommentOnSpectrum.__schema__()
             try:
                 c = CommentOnSpectrum.get_if_accessible_by(
@@ -435,13 +435,13 @@ class CommentHandler(BaseHandler):
               type: string
             description: |
                What underlying data the comment is on:
-               "sources" or "spectrum".
+               "sources" or "spectra".
           - in: path
             name: resource_id
             required: true
             schema:
               type: string
-              enum: [sources, spectrum]
+              enum: [sources, spectra]
             description: |
                The ID of the source or spectrum
                that the comment is posted to.
@@ -463,7 +463,7 @@ class CommentHandler(BaseHandler):
         try:
             comment_id = int(comment_id)
         except (TypeError, ValueError):
-            return self.error("Must provide a valid (scalar integer) comment ID. ")
+            return self.error("Must provide a valid (scalar integer) comment ID.")
 
         if associated_resource_type.lower() == "sources":
             try:
@@ -473,7 +473,7 @@ class CommentHandler(BaseHandler):
             except AccessError:
                 return self.error('Could not find any accessible comments.', status=403)
             comment_resource_id_str = str(c.obj_id)
-        elif associated_resource_type.lower() == "spectrum":
+        elif associated_resource_type.lower() == "spectra":
             try:
                 c = CommentOnSpectrum.get_if_accessible_by(
                     comment_id, self.current_user, mode="delete", raise_if_none=True
@@ -529,13 +529,13 @@ class CommentAttachmentHandler(BaseHandler):
               type: string
             description: |
                What underlying data the comment is on:
-               "sources" or "spectrum".
+               "sources" or "spectra".
           - in: path
             name: resource_id
             required: true
             schema:
               type: string
-              enum: [sources, spectrum]
+              enum: [sources, spectra]
             description: |
                The ID of the source or spectrum
                that the comment is posted to.
@@ -594,7 +594,7 @@ class CommentAttachmentHandler(BaseHandler):
                 return self.error('Could not find any accessible comments.', status=403)
             comment_resource_id_str = str(comment.obj_id)
 
-        elif associated_resource_type.lower() == "spectrum":
+        elif associated_resource_type.lower() == "spectra":
             try:
                 comment = CommentOnSpectrum.get_if_accessible_by(
                     comment_id, self.current_user, raise_if_none=True

--- a/skyportal/tests/api/test_annotations.py
+++ b/skyportal/tests/api/test_annotations.py
@@ -7,7 +7,7 @@ def test_post_without_origin_fails(annotation_token, public_source, public_group
     # this should not work, since no "origin" is given
     status, data = api(
         'POST',
-        f'sources/{public_source.id}/annotation',
+        f'sources/{public_source.id}/annotations',
         data={
             'obj_id': public_source.id,
             'data': {'offset_from_host_galaxy': 1.5},
@@ -22,7 +22,7 @@ def test_post_without_origin_fails(annotation_token, public_source, public_group
     # this should not work, since "origin" is empty
     status, data = api(
         'POST',
-        f'sources/{public_source.id}/annotation',
+        f'sources/{public_source.id}/annotations',
         data={
             'obj_id': public_source.id,
             'origin': '',
@@ -41,7 +41,7 @@ def test_post_same_origin_fails(annotation_token, public_source, public_group):
     # first time adding an annotation to this object from Kowalski
     status, data = api(
         'POST',
-        f'sources/{public_source.id}/annotation',
+        f'sources/{public_source.id}/annotations',
         data={
             'obj_id': public_source.id,
             'origin': 'kowalski',
@@ -57,7 +57,7 @@ def test_post_same_origin_fails(annotation_token, public_source, public_group):
     # instead, try updating the existing annotation if you have new information!
     status, data = api(
         'POST',
-        f'sources/{public_source.id}/annotation',
+        f'sources/{public_source.id}/annotations',
         data={
             'obj_id': public_source.id,
             'origin': 'kowalski',
@@ -76,7 +76,7 @@ def test_add_and_retrieve_annotation_group_id(
 ):
     status, data = api(
         'POST',
-        f'sources/{public_source.id}/annotation',
+        f'sources/{public_source.id}/annotations',
         data={
             'obj_id': public_source.id,
             'origin': 'kowalski',
@@ -90,7 +90,7 @@ def test_add_and_retrieve_annotation_group_id(
 
     status, data = api(
         'GET',
-        f'sources/{public_source.id}/annotation/{annotation_id}',
+        f'sources/{public_source.id}/annotations/{annotation_id}',
         token=annotation_token,
     )
 
@@ -102,7 +102,7 @@ def test_add_and_retrieve_annotation_group_id(
 def test_add_and_retrieve_annotation_no_group_id(annotation_token, public_source):
     status, data = api(
         'POST',
-        f'sources/{public_source.id}/annotation',
+        f'sources/{public_source.id}/annotations',
         data={
             'obj_id': public_source.id,
             'origin': 'kowalski',
@@ -115,7 +115,7 @@ def test_add_and_retrieve_annotation_no_group_id(annotation_token, public_source
 
     status, data = api(
         'GET',
-        f'sources/{public_source.id}/annotation/{annotation_id}',
+        f'sources/{public_source.id}/annotations/{annotation_id}',
         token=annotation_token,
     )
 
@@ -133,7 +133,7 @@ def test_add_and_retrieve_annotation_group_access(
 ):
     status, data = api(
         'POST',
-        f'sources/{public_source_two_groups.id}/annotation',
+        f'sources/{public_source_two_groups.id}/annotations',
         data={
             'obj_id': public_source_two_groups.id,
             'origin': 'kowalski',
@@ -149,7 +149,7 @@ def test_add_and_retrieve_annotation_group_access(
     # This token belongs to public_group2
     status, data = api(
         'GET',
-        f'sources/{public_source_two_groups.id}/annotation/{annotation_id}',
+        f'sources/{public_source_two_groups.id}/annotations/{annotation_id}',
         token=annotation_token_two_groups,
     )
     assert status == 200
@@ -159,7 +159,7 @@ def test_add_and_retrieve_annotation_group_access(
     # This token does not belong to public_group2
     status, data = api(
         'GET',
-        f'sources/{public_source_two_groups.id}/annotation/{annotation_id}',
+        f'sources/{public_source_two_groups.id}/annotations/{annotation_id}',
         token=annotation_token,
     )
     assert status == 403
@@ -167,7 +167,7 @@ def test_add_and_retrieve_annotation_group_access(
     # Both tokens should be able to view this annotation
     status, data = api(
         'POST',
-        f'sources/{public_source_two_groups.id}/annotation',
+        f'sources/{public_source_two_groups.id}/annotations',
         data={
             'obj_id': public_source_two_groups.id,
             'origin': 'GAIA',
@@ -182,7 +182,7 @@ def test_add_and_retrieve_annotation_group_access(
 
     status, data = api(
         'GET',
-        f'sources/{public_source_two_groups.id}/annotation/{annotation_id}',
+        f'sources/{public_source_two_groups.id}/annotations/{annotation_id}',
         token=annotation_token_two_groups,
     )
     assert status == 200
@@ -191,7 +191,7 @@ def test_add_and_retrieve_annotation_group_access(
 
     status, data = api(
         'GET',
-        f'sources/{public_source_two_groups.id}/annotation/{annotation_id}',
+        f'sources/{public_source_two_groups.id}/annotations/{annotation_id}',
         token=annotation_token,
     )
     assert status == 200
@@ -207,7 +207,7 @@ def test_update_annotation_group_list(
 ):
     status, data = api(
         'POST',
-        f'sources/{public_source_two_groups.id}/annotation',
+        f'sources/{public_source_two_groups.id}/annotations',
         data={
             'obj_id': public_source_two_groups.id,
             'origin': 'kowalski',
@@ -222,7 +222,7 @@ def test_update_annotation_group_list(
     # This token belongs to public_group2
     status, data = api(
         'GET',
-        f'sources/{public_source_two_groups.id}/annotation/{annotation_id}',
+        f'sources/{public_source_two_groups.id}/annotations/{annotation_id}',
         token=annotation_token_two_groups,
     )
     assert status == 200
@@ -232,7 +232,7 @@ def test_update_annotation_group_list(
     # This token does not belong to public_group2
     status, data = api(
         'GET',
-        f'sources/{public_source_two_groups.id}/annotation/{annotation_id}',
+        f'sources/{public_source_two_groups.id}/annotations/{annotation_id}',
         token=annotation_token,
     )
     assert status == 403
@@ -240,7 +240,7 @@ def test_update_annotation_group_list(
     # Both tokens should be able to view annotation after updating group list
     status, data = api(
         'PUT',
-        f'sources/{public_source_two_groups.id}/annotation/{annotation_id}',
+        f'sources/{public_source_two_groups.id}/annotations/{annotation_id}',
         data={
             'data': {'offset_from_host_galaxy': 1.7},
             'group_ids': [public_group.id, public_group2.id],
@@ -251,7 +251,7 @@ def test_update_annotation_group_list(
 
     status, data = api(
         'GET',
-        f'sources/{public_source_two_groups.id}/annotation/{annotation_id}',
+        f'sources/{public_source_two_groups.id}/annotations/{annotation_id}',
         token=annotation_token_two_groups,
     )
     assert status == 200
@@ -259,7 +259,7 @@ def test_update_annotation_group_list(
 
     status, data = api(
         'GET',
-        f'sources/{public_source_two_groups.id}/annotation/{annotation_id}',
+        f'sources/{public_source_two_groups.id}/annotations/{annotation_id}',
         token=annotation_token,
     )
     assert status == 200
@@ -269,7 +269,7 @@ def test_update_annotation_group_list(
 def test_cannot_add_annotation_without_permission(view_only_token, public_source):
     status, data = api(
         'POST',
-        f'sources/{public_source.id}/annotation',
+        f'sources/{public_source.id}/annotations',
         data={
             'obj_id': public_source.id,
             'origin': 'kowalski',
@@ -286,7 +286,7 @@ def test_delete_annotation(annotation_token, public_source):
 
     status, data = api(
         'POST',
-        f'sources/{public_source.id}/annotation',
+        f'sources/{public_source.id}/annotations',
         data={
             'obj_id': public_source.id,
             'origin': origin,
@@ -299,7 +299,7 @@ def test_delete_annotation(annotation_token, public_source):
 
     status, data = api(
         'GET',
-        f'sources/{public_source.id}/annotation/{annotation_id}',
+        f'sources/{public_source.id}/annotations/{annotation_id}',
         token=annotation_token,
     )
     assert status == 200
@@ -309,7 +309,7 @@ def test_delete_annotation(annotation_token, public_source):
     # delete should fail if using the wrong object ID
     status, data = api(
         'DELETE',
-        f'sources/{public_source.id}zzz/annotation/{annotation_id}',
+        f'sources/{public_source.id}zzz/annotations/{annotation_id}',
         token=annotation_token,
     )
     assert status == 400
@@ -320,14 +320,14 @@ def test_delete_annotation(annotation_token, public_source):
 
     status, data = api(
         'DELETE',
-        f'sources/{public_source.id}/annotation/{annotation_id}',
+        f'sources/{public_source.id}/annotations/{annotation_id}',
         token=annotation_token,
     )
     assert status == 200
 
     status, data = api(
         'GET',
-        f'sources/{public_source.id}/annotation/{annotation_id}',
+        f'sources/{public_source.id}/annotations/{annotation_id}',
         token=annotation_token,
     )
     assert status == 403
@@ -338,7 +338,7 @@ def test_obj_annotations(annotation_token, public_source, public_group):
 
     status, data = api(
         'POST',
-        f'sources/{public_source.id}/annotation',
+        f'sources/{public_source.id}/annotations',
         data={
             'obj_id': public_source.id,
             'origin': origin,
@@ -351,7 +351,7 @@ def test_obj_annotations(annotation_token, public_source, public_group):
 
     status, data = api(
         'GET',
-        f'sources/{public_source.id}/annotation/{annotation_id}',
+        f'sources/{public_source.id}/annotations/{annotation_id}',
         token=annotation_token,
     )
     assert status == 200
@@ -369,7 +369,7 @@ def test_cannot_add_annotation_without_data(
 ):
     status, data = api(
         'POST',
-        f'sources/{public_source.id}/annotation',
+        f'sources/{public_source.id}/annotations',
         data={
             'obj_id': public_source.id,
             'origin': 'kowalski',
@@ -385,7 +385,7 @@ def test_post_invalid_data(annotation_token, public_source, public_group):
     origin = str(uuid.uuid4())
     status, data = api(
         'POST',
-        f'sources/{public_source.id}/annotation',
+        f'sources/{public_source.id}/annotations',
         data={
             'obj_id': public_source.id,
             'data': "Test",

--- a/skyportal/tests/api/test_candidates.py
+++ b/skyportal/tests/api/test_candidates.py
@@ -225,7 +225,7 @@ def test_candidate_list_sorting_basic(
     origin = str(uuid.uuid4())
     status, data = api(
         "POST",
-        f"sources/{public_candidate.id}/annotation",
+        f"sources/{public_candidate.id}/annotations",
         data={
             "obj_id": public_candidate.id,
             "origin": origin,
@@ -237,7 +237,7 @@ def test_candidate_list_sorting_basic(
 
     status, data = api(
         "POST",
-        f"sources/{public_candidate2.id}/annotation",
+        f"sources/{public_candidate2.id}/annotations",
         data={
             "obj_id": public_candidate2.id,
             "origin": origin,
@@ -270,7 +270,7 @@ def test_candidate_list_sorting_different_origins(
     origin2 = str(uuid.uuid4())
     status, data = api(
         "POST",
-        f"sources/{public_candidate.id}/annotation",
+        f"sources/{public_candidate.id}/annotations",
         data={
             "obj_id": public_candidate.id,
             "origin": origin,
@@ -282,7 +282,7 @@ def test_candidate_list_sorting_different_origins(
 
     status, data = api(
         "POST",
-        f"sources/{public_candidate2.id}/annotation",
+        f"sources/{public_candidate2.id}/annotations",
         data={
             "obj_id": public_candidate2.id,
             "origin": origin2,
@@ -319,7 +319,7 @@ def test_candidate_list_sorting_hidden_group(
     # Post an annotation that belongs only to public_group2 (not allowed for view_only_token)
     status, data = api(
         "POST",
-        f"sources/{public_candidate_two_groups.id}/annotation",
+        f"sources/{public_candidate_two_groups.id}/annotations",
         data={
             "obj_id": public_candidate_two_groups.id,
             "origin": f"{public_group2.id}",
@@ -333,7 +333,7 @@ def test_candidate_list_sorting_hidden_group(
     # This one belongs to both public groups and is thus visible
     status, data = api(
         "POST",
-        f"sources/{public_candidate2.id}/annotation",
+        f"sources/{public_candidate2.id}/annotations",
         data={
             "obj_id": public_candidate2.id,
             "origin": f"{public_group2.id}",
@@ -367,7 +367,7 @@ def test_candidate_list_sorting_null_value(
     origin = str(uuid.uuid4())
     status, data = api(
         "POST",
-        f"sources/{public_candidate.id}/annotation",
+        f"sources/{public_candidate.id}/annotations",
         data={
             "obj_id": public_candidate.id,
             "origin": origin,
@@ -379,7 +379,7 @@ def test_candidate_list_sorting_null_value(
 
     status, data = api(
         "POST",
-        f"sources/{public_candidate2.id}/annotation",
+        f"sources/{public_candidate2.id}/annotations",
         data={
             "obj_id": public_candidate2.id,
             "origin": origin,
@@ -413,7 +413,7 @@ def test_candidate_list_filtering_numeric(
     origin = str(uuid.uuid4())
     status, data = api(
         "POST",
-        f"sources/{public_candidate.id}/annotation",
+        f"sources/{public_candidate.id}/annotations",
         data={
             "obj_id": public_candidate.id,
             "origin": origin,
@@ -425,7 +425,7 @@ def test_candidate_list_filtering_numeric(
 
     status, data = api(
         "POST",
-        f"sources/{public_candidate2.id}/annotation",
+        f"sources/{public_candidate2.id}/annotations",
         data={
             "obj_id": public_candidate2.id,
             "origin": origin,
@@ -456,7 +456,7 @@ def test_candidate_list_filtering_boolean(
     origin = str(uuid.uuid4())
     status, data = api(
         "POST",
-        f"sources/{public_candidate.id}/annotation",
+        f"sources/{public_candidate.id}/annotations",
         data={
             "obj_id": public_candidate.id,
             "origin": origin,
@@ -468,7 +468,7 @@ def test_candidate_list_filtering_boolean(
 
     status, data = api(
         "POST",
-        f"sources/{public_candidate2.id}/annotation",
+        f"sources/{public_candidate2.id}/annotations",
         data={
             "obj_id": public_candidate2.id,
             "origin": origin,
@@ -499,7 +499,7 @@ def test_candidate_list_filtering_string(
     origin = str(uuid.uuid4())
     status, data = api(
         "POST",
-        f"sources/{public_candidate.id}/annotation",
+        f"sources/{public_candidate.id}/annotations",
         data={
             "obj_id": public_candidate.id,
             "origin": origin,
@@ -511,7 +511,7 @@ def test_candidate_list_filtering_string(
 
     status, data = api(
         "POST",
-        f"sources/{public_candidate2.id}/annotation",
+        f"sources/{public_candidate2.id}/annotations",
         data={
             "obj_id": public_candidate2.id,
             "origin": origin,
@@ -703,7 +703,7 @@ def test_exclude_by_outdated_annotations(
     # add an annotation from this origin
     status, data = api(
         "POST",
-        f"sources/{public_candidate.id}/annotation",
+        f"sources/{public_candidate.id}/annotations",
         data={"obj_id": public_candidate.id, "origin": origin, "data": {'value1': 1}},
         token=annotation_token,
     )

--- a/skyportal/tests/api/test_color_mag.py
+++ b/skyportal/tests/api/test_color_mag.py
@@ -5,7 +5,7 @@ def test_post_retrieve_color_mag_data(annotation_token, user, public_source):
 
     status, data = api(
         'POST',
-        f'sources/{public_source.id}/annotation',
+        f'sources/{public_source.id}/annotations',
         data={
             'obj_id': public_source.id,
             'origin': 'cross_match1',
@@ -33,7 +33,7 @@ def test_post_retrieve_color_mag_data(annotation_token, user, public_source):
     # add absorption by an edit to the annotation
     status, data = api(
         'PUT',
-        f'sources/{public_source.id}/annotation/{annotation_id}',
+        f'sources/{public_source.id}/annotations/{annotation_id}',
         data={
             'obj_id': public_source.id,
             'origin': 'cross_match1',
@@ -63,7 +63,7 @@ def test_post_retrieve_color_mag_data(annotation_token, user, public_source):
     # replace the magnitude in apparent bands with the absolute mag and color
     status, data = api(
         'PUT',
-        f'sources/{public_source.id}/annotation/{annotation_id}',
+        f'sources/{public_source.id}/annotations/{annotation_id}',
         data={
             'obj_id': public_source.id,
             'origin': 'cross_match1',
@@ -124,7 +124,7 @@ def test_change_color_mag_keys(annotation_token, user, public_source):
 
     status, data = api(
         'POST',
-        f'sources/{public_source.id}/annotation',
+        f'sources/{public_source.id}/annotations',
         data={
             'obj_id': public_source.id,
             'origin': 'cross_match1',
@@ -149,7 +149,7 @@ def test_change_color_mag_keys(annotation_token, user, public_source):
     # change the keys, replace capital letters with underscores
     status, data = api(
         'PUT',
-        f'sources/{public_source.id}/annotation/{annotation_id}',
+        f'sources/{public_source.id}/annotations/{annotation_id}',
         data={
             'obj_id': public_source.id,
             'origin': 'cross_match1',
@@ -173,7 +173,7 @@ def test_change_color_mag_keys(annotation_token, user, public_source):
     # change the keys to completely new names, rename the catalog as well
     status, data = api(
         'PUT',
-        f'sources/{public_source.id}/annotation/{annotation_id}',
+        f'sources/{public_source.id}/annotations/{annotation_id}',
         data={
             'obj_id': public_source.id,
             'origin': 'cross_match1',
@@ -206,7 +206,7 @@ def test_change_color_mag_keys(annotation_token, user, public_source):
 def test_add_multiple_color_mag_annotations(annotation_token, user, public_source):
     status, data = api(
         'POST',
-        f'sources/{public_source.id}/annotation',
+        f'sources/{public_source.id}/annotations',
         data={
             'obj_id': public_source.id,
             'origin': 'cross_match1',
@@ -230,7 +230,7 @@ def test_add_multiple_color_mag_annotations(annotation_token, user, public_sourc
     # post from a second origin
     status, data = api(
         'POST',
-        f'sources/{public_source.id}/annotation',
+        f'sources/{public_source.id}/annotations',
         data={
             'obj_id': public_source.id,
             'origin': 'cross_match2',
@@ -245,7 +245,7 @@ def test_add_multiple_color_mag_annotations(annotation_token, user, public_sourc
     # post from a third origin
     status, data = api(
         'POST',
-        f'sources/{public_source.id}/annotation',
+        f'sources/{public_source.id}/annotations',
         data={
             'obj_id': public_source.id,
             'origin': 'cross_match3',

--- a/skyportal/tests/api/test_comments.py
+++ b/skyportal/tests/api/test_comments.py
@@ -4,7 +4,7 @@ from skyportal.tests import api
 def test_add_and_retrieve_comment_group_id(comment_token, public_source, public_group):
     status, data = api(
         'POST',
-        f'sources/{public_source.id}/comment',
+        f'sources/{public_source.id}/comments',
         data={
             'obj_id': public_source.id,
             'text': 'Comment text',
@@ -16,7 +16,7 @@ def test_add_and_retrieve_comment_group_id(comment_token, public_source, public_
     comment_id = data['data']['comment_id']
 
     status, data = api(
-        'GET', f'sources/{public_source.id}/comment/{comment_id}', token=comment_token
+        'GET', f'sources/{public_source.id}/comments/{comment_id}', token=comment_token
     )
 
     assert status == 200
@@ -27,7 +27,7 @@ def test_add_and_retrieve_comment_group_id(comment_token, public_source, public_
 def test_add_and_retrieve_comment_no_group_id(comment_token, public_source):
     status, data = api(
         'POST',
-        f'sources/{public_source.id}/comment',
+        f'sources/{public_source.id}/comments',
         data={'obj_id': public_source.id, 'text': 'Comment text'},
         token=comment_token,
     )
@@ -35,7 +35,7 @@ def test_add_and_retrieve_comment_no_group_id(comment_token, public_source):
     comment_id = data['data']['comment_id']
 
     status, data = api(
-        'GET', f'sources/{public_source.id}/comment/{comment_id}', token=comment_token
+        'GET', f'sources/{public_source.id}/comments/{comment_id}', token=comment_token
     )
 
     assert status == 200
@@ -51,7 +51,7 @@ def test_add_and_retrieve_comment_group_access(
 ):
     status, data = api(
         'POST',
-        f'sources/{public_source_two_groups.id}/comment',
+        f'sources/{public_source_two_groups.id}/comments',
         data={
             'obj_id': public_source_two_groups.id,
             'text': 'Comment text',
@@ -65,7 +65,7 @@ def test_add_and_retrieve_comment_group_access(
     # This token belongs to public_group2
     status, data = api(
         'GET',
-        f'sources/{public_source_two_groups.id}/comment/{comment_id}',
+        f'sources/{public_source_two_groups.id}/comments/{comment_id}',
         token=comment_token_two_groups,
     )
     assert status == 200
@@ -74,7 +74,7 @@ def test_add_and_retrieve_comment_group_access(
     # This token does not belong to public_group2
     status, data = api(
         'GET',
-        f'sources/{public_source_two_groups.id}/comment/{comment_id}',
+        f'sources/{public_source_two_groups.id}/comments/{comment_id}',
         token=comment_token,
     )
     assert status == 403
@@ -82,7 +82,7 @@ def test_add_and_retrieve_comment_group_access(
     # Both tokens should be able to view this comment
     status, data = api(
         'POST',
-        f'sources/{public_source_two_groups.id}/comment',
+        f'sources/{public_source_two_groups.id}/comments',
         data={
             'obj_id': public_source_two_groups.id,
             'text': 'Comment text',
@@ -95,7 +95,7 @@ def test_add_and_retrieve_comment_group_access(
 
     status, data = api(
         'GET',
-        f'sources/{public_source_two_groups.id}/comment/{comment_id}',
+        f'sources/{public_source_two_groups.id}/comments/{comment_id}',
         token=comment_token_two_groups,
     )
     assert status == 200
@@ -103,7 +103,7 @@ def test_add_and_retrieve_comment_group_access(
 
     status, data = api(
         'GET',
-        f'sources/{public_source_two_groups.id}/comment/{comment_id}',
+        f'sources/{public_source_two_groups.id}/comments/{comment_id}',
         token=comment_token,
     )
     assert status == 200
@@ -119,7 +119,7 @@ def test_update_comment_group_list(
 ):
     status, data = api(
         'POST',
-        f'sources/{public_source_two_groups.id}/comment',
+        f'sources/{public_source_two_groups.id}/comments',
         data={
             'obj_id': public_source_two_groups.id,
             'text': 'Comment text',
@@ -133,7 +133,7 @@ def test_update_comment_group_list(
     # This token belongs to public_group2
     status, data = api(
         'GET',
-        f'sources/{public_source_two_groups.id}/comment/{comment_id}',
+        f'sources/{public_source_two_groups.id}/comments/{comment_id}',
         token=comment_token_two_groups,
     )
     assert status == 200
@@ -142,7 +142,7 @@ def test_update_comment_group_list(
     # This token does not belnog to public_group2
     status, data = api(
         'GET',
-        f'sources/{public_source_two_groups.id}/comment/{comment_id}',
+        f'sources/{public_source_two_groups.id}/comments/{comment_id}',
         token=comment_token,
     )
     assert status == 403
@@ -150,7 +150,7 @@ def test_update_comment_group_list(
     # Both tokens should be able to view comment after updating group list
     status, data = api(
         'PUT',
-        f'sources/{public_source_two_groups.id}/comment/{comment_id}',
+        f'sources/{public_source_two_groups.id}/comments/{comment_id}',
         data={
             'text': 'Comment text new',
             'group_ids': [public_group.id, public_group2.id],
@@ -161,7 +161,7 @@ def test_update_comment_group_list(
 
     status, data = api(
         'GET',
-        f'sources/{public_source_two_groups.id}/comment/{comment_id}',
+        f'sources/{public_source_two_groups.id}/comments/{comment_id}',
         token=comment_token_two_groups,
     )
     assert status == 200
@@ -169,7 +169,7 @@ def test_update_comment_group_list(
 
     status, data = api(
         'GET',
-        f'sources/{public_source_two_groups.id}/comment/{comment_id}',
+        f'sources/{public_source_two_groups.id}/comments/{comment_id}',
         token=comment_token,
     )
     assert status == 200
@@ -179,7 +179,7 @@ def test_update_comment_group_list(
 def test_cannot_add_comment_without_permission(view_only_token, public_source):
     status, data = api(
         'POST',
-        f'sources/{public_source.id}/comment',
+        f'sources/{public_source.id}/comments',
         data={'obj_id': public_source.id, 'text': 'Comment text'},
         token=view_only_token,
     )
@@ -190,7 +190,7 @@ def test_cannot_add_comment_without_permission(view_only_token, public_source):
 def test_delete_comment(comment_token, public_source):
     status, data = api(
         'POST',
-        f'sources/{public_source.id}/comment',
+        f'sources/{public_source.id}/comments',
         data={'obj_id': public_source.id, 'text': 'Comment text'},
         token=comment_token,
     )
@@ -198,7 +198,7 @@ def test_delete_comment(comment_token, public_source):
     comment_id = data['data']['comment_id']
 
     status, data = api(
-        'GET', f'sources/{public_source.id}/comment/{comment_id}', token=comment_token
+        'GET', f'sources/{public_source.id}/comments/{comment_id}', token=comment_token
     )
     assert status == 200
     assert data['data']['text'] == 'Comment text'
@@ -206,7 +206,7 @@ def test_delete_comment(comment_token, public_source):
     # try to delete using the wrong object ID
     status, data = api(
         'DELETE',
-        f'sources/{public_source.id}zzz/comment/{comment_id}',
+        f'sources/{public_source.id}zzz/comments/{comment_id}',
         token=comment_token,
     )
     assert status == 400
@@ -217,13 +217,13 @@ def test_delete_comment(comment_token, public_source):
 
     status, data = api(
         'DELETE',
-        f'sources/{public_source.id}/comment/{comment_id}',
+        f'sources/{public_source.id}/comments/{comment_id}',
         token=comment_token,
     )
     assert status == 200
 
     status, data = api(
-        'GET', f'sources/{public_source.id}/comment/{comment_id}', token=comment_token
+        'GET', f'sources/{public_source.id}/comments/{comment_id}', token=comment_token
     )
     assert status == 403
 
@@ -234,7 +234,7 @@ def test_problematic_put_comment_attachment_1275(
 
     status, data = api(
         'POST',
-        f'sources/{public_source.id}/comment',
+        f'sources/{public_source.id}/comments',
         data={
             'obj_id': public_source.id,
             'text': 'asdf',
@@ -248,7 +248,7 @@ def test_problematic_put_comment_attachment_1275(
     # need to specify both comment name and bytes
     status2, data2 = api(
         'PUT',
-        f'sources/{public_source.id}/comment/{data["data"]["comment_id"]}',
+        f'sources/{public_source.id}/comments/{data["data"]["comment_id"]}',
         data={
             "attachment_bytes": "eyJ0aW1lc3RhbXAiOiAiMjAyMC0xMS0wNFQxMjowMDowMyIsICJydW4iOiAxODM5LCAiZHVyYXRpb24iOiAwLjE0NiwgInJlc3VsdCI6IHsibW9kZWwiOiAic2FsdDIiLCAiZml0X2xjX3BhcmFtZXRlcnMiOiB7ImJvdW5kcyI6IHsiYyI6IFstMiwgNV0sICJ4MSI6IFstNSwgNV0sICJ6IjogWzAsIDAuMl19fSwgImZpdF9hY2NlcHRhYmxlIjogZmFsc2UsICJwbG90X2luZm8iOiAic2FsdDIgY2hpc3EgMjAuMjkgbmRvZiAxIG9rIGZpdCBGYWxzZSIsICJtb2RlbF9hbmFseXNpcyI6IHsiaGFzX3ByZW1heF9kYXRhIjogdHJ1ZSwgImhhc19wb3N0bWF4X2RhdGEiOiBmYWxzZSwgIngxX2luX3JhbmdlIjogdHJ1ZSwgIl94MV9yYW5nZSI6IFstNCwgNF0sICJjX29rIjogdHJ1ZSwgIl9jX3JhbmdlIjogWy0xLCAyXX0sICJmaXRfcmVzdWx0cyI6IHsieiI6IDAuMTE3NDM5NTYwNTE3MDEwNjUsICJ0MCI6IDI0NTkxNTguODE5NzYyNTE2MywgIngwIjogMC4wMDA2MDg1NTg3NzI2MjI5NDY3LCAieDEiOiAtMC44NzM1ODM5NTY4MTk5NjczLCAiYyI6IC0wLjA1OTg1NTgxMTY2MDA2MzE1LCAibXdlYnYiOiAwLjA5OTU2MTk1NjAzOTAzMTEyLCAibXdyX3YiOiAzLjEsICJ6LmVyciI6IDAuMDIxNTUyNTQwMzEyMzk1NDI0LCAidDAuZXJyIjogMC45NTczNDkzNTY0OTY3MDY2LCAieDAuZXJyIjogNi43NDYwMTY5NDY3ODk5NDllLTA1LCAieDEuZXJyIjogMC42NDc4NTA5NzU5ODY5OTY2LCAiYy5lcnIiOiAwLjEzNDQxMzAzNjM5NjQxMzU1fSwgInNuY29zbW9faW5mbyI6IHsic3VjY2VzcyI6IHRydWUsICJjaGlzcSI6IDIwLjI5NDAxNzkxMDExMjMxMywgIm5kb2YiOiAxLCAiY2hpc3Fkb2YiOiAyMC4yOTQwMTc5MTAxMTIzMTN9LCAiZmx1eF9kaWN0IjogeyJ6dGZnIjogWzAuMCwgLTAuMDQyNjA1ODU1NzUwNDczMzYsIC0wLjE1OTc2MzYxMjQ2NDMxOTQyLCAtMC41MDU5ODM5ODUzNTUyNDg1LCAtMC4xMDU5NzkwNDU0NzgyOTA4MywgMy44MjIzMDg5NDc0ODQ1NzEsIDEyLjE5Njc1NDg2NzEwMDE0NywgMjMuODgzNTQ0OTEzNTM0MTUsIDM4LjIyMzIzMjgyMDM3NzUyLCA1NS4wMTU0NjcyNzgyNzMwOCwgNzQuMzQyNTQxNDE2MzQ5MjIsIDk2LjMyNzQ1MzkzMzE2MDA5LCAxMjEuMjMwODU1MjE3MTg2ODMsIDE0OS42NzE5NzMzNDU4Mzg4NiwgMTc4LjU4NzEzMzY3MjU1MDI3LCAyMDUuMDcyMDU1NjU4Nzg4NDYsIDIyOC4wNTUzMTYwNjg0MjQsIDI0Ny4zNTIzMjM5ODA4Nzg1NywgMjYyLjYwOTI1MTk2MzQ1NzMsIDI3My45NjAxOTExOTE4NTEsIDI4Mi4wMTYzOTE3NTE3NzMsIDI4Ni4zNzI2Mjg3NjU4NjE2MywgMjg2LjY4ODcwMTAxODEzNDQ1LCAyODMuNTU0NTY3MTE3MzQ4MSwgMjc3LjY5MjY0NTUyNDYwODgsIDI2OS40ODM1NDU5ODQ2MTMzLCAyNTkuMTAxNDEyMTkxMjIwOCwgMjQ2Ljk2OTEyOTQ0OTc2NTE1LCAyMzMuODk5MTY4NzM2OTE5MjgsIDIyMC4xMzIyNzI0NjI2MDgzNCwgMjA1LjcxNjY4NzM5MzQxMzE0LCAxOTAuNTk3MTUyMDAzOTQzODUsIDE3NS41NTM4NDE0NDAyMjYyMiwgMTYxLjE2NTk5Mzk2NDQ1NDMyLCAxNDcuNTEwNTE3ODIyNjI0MTcsIDEzNC40NDYyMjA0NjIxODY5NCwgMTIxLjg5NDI1MDE3MDAxNDM5LCAxMDkuOTA0OTI2NzQzMDg2NzIsIDk4Ljg1ODU4MjA1NTk5MDE0LCA4OC44MjIyNDkyNDQ5ODgwNiwgNzkuODU1NDY1Nzk5NzkzOTMsIDcyLjA5NTcyMzMzMTQ2NzIsIDY1LjMwMjgyMzM5NDQzNzU3LCA1OS4yNTMxMjgyMDM2MzYzNDQsIDUzLjkyNjI2NjAzMjI5NDUyLCA0OS40MTk3OTAzMTc3NTMyOCwgNDUuNjc4NTQ4MjU5MDMwNjQsIDQyLjMxMjkyMDczNTM0MDk3LCAzOS4xMzUwNDI0OTI2NjEzMSwgMzYuMTc1NTQ2NTcyMTI5NywgMzMuNDI4OTg3OTU4MTgzNDUsIDMwLjkyODcxOTcyNjIzMzE4NywgMjguNzUyMjgxODYxNTg1NjQsIDI2LjkwMjQ3ODU5MDAzMDA5NiwgMjUuMzMzOTc4MzQ4MzEyMzYsIDI0LjAxMTA1NjIzOTM4MjkzNSwgMjIuOTAzODgyMjIyNjQwNTU0LCAyMS45ODU1MjExMDM5NjA1NTgsIDIxLjE4MzYxNTc5ODI1OTE3MiwgMjAuNDUyMjYzMDY5MTMwNDY3LCAxOS43ODQ2NDgxNDA4MjM3NTUsIDE5LjE3NTU1OTc1NTQwMzQyNywgMTguNjIwMzc0ODc2NTc1MjksIDE4LjExNTA4NTAxNDE3MjMxNSwgMTcuNjU2MjcwMzk5NzY4MzIsIDE3LjI0MDMyMDg1NjEyNTk5LCAxNi44NTkxMTMwMzUwMTQ1NzcsIDE2LjQ4NjE4ODc2Njc0MTY5OCwgMTYuMTE4OTQwODAyOTc3MDQ3LCAxNS43NTg0NzM3NDM2NDc4NjIsIDE1LjQwNTc0NTcwNDAwMTI0NiwgMTUuMDYxNzIzMzM0MjQ2MDQzLCAxNC43MjczODEwMjI5Nzk4MDQsIDE0LjQwMzY5NTMxNTY1OTUzLCAxNC4wOTE2Mzk5MTExNzczNTMsIDEzLjc5MjE4MTE0NDkwNTA1OCwgMTMuNTA2MjczODY5OTM1ODA3LCAxMy4yMzQ4Njg0ODM3Njc1MzksIDEyLjk4MTU3MzMxODc4OTYyN10sICJ6dGZyIjogWzAuMCwgMC4yMDkwMjkyNzU5Mzc3MzQ5LCAwLjc4ODc0NjQ5ODgxMDcwMzksIDEuNzIyNTcyMDQ5MDAyNDYxNCwgMy42OTI5MjkzMjcwMDQxNDMyLCA4Ljc5MDcxNTY1MDg1NDgwNSwgMTcuNjMyNDU0MDIxMTYyMzM1LCAyOS4yNTAwMTgzNTEwOTI2MTcsIDQzLjA2OTYyOTQwMjAzMDcxLCA1OC44MjcyMTA3OTA5ODU1NywgNzYuNDg2NjMwNDI0MzgxMzksIDk2LjE5OTQ4Mzk4ODEwOTcyLCAxMTguMjA0MzUzMTc5NjA4NSwgMTQzLjAwNzYzODUwNjUxMDY2LCAxNjguMzEyOTYwNzk1NjcyMDQsIDE5MS45NDMxNTA1MTU0NTUwNywgMjEzLjExMjQ5MjAxODQ1MDMsIDIzMS43MDU4NjcwOTQ1MjU0MiwgMjQ3LjQ3Nzg0MDIwMzIxNTYsIDI2MC41NjYzOTUwNzY4NzIzNywgMjcxLjQ3ODE4NDY2MTkwMjcsIDI3OS44ODk5NTU4MjU4NTQ1NCwgMjg1LjUzNjM3MjA2NjA5NTA1LCAyODguNTYwNDMyMzQ4MTA3ODQsIDI4OS4yMDkxODAzODM0NjU1LCAyODcuNjUwMjExNzU1NDQxNywgMjg0LjAxMjM5MTM1MDM1NTcsIDI3OC40MDEyNzQyOTkwNjQ1LCAyNzAuNzQ3ODQ1MjM1ODM2MTcsIDI2MS4yMDkzMzY3NjQxOTcyLCAyNDkuOTY1NDI1MjA5MDkzNjQsIDIzNi45OTYwODA4NDE3NDY1NiwgMjIzLjgyMjE4ODMwMjU3MjMsIDIxMS42MDIyMzAxOTM5NTMzMiwgMjAwLjU3Njg4NDg1MTY3NjUsIDE5MC41OTQ5NzcwNDMxMDUzMywgMTgxLjU4NjIyMjIwNDI1NTUzLCAxNzMuNDE4MDQxNzE4Nzc0NzMsIDE2NS43MzA3MDQ1NzY4OTE4NCwgMTU4LjQ4MjI5NTMyNDg2NTAyLCAxNTEuNjk5NTg5MDg1MzM3ODYsIDE0NS40NTE4MTQ5NDI5MDg2NywgMTM5LjU4NDA3NTMzMzM1MzIsIDEzMy45NTkxODY4MzI4Njg3NywgMTI4LjU3MzUxMzA2ODM0MDUsIDEyMy41MTE2ODQ3MzA1NTI0LCAxMTguNzIxNzkwNTIxMTI0MTMsIDExMy44MDQ0MDc3MTY2NDgyOSwgMTA4LjYwODM1NTg2NDcxNzEzLCAxMDMuMjQxMzg2NjgzMDIxNDUsIDk3Ljc2NTI0NjgyMjU0MDA4LCA5Mi4zMzM3MTQxNjc3MjA4MSwgODcuMTk3NDkyMjAyMTk5MDQsIDgyLjQyODMxMDQ2NDc4ODMyLCA3Ny45Nzc5MjUyNzYzNzA4OCwgNzMuODEwMDcxNTY1NjgzNjMsIDY5Ljg5MTk0NDMyNjg0OSwgNjYuMTk5MzM4MTkxNjMwNCwgNjIuODE0MDY4Mjk4NzQ1Njk2LCA1OS43NzUwOTExMzk3MjA2MywgNTcuMDUxMDcyNjc2ODk3MTUsIDU0LjYxNDMxOTc2NDU2NTM0NCwgNTIuNDQxMzM3NjgzNjU1NjYsIDUwLjUxMTUyNzYyMjUyMDkyLCA0OC44MDY4ODUwNDEwMjEyMiwgNDcuMzA5MjE5ODg4NjkxNjE1LCA0NS45ODU1MTU2NDIxNDYxNywgNDQuNzQxNDAwNjkzNDQ3MDQsIDQzLjU2MjcwOTkyODYwOTE2NiwgNDIuNDQ3OTkwOTkzNDI2OTksIDQxLjM5NTQ1MDExNjg4MzUsIDQwLjQwMzQzMDc2MDk2MTY4LCAzOS40NzA0MDYxMjgyMjcyNCwgMzguNTk0OTYwNzIwNjY3NCwgMzcuNzc1Nzc3NzI1ODY5OTQsIDM3LjAxMTYzMDk2NDg1NDUyNSwgMzYuMzAxMzgwMzgzNDY1NjU2LCAzNS42NDM5NTk0MzY0NjcxNSwgMzUuMDQzODYwODA3MzQ5ODk0XSwgIm9ic2pkIjogWzI0NTkxMzYuNDcwOTcxMzA2LCAyNDU5MTM3LjQ3MDk3MTMwNiwgMjQ1OTEzOC40NzA5NzEzMDYsIDI0NTkxMzkuNDcwOTcxMzA2LCAyNDU5MTQwLjQ3MDk3MTMwNiwgMjQ1OTE0MS40NzA5NzEzMDYsIDI0NTkxNDIuNDcwOTcxMzA2LCAyNDU5MTQzLjQ3MDk3MTMwNiwgMjQ1OTE0NC40NzA5NzEzMDYsIDI0NTkxNDUuNDcwOTcxMzA2LCAyNDU5MTQ2LjQ3MDk3MTMwNiwgMjQ1OTE0Ny40NzA5NzEzMDYsIDI0NTkxNDguNDcwOTcxMzA2LCAyNDU5MTQ5LjQ3MDk3MTMwNiwgMjQ1OTE1MC40NzA5NzEzMDYsIDI0NTkxNTEuNDcwOTcxMzA2LCAyNDU5MTUyLjQ3MDk3MTMwNiwgMjQ1OTE1My40NzA5NzEzMDYsIDI0NTkxNTQuNDcwOTcxMzA2LCAyNDU5MTU1LjQ3MDk3MTMwNiwgMjQ1OTE1Ni40NzA5NzEzMDYsIDI0NTkxNTcuNDcwOTcxMzA2LCAyNDU5MTU4LjQ3MDk3MTMwNiwgMjQ1OTE1OS40NzA5NzEzMDYsIDI0NTkxNjAuNDcwOTcxMzA2LCAyNDU5MTYxLjQ3MDk3MTMwNiwgMjQ1OTE2Mi40NzA5NzEzMDYsIDI0NTkxNjMuNDcwOTcxMzA2LCAyNDU5MTY0LjQ3MDk3MTMwNiwgMjQ1OTE2NS40NzA5NzEzMDYsIDI0NTkxNjYuNDcwOTcxMzA2LCAyNDU5MTY3LjQ3MDk3MTMwNiwgMjQ1OTE2OC40NzA5NzEzMDYsIDI0NTkxNjkuNDcwOTcxMzA2LCAyNDU5MTcwLjQ3MDk3MTMwNiwgMjQ1OTE3MS40NzA5NzEzMDYsIDI0NTkxNzIuNDcwOTcxMzA2LCAyNDU5MTczLjQ3MDk3MTMwNiwgMjQ1OTE3NC40NzA5NzEzMDYsIDI0NTkxNzUuNDcwOTcxMzA2LCAyNDU5MTc2LjQ3MDk3MTMwNiwgMjQ1OTE3Ny40NzA5NzEzMDYsIDI0NTkxNzguNDcwOTcxMzA2LCAyNDU5MTc5LjQ3MDk3MTMwNiwgMjQ1OTE4MC40NzA5NzEzMDYsIDI0NTkxODEuNDcwOTcxMzA2LCAyNDU5MTgyLjQ3MDk3MTMwNiwgMjQ1OTE4My40NzA5NzEzMDYsIDI0NTkxODQuNDcwOTcxMzA2LCAyNDU5MTg1LjQ3MDk3MTMwNiwgMjQ1OTE4Ni40NzA5NzEzMDYsIDI0NTkxODcuNDcwOTcxMzA2LCAyNDU5MTg4LjQ3MDk3MTMwNiwgMjQ1OTE4OS40NzA5NzEzMDYsIDI0NTkxOTAuNDcwOTcxMzA2LCAyNDU5MTkxLjQ3MDk3MTMwNiwgMjQ1OTE5Mi40NzA5NzEzMDYsIDI0NTkxOTMuNDcwOTcxMzA2LCAyNDU5MTk0LjQ3MDk3MTMwNiwgMjQ1OTE5NS40NzA5NzEzMDYsIDI0NTkxOTYuNDcwOTcxMzA2LCAyNDU5MTk3LjQ3MDk3MTMwNiwgMjQ1OTE5OC40NzA5NzEzMDYsIDI0NTkxOTkuNDcwOTcxMzA2LCAyNDU5MjAwLjQ3MDk3MTMwNiwgMjQ1OTIwMS40NzA5NzEzMDYsIDI0NTkyMDIuNDcwOTcxMzA2LCAyNDU5MjAzLjQ3MDk3MTMwNiwgMjQ1OTIwNC40NzA5NzEzMDYsIDI0NTkyMDUuNDcwOTcxMzA2LCAyNDU5MjA2LjQ3MDk3MTMwNiwgMjQ1OTIwNy40NzA5NzEzMDYsIDI0NTkyMDguNDcwOTcxMzA2LCAyNDU5MjA5LjQ3MDk3MTMwNiwgMjQ1OTIxMC40NzA5NzEzMDYsIDI0NTkyMTEuNDcwOTcxMzA2LCAyNDU5MjEyLjQ3MDk3MTMwNiwgMjQ1OTIxMy40NzA5NzEzMDYsIDI0NTkyMTQuNDcwOTcxMzA2XX19fQ=="
         },
@@ -265,7 +265,7 @@ def test_problematic_put_comment_attachment_1275(
 
     status2, data2 = api(
         'PUT',
-        f'sources/{public_source.id}/comment/{data["data"]["comment_id"]}',
+        f'sources/{public_source.id}/comments/{data["data"]["comment_id"]}',
         data=payload,
         token=super_admin_token,
     )
@@ -275,7 +275,7 @@ def test_problematic_put_comment_attachment_1275(
 
     status3, data3 = api(
         'GET',
-        f'sources/{public_source.id}/comment/{data["data"]["comment_id"]}',
+        f'sources/{public_source.id}/comments/{data["data"]["comment_id"]}',
         token=super_admin_token,
     )
     assert status3 == 200
@@ -290,7 +290,7 @@ def test_problematic_post_comment_attachment_1275(
 
     status, data = api(
         'POST',
-        f'sources/{public_source.id}/comment',
+        f'sources/{public_source.id}/comments',
         data={
             'obj_id': public_source.id,
             'text': 'asdf',

--- a/skyportal/tests/api/test_comments_on_spectrum.py
+++ b/skyportal/tests/api/test_comments_on_spectrum.py
@@ -23,7 +23,7 @@ def test_add_and_retrieve_comment_group_id(
 
     status, data = api(
         'POST',
-        f'spectrum/{spectrum_id}/comment',
+        f'spectra/{spectrum_id}/comments',
         data={
             'obj_id': public_source.id,
             'spectrum_id': spectrum_id,
@@ -36,7 +36,7 @@ def test_add_and_retrieve_comment_group_id(
     comment_id = data['data']['comment_id']
 
     status, data = api(
-        'GET', f'spectrum/{spectrum_id}/comment/{comment_id}', token=comment_token
+        'GET', f'spectra/{spectrum_id}/comments/{comment_id}', token=comment_token
     )
 
     assert status == 200
@@ -71,7 +71,7 @@ def test_add_and_retrieve_comment_group_access(
 
     status, data = api(
         'POST',
-        f'spectrum/{spectrum_id}/comment',
+        f'spectra/{spectrum_id}/comments',
         data={
             'obj_id': public_source_two_groups.id,
             'spectrum_id': spectrum_id,
@@ -86,7 +86,7 @@ def test_add_and_retrieve_comment_group_access(
     # This token belongs to public_group2
     status, data = api(
         'GET',
-        f'spectrum/{spectrum_id}/comment/{comment_id}',
+        f'spectra/{spectrum_id}/comments/{comment_id}',
         token=comment_token_two_groups,
     )
     assert status == 200
@@ -94,14 +94,14 @@ def test_add_and_retrieve_comment_group_access(
 
     # This token does not belong to public_group2
     status, data = api(
-        'GET', f'spectrum/{spectrum_id}/comment/{comment_id}', token=comment_token
+        'GET', f'spectra/{spectrum_id}/comments/{comment_id}', token=comment_token
     )
     assert status == 403
 
     # Both tokens should be able to view this comment, but not the underlying spectrum
     status, data = api(
         'POST',
-        f'spectrum/{spectrum_id}/comment',
+        f'spectra/{spectrum_id}/comments',
         data={
             'obj_id': public_source_two_groups.id,
             'spectrum_id': spectrum_id,
@@ -115,14 +115,14 @@ def test_add_and_retrieve_comment_group_access(
 
     status, data = api(
         'GET',
-        f'spectrum/{spectrum_id}/comment/{comment_id}',
+        f'spectra/{spectrum_id}/comments/{comment_id}',
         token=comment_token_two_groups,
     )
     assert status == 200
     assert data['data']['text'] == 'Comment text'
 
     status, data = api(
-        'GET', f'spectrum/{spectrum_id}/comment/{comment_id}', token=comment_token
+        'GET', f'spectra/{spectrum_id}/comments/{comment_id}', token=comment_token
     )
     assert status == 403  # the underlying spectrum is not accessible to group1
 
@@ -146,7 +146,7 @@ def test_add_and_retrieve_comment_group_access(
 
     status, data = api(
         'POST',
-        f'spectrum/{spectrum_id}/comment',
+        f'spectra/{spectrum_id}/comments',
         data={
             'obj_id': public_source_two_groups.id,
             'spectrum_id': spectrum_id,
@@ -160,14 +160,14 @@ def test_add_and_retrieve_comment_group_access(
 
     # token for group1 can view the spectrum but cannot see comment
     status, data = api(
-        'GET', f'spectrum/{spectrum_id}/comment/{comment_id}', token=comment_token
+        'GET', f'spectra/{spectrum_id}/comments/{comment_id}', token=comment_token
     )
     assert status == 403
 
     # Both tokens should be able to view comment after updating group list
     status, data = api(
         'PUT',
-        f'spectrum/{spectrum_id}/comment/{comment_id}',
+        f'spectra/{spectrum_id}/comments/{comment_id}',
         data={
             'text': 'New comment text',
             'group_ids': [public_group.id, public_group2.id],
@@ -178,7 +178,7 @@ def test_add_and_retrieve_comment_group_access(
 
     # the new comment on the new spectrum should now accessible
     status, data = api(
-        'GET', f'spectrum/{spectrum_id}/comment/{comment_id}', token=comment_token
+        'GET', f'spectra/{spectrum_id}/comments/{comment_id}', token=comment_token
     )
     assert status == 200
     assert data['data']['text'] == 'New comment text'
@@ -206,7 +206,7 @@ def test_cannot_add_comment_without_permission(
 
     status, data = api(
         'POST',
-        f'spectrum/{spectrum_id}/comment',
+        f'spectra/{spectrum_id}/comments',
         data={
             'obj_id': public_source.id,
             'spectrum_id': spectrum_id,
@@ -238,7 +238,7 @@ def test_delete_comment(comment_token, upload_data_token, public_source, lris):
 
     status, data = api(
         'POST',
-        f'spectrum/{spectrum_id}/comment',
+        f'spectra/{spectrum_id}/comments',
         data={
             'obj_id': public_source.id,
             'spectrum_id': spectrum_id,
@@ -250,14 +250,14 @@ def test_delete_comment(comment_token, upload_data_token, public_source, lris):
     comment_id = data['data']['comment_id']
 
     status, data = api(
-        'GET', f'spectrum/{spectrum_id}/comment/{comment_id}', token=comment_token
+        'GET', f'spectra/{spectrum_id}/comments/{comment_id}', token=comment_token
     )
     assert status == 200
     assert data['data']['text'] == 'Comment text'
 
     # try to delete using the wrong spectrum ID
     status, data = api(
-        'DELETE', f'spectrum/{spectrum_id+1}/comment/{comment_id}', token=comment_token
+        'DELETE', f'spectra/{spectrum_id+1}/comments/{comment_id}', token=comment_token
     )
     assert status == 400
     assert (
@@ -266,11 +266,11 @@ def test_delete_comment(comment_token, upload_data_token, public_source, lris):
     )
 
     status, data = api(
-        'DELETE', f'spectrum/{spectrum_id}/comment/{comment_id}', token=comment_token
+        'DELETE', f'spectra/{spectrum_id}/comments/{comment_id}', token=comment_token
     )
     assert status == 200
 
     status, data = api(
-        'GET', f'spectrum/{spectrum_id}/comment/{comment_id}', token=comment_token
+        'GET', f'spectra/{spectrum_id}/comments/{comment_id}', token=comment_token
     )
     assert status == 403

--- a/skyportal/tests/frontend/sources_and_followup_etc/test_source_list.py
+++ b/skyportal/tests/frontend/sources_and_followup_etc/test_source_list.py
@@ -389,7 +389,7 @@ def test_hr_diagram(
 
     status, data = api(
         'POST',
-        f'sources/{source_id}/annotation',
+        f'sources/{source_id}/annotations',
         data={
             'obj_id': source_id,
             'origin': 'cross_match1',

--- a/skyportal/tests/frontend/sources_and_followup_etc/test_sources.py
+++ b/skyportal/tests/frontend/sources_and_followup_etc/test_sources.py
@@ -634,7 +634,7 @@ def test_source_hr_diagram(driver, user, public_source, annotation_token):
 
     status, data = api(
         'POST',
-        f'sources/{public_source.id}/annotation',
+        f'sources/{public_source.id}/annotations',
         data={
             'obj_id': public_source.id,
             'origin': 'cross_match1',

--- a/skyportal/tests/frontend/test_newsfeed.py
+++ b/skyportal/tests/frontend/test_newsfeed.py
@@ -28,7 +28,7 @@ def test_news_feed(driver, user, public_group, upload_data_token, comment_token)
 
         status, data = api(
             'POST',
-            f'sources/{obj_id_base}_{i}/comment',
+            f'sources/{obj_id_base}_{i}/comments',
             data={'obj_id': f'{obj_id_base}_{i}', 'text': f'comment_text_{i}'},
             token=comment_token,
         )
@@ -76,7 +76,7 @@ def test_news_feed_prefs_widget(
 
         status, data = api(
             'POST',
-            f'sources/{obj_id_base}_{i}/comment',
+            f'sources/{obj_id_base}_{i}/comments',
             data={'obj_id': f'{obj_id_base}_{i}', 'text': f'comment_text_{i}'},
             token=comment_token,
         )

--- a/skyportal/tests/frontend/test_scanning_page.py
+++ b/skyportal/tests/frontend/test_scanning_page.py
@@ -323,7 +323,7 @@ def test_submit_annotations_sorting(
     origin = str(uuid.uuid4())[:5]
     status, data = api(
         "POST",
-        f"sources/{public_candidate.id}/annotation",
+        f"sources/{public_candidate.id}/annotations",
         data={
             "obj_id": public_candidate.id,
             "origin": origin,
@@ -334,7 +334,7 @@ def test_submit_annotations_sorting(
     assert status == 200
     status, data = api(
         "POST",
-        f"sources/{public_candidate2.id}/annotation",
+        f"sources/{public_candidate2.id}/annotations",
         data={
             "obj_id": public_candidate2.id,
             "origin": origin,
@@ -388,7 +388,7 @@ def test_submit_annotations_filtering(
     origin = str(uuid.uuid4())
     status, data = api(
         "POST",
-        f"sources/{public_candidate.id}/annotation",
+        f"sources/{public_candidate.id}/annotations",
         data={
             "obj_id": public_candidate.id,
             "origin": origin,
@@ -399,7 +399,7 @@ def test_submit_annotations_filtering(
     assert status == 200
     status, data = api(
         "POST",
-        f"sources/{public_candidate2.id}/annotation",
+        f"sources/{public_candidate2.id}/annotations",
         data={
             "obj_id": public_candidate2.id,
             "origin": origin,
@@ -660,7 +660,7 @@ def test_add_scanning_profile(
     # Post an annotation to the test source, to test setting annotation sorting
     status, _ = api(
         'POST',
-        f'sources/{public_source.id}/annotation',
+        f'sources/{public_source.id}/annotations',
         data={
             'obj_id': public_source.id,
             'origin': 'kowalski',

--- a/static/js/components/CommentAttachmentPreview.jsx
+++ b/static/js/components/CommentAttachmentPreview.jsx
@@ -165,7 +165,7 @@ const CommentAttachmentPreview = ({
   }
 
   // The FilePreviewer expects a url ending with .pdf for PDF files
-  const baseUrl = `/api/${associatedResourceType}/${objectID}/comment/${commentId}/attachment`;
+  const baseUrl = `/api/${associatedResourceType}/${objectID}/comments/${commentId}/attachment`;
   const url = fileType === "pdf" ? `${baseUrl}.pdf` : baseUrl;
 
   return (

--- a/static/js/ducks/source.js
+++ b/static/js/ducks/source.js
@@ -87,7 +87,7 @@ export function addComment(formData) {
         if (formData.spectrum_id) {
           dispatch(
             API.POST(
-              `/api/spectrum/${formData.spectrum_id}/comment`,
+              `/api/spectra/${formData.spectrum_id}/comments`,
               ADD_COMMENT,
               formData
             )
@@ -95,7 +95,7 @@ export function addComment(formData) {
         } else {
           dispatch(
             API.POST(
-              `/api/sources/${formData.obj_id}/comment`,
+              `/api/sources/${formData.obj_id}/comments`,
               ADD_COMMENT,
               formData
             )
@@ -106,13 +106,13 @@ export function addComment(formData) {
   }
   if (formData.spectrum_id) {
     return API.POST(
-      `/api/spectrum/${formData.spectrum_id}/comment`,
+      `/api/spectra/${formData.spectrum_id}/comments`,
       ADD_COMMENT,
       formData
     );
   }
   return API.POST(
-    `/api/sources/${formData.obj_id}/comment`,
+    `/api/sources/${formData.obj_id}/comments`,
     ADD_COMMENT,
     formData
   );
@@ -120,28 +120,28 @@ export function addComment(formData) {
 
 export function deleteComment(sourceID, commentID) {
   return API.DELETE(
-    `/api/sources/${sourceID}/comment/${commentID}`,
+    `/api/sources/${sourceID}/comments/${commentID}`,
     DELETE_COMMENT
   );
 }
 
 export function deleteCommentOnSpectrum(spectrumID, commentID) {
   return API.DELETE(
-    `/api/spectrum/${spectrumID}/comment/${commentID}`,
+    `/api/spectra/${spectrumID}/comments/${commentID}`,
     DELETE_COMMENT_ON_SPECTRUM
   );
 }
 
 export function getCommentAttachment(sourceID, commentID) {
   return API.GET(
-    `/api/sources/${sourceID}/comment/${commentID}/attachment`,
+    `/api/sources/${sourceID}/comments/${commentID}/attachment`,
     GET_COMMENT_ATTACHMENT
   );
 }
 
 export function getCommentOnSpectrumAttachment(spectrumID, commentID) {
   return API.GET(
-    `/api/spectrum/${spectrumID}/comment/${commentID}/attachment`,
+    `/api/spectra/${spectrumID}/comments/${commentID}/attachment`,
     GET_COMMENT_ON_SPECTRUM_ATTACHMENT
   );
 }


### PR DESCRIPTION
This patch updates the comments API endpoints such that
we consistently use plural nouns when specifying resources,
e.g. `api/sources/<source_id>/comments/<comment_id>`.

We also add `api/spectra` in addition to the existing (now
deprecated) `api/spectrum` endpoint. Tests and demo data yaml
are updated.