### PR TITLE
Add handler for GET api/{sources,spectra}/comments endpoint

### DIFF
--- a/skyportal/handlers/api/annotation.py
+++ b/skyportal/handlers/api/annotation.py
@@ -56,10 +56,23 @@ class AnnotationHandler(BaseHandler):
             - sources
           parameters:
             - in: path
-              name: obj_id
+              name: associated_resource_type
               required: true
               schema:
                 type: string
+                enum: [sources]
+              description: |
+                 What underlying data the annotation is on:
+                 currently only "sources" is supported.
+            - in: path
+              name: resource_id
+              required: true
+              schema:
+                type: string
+              description: |
+                 The ID of the underlying data.
+                 This would be a string for a source ID
+                 or an integer for other data types like spectrum.
           responses:
             200:
               content:

--- a/skyportal/tests/api/test_annotations.py
+++ b/skyportal/tests/api/test_annotations.py
@@ -397,3 +397,29 @@ def test_post_invalid_data(annotation_token, public_source, public_group):
 
     assert status == 400
     assert 'Invalid data' in data["message"]
+
+
+def test_fetch_all_annotations_on_obj(annotation_token, public_source, public_group):
+    status, data = api(
+        'POST',
+        f'sources/{public_source.id}/annotations',
+        data={
+            'obj_id': public_source.id,
+            'origin': 'kowalski',
+            'data': {'offset_from_host_galaxy': 1.5},
+            'group_ids': [public_group.id],
+        },
+        token=annotation_token,
+    )
+    assert status == 200
+
+    status, data = api(
+        'GET',
+        f'sources/{public_source.id}/annotations',
+        token=annotation_token,
+    )
+
+    assert status == 200
+    assert len(data['data']) == 1
+    assert data['data'][0]['data'] == {'offset_from_host_galaxy': 1.5}
+    assert data['data'][0]['origin'] == 'kowalski'

--- a/skyportal/tests/api/test_comments.py
+++ b/skyportal/tests/api/test_comments.py
@@ -1,3 +1,4 @@
+import uuid
 from skyportal.tests import api
 
 
@@ -304,3 +305,21 @@ def test_problematic_post_comment_attachment_1275(
     )
     assert status == 200
     assert data['status'] == 'success'
+
+
+def test_fetch_all_comments_on_obj(comment_token, public_source):
+    comment_text = str(uuid.uuid4())
+    status, data = api(
+        'POST',
+        f'sources/{public_source.id}/comments',
+        data={'obj_id': public_source.id, 'text': comment_text},
+        token=comment_token,
+    )
+    assert status == 200
+
+    status, data = api(
+        'GET', f'sources/{public_source.id}/comments', token=comment_token
+    )
+
+    assert status == 200
+    assert any([comment['text'] == comment_text for comment in data['data']])


### PR DESCRIPTION
This patch adds a handler for fetching all comments associated with
the specified resource (obj, spectrum), and adds tests for this
handler as well as the already-existing annotations handler.