### PR TITLE
Do not require obj_id in annotation POST payload

### DIFF
--- a/skyportal/handlers/api/annotation.py
+++ b/skyportal/handlers/api/annotation.py
@@ -179,7 +179,6 @@ class AnnotationHandler(BaseHandler):
                       groups.
 
                 required:
-                  - obj_id
                   - origin
                   - data
         responses:

--- a/skyportal/handlers/api/annotation.py
+++ b/skyportal/handlers/api/annotation.py
@@ -199,6 +199,8 @@ class AnnotationHandler(BaseHandler):
                               description: New annotation ID
         """
         data = self.get_json()
+        if associated_resource_type == "sources":
+            data["obj_id"] = resource_id
         group_ids = data.pop('group_ids', None)
         if not group_ids:
             groups = self.current_user.accessible_groups

--- a/skyportal/tests/api/test_annotations.py
+++ b/skyportal/tests/api/test_annotations.py
@@ -9,7 +9,6 @@ def test_post_without_origin_fails(annotation_token, public_source, public_group
         'POST',
         f'sources/{public_source.id}/annotations',
         data={
-            'obj_id': public_source.id,
             'data': {'offset_from_host_galaxy': 1.5},
             'group_ids': [public_group.id],
         },
@@ -24,7 +23,6 @@ def test_post_without_origin_fails(annotation_token, public_source, public_group
         'POST',
         f'sources/{public_source.id}/annotations',
         data={
-            'obj_id': public_source.id,
             'origin': '',
             'data': {'offset_from_host_galaxy': 1.5},
             'group_ids': [public_group.id],
@@ -43,7 +41,6 @@ def test_post_same_origin_fails(annotation_token, public_source, public_group):
         'POST',
         f'sources/{public_source.id}/annotations',
         data={
-            'obj_id': public_source.id,
             'origin': 'kowalski',
             'data': {'offset_from_host_galaxy': 1.5},
             'group_ids': [public_group.id],
@@ -59,7 +56,6 @@ def test_post_same_origin_fails(annotation_token, public_source, public_group):
         'POST',
         f'sources/{public_source.id}/annotations',
         data={
-            'obj_id': public_source.id,
             'origin': 'kowalski',
             'data': {'offset_from_host_galaxy': 1.5},
             'group_ids': [public_group.id],
@@ -78,7 +74,6 @@ def test_add_and_retrieve_annotation_group_id(
         'POST',
         f'sources/{public_source.id}/annotations',
         data={
-            'obj_id': public_source.id,
             'origin': 'kowalski',
             'data': {'offset_from_host_galaxy': 1.5},
             'group_ids': [public_group.id],
@@ -104,7 +99,6 @@ def test_add_and_retrieve_annotation_no_group_id(annotation_token, public_source
         'POST',
         f'sources/{public_source.id}/annotations',
         data={
-            'obj_id': public_source.id,
             'origin': 'kowalski',
             'data': {'offset_from_host_galaxy': 1.5},
         },
@@ -135,7 +129,6 @@ def test_add_and_retrieve_annotation_group_access(
         'POST',
         f'sources/{public_source_two_groups.id}/annotations',
         data={
-            'obj_id': public_source_two_groups.id,
             'origin': 'kowalski',
             'data': {'offset_from_host_galaxy': 1.5},
             'group_ids': [public_group2.id],
@@ -169,7 +162,6 @@ def test_add_and_retrieve_annotation_group_access(
         'POST',
         f'sources/{public_source_two_groups.id}/annotations',
         data={
-            'obj_id': public_source_two_groups.id,
             'origin': 'GAIA',
             'data': {'offset_from_host_galaxy': 1.5},
             'group_ids': [public_group.id, public_group2.id],
@@ -209,7 +201,6 @@ def test_update_annotation_group_list(
         'POST',
         f'sources/{public_source_two_groups.id}/annotations',
         data={
-            'obj_id': public_source_two_groups.id,
             'origin': 'kowalski',
             'data': {'offset_from_host_galaxy': 1.5},
             'group_ids': [public_group2.id],
@@ -271,7 +262,6 @@ def test_cannot_add_annotation_without_permission(view_only_token, public_source
         'POST',
         f'sources/{public_source.id}/annotations',
         data={
-            'obj_id': public_source.id,
             'origin': 'kowalski',
             'data': {'offset_from_host_galaxy': 1.5},
         },
@@ -288,7 +278,6 @@ def test_delete_annotation(annotation_token, public_source):
         'POST',
         f'sources/{public_source.id}/annotations',
         data={
-            'obj_id': public_source.id,
             'origin': origin,
             'data': {'offset_from_host_galaxy': 1.5},
         },
@@ -340,7 +329,6 @@ def test_obj_annotations(annotation_token, public_source, public_group):
         'POST',
         f'sources/{public_source.id}/annotations',
         data={
-            'obj_id': public_source.id,
             'origin': origin,
             'data': {'offset_from_host_galaxy': 1.5},
         },
@@ -371,7 +359,6 @@ def test_cannot_add_annotation_without_data(
         'POST',
         f'sources/{public_source.id}/annotations',
         data={
-            'obj_id': public_source.id,
             'origin': 'kowalski',
             'group_ids': [public_group.id],
         },
@@ -387,7 +374,6 @@ def test_post_invalid_data(annotation_token, public_source, public_group):
         'POST',
         f'sources/{public_source.id}/annotations',
         data={
-            'obj_id': public_source.id,
             'data': "Test",
             'origin': origin,
             'group_ids': [public_group.id],
@@ -404,7 +390,6 @@ def test_fetch_all_annotations_on_obj(annotation_token, public_source, public_gr
         'POST',
         f'sources/{public_source.id}/annotations',
         data={
-            'obj_id': public_source.id,
             'origin': 'kowalski',
             'data': {'offset_from_host_galaxy': 1.5},
             'group_ids': [public_group.id],

--- a/skyportal/tests/api/test_comments.py
+++ b/skyportal/tests/api/test_comments.py
@@ -7,7 +7,6 @@ def test_add_and_retrieve_comment_group_id(comment_token, public_source, public_
         'POST',
         f'sources/{public_source.id}/comments',
         data={
-            'obj_id': public_source.id,
             'text': 'Comment text',
             'group_ids': [public_group.id],
         },
@@ -29,7 +28,7 @@ def test_add_and_retrieve_comment_no_group_id(comment_token, public_source):
     status, data = api(
         'POST',
         f'sources/{public_source.id}/comments',
-        data={'obj_id': public_source.id, 'text': 'Comment text'},
+        data={'text': 'Comment text'},
         token=comment_token,
     )
     assert status == 200
@@ -54,7 +53,6 @@ def test_add_and_retrieve_comment_group_access(
         'POST',
         f'sources/{public_source_two_groups.id}/comments',
         data={
-            'obj_id': public_source_two_groups.id,
             'text': 'Comment text',
             'group_ids': [public_group2.id],
         },
@@ -85,7 +83,6 @@ def test_add_and_retrieve_comment_group_access(
         'POST',
         f'sources/{public_source_two_groups.id}/comments',
         data={
-            'obj_id': public_source_two_groups.id,
             'text': 'Comment text',
             'group_ids': [public_group.id, public_group2.id],
         },
@@ -122,7 +119,6 @@ def test_update_comment_group_list(
         'POST',
         f'sources/{public_source_two_groups.id}/comments',
         data={
-            'obj_id': public_source_two_groups.id,
             'text': 'Comment text',
             'group_ids': [public_group2.id],
         },
@@ -181,7 +177,7 @@ def test_cannot_add_comment_without_permission(view_only_token, public_source):
     status, data = api(
         'POST',
         f'sources/{public_source.id}/comments',
-        data={'obj_id': public_source.id, 'text': 'Comment text'},
+        data={'text': 'Comment text'},
         token=view_only_token,
     )
     assert status == 400
@@ -192,7 +188,7 @@ def test_delete_comment(comment_token, public_source):
     status, data = api(
         'POST',
         f'sources/{public_source.id}/comments',
-        data={'obj_id': public_source.id, 'text': 'Comment text'},
+        data={'text': 'Comment text'},
         token=comment_token,
     )
     assert status == 200
@@ -237,7 +233,6 @@ def test_problematic_put_comment_attachment_1275(
         'POST',
         f'sources/{public_source.id}/comments',
         data={
-            'obj_id': public_source.id,
             'text': 'asdf',
             'group_ids': [public_group.id],
         },
@@ -293,7 +288,6 @@ def test_problematic_post_comment_attachment_1275(
         'POST',
         f'sources/{public_source.id}/comments',
         data={
-            'obj_id': public_source.id,
             'text': 'asdf',
             'group_ids': [public_group.id],
             "attachment": {
@@ -312,7 +306,7 @@ def test_fetch_all_comments_on_obj(comment_token, public_source):
     status, data = api(
         'POST',
         f'sources/{public_source.id}/comments',
-        data={'obj_id': public_source.id, 'text': comment_text},
+        data={'text': comment_text},
         token=comment_token,
     )
     assert status == 200

--- a/skyportal/tests/api/test_comments_on_spectrum.py
+++ b/skyportal/tests/api/test_comments_on_spectrum.py
@@ -27,7 +27,6 @@ def test_add_and_retrieve_comment_group_id(
         'POST',
         f'spectra/{spectrum_id}/comments',
         data={
-            'obj_id': public_source.id,
             'spectrum_id': spectrum_id,
             'text': 'Comment text',
             'group_ids': [public_group.id],
@@ -75,7 +74,6 @@ def test_add_and_retrieve_comment_group_access(
         'POST',
         f'spectra/{spectrum_id}/comments',
         data={
-            'obj_id': public_source_two_groups.id,
             'spectrum_id': spectrum_id,
             'text': 'Comment text',
             'group_ids': [public_group2.id],
@@ -105,7 +103,6 @@ def test_add_and_retrieve_comment_group_access(
         'POST',
         f'spectra/{spectrum_id}/comments',
         data={
-            'obj_id': public_source_two_groups.id,
             'spectrum_id': spectrum_id,
             'text': 'Comment text',
             'group_ids': [public_group.id, public_group2.id],
@@ -150,7 +147,6 @@ def test_add_and_retrieve_comment_group_access(
         'POST',
         f'spectra/{spectrum_id}/comments',
         data={
-            'obj_id': public_source_two_groups.id,
             'spectrum_id': spectrum_id,
             'text': 'New comment text',
             'group_ids': [public_group2.id],
@@ -210,7 +206,6 @@ def test_cannot_add_comment_without_permission(
         'POST',
         f'spectra/{spectrum_id}/comments',
         data={
-            'obj_id': public_source.id,
             'spectrum_id': spectrum_id,
             'text': 'Comment text',
         },
@@ -242,7 +237,6 @@ def test_delete_comment(comment_token, upload_data_token, public_source, lris):
         'POST',
         f'spectra/{spectrum_id}/comments',
         data={
-            'obj_id': public_source.id,
             'spectrum_id': spectrum_id,
             'text': 'Comment text',
         },
@@ -302,7 +296,6 @@ def test_fetch_all_spectrum_comments(
         'POST',
         f'spectra/{spectrum_id}/comments',
         data={
-            'obj_id': public_source.id,
             'spectrum_id': spectrum_id,
             'text': comment_text,
             'group_ids': [public_group.id],


### PR DESCRIPTION
This is already provided in the request URL.

Closes https://github.com/skyportal/skyportal/issues/2330 