### PR TITLE
Explicitly require react-resizable in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "react-json-view": "1.21.3",
     "react-markdown": "4.3.1",
     "react-redux": "7.2.4",
+    "react-resizable": "3.0.4",
     "react-responsive": "8.2.0",
     "react-router-dom": "5.3.0",
     "react-simple-dropdown": "3.2.3",


### PR DESCRIPTION
In some installations, this package was missing after
running `make run`, causing webpack bundling to fail.