### PR TITLE
Provide valid user ID to thumbnail gen routine

### DIFF
--- a/skyportal/handlers/api/candidate.py
+++ b/skyportal/handlers/api/candidate.py
@@ -1031,7 +1031,7 @@ class CandidateHandler(BaseHandler):
             IOLoop.current().run_in_executor(
                 None,
                 lambda: add_linked_thumbnails_and_push_ws_msg(
-                    obj.id, self.current_user.id
+                    obj.id, self.associated_user_object.id
                 ),
             )
 

--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -707,7 +707,7 @@ class SourceHandler(BaseHandler):
                     IOLoop.current().run_in_executor(
                         None,
                         lambda: add_ps1_thumbnail_and_push_ws_msg(
-                            obj_id, self.current_user.id
+                            obj_id, self.associated_user_object.id
                         ),
                     )
                 if (
@@ -717,7 +717,7 @@ class SourceHandler(BaseHandler):
                     IOLoop.current().run_in_executor(
                         None,
                         lambda: add_linked_thumbnails_and_push_ws_msg(
-                            obj_id, self.current_user.id
+                            obj_id, self.associated_user_object.id
                         ),
                     )
             if include_comments:
@@ -1454,7 +1454,7 @@ class SourceHandler(BaseHandler):
             IOLoop.current().run_in_executor(
                 None,
                 lambda: add_linked_thumbnails_and_push_ws_msg(
-                    obj.id, self.current_user.id
+                    obj.id, self.associated_user_object.id
                 ),
             )
         else:
@@ -2136,6 +2136,8 @@ class PS1ThumbnailHandler(BaseHandler):
         if obj_id is None:
             return self.error("Missing required parameter objID")
         IOLoop.current().add_callback(
-            lambda: add_ps1_thumbnail_and_push_ws_msg(obj_id, self.current_user.id)
+            lambda: add_ps1_thumbnail_and_push_ws_msg(
+                obj_id, self.associated_user_object.id
+            )
         )
         return self.success()


### PR DESCRIPTION
This patch ensures that a valid user ID is always provided
to the thumbnail generation routine in the case that the request
is initiated by a token.

Resolves errors like the following:
```
[10:33:35 api/candidate] Unable to add linked thumbnails to ZTFJ201825+380316: (psycopg2.errors.InvalidTextRepresentation) 
invalid input syntax for type integer: "856bab7b-15f9-4ba1-b302-f091ab8ce15b"                                                      
LINE 3: WHERE users.id = '856bab7b-15f9-4ba1-b302-f091ab8ce15b'                                                                
```