### PR TITLE
Toggle switch for enabling probability normalization in MultipleClassificationForm

### DIFF
--- a/static/js/components/MultipleClassificationsForm.jsx
+++ b/static/js/components/MultipleClassificationsForm.jsx
@@ -109,11 +109,18 @@ const MultipleClassificationsForm = ({
   });
   const sortedClassifications = getSortedClasses(currentClassifications);
 
+  const normalizeProbabilities = useSelector(
+    (state) => state.classifications.normalizeProbabilities
+  );
+
   const [normalizeProbabilitiesChecked, setNormalizeProbabilitiesChecked] =
-    useState(true);
+    useState(normalizeProbabilities);
 
   const handleNormalizeProbabilitiesSwitchChange = (event) => {
     setNormalizeProbabilitiesChecked(event.target.checked);
+    dispatch(
+      ClassificationsActions.setNormalizeProbabilities(event.target.checked)
+    );
   };
 
   // For each existing taxonomy/classification, update initial sliders
@@ -487,7 +494,7 @@ const MultipleClassificationsForm = ({
         <FormControlLabel
           control={
             <Switch
-              checked={normalizeProbabilitiesChecked}
+              checked={normalizeProbabilities || false}
               onChange={handleNormalizeProbabilitiesSwitchChange}
               inputProps={{ "aria-label": "controlled" }}
             />

--- a/static/js/ducks/classifications.js
+++ b/static/js/ducks/classifications.js
@@ -1,11 +1,18 @@
 import store from "../store";
 
 const SET_TAXONOMY = "skyportal/SET_TAXONOMY";
+const SET_NORMALIZE_PROBABILITIES = "skyportal/SET_NORMALIZE_PROBABILITIES";
 
 // eslint-disable-next-line import/prefer-default-export
 export const setTaxonomy = (taxonomy) => ({
   type: SET_TAXONOMY,
   taxonomy,
+});
+
+// eslint-disable-next-line import/prefer-default-export
+export const setNormalizeProbabilities = (normalizeProbabilities) => ({
+  type: SET_NORMALIZE_PROBABILITIES,
+  normalizeProbabilities,
 });
 
 const reducer = (state = { rotateLogo: false }, action) => {
@@ -15,6 +22,13 @@ const reducer = (state = { rotateLogo: false }, action) => {
       return {
         ...state,
         taxonomy,
+      };
+    }
+    case SET_NORMALIZE_PROBABILITIES: {
+      const { normalizeProbabilities } = action;
+      return {
+        ...state,
+        normalizeProbabilities,
       };
     }
     default:


### PR DESCRIPTION
This PR closes #2354:

![normalize_probabilities](https://user-images.githubusercontent.com/7557205/136914589-f17f0364-73e0-4d8f-971c-df7d7be39230.gif)

