### PR TITLE
Correctly configure allocation -> requests relationship

### DIFF
--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -1799,6 +1799,7 @@ class Allocation(Base):
         'FollowupRequest',
         back_populates='allocation',
         doc='The requests made against this allocation.',
+        passive_deletes=True,
     )
 
     group_id = sa.Column(

--- a/skyportal/tests/api/test_allocations.py
+++ b/skyportal/tests/api/test_allocations.py
@@ -102,3 +102,52 @@ def test_read_only_user_get_invalid_allocation_id(view_only_token):
     status, data = api('GET', f'allocation/{-1}', token=view_only_token)
     assert status == 400
     assert data['status'] == 'error'
+
+
+def test_delete_allocation_cascades_to_requests(
+    public_group, public_source, super_admin_token, sedm
+):
+    request_data = {
+        'group_id': public_group.id,
+        'instrument_id': sedm.id,
+        'pi': 'Shri Kulkarni',
+        'hours_allocated': 200,
+        'start_date': '3021-02-27T00:00:00',
+        'end_date': '3021-07-20T00:00:00',
+        'proposal_id': 'COO-2020A-P01',
+    }
+
+    status, data = api('POST', 'allocation', data=request_data, token=super_admin_token)
+    assert status == 200
+    assert data['status'] == 'success'
+    allocation_id = data['data']['id']
+
+    request_data = {
+        'allocation_id': allocation_id,
+        'obj_id': public_source.id,
+        'payload': {
+            'priority': 5,
+            'start_date': '3020-09-01',
+            'end_date': '3022-09-01',
+            'observation_type': 'IFU',
+        },
+    }
+
+    status, data = api(
+        'POST', 'followup_request', data=request_data, token=super_admin_token
+    )
+    assert status == 200
+    assert data['status'] == 'success'
+    request_id = data['data']['id']
+
+    status, data = api('GET', f'followup_request/{request_id}', token=super_admin_token)
+    assert status == 200
+    assert data['status'] == 'success'
+
+    status, data = api("DELETE", f"allocation/{allocation_id}", token=super_admin_token)
+    assert status == 200
+    assert data['status'] == "success"
+
+    status, data = api('GET', f'followup_request/{request_id}', token=super_admin_token)
+    assert status == 400
+    assert "Could not retrieve followup request" in data['message']


### PR DESCRIPTION
This patch addresses a mis-configuration in the allocation ->
followup requests relationship whereby an error would occur if
attempting to delete an allocation via `DBSession.delete`, which
requires `passive_deletes=True` to be specified on the relationship
pointing to the child class. An API test is added to ensure this now
works as expected (this test will fail without the relationship change).