### PR TITLE
Add optional chaining to Array.forEach in JS src

### DIFF
--- a/static/js/components/MultipleClassificationsForm.jsx
+++ b/static/js/components/MultipleClassificationsForm.jsx
@@ -210,7 +210,7 @@ const MultipleClassificationsForm = ({
     if (normalizeProbabilitiesChecked) {
       // Update higher-level classification probabilities to be
       // the sum of the subclasses' probabilities.
-      path.forEach((ancestor, i) => {
+      path?.forEach((ancestor, i) => {
         const subpath = path.slice(i + 1);
         const probabilityOfSubclasses = Math.min(
           sumChildren(getNode(ancestor, subpath), newFormState),


### PR DESCRIPTION
Adds a missing `?` optional chaining to an instance of
`Array.forEach` in `MultipleClassificationsForm` that had been
causing front-end crashes.