### PR TITLE
Fix bug in update user listener

### DIFF
--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -4242,7 +4242,7 @@ def update_single_user_group(mapper, connection, target):
     def receive_after_flush(session, context):
         single_user_group = target.single_user_group
         single_user_group.name = slugify(target.username)
-        DBSession().add(single_user_group)
+        DBSession().merge(single_user_group)
 
 
 # Group / user / stream permissions


### PR DESCRIPTION
This fixes a bug in the update user event listener
whereby SQLAlchemy would sometimes error when attempting
to `Session.add` an existing single user group; it is here
updated to use `Session.merge`.