### PR TITLE
Upgrade webpack to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "npm-check": "5.9.2",
     "numeral": "2.0.6",
     "papaparse": "5.3.1",
+    "path-browserify": "1.0.1",
     "prop-types": "15.7.2",
     "qrcode.react": "1.0.1",
     "raw-loader": "4.0.2",
@@ -97,8 +98,8 @@
     "eslint-plugin-react": "7.27.1",
     "eslint-plugin-react-hooks": "4.2.0",
     "json-loader": "0.5.7",
-    "webpack": "4.46.0",
-    "webpack-bundle-analyzer": "4.4.2",
+    "webpack": "5.64.4",
+    "webpack-bundle-analyzer": "4.5.0",
     "webpack-cli": "4.9.1"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "numeral": "2.0.6",
     "papaparse": "5.3.1",
     "path-browserify": "1.0.1",
+    "process": "0.11.10",
     "prop-types": "15.7.2",
     "qrcode.react": "1.0.1",
     "raw-loader": "4.0.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -103,7 +103,9 @@ const config = {
       ),
     },
     extensions: [".js", ".jsx", ".json"],
+    fallback: { path: path.resolve(__dirname, "node_modules/path-browserify") },
   },
+
   watchOptions: {
     ignored: /node_modules/,
     // Set to true if you have trouble with JS change monitoring

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require("path");
+const webpack = require("webpack");
 
 // const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
@@ -13,7 +14,7 @@ const config = {
     path: path.resolve(__dirname, "static/build"),
     publicPath: "/static/build/",
     filename: "[name].bundle.js",
-    chunkFilename: "[name].[chunkHash].bundle.js",
+    chunkFilename: "[name].[contenthash].bundle.js",
   },
   module: {
     rules: [
@@ -85,6 +86,9 @@ const config = {
   plugins: [
     // Uncomment the following line to enable bundle size analysis
     //    new BundleAnalyzerPlugin()
+    new webpack.ProvidePlugin({
+      process: path.resolve(__dirname, "node_modules/process/browser.js"),
+    }),
   ],
   resolve: {
     alias: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -86,6 +86,7 @@ const config = {
   plugins: [
     // Uncomment the following line to enable bundle size analysis
     //    new BundleAnalyzerPlugin()
+    // Needed for non-polyfilled node modules; we aim to remove this when possible
     new webpack.ProvidePlugin({
       process: path.resolve(__dirname, "node_modules/process/browser.js"),
     }),
@@ -107,6 +108,7 @@ const config = {
       ),
     },
     extensions: [".js", ".jsx", ".json"],
+    // Needed for non-polyfilled node modules; we aim to remove this when possible
     fallback: { path: path.resolve(__dirname, "node_modules/path-browserify") },
   },
 


### PR DESCRIPTION
Upgrade webpack to v5.x and browserify non-polyfilled node modules for
v5 compatibility.