### PR TITLE
Update py3-validate-email API usage

### DIFF
--- a/skyportal/handlers/api/internal/profile.py
+++ b/skyportal/handlers/api/internal/profile.py
@@ -181,10 +181,9 @@ class ProfileHandler(BaseHandler):
             if email not in [None, ""]:
                 if not validate_email(
                     email_address=email,
-                    check_regex=True,
-                    check_mx=False,
-                    use_blacklist=True,
-                    debug=False,
+                    check_blacklist=False,
+                    check_dns=False,
+                    check_smtp=False,
                 ):
                     return self.error("Email does not appear to be valid")
                 user.contact_email = email

--- a/skyportal/handlers/api/user.py
+++ b/skyportal/handlers/api/user.py
@@ -338,10 +338,9 @@ class UserHandler(BaseHandler):
         if email not in [None, ""]:
             if not validate_email(
                 email_address=email,
-                check_regex=True,
-                check_mx=False,
-                use_blacklist=True,
-                debug=False,
+                check_blacklist=False,
+                check_dns=False,
+                check_smtp=False,
             ):
                 return self.error("Email does not appear to be valid")
             contact_email = email


### PR DESCRIPTION
This patch updates our usage of the validate_email API to
accord with the new (breaking) API changes and also disables
often-expensive network-dependent checks (e.g. initiating SMTP
connections, etc).