### PR TITLE
SEDMv2 triggering interface

### DIFF
--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -20,6 +20,7 @@ app:
 
   # this endpoint does not actually do anything -- it is just for testing
   sedm_endpoint: http://pharos.caltech.edu/add_fritz
+  sedmv2_endpoint:
 
   lt_host: 161.72.57.3
   lt_port: 8080

--- a/data/db_demo.yaml
+++ b/data/db_demo.yaml
@@ -170,6 +170,14 @@ telescope:
     nickname: CTIO-4m
     skycam_link: null
     =id: CTIO-4m
+  - diameter: 2.1
+    elevation: 2096.0
+    lat: 31.9599
+    lon: -111.5997
+    name: Kitt Peak 2.1m Telescope
+    nickname: KPNO2m
+    skycam_link: null
+    =id: KPNO2m
 
 instrument:
   - name: ZTF
@@ -260,6 +268,13 @@ instrument:
     #   file: ../data/DECam_Fields.csv
     # field_region:
     #   file: ../data/DECam_Region.reg
+  - name: SEDMv2
+    type: imaging spectrograph
+    band: V
+    telescope_id: =KPNO2m
+    filters: ["sdssg", "sdssr", "sdssi", "sdssz"]
+    api_classname: SEDMv2API
+    =id: SEDMv2
 
 allocation:
   - pi: Michael Coughlin
@@ -328,6 +343,13 @@ allocation:
     hours_allocated: 100
     group_id: =program_A
     instrument_id: =ZTF
+  - pi: Michael Coughlin
+    proposal_id: SEDMv2-001
+    start_date: "3020-02-12T00:00:00"
+    end_date: "3020-07-12T00:00:00"
+    hours_allocated: 100
+    group_id: =program_A
+    instrument_id: =SEDMv2
 
 candidates:
   - id: ZTF21aaqjmps

--- a/data/db_demo.yaml
+++ b/data/db_demo.yaml
@@ -273,7 +273,7 @@ instrument:
     band: V
     telescope_id: =KPNO2m
     filters: ["sdssg", "sdssr", "sdssi", "sdssz"]
-    api_classname: SEDMv2API
+    api_classname: SEDMV2API
     =id: SEDMv2
 
 allocation:

--- a/data/instruments.yaml
+++ b/data/instruments.yaml
@@ -346,5 +346,5 @@
   band: V
   telescope_id: =KPNO2m
   filters: ["sdssg", "sdssr", "sdssi", "sdssz"]
-  api_classname: SEDMv2API
+  api_classname: SEDMV2API
   =id: SEDMv2

--- a/data/instruments.yaml
+++ b/data/instruments.yaml
@@ -341,3 +341,10 @@
   type: imager
   # todo: add unfiltered
   filters: []
+- name: SEDMv2
+  type: imaging spectrograph
+  band: V
+  telescope_id: =KPNO2m
+  filters: ["sdssg", "sdssr", "sdssi", "sdssz"]
+  api_classname: SEDMv2API
+  =id: SEDMv2

--- a/data/telescopes.yaml
+++ b/data/telescopes.yaml
@@ -503,3 +503,11 @@
   nickname: CNEOST
   skycam_link: null
   =id: CNEOST
+- diameter: 2.1
+  elevation: 2096.0
+  lat: 31.9599
+  lon: -111.5997
+  name: Kitt Peak 2.1m Telescope
+  nickname: KPNO2m
+  skycam_link: null
+  =id: KPNO2m

--- a/skyportal/facility_apis/__init__.py
+++ b/skyportal/facility_apis/__init__.py
@@ -1,5 +1,6 @@
 from .interface import FollowUpAPI, Listener
 from .sedm import SEDMAPI, SEDMListener
+from .sedmv2 import SEDMv2API
 from .lt import IOOAPI, IOIAPI, SPRATAPI
 from .lco import SINISTROAPI, SPECTRALAPI, FLOYDSAPI, MUSCATAPI
 from .ztf import ZTFAPI

--- a/skyportal/facility_apis/__init__.py
+++ b/skyportal/facility_apis/__init__.py
@@ -1,6 +1,6 @@
 from .interface import FollowUpAPI, Listener
 from .sedm import SEDMAPI, SEDMListener
-from .sedmv2 import SEDMv2API
+from .sedmv2 import SEDMV2API
 from .lt import IOOAPI, IOIAPI, SPRATAPI
 from .lco import SINISTROAPI, SPECTRALAPI, FLOYDSAPI, MUSCATAPI
 from .ztf import ZTFAPI

--- a/skyportal/facility_apis/sedmv2.py
+++ b/skyportal/facility_apis/sedmv2.py
@@ -51,7 +51,7 @@ def validate_request_to_sedmv2(request):
         request.payload["minimum_lunar_distance"] < 0
         or request.payload["minimum_lunar_distance"] > 180
     ):
-        raise ValueError('maximum_airmass must be within 0-180.')
+        raise ValueError('minimum lunar distance must be within 0-180.')
 
     if request.payload["priority"] < 1 or request.payload["priority"] > 5:
         raise ValueError('priority must be within 1-5.')

--- a/skyportal/facility_apis/sedmv2.py
+++ b/skyportal/facility_apis/sedmv2.py
@@ -38,7 +38,7 @@ def validate_request_to_sedmv2(request):
             raise ValueError(f'Filter configuration {filt} unknown.')
 
 
-class SEDMv2API(FollowUpAPI):
+class SEDMV2API(FollowUpAPI):
     """SkyPortal interface to the Spectral Energy Distribution machine (SEDMv2)."""
 
     @staticmethod
@@ -56,7 +56,19 @@ class SEDMv2API(FollowUpAPI):
         validate_request_to_sedmv2(request)
 
         if cfg['app.sedmv2_endpoint'] is not None:
-            r = requests.post(cfg['app.sedmv2_endpoint'], json=request.payload)
+            altdata = request.allocation.altdata
+
+            payload = {
+                'obj_id': request.obj_id,
+                'allocation_id': request.allocation.id,
+                'payload': request.payload,
+            }
+
+            r = requests.post(
+                cfg['app.sedmv2_endpoint'],
+                json=payload,
+                headers={"Authorization": f"token {altdata['api_token']}"},
+            )
 
             if r.status_code == 200:
                 request.status = 'submitted'

--- a/skyportal/facility_apis/sedmv2.py
+++ b/skyportal/facility_apis/sedmv2.py
@@ -193,8 +193,8 @@ class SEDMV2API(FollowUpAPI):
             "priority": {
                 "type": "number",
                 "default": 1.0,
-                "minimum": 1,
-                "maximum": 5,
+                "minimum": 1.0,
+                "maximum": 5.0,
                 "title": "Priority",
             },
             "start_date": {

--- a/skyportal/facility_apis/sedmv2.py
+++ b/skyportal/facility_apis/sedmv2.py
@@ -38,6 +38,24 @@ def validate_request_to_sedmv2(request):
         if filt not in ["IFU", "g", "r", "i", "z"]:
             raise ValueError(f'Filter configuration {filt} unknown.')
 
+    if request.payload["exposure_time"] < 0:
+        raise ValueError('exposure_time must be positive.')
+
+    if request.payload["exposure_counts"] < 1:
+        raise ValueError('exposure_counts must be at least 1.')
+
+    if request.payload["maximum_airmass"] < 1:
+        raise ValueError('maximum_airmass must be at least 1.')
+
+    if (
+        request.payload["minimum_lunar_distance"] < 0
+        or request.payload["minimum_lunar_distance"] > 180
+    ):
+        raise ValueError('maximum_airmass must be within 0-180.')
+
+    if request.payload["priority"] < 1 or request.payload["priority"] > 5:
+        raise ValueError('priority must be within 1-5.')
+
 
 class SEDMV2API(FollowUpAPI):
     """SkyPortal interface to the Spectral Energy Distribution machine (SEDMv2)."""
@@ -184,7 +202,7 @@ class SEDMV2API(FollowUpAPI):
                 "maximum": 3,
             },
             "minimum_lunar_distance": {
-                "title": "Maximum Seeing [arcsec] (0-180)",
+                "title": "Maximum Lunar Distance [deg] (0-180)",
                 "type": "number",
                 "default": 30.0,
                 "minimum": 0,

--- a/skyportal/facility_apis/sedmv2.py
+++ b/skyportal/facility_apis/sedmv2.py
@@ -127,8 +127,6 @@ class SEDMV2API(FollowUpAPI):
 
         from ..models import DBSession, FollowupRequest, FacilityTransaction
 
-        validate_request_to_sedmv2(request)
-
         if cfg['app.sedmv2_endpoint'] is not None:
             altdata = request.allocation.altdata
 

--- a/skyportal/facility_apis/sedmv2.py
+++ b/skyportal/facility_apis/sedmv2.py
@@ -1,0 +1,195 @@
+from . import FollowUpAPI
+from baselayer.app.env import load_env
+from datetime import datetime, timedelta
+import requests
+
+from ..utils import http
+
+env, cfg = load_env()
+
+
+def validate_request_to_sedmv2(request):
+    """Validate FollowupRequest contents for SEDMv2 queue.
+
+    Parameters
+    ----------
+    request: skyportal.models.FollowupRequest
+        The request to send to SEDM.
+
+    method_value: 'new', 'edit', 'delete'
+        The desired SEDMv2 queue action.
+    """
+
+    for param in [
+        "observation_choices",
+        "exposure_time",
+        "exposure_counts",
+        "maximum_airmass",
+        "minimum_lunar_distance",
+        "priority",
+        "start_date",
+        "end_date",
+    ]:
+        if param not in request.payload:
+            raise ValueError(f'Parameter {param} required.')
+
+    for filt in request.payload["observation_choices"]:
+        if filt not in ["IFU", "g", "r", "i", "z"]:
+            raise ValueError(f'Filter configuration {filt} unknown.')
+
+
+class SEDMv2API(FollowUpAPI):
+    """SkyPortal interface to the Spectral Energy Distribution machine (SEDMv2)."""
+
+    @staticmethod
+    def submit(request):
+        """Submit a follow-up request to SEDMv2.
+
+        Parameters
+        ----------
+        request: skyportal.models.FollowupRequest
+            The request to submit.
+        """
+
+        from ..models import FacilityTransaction, DBSession
+
+        validate_request_to_sedmv2(request)
+
+        if cfg['app.sedmv2_endpoint'] is not None:
+            r = requests.post(cfg['app.sedmv2_endpoint'], json=request.payload)
+
+            if r.status_code == 200:
+                request.status = 'submitted'
+            else:
+                request.status = f'rejected: {r.content}'
+
+            transaction = FacilityTransaction(
+                request=http.serialize_requests_request(r.request),
+                response=http.serialize_requests_response(r),
+                followup_request=request,
+                initiator_id=request.last_modified_by_id,
+            )
+        else:
+            request.status = 'submitted'
+
+            transaction = FacilityTransaction(
+                request=None,
+                response=None,
+                followup_request=request,
+                initiator_id=request.last_modified_by_id,
+            )
+
+        DBSession().add(transaction)
+
+    @staticmethod
+    def delete(request):
+        """Delete a follow-up request from SEDMv2 queue.
+
+        Parameters
+        ----------
+        request: skyportal.models.FollowupRequest
+            The request to delete from the queue and the SkyPortal database.
+        """
+
+        from ..models import FacilityTransaction, DBSession
+
+        validate_request_to_sedmv2(request)
+
+        if cfg['app.sedmv2_endpoint'] is not None:
+            r = requests.delete(cfg['app.sedmv2_endpoint'], json=request.payload)
+            r.raise_for_status()
+            request.status = "deleted"
+
+            transaction = FacilityTransaction(
+                request=http.serialize_requests_request(r.request),
+                response=http.serialize_requests_response(r),
+                followup_request=request,
+                initiator_id=request.last_modified_by_id,
+            )
+        else:
+            request.status = 'deleted'
+
+            transaction = FacilityTransaction(
+                request=None,
+                response=None,
+                followup_request=request,
+                initiator_id=request.last_modified_by_id,
+            )
+
+        DBSession().add(transaction)
+
+    form_json_schema = {
+        "type": "object",
+        "properties": {
+            "observation_choices": {
+                "type": "array",
+                "title": "Desired Observations",
+                "items": {"type": "string", "enum": ["g", "r", "i", "z", "IFU"]},
+                "uniqueItems": True,
+                "minItems": 1,
+            },
+            "exposure_time": {
+                "title": "Exposure Time [s]",
+                "type": "number",
+                "default": 300.0,
+            },
+            "exposure_counts": {
+                "title": "Exposure Counts",
+                "type": "number",
+                "default": 1,
+            },
+            "maximum_airmass": {
+                "title": "Maximum Airmass (1-3)",
+                "type": "number",
+                "default": 2.0,
+                "minimum": 1,
+                "maximum": 3,
+            },
+            "minimum_lunar_distance": {
+                "title": "Maximum Seeing [arcsec] (0-180)",
+                "type": "number",
+                "default": 30.0,
+                "minimum": 0,
+                "maximum": 180,
+            },
+            "priority": {
+                "type": "number",
+                "default": 1.0,
+                "minimum": 1,
+                "maximum": 5,
+                "title": "Priority",
+            },
+            "start_date": {
+                "type": "string",
+                "format": "date",
+                "default": datetime.utcnow().date().isoformat(),
+                "title": "Start Date (UT)",
+            },
+            "end_date": {
+                "type": "string",
+                "format": "date",
+                "title": "End Date (UT)",
+                "default": (datetime.utcnow().date() + timedelta(days=7)).isoformat(),
+            },
+        },
+        "required": [
+            "observation_choices",
+            "priority",
+            "start_date",
+            "end_date",
+            "exposure_time",
+            "exposure_counts",
+            "maximum_airmass",
+            "minimum_lunar_distance",
+        ],
+    }
+
+    ui_json_schema = {"observation_choices": {"ui:widget": "checkboxes"}}
+
+    alias_lookup = {
+        'observation_choices': "Request",
+        'start_date': "Start Date",
+        'end_date': "End Date",
+        'priority': "Priority",
+        'observation_type': 'Mode',
+    }

--- a/skyportal/tests/flaky/test_followup_requests.py
+++ b/skyportal/tests/flaky/test_followup_requests.py
@@ -165,6 +165,72 @@ def add_allocation_ztf(instrument_id, group_id, token):
     return data["data"]
 
 
+def add_allocation_sedmv2(instrument_id, group_id, token):
+    status, data = api(
+        "POST",
+        "allocation",
+        data={
+            "group_id": group_id,
+            "instrument_id": instrument_id,
+            "hours_allocated": 100,
+            "pi": "Ed Hubble",
+            '_altdata': '{"access_token": "testtoken"}',
+        },
+        token=token,
+    )
+    assert status == 200
+    assert data["status"] == "success"
+    return data["data"]
+
+
+def add_followup_request_using_frontend_and_verify_SEDMv2(
+    driver, super_admin_user, public_source, super_admin_token, public_group
+):
+    """Adds a new followup request and makes sure it renders properly."""
+    idata = add_telescope_and_instrument("SEDMv2", super_admin_token)
+    add_allocation_sedmv2(idata['id'], public_group.id, super_admin_token)
+
+    driver.get(f"/become_user/{super_admin_user.id}")
+
+    driver.get(f"/source/{public_source.id}")
+
+    submit_button_xpath = (
+        '//div[@data-testid="followup-request-form"]//button[@type="submit"]'
+    )
+    driver.wait_for_xpath(submit_button_xpath)
+
+    select_box = driver.find_element_by_id(
+        "mui-component-select-followupRequestAllocationSelect"
+    )
+    select_box.click()
+
+    driver.click_xpath(
+        f'//li[contains(text(), "SEDMv2")][contains(text(), "{public_group.name}")]',
+        scroll_parent=True,
+    )
+
+    # Click somewhere outside to remove focus from instrument select
+    driver.click_xpath("//header")
+
+    # IFU option
+    driver.click_xpath(
+        '//input[@id="root_observation_choices_4"]', wait_clickable=False
+    )
+
+    driver.click_xpath(submit_button_xpath)
+
+    driver.click_xpath("//div[@data-testid='SEDMv2-requests-header']")
+    driver.wait_for_xpath(
+        '//div[contains(@data-testid, "SEDMv2_followupRequestsTable")]//div[contains(., "IFU")]'
+    )
+    driver.wait_for_xpath(
+        '''//div[contains(@data-testid, "SEDMv2_followupRequestsTable")]//div[contains(., "300")]'''
+    )
+    driver.wait_for_xpath(
+        '''//div[contains(@data-testid, "SEDMv2_followupRequestsTable")]//div[contains(., "submitted")]'''
+    )
+
+
 def add_followup_request_using_frontend_and_verify_ZTF(
     driver, super_admin_user, public_source, super_admin_token, public_group
 ):
@@ -623,6 +689,16 @@ def add_followup_request_using_frontend_and_verify_IOO(
     )
 
 
+# @pytest.mark.flaky(reruns=2)
+def test_submit_new_followup_request_SEDMv2(
+    driver, super_admin_user, public_source, super_admin_token, public_group
+):
+
+    add_followup_request_using_frontend_and_verify_SEDMv2(
+        driver, super_admin_user, public_source, super_admin_token, public_group
+    )
+
+
 @pytest.mark.flaky(reruns=2)
 @pytest.mark.skipif(not ztf_isonline, reason="ZTF server down")
 def test_submit_new_followup_request_ZTF(
@@ -756,6 +832,28 @@ def test_edit_existing_followup_request(
     )
     driver.wait_for_xpath(
         '''//div[contains(@data-testid, "SEDM_followupRequestsTable")]//div[contains(., "submitted")]'''
+    )
+
+
+def test_delete_followup_request_SEDMv2(
+    driver, super_admin_user, public_source, super_admin_token, public_group
+):
+    add_followup_request_using_frontend_and_verify_SEDMv2(
+        driver, super_admin_user, public_source, super_admin_token, public_group
+    )
+
+    driver.click_xpath(
+        '//button[contains(@data-testid, "deleteRequest")]', scroll_parent=True
+    )
+
+    driver.wait_for_xpath_to_disappear(
+        '''//div[contains(@data-testid, "SEDMv2_followupRequestsTable")]//div[contains(., "IFU")]'''
+    )
+    driver.wait_for_xpath_to_disappear(
+        '''//div[contains(@data-testid, "SEDMv2_followupRequestsTable")]//div[contains(., "300")]'''
+    )
+    driver.wait_for_xpath_to_disappear(
+        '''//div[contains(@data-testid, "SEDMv2_followupRequestsTable")]//div[contains(., "submitted")]'''
     )
 
 

--- a/skyportal/tests/flaky/test_followup_requests.py
+++ b/skyportal/tests/flaky/test_followup_requests.py
@@ -108,7 +108,6 @@ def add_allocation_sedm(instrument_id, group_id, token):
     )
     assert status == 200
     assert data["status"] == "success"
-    return data["data"]
 
 
 def add_allocation_lt(instrument_id, group_id, token):
@@ -126,7 +125,6 @@ def add_allocation_lt(instrument_id, group_id, token):
     )
     assert status == 200
     assert data["status"] == "success"
-    return data["data"]
 
 
 def add_allocation_lco(instrument_id, group_id, token):
@@ -144,7 +142,6 @@ def add_allocation_lco(instrument_id, group_id, token):
     )
     assert status == 200
     assert data["status"] == "success"
-    return data["data"]
 
 
 def add_allocation_ztf(instrument_id, group_id, token):
@@ -162,7 +159,6 @@ def add_allocation_ztf(instrument_id, group_id, token):
     )
     assert status == 200
     assert data["status"] == "success"
-    return data["data"]
 
 
 def add_allocation_sedmv2(instrument_id, group_id, token):
@@ -180,7 +176,6 @@ def add_allocation_sedmv2(instrument_id, group_id, token):
     )
     assert status == 200
     assert data["status"] == "success"
-    return data["data"]
 
 
 def add_followup_request_using_frontend_and_verify_SEDMv2(


### PR DESCRIPTION
This PR enables the two pathways that would need to exist here: (i) a local SkyPortal instance that the request is being made on and (ii) an external SkyPortal instance that this instance would take to (like we would for any other system). So we support both pathways.