### PR TITLE
Update webpack config to resolve missing Buffer

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@rjsf/core": "2.5.1",
     "@rjsf/material-ui": "2.4.0",
     "autosuggest-highlight": "3.1.1",
+    "buffer": "6.0.3",
     "check-dependencies": "1.1.0",
     "clsx": "1.1.1",
     "convert-css-length": "2.0.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -90,6 +90,9 @@ const config = {
     new webpack.ProvidePlugin({
       process: path.resolve(__dirname, "node_modules/process/browser.js"),
     }),
+    new webpack.ProvidePlugin({
+      Buffer: ["buffer", "Buffer"],
+    }),
   ],
   resolve: {
     alias: {
@@ -109,7 +112,10 @@ const config = {
     },
     extensions: [".js", ".jsx", ".json"],
     // Needed for non-polyfilled node modules; we aim to remove this when possible
-    fallback: { path: path.resolve(__dirname, "node_modules/path-browserify") },
+    fallback: {
+      path: path.resolve(__dirname, "node_modules/path-browserify"),
+      buffer: path.resolve(__dirname, "node_modules/buffer"),
+    },
   },
 
   watchOptions: {


### PR DESCRIPTION
This patch includes a module plugin to resolve
the no-longer-polyfilled Buffer library.