### PR TITLE
bump astropy ligo.skymaps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ seaborn==0.11.2
 bokeh==2.4.1
 pytest-randomly==3.10.1
 factory-boy==3.2.1
-astropy==4.3.1
+astropy>=5.0.0
 aplpy==2.0.3
 reproject==0.8
 avro-python3==1.10.2
@@ -45,7 +45,7 @@ lxml==4.6.3
 suds-py3==1.4.4.1
 vcrpy==4.1.1
 aiosmtpd==1.4.2
-ligo.skymap==0.5.3
+ligo.skymap>=0.6.0
 healpy==1.15.0
 pygcn==1.1.1
 xmlschema==1.9.0


### PR DESCRIPTION
Supersedes #2483: we need to bump astropy to comport with ligo skymap pinning of astropy==5.0