### PR TITLE
Use requests.Session in api utility function

### DIFF
--- a/skyportal/tests/__init__.py
+++ b/skyportal/tests/__init__.py
@@ -10,6 +10,11 @@ IS_CI_BUILD = "TRAVIS" in os.environ or "GITHUB_ACTIONS" in os.environ
 
 patch_requests()
 
+session = requests.Session()
+session.trust_env = (
+    False  # Otherwise pre-existing netrc config will override auth headers
+)
+
 
 def api(
     method, endpoint, data=None, params=None, host=None, token=None, raw_response=False
@@ -48,7 +53,7 @@ def api(
         host = f'http://localhost:{cfg["ports.app"]}'
     url = urllib.parse.urljoin(host, f'/api/{endpoint}')
     headers = {'Authorization': f'token {token}'} if token else None
-    response = requests.request(method, url, json=data, params=params, headers=headers)
+    response = session.request(method, url, json=data, params=params, headers=headers)
 
     if raw_response:
         return response


### PR DESCRIPTION
This allows us to bypass pre-existing netrc configurations
on the user's system that would be used to override the specified
authorization headers for every request.

Closes #2496 