### PR TITLE
Dockerfile: copy config before setting up services which may rely on it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,8 @@ ADD . /skyportal
 WORKDIR /skyportal
 
 RUN bash -c "\
+    cp docker.yaml config.yaml && \
+    \
     source /skyportal_env/bin/activate && \
     make system_setup && \
     \
@@ -36,9 +38,7 @@ RUN bash -c "\
     chown -R skyportal.skyportal /skyportal && \
     \
     mkdir -p /skyportal/static/thumbnails && \
-    chown -R skyportal.skyportal /skyportal/static/thumbnails && \
-    \
-    cp docker.yaml config.yaml"
+    chown -R skyportal.skyportal /skyportal/static/thumbnails"
 
 USER skyportal
 


### PR DESCRIPTION
E.g., the nginx configuration is templated, and depends on the skyportal
config to know which IP addresses to whitelist.

Closes gh-2536