### PR TITLE
Draft: Example of slack channel follow-up request

### DIFF
--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -38,6 +38,11 @@ app:
     protocol: http
     host: herculesii.astro.berkeley.edu
 
+  t80cam:
+    protocol: https
+    host: hooks.slack.com
+    slack_channel: TFRQJA3CJ/B02T7F1C2AW
+
   # See https://stackoverflow.com/a/35604855 for syntax
   # These are Javascript component routes
   routes:

--- a/data/db_demo.yaml
+++ b/data/db_demo.yaml
@@ -186,6 +186,14 @@ telescope:
     nickname: KPNO2m
     skycam_link: null
     =id: KPNO2m
+  - diameter: 0.8
+    elevation: 1957.0
+    lat: 40.0420111
+    lon: -1.0161911
+    name: Javalambre Auxiliary Survey Telescope
+    nickname: JAST
+    skycam_link: null
+    =id: JAST
 
 instrument:
   - name: ZTF
@@ -290,6 +298,13 @@ instrument:
     filters: ["sdssg", "sdssr", "sdssi", "sdssz"]
     api_classname: SEDMV2API
     =id: SEDMv2
+  - band: optical
+    name: T80CAM
+    telescope_id: =JAST
+    type: imager
+    filters: ['sdssg', 'sdssr', 'sdssi', 'sdssz']
+    api_classname: T80CAMAPI
+    =id: T80CAM
 
 allocation:
   - pi: Michael Coughlin
@@ -372,6 +387,13 @@ allocation:
     hours_allocated: 100
     group_id: =program_A
     instrument_id: =KAIT
+  - pi: Michael Coughlin
+    proposal_id: T80CAM-001
+    start_date: "3020-02-12T00:00:00"
+    end_date: "3020-07-12T00:00:00"
+    hours_allocated: 100
+    group_id: =program_A
+    instrument_id: =T80CAM
 
 candidates:
   - id: ZTF21aaqjmps

--- a/skyportal/facility_apis/__init__.py
+++ b/skyportal/facility_apis/__init__.py
@@ -4,4 +4,5 @@ from .sedm import SEDMAPI, SEDMListener
 from .sedmv2 import SEDMV2API
 from .lt import IOOAPI, IOIAPI, SPRATAPI
 from .lco import SINISTROAPI, SPECTRALAPI, FLOYDSAPI, MUSCATAPI
+from .t80cam import T80CAMAPI
 from .ztf import ZTFAPI

--- a/skyportal/utils/http.py
+++ b/skyportal/utils/http.py
@@ -1,6 +1,9 @@
 def serialize_requests_request(request):
     if request.body is not None:
-        body = request.body.decode()
+        if isinstance(request.body, bytes):
+            body = request.body.decode()
+        else:
+            body = request.body
     else:
         body = ''
 


### PR DESCRIPTION
Slack is a common place to track submission requests, and this PR gives an example where we use the microservice to submit requests to a slack channel. Testing it seems complicated because it isn't a typical API endpoint.