### PR TITLE
Return JSON data whenever available from API utility function

### DIFF
--- a/skyportal/tests/__init__.py
+++ b/skyportal/tests/__init__.py
@@ -58,10 +58,8 @@ def api(
     if raw_response:
         return response
     else:
-        if response.status_code in (200, 400):
-            if method == "HEAD":
-                return response.status_code, None
-            else:
-                return response.status_code, response.json()
-        else:
-            return response.status_code, None
+        try:
+            data = response.json()
+        except requests.exceptions.JSONDecodeError:
+            data = None
+        return response.status_code, data


### PR DESCRIPTION
Before, we only returned data for HTTP 200 or 400, but there's no
reason to make those special.  In fact, since we recently started
using other error codes like 401, the API function misbehaves in those
cases.