### PR TITLE
SQLAlchemy 1.4.X compat version

### DIFF
--- a/.github/workflows/test_migrations.yaml
+++ b/.github/workflows/test_migrations.yaml
@@ -138,6 +138,7 @@ jobs:
           createdb -h localhost -U skyportal skyportal_test
           psql -U skyportal -h localhost -c "GRANT ALL PRIVILEGES ON DATABASE skyportal_test TO skyportal;" skyportal_test
 
+          export NPM_CONFIG_LEGACY_PEER_DEPS="true"
           make db_init
 
           pip list --format=columns
@@ -148,6 +149,7 @@ jobs:
 
       - name: Test loading demo data
         run: |
+          export NPM_CONFIG_LEGACY_PEER_DEPS="true"
           make run &
           sleep 10 && make load_demo_data
           kill %1
@@ -226,7 +228,7 @@ jobs:
 
           createdb -h localhost -U skyportal skyportal2
           psql -U skyportal -h localhost -c "GRANT ALL PRIVILEGES ON DATABASE skyportal2 TO skyportal;" skyportal2
-
+          export NPM_CONFIG_LEGACY_PEER_DEPS="true"
           make db_init
 
           make run &

--- a/.github/workflows/test_migrations.yaml
+++ b/.github/workflows/test_migrations.yaml
@@ -22,7 +22,7 @@ jobs:
       # (e.g., to get access to a newer data loader or dependencies).
       # Pick any commit known to have passed the migration tests on
       # CI, or which has deployed successfully.
-      MIGRATION_REFERENCE: 880cd56716015e33df22af1d256717ce98d7eb84
+      MIGRATION_REFERENCE: 88b66a5a4aaaff761315dc4c79251fc3cfec46d7
 
     services:
       postgres:

--- a/requirements.docs.txt
+++ b/requirements.docs.txt
@@ -4,4 +4,5 @@ numpydoc
 sphinx-rtd-theme
 notedown
 jsx-lexer
-eralchemy==1.2.10
+# need a fix for SQLA1.4
+git+https://github.com/sturzaam/eralchemy@Sturzaam-patch-1#egg=eralchemy

--- a/skyportal/app_server.py
+++ b/skyportal/app_server.py
@@ -1,6 +1,7 @@
 import tornado.web
 
 from baselayer.app.app_server import MainPageHandler
+from baselayer.app.model_util import create_tables
 from baselayer.log import make_log
 
 from skyportal.handlers import BecomeUserHandler, LogoutHandler
@@ -302,7 +303,12 @@ def make_app(cfg, baselayer_handlers, baselayer_settings, process=None, env=None
         engine_args={'pool_size': 10, 'max_overflow': 15, 'pool_recycle': 3600},
     )
 
+    # If tables are found in the database, new tables will only be added
+    # in debug mode.  In production, we leave the tables alone, since
+    # migrations might be used.
+    create_tables(add=env.debug)
     model_util.refresh_enums()
+
     model_util.setup_permissions()
     app.cfg = cfg
 

--- a/skyportal/app_server.py
+++ b/skyportal/app_server.py
@@ -1,7 +1,6 @@
 import tornado.web
 
 from baselayer.app.app_server import MainPageHandler
-from baselayer.app.model_util import create_tables
 from baselayer.log import make_log
 
 from skyportal.handlers import BecomeUserHandler, LogoutHandler
@@ -303,12 +302,7 @@ def make_app(cfg, baselayer_handlers, baselayer_settings, process=None, env=None
         engine_args={'pool_size': 10, 'max_overflow': 15, 'pool_recycle': 3600},
     )
 
-    # If tables are found in the database, new tables will only be added
-    # in debug mode.  In production, we leave the tables alone, since
-    # migrations might be used.
-    create_tables(add=env.debug)
     model_util.refresh_enums()
-
     model_util.setup_permissions()
     app.cfg = cfg
 

--- a/skyportal/handlers/api/candidate.py
+++ b/skyportal/handlers/api/candidate.py
@@ -9,11 +9,11 @@ import numpy as np
 
 from tornado.ioloop import IOLoop
 
+import sqlalchemy as sa
 from sqlalchemy.orm import joinedload
 from sqlalchemy.orm import sessionmaker, scoped_session
-from sqlalchemy.sql.expression import case, func, FromClause
-from sqlalchemy.ext.compiler import compiles
-from sqlalchemy.sql import column
+from sqlalchemy.sql.expression import case, func
+from sqlalchemy.sql import column, Values
 from sqlalchemy.types import Float, Boolean, String, Integer
 from marshmallow.exceptions import ValidationError
 
@@ -822,15 +822,16 @@ class CandidateHandler(BaseHandler):
             if "Page number out of range" in str(e):
                 return self.error("Page number out of range.")
             raise
+
         matching_source_ids = (
             Source.query_records_accessible_by(
                 self.current_user, columns=[Source.obj_id]
             )
-            .filter(Source.obj_id.in_([obj.id for obj in query_results["candidates"]]))
+            .filter(Source.obj_id.in_([obj.id for obj, in query_results["candidates"]]))
             .all()
         )
         candidate_list = []
-        for obj in query_results["candidates"]:
+        for (obj,) in query_results["candidates"]:
             with DBSession().no_autoflush:
                 obj.is_source = (obj.id,) in matching_source_ids
                 if obj.is_source:
@@ -1092,52 +1093,22 @@ def get_obj_id_values(obj_ids):
     values_table: `sqlalchemy.sql.expression.FromClause`
         The VALUES representation of the Obj IDs list.
     """
-    # https://github.com/sqlalchemy/sqlalchemy/wiki/PGValues
-    class _obj_id_values(FromClause):
-        named_with_column = True
-
-        def __init__(self, columns, *args, **kw):
-            self._column_args = columns
-            self.list = args
-            self.alias_name = self.name = kw.pop("alias_name", None)
-
-        def _populate_column_collection(self):
-            for c in self._column_args:
-                c._make_proxy(self)
-
-        @property
-        def _from_objects(self):
-            return [self]
-
-    # https://github.com/sqlalchemy/sqlalchemy/wiki/PGValues
-    @compiles(_obj_id_values)
-    def compile_values(element, compiler, asfrom=False, **kw):
-        columns = element.columns
-        v = "VALUES %s" % ", ".join(
-            "(%s)"
-            % ", ".join(
-                compiler.render_literal_value(elem, column.type)
-                for elem, column in zip(tup, columns)
-            )
-            for tup in element.list
+    values_table = (
+        Values(
+            column("id", String),
+            column("ordering", Integer),
         )
-        if asfrom:
-            if element.alias_name:
-                v = "(%s) AS %s (%s)" % (
-                    v,
-                    element.alias_name,
-                    (", ".join(c.name for c in element.columns)),
+        .data(
+            [
+                (
+                    obj_id,
+                    idx,
                 )
-            else:
-                v = "(%s)" % v
-        return v
-
-    values_table = _obj_id_values(
-        (column("id", String), column("ordering", Integer)),
-        *[(obj_id, idx) for idx, obj_id in enumerate(obj_ids)],
-        alias_name="values_table",
+                for idx, obj_id in enumerate(obj_ids)
+            ]
+        )
+        .alias("values_table")
     )
-
     return values_table
 
 
@@ -1252,19 +1223,33 @@ def grab_query_results(
             raise ValueError("Page number out of range.")
 
     items = []
-    query_options = [joinedload(Obj.thumbnails)] if include_thumbnails else []
-
     if len(obj_ids_in_page) > 0:
         # If there are no values, the VALUES statement above will cause a syntax error,
         # so only filter on the values if they exist
         obj_ids_values = get_obj_id_values(obj_ids_in_page)
-        items = (
-            DBSession()
-            .query(Obj)
-            .options(query_options)
-            .join(obj_ids_values, obj_ids_values.c.id == Obj.id)
-            .order_by(obj_ids_values.c.ordering)
-        )
+        if include_thumbnails:
+            items = (
+                DBSession()
+                .execute(
+                    sa.select(Obj)
+                    .options(joinedload(Obj.thumbnails))
+                    .join(obj_ids_values, obj_ids_values.c.id == Obj.id)
+                    .order_by(obj_ids_values.c.ordering)
+                )
+                .unique()
+                .all()
+            )
+        else:
+            items = (
+                DBSession()
+                .execute(
+                    sa.select(Obj)
+                    .join(obj_ids_values, obj_ids_values.c.id == Obj.id)
+                    .order_by(obj_ids_values.c.ordering)
+                )
+                .unique()
+                .all()
+            )
 
     info[items_name] = items
     return info

--- a/skyportal/handlers/api/internal/annotations_info.py
+++ b/skyportal/handlers/api/internal/annotations_info.py
@@ -1,80 +1,8 @@
 from collections import defaultdict
 from sqlalchemy import func, literal
-from sqlalchemy.ext.compiler import compiles
-from sqlalchemy.sql import functions
-from sqlalchemy.sql.elements import ColumnClause
-from sqlalchemy.sql.selectable import FromClause
 from baselayer.app.access import auth_or_token
 from ...base import BaseHandler
 from ....models import Annotation
-
-
-# Helper classes/functions below provide a workaround for PostgreSQL functions
-# returning multiple columns, unsupported by SA
-# See https://stackoverflow.com/questions/33865038/joining-with-set-returning-function-srf-and-access-columns-in-sqlalchemy
-# for details
-class FunctionColumn(ColumnClause):
-    def __init__(self, function, name, type_=None):
-        self.function = self.table = function
-        self.name = self.key = name
-        self.type_ = type_
-        self.is_literal = False
-
-    @property
-    def _from_objects(self):
-        return []
-
-    def _make_proxy(
-        self, selectable, name=None, attach=True, name_is_truncatable=False, **kw
-    ):
-        if self.name == self.function.name:
-            name = selectable.name
-        else:
-            name = self.name
-
-        co = ColumnClause(name, self.type)
-        co.key = self.name
-        co._proxies = [self]
-        if selectable._is_clone_of is not None:
-            co._is_clone_of = selectable._is_clone_of.columns.get(co.key)
-        co.table = selectable
-        co.named_with_table = False
-        if attach:
-            selectable._columns[co.key] = co
-        return co
-
-
-@compiles(FunctionColumn)
-def _compile_function_column(element, compiler, **kw):
-    if kw.get('asfrom', False):
-        return "(%s).%s" % (
-            compiler.process(element.function, **kw),
-            compiler.preparer.quote(element.name),
-        )
-    else:
-        return element.name
-
-
-class ColumnFunction(functions.FunctionElement):
-    __visit_name__ = 'function'
-
-    @property
-    def columns(self):
-        return FromClause.columns.fget(self)
-
-    def _populate_column_collection(self):
-        for name in self.column_names:
-            self._columns[name] = FunctionColumn(self, name)
-
-
-class jsonb_each_func(ColumnFunction):
-    name = 'jsonb_each'
-    column_names = ['key', 'value']
-
-
-@compiles(jsonb_each_func)
-def _compile_jsonb_each_func(element, compiler, **kw):
-    return compiler.visit_function(element, **kw)
 
 
 class AnnotationsInfoHandler(BaseHandler):
@@ -104,9 +32,7 @@ class AnnotationsInfoHandler(BaseHandler):
         # filters to apply on the auto-annotations column on the scanning page.
         # For example, if given that an annotation field is numeric we should
         # have min/max fields on the form.
-        annotations = jsonb_each_func(
-            Annotation.data
-        )  # Get each key/value tuple in annotations
+        annotations = func.jsonb_each(Annotation.data).table_valued("key", "value")
 
         # Objs are read-public, so no need to check that annotations belong to an unreadable obj
         # Instead, just check for annotation group membership

--- a/skyportal/handlers/api/photometry.py
+++ b/skyportal/handlers/api/photometry.py
@@ -1,5 +1,4 @@
 import uuid
-import math
 import datetime
 import json
 from io import StringIO
@@ -13,9 +12,7 @@ import sncosmo
 from sncosmo.photdata import PhotometricData
 
 import sqlalchemy as sa
-from sqlalchemy.ext.compiler import compiles
-from sqlalchemy.sql.expression import FromClause
-from sqlalchemy.sql import column
+from sqlalchemy.sql import column, Values
 from sqlalchemy.orm import joinedload
 from sqlalchemy import and_
 
@@ -53,6 +50,7 @@ def save_data_using_copy(rows, table, columns):
     # Coerce missing non-numbers and numbers, respectively, for SQLAlchemy
     df.replace("NaN", "null", inplace=True)
     df.replace(np.nan, "NaN", inplace=True)
+
     df.to_csv(
         output,
         index=False,
@@ -397,69 +395,8 @@ class PhotometryHandler(BaseHandler):
            The join condition for cross matching the VALUES representation of
            `df` against the Photometry table using the deduplication index.
         """
-
-        # https://github.com/sqlalchemy/sqlalchemy/wiki/PGValues
-        class _photometry_values(FromClause):
-            """Render a postgres VALUES statement (in-memory constant table)."""
-
-            named_with_column = True
-
-            def __init__(self, columns, *args, **kw):
-                self._column_args = columns
-                self.list = args
-                self.alias_name = self.name = kw.pop("alias_name", None)
-
-            def _populate_column_collection(self):
-                for c in self._column_args:
-                    c._make_proxy(self)  # noqa
-
-            @property
-            def _from_objects(self):
-                return [self]
-
-        # https://github.com/sqlalchemy/sqlalchemy/wiki/PGValues
-        @compiles(_photometry_values)
-        def _compile_photometry_values(element, compiler, asfrom=False, **kw):
-            columns = element.columns
-
-            value_types = {
-                'pdidx': 'INTEGER',
-                'obj_id': 'CHARACTER VARYING',
-                'instrument_id': 'INTEGER',
-                'origin': 'CHARACTER VARYING',
-                'mjd': 'DOUBLE PRECISION',
-                'fluxerr': 'DOUBLE PRECISION',
-                'flux': 'DOUBLE PRECISION',
-            }
-
-            def coerced_value(elem, column):
-                literal_value = compiler.render_literal_value(elem, column.type)
-                cast_value = value_types[column.name]
-                return f'{literal_value}::{cast_value}'
-
-            v = "VALUES %s" % ", ".join(
-                "(%s)"
-                % ", ".join(
-                    coerced_value(elem, column)
-                    if not (isinstance(elem, float) and math.isnan(elem))
-                    else "'NaN'::numeric"
-                    for elem, column in zip(tup, columns)
-                )
-                for tup in element.list
-            )
-            if asfrom:
-                if element.alias_name:
-                    v = "(%s) AS %s (%s)" % (
-                        v,
-                        element.alias_name,
-                        (", ".join(c.name for c in element.columns)),
-                    )
-                else:
-                    v = "(%s)" % v
-            return v
-
-        values_table = _photometry_values(
-            (
+        values_table = (
+            Values(
                 column("pdidx", sa.Integer),
                 column("obj_id", sa.String),
                 column("instrument_id", sa.Integer),
@@ -467,20 +404,22 @@ class PhotometryHandler(BaseHandler):
                 column("mjd", sa.Float),
                 column("fluxerr", sa.Float),
                 column("flux", sa.Float),
-            ),
-            *[
-                (
-                    row.Index,
-                    row.obj_id,
-                    row.instrument_id,
-                    row.origin,
-                    float(row.mjd),
-                    float(row.standardized_fluxerr),
-                    float(row.standardized_flux),
-                )
-                for row in df.itertuples()
-            ],
-            alias_name="values_table",
+            )
+            .data(
+                [
+                    (
+                        row.Index,
+                        row.obj_id,
+                        row.instrument_id,
+                        row.origin,
+                        float(row.mjd),
+                        float(row.standardized_fluxerr),
+                        float(row.standardized_flux),
+                    )
+                    for row in df.itertuples()
+                ]
+            )
+            .alias("values_table")
         )
 
         # make sure no duplicate data are posted using the index
@@ -499,12 +438,14 @@ class PhotometryHandler(BaseHandler):
         self, df, instrument_cache, group_ids, stream_ids, validate=True
     ):
         # check for existing photometry and error if any is found
-
         if validate:
             values_table, condition = self.get_values_table_and_condition(df)
 
             duplicated_photometry = (
-                DBSession().query(Photometry).join(values_table, condition)
+                DBSession()
+                .execute(sa.select(Photometry).join(values_table, condition))
+                .scalars()
+                .all()
             )
 
             dict_rep = [d.to_dict() for d in duplicated_photometry]
@@ -666,8 +607,12 @@ class PhotometryHandler(BaseHandler):
         elif group_ids == 'all':
             public_group = (
                 DBSession()
-                .query(Group)
-                .filter(Group.name == cfg["misc"]["public_group_name"])
+                .execute(
+                    sa.select(Group).filter(
+                        Group.name == cfg["misc"]["public_group_name"]
+                    )
+                )
+                .scalars()
                 .first()
             )
             group_ids = [public_group.id]
@@ -841,9 +786,8 @@ class PhotometryHandler(BaseHandler):
             f'LOCK TABLE {Photometry.__tablename__} IN SHARE ROW EXCLUSIVE MODE'
         )
 
-        new_photometry_query = (
-            DBSession()
-            .query(values_table.c.pdidx)
+        new_photometry_query = DBSession().execute(
+            sa.select(values_table.c.pdidx)
             .outerjoin(Photometry, condition)
             .filter(Photometry.id.is_(None))
         )
@@ -854,10 +798,14 @@ class PhotometryHandler(BaseHandler):
 
         duplicated_photometry = (
             DBSession()
-            .query(values_table.c.pdidx, Photometry)
-            .join(Photometry, condition)
-            .options(joinedload(Photometry.groups))
-            .options(joinedload(Photometry.streams))
+            .execute(
+                sa.select(values_table.c.pdidx, Photometry)
+                .join(Photometry, condition)
+                .options(joinedload(Photometry.groups))
+                .options(joinedload(Photometry.streams))
+            )
+            .unique()
+            .all()
         )
 
         for df_index, duplicate in duplicated_photometry:
@@ -871,8 +819,8 @@ class PhotometryHandler(BaseHandler):
                 group_ids_update = set(group_ids).union(duplicate_group_ids)
                 groups = (
                     DBSession()
-                    .query(Group)
-                    .filter(Group.id.in_(group_ids_update))
+                    .execute(sa.select(Group).filter(Group.id.in_(group_ids_update)))
+                    .scalars()
                     .all()
                 )
                 # update the corresponding photometry entry in the db

--- a/skyportal/handlers/api/public_group.py
+++ b/skyportal/handlers/api/public_group.py
@@ -1,7 +1,8 @@
+import sqlalchemy as sa
 from baselayer.app.access import auth_or_token
 from baselayer.app.env import load_env
 from ..base import BaseHandler
-from ...models import Group
+from ...models import Group, DBSession
 
 
 env, cfg = load_env()
@@ -22,7 +23,13 @@ class PublicGroupHandler(BaseHandler):
                 application/json:
                   schema: SingleGroup
         """
-        pg = Group.query.filter(Group.name == cfg['misc.public_group_name']).first()
+        pg = (
+            DBSession.execute(
+                sa.select(Group).filter(Group.name == cfg['misc.public_group_name'])
+            )
+            .scalars()
+            .first()
+        )
         if pg is None:
             return self.error('Public group does not exist')
         self.verify_and_commit()

--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -919,18 +919,18 @@ class SourceHandler(BaseHandler):
             other = ca.Point(ra=ra, dec=dec)
             obj_query = obj_query.filter(Obj.within(other, radius))
         if start_date:
-            start_date = arrow.get(start_date.strip()).datetime
+            start_date = str(arrow.get(start_date.strip()).datetime)
             obj_query = obj_query.filter(
                 Obj.last_detected_at(self.current_user) >= start_date
             )
         if end_date:
-            end_date = arrow.get(end_date.strip()).datetime
+            end_date = str(arrow.get(end_date.strip()).datetime)
             obj_query = obj_query.filter(
                 Obj.last_detected_at(self.current_user) <= end_date
             )
         if has_spectrum_after:
             try:
-                has_spectrum_after = arrow.get(has_spectrum_after.strip()).datetime
+                has_spectrum_after = str(arrow.get(has_spectrum_after.strip()).datetime)
             except arrow.ParserError:
                 return self.error(
                     f"Invalid input for parameter hasSpectrumAfter:{has_spectrum_after}"
@@ -945,7 +945,9 @@ class SourceHandler(BaseHandler):
             )
         if has_spectrum_before:
             try:
-                has_spectrum_before = arrow.get(has_spectrum_before.strip()).datetime
+                has_spectrum_before = str(
+                    arrow.get(has_spectrum_before.strip()).datetime
+                )
             except arrow.ParserError:
                 return self.error(
                     f"Invalid input for parameter hasSpectrumBefore:{has_spectrum_before}"
@@ -964,9 +966,9 @@ class SourceHandler(BaseHandler):
             source_query = source_query.filter(Source.saved_at >= saved_after)
         if created_or_modified_after:
             try:
-                created_or_modified_date = arrow.get(
-                    created_or_modified_after.strip()
-                ).datetime
+                created_or_modified_date = str(
+                    arrow.get(created_or_modified_after.strip()).datetime
+                )
             except arrow.ParserError:
                 return self.error("Invalid value provided for createdOrModifiedAfter")
             obj_query = obj_query.filter(
@@ -1256,7 +1258,7 @@ class SourceHandler(BaseHandler):
                         peak_detected_mag,
                     ) = result
                 else:
-                    obj = result
+                    (obj,) = result
                 obj_list.append(obj.to_dict())
 
                 if include_comments:

--- a/skyportal/models/group.py
+++ b/skyportal/models/group.py
@@ -17,6 +17,7 @@ from baselayer.app.models import (
     AccessibleIfUserMatches,
     CustomUserAccessControl,
     public,
+    safe_aliased,
 )
 from baselayer.app.env import load_env
 
@@ -26,7 +27,7 @@ _, cfg = load_env()
 
 # group admins can set the admin status of other group members
 def groupuser_update_access_logic(cls, user_or_token):
-    aliased = sa.orm.aliased(cls)
+    aliased = safe_aliased(cls)
     user_id = UserAccessControl.user_id_from_user_or_token(user_or_token)
     query = DBSession().query(cls).join(aliased, cls.group_id == aliased.group_id)
     if not user_or_token.is_system_admin:
@@ -112,7 +113,7 @@ class AccessibleIfGroupUserMatches(AccessibleIfUserMatches):
         if columns is not None:
             query = DBSession().query(*columns).select_from(cls)
         else:
-            query = DBSession().query(cls)
+            query = DBSession().query(cls).select_from(cls)
 
         # traverse the relationship chain via sequential JOINs
         for relationship_name in self.relationship_names:

--- a/skyportal/models/schema.py
+++ b/skyportal/models/schema.py
@@ -107,7 +107,9 @@ def setup_schema():
     module.
 
     """
-    for class_ in _Base._decl_class_registry.values():
+    # for class_ in _Base._decl_class_registry.values():
+    for mapper in _Base.registry.mappers:
+        class_ = mapper.class_
         if hasattr(class_, '__tablename__'):
             if class_.__name__.endswith('Schema'):
                 raise _ModelConversionError(

--- a/skyportal/models/schema.py
+++ b/skyportal/models/schema.py
@@ -194,112 +194,152 @@ class PhotBaseFlexible(object):
     or deserialization."""
 
     mjd = fields.Field(
-        description='MJD of the observation(s). Can be a given as a '
-        'scalar or a 1D list. If a scalar, will be '
-        'broadcast to all values given as lists. '
-        'Null values not allowed.',
+        metadata={
+            'description': (
+                'MJD of the observation(s). Can be a given as a '
+                'scalar or a 1D list. If a scalar, will be '
+                'broadcast to all values given as lists. '
+                'Null values not allowed.'
+            ),
+        },
         required=True,
     )
 
     filter = fields.Field(
         required=True,
-        description='The bandpass of the observation(s). '
-        'Can be given as a scalar or a 1D list. '
-        'If a scalar, will be broadcast to all values '
-        'given as lists. Null values not allowed. Allowed values: '
-        f'{force_render_enum_markdown(ALLOWED_BANDPASSES)}',
+        metadata={
+            'description': (
+                'The bandpass of the observation(s). '
+                'Can be given as a scalar or a 1D list. '
+                'If a scalar, will be broadcast to all values '
+                'given as lists. Null values not allowed. Allowed values: '
+                f'{force_render_enum_markdown(ALLOWED_BANDPASSES)}'
+            )
+        },
     )
 
     obj_id = fields.Field(
-        description='ID of the `Obj`(s) to which the '
-        'photometry will be attached. '
-        'Can be given as a scalar or a 1D list. '
-        'If a scalar, will be broadcast to all values '
-        'given as lists. Null values are not allowed.',
+        metadata={
+            'description': (
+                'ID of the `Obj`(s) to which the '
+                'photometry will be attached. '
+                'Can be given as a scalar or a 1D list. '
+                'If a scalar, will be broadcast to all values '
+                'given as lists. Null values are not allowed.'
+            )
+        },
         required=True,
     )
 
     instrument_id = fields.Field(
-        description='ID of the `Instrument`(s) with which the '
-        'photometry was acquired. '
-        'Can be given as a scalar or a 1D list. '
-        'If a scalar, will be broadcast to all values '
-        'given as lists. Null values are not allowed.',
+        metadata={
+            'description': (
+                'ID of the `Instrument`(s) with which the '
+                'photometry was acquired. '
+                'Can be given as a scalar or a 1D list. '
+                'If a scalar, will be broadcast to all values '
+                'given as lists. Null values are not allowed.'
+            ),
+        },
         required=True,
     )
 
     assignment_id = fields.Integer(
-        description='ID of the classical assignment which generated the photometry',
+        metadata={
+            'description': 'ID of the classical assignment which generated the photometry'
+        },
         required=False,
         missing=None,
     )
 
     ra = fields.Field(
-        description='ICRS Right Ascension of the centroid '
-        'of the photometric aperture [deg]. '
-        'Can be given as a scalar or a 1D list. '
-        'If a scalar, will be broadcast to all values '
-        'given as lists. Null values allowed.',
+        metadata={
+            'description': (
+                'ICRS Right Ascension of the centroid '
+                'of the photometric aperture [deg]. '
+                'Can be given as a scalar or a 1D list. '
+                'If a scalar, will be broadcast to all values '
+                'given as lists. Null values allowed.'
+            )
+        },
         required=False,
         missing=None,
     )
 
     dec = fields.Field(
-        description='ICRS Declination of the centroid '
-        'of the photometric aperture [deg]. '
-        'Can be given as a scalar or a 1D list. '
-        'If a scalar, will be broadcast to all values '
-        'given as lists. Null values allowed.',
+        metadata={
+            'description': (
+                'ICRS Declination of the centroid '
+                'of the photometric aperture [deg]. '
+                'Can be given as a scalar or a 1D list. '
+                'If a scalar, will be broadcast to all values '
+                'given as lists. Null values allowed.'
+            )
+        },
         required=False,
         missing=None,
     )
 
     ra_unc = fields.Field(
-        description='Uncertainty on RA [arcsec]. '
-        'Can be given as a scalar or a 1D list. '
-        'If a scalar, will be broadcast to all values '
-        'given as lists. Null values allowed.',
+        metadata={
+            'description': 'Uncertainty on RA [arcsec]. '
+            'Can be given as a scalar or a 1D list. '
+            'If a scalar, will be broadcast to all values '
+            'given as lists. Null values allowed.'
+        },
         required=False,
         missing=None,
     )
 
     dec_unc = fields.Field(
-        description='Uncertainty on dec [arcsec]. '
-        'Can be given as a scalar or a 1D list. '
-        'If a scalar, will be broadcast to all values '
-        'given as lists. Null values allowed.',
+        metadata={
+            'description': 'Uncertainty on dec [arcsec]. '
+            'Can be given as a scalar or a 1D list. '
+            'If a scalar, will be broadcast to all values '
+            'given as lists. Null values allowed.'
+        },
         required=False,
         missing=None,
     )
 
     origin = fields.Field(
-        description="Provenance of the Photometry. If a record is "
-        "already present with identical origin, only the "
-        "groups or streams list will be updated (other data assumed "
-        "identical). Defaults to None.",
+        metadata={
+            'description': "Provenance of the Photometry. If a record is "
+            "already present with identical origin, only the "
+            "groups or streams list will be updated (other data assumed "
+            "identical). Defaults to None."
+        },
         missing=None,
     )
 
     group_ids = fields.Field(
-        description="List of group IDs to which photometry points will be visible. "
-        "If 'all', will be shared with site-wide public group (visible to all users "
-        "who can view associated source).",
+        metadata={
+            "description": "List of group IDs to which photometry points will be visible. "
+            "If 'all', will be shared with site-wide public group (visible to all users "
+            "who can view associated source)."
+        },
         required=False,
         missing=[],
     )
 
     stream_ids = fields.Field(
-        description="List of stream IDs to which photometry points will be visible.",
+        metadata={
+            'description': "List of stream IDs to which photometry points will be visible."
+        },
         required=False,
         missing=[],
     )
 
     altdata = fields.Field(
-        description="Misc. alternative metadata stored in JSON "
-        "format, e.g. `{'calibration': {'source': 'ps1', "
-        "'color_term': 0.012}, 'photometry_method': 'allstar', "
-        "'method_reference': 'Masci et al. (2015)'}`. Can be a list of "
-        "dicts or a single dict which will be broadcast to all values.",
+        metadata={
+            "description": (
+                "Misc. alternative metadata stored in JSON "
+                "format, e.g. `{'calibration': {'source': 'ps1',"
+                "'color_term': 0.012}, 'photometry_method': 'allstar', "
+                "'method_reference': 'Masci et al. (2015)'}`. Can be a list of "
+                "dicts or a single dict which will be broadcast to all values."
+            )
+        },
         missing=None,
         default=None,
         required=False,
@@ -324,46 +364,58 @@ class PhotFluxFlexible(_Schema, PhotBaseFlexible):
 
     magsys = fields.Field(
         required=True,
-        description='The magnitude system to which the flux, flux error, '
-        'and the zeropoint are tied. '
-        'Can be given as a scalar or a 1D list. '
-        'If a scalar, will be broadcast to all values '
-        'given as lists. Null values not allowed. Allowed values: '
-        f'{force_render_enum_markdown(ALLOWED_MAGSYSTEMS)}',
+        metadata={
+            'description': (
+                'The magnitude system to which the flux, flux error, '
+                'and the zeropoint are tied. '
+                'Can be given as a scalar or a 1D list. '
+                'If a scalar, will be broadcast to all values '
+                'given as lists. Null values not allowed. Allowed values: '
+                f'{force_render_enum_markdown(ALLOWED_MAGSYSTEMS)}'
+            ),
+        },
     )
 
     flux = fields.Field(
-        description='Flux of the observation(s) in counts. '
-        'Can be given as a scalar or a 1D list. '
-        'If a scalar, will be broadcast to all values '
-        'given as lists. Null values allowed, to accommodate,'
-        'e.g., upper limits from ZTF1, where flux is not provided '
-        'for non-detections. For a given photometry '
-        'point, if `flux` is null, `fluxerr` is '
-        'used to derive a n-sigma limiting magnitude '
-        '(where n is configurable; 3.0 by default) '
-        'when the photometry point is requested in '
-        'magnitude space from the Photomety GET api.',
+        metadata={
+            'description': (
+                'Flux of the observation(s) in counts. '
+                'Can be given as a scalar or a 1D list. '
+                'If a scalar, will be broadcast to all values '
+                'given as lists. Null values allowed, to accommodate,'
+                'e.g., upper limits from ZTF1, where flux is not provided '
+                'for non-detections. For a given photometry '
+                'point, if `flux` is null, `fluxerr` is '
+                'used to derive a n-sigma limiting magnitude '
+                '(where n is configurable; 3.0 by default) '
+                'when the photometry point is requested in '
+                'magnitude space from the Photomety GET api.'
+            ),
+        },
         required=False,
         missing=None,
     )
 
     fluxerr = fields.Field(
-        description='Gaussian error on the flux in counts. '
-        'Can be given as a scalar or a 1D list. '
-        'If a scalar, will be broadcast to all values '
-        'given as lists. Null values not allowed.',
+        metadata={
+            'description': 'Gaussian error on the flux in counts. '
+            'Can be given as a scalar or a 1D list. '
+            'If a scalar, will be broadcast to all values '
+            'given as lists. Null values not allowed.'
+        },
         required=True,
         validate=validate_fluxerr,
     )
 
     zp = fields.Field(
-        description='Magnitude zeropoint, given by `zp` in the '
-        'equation `m = -2.5 log10(flux) + zp`. '
-        '`m` is the magnitude of the object in the '
-        'magnitude system `magsys`. '
-        'Can be given as a scalar or a 1D list. '
-        'Null values not allowed.',
+        metadata={
+            'description': 'Magnitude zeropoint, given by `zp` in the '
+            'equation `m = -2.5 log10(flux) + zp`. '
+            '`m` is the magnitude of the object in the '
+            'magnitude system `magsys`. '
+            'Can be given as a scalar or a 1D list. '
+            'Null values not allowed.'
+        },
         required=True,
     )
 
@@ -385,52 +437,62 @@ class PhotMagFlexible(_Schema, PhotBaseFlexible):
 
     magsys = fields.Field(
         required=True,
-        description='The magnitude system to which the magnitude, '
-        'magnitude error, and limiting magnitude are tied. '
-        'Can be given as a scalar or a 1D list. '
-        'If a scalar, will be broadcast to all values '
-        'given as lists. Null values not allowed. Allowed values: '
-        f'{force_render_enum_markdown(ALLOWED_MAGSYSTEMS)}',
+        metadata={
+            'description': 'The magnitude system to which the magnitude, '
+            'magnitude error, and limiting magnitude are tied. '
+            'Can be given as a scalar or a 1D list. '
+            'If a scalar, will be broadcast to all values '
+            'given as lists. Null values not allowed. Allowed values: '
+            f'{force_render_enum_markdown(ALLOWED_MAGSYSTEMS)}'
+        },
     )
 
     mag = fields.Field(
-        description='Magnitude of the observation in the '
-        'magnitude system `magsys`. '
-        'Can be given as a scalar or a 1D list. '
-        'If a scalar, will be broadcast to all values '
-        'given as lists. Null values allowed for non-detections. '
-        'If `mag` is null, the corresponding '
-        '`magerr` must also be null.',
+        metadata={
+            'description': 'Magnitude of the observation in the '
+            'magnitude system `magsys`. '
+            'Can be given as a scalar or a 1D list. '
+            'If a scalar, will be broadcast to all values '
+            'given as lists. Null values allowed for non-detections. '
+            'If `mag` is null, the corresponding '
+            '`magerr` must also be null.'
+        },
         required=False,
         missing=None,
     )
 
     magerr = fields.Field(
-        description='Magnitude of the observation in the '
-        'magnitude system `magsys`. '
-        'Can be given as a scalar or a 1D list. '
-        'If a scalar, will be broadcast to all values '
-        'given as lists. Null values allowed for non-detections. '
-        'If `magerr` is null, the corresponding `mag` '
-        'must also be null.',
+        metadata={
+            'description': 'Magnitude of the observation in the '
+            'magnitude system `magsys`. '
+            'Can be given as a scalar or a 1D list. '
+            'If a scalar, will be broadcast to all values '
+            'given as lists. Null values allowed for non-detections. '
+            'If `magerr` is null, the corresponding `mag` '
+            'must also be null.'
+        },
         required=False,
         missing=None,
     )
 
     limiting_mag = fields.Field(
-        description='Limiting magnitude of the image '
-        'in the magnitude system `magsys`. '
-        'Can be given as a scalar or a 1D list. '
-        'If a scalar, will be broadcast to all values '
-        'given as lists. Null values not allowed.',
+        metadata={
+            'description': 'Limiting magnitude of the image '
+            'in the magnitude system `magsys`. '
+            'Can be given as a scalar or a 1D list. '
+            'If a scalar, will be broadcast to all values '
+            'given as lists. Null values not allowed.'
+        },
         required=True,
     )
 
     limiting_mag_nsigma = fields.Field(
-        description='Number of standard deviations '
-        'above the background that the limiting '
-        'magnitudes correspond to. Null values '
-        f'not allowed. Default = {PHOT_DETECTION_THRESHOLD}.',
+        metadata={
+            'description': 'Number of standard deviations '
+            'above the background that the limiting '
+            'magnitudes correspond to. Null values '
+            f'not allowed. Default = {PHOT_DETECTION_THRESHOLD}.'
+        },
         required=False,
         missing=PHOT_DETECTION_THRESHOLD,
     )
@@ -443,80 +505,113 @@ class PhotBase(object):
     PhotometryHandler.get`.
     """
 
-    mjd = fields.Number(description='MJD of the observation.', required=True)
+    mjd = fields.Number(
+        metadata={'description': 'MJD of the observation.'}, required=True
+    )
     magsys = ApispecEnumField(
         py_allowed_magsystems,
         required=True,
-        description='The magnitude system to which the '
-        'flux and the zeropoint are tied.',
+        metadata={
+            'description': 'The magnitude system to which the '
+            'flux and the zeropoint are tied.'
+        },
     )
     filter = ApispecEnumField(
         py_allowed_bandpasses,
         required=True,
-        description='The bandpass of the observation.',
+        metadata={'description': 'The bandpass of the observation.'},
     )
 
     obj_id = fields.String(
-        description='ID of the Object to which the ' 'photometry will be attached.',
+        metadata={
+            'description': 'ID of the Object to which the '
+            'photometry will be attached.'
+        },
         required=True,
     )
 
     instrument_id = fields.Integer(
-        description='ID of the instrument with which'
-        ' the observation was carried '
-        'out.',
+        metadata={
+            'description': 'ID of the instrument with which'
+            ' the observation was carried '
+            'out.'
+        },
         required=True,
     )
 
     assignment_id = fields.Integer(
-        description='ID of the classical assignment which generated the photometry',
+        metadata={
+            'description': 'ID of the classical assignment which generated the photometry'
+        },
         required=False,
         missing=None,
     )
 
     origin = fields.Field(
-        description="Provenance of the Photometry. If a record is "
-        "already present with identical origin, only the "
-        "groups or streams list will be updated (other data assumed "
-        "identical). Defaults to None.",
+        metadata={
+            'description': (
+                "Provenance of the Photometry. If a record is "
+                "already present with identical origin, only the "
+                "groups or streams list will be updated (other data assumed "
+                "identical). Defaults to None."
+            )
+        },
         missing=None,
     )
 
     ra = fields.Number(
-        description='ICRS Right Ascension of the centroid '
-        'of the photometric aperture [deg].',
+        metadata={
+            "description": (
+                'ICRS Right Ascension of the centroid '
+                'of the photometric aperture [deg].'
+            )
+        },
         missing=None,
         default=None,
     )
     dec = fields.Number(
-        description='ICRS Declination of the centroid '
-        'of the photometric aperture [deg].',
+        metadata={
+            'description': 'ICRS Declination of the centroid '
+            'of the photometric aperture [deg].'
+        },
         missing=None,
         default=None,
     )
 
     ra_unc = fields.Number(
-        description='Uncertainty on RA [arcsec].', missing=None, default=None
+        metadata={'description': 'Uncertainty on RA [arcsec].'},
+        missing=None,
+        default=None,
     )
 
     dec_unc = fields.Number(
-        description='Uncertainty on dec [arcsec].', missing=None, default=None
+        metadata={'description': 'Uncertainty on dec [arcsec].'},
+        missing=None,
+        default=None,
     )
 
     alert_id = fields.Integer(
-        description="Corresponding alert ID. If a record is "
-        "already present with identical alert ID, only the "
-        "groups list will be updated (other alert data assumed "
-        "identical). Defaults to None.",
+        metadata={
+            'description': (
+                "Corresponding alert ID. If a record is "
+                "already present with identical alert ID, only the "
+                "groups list will be updated (other alert data assumed "
+                "identical). Defaults to None."
+            )
+        },
         missing=None,
         default=None,
     )
 
     altdata = fields.Dict(
-        description="Misc. alternative metadata stored in JSON "
-        "format, e.g. `{'calibration': {'source': 'ps1', "
-        "'color_term': 0.012}, 'photometry_method': 'allstar', "
-        "'method_reference': 'Masci et al. (2015)'}`",
+        metadata={
+            "description": (
+                "Misc. alternative metadata stored in JSON "
+                "format, e.g. `{'calibration': {'source': 'ps1',"
+                "'color_term': 0.012}, 'photometry_method': 'allstar', "
+                "'method_reference': 'Masci et al. (2015)'}`"
+            )
+        },
         missing=None,
         default=None,
     )
@@ -537,26 +632,30 @@ class PhotometryFlux(_Schema, PhotBase):
     """
 
     flux = fields.Number(
-        description='Flux of the observation in counts. '
-        'Can be null to accommodate upper '
-        'limits from ZTF1, where no flux is measured '
-        'for non-detections. If flux is null, '
-        'the flux error is used to derive a '
-        'limiting magnitude.',
+        metadata={
+            'description': 'Flux of the observation in counts. '
+            'Can be null to accommodate upper '
+            'limits from ZTF1, where no flux is measured '
+            'for non-detections. If flux is null, '
+            'the flux error is used to derive a '
+            'limiting magnitude.'
+        },
         required=False,
         missing=None,
         default=None,
     )
 
     fluxerr = fields.Number(
-        description='Gaussian error on the flux in counts.', required=True
+        metadata={'description': 'Gaussian error on the flux in counts.'}, required=True
     )
 
     zp = fields.Number(
-        description='Magnitude zeropoint, given by `ZP` in the '
-        'equation m = -2.5 log10(flux) + `ZP`. '
-        'm is the magnitude of the object in the '
-        'magnitude system `magsys`.',
+        metadata={
+            'description': 'Magnitude zeropoint, given by `ZP` in the '
+            'equation m = -2.5 log10(flux) + `ZP`. '
+            'm is the magnitude of the object in the '
+            'magnitude system `magsys`.'
+        },
         required=True,
     )
 
@@ -633,24 +732,30 @@ class PhotometryMag(_Schema, PhotBase):
     """
 
     mag = fields.Number(
-        description='Magnitude of the observation in the '
-        'magnitude system `magsys`. Can be null '
-        'in the case of a non-detection.',
+        metadata={
+            'description': 'Magnitude of the observation in the '
+            'magnitude system `magsys`. Can be null '
+            'in the case of a non-detection.'
+        },
         required=False,
         missing=None,
         default=None,
     )
     magerr = fields.Number(
-        description='Magnitude error of the observation in '
-        'the magnitude system `magsys`. Can be '
-        'null in the case of a non-detection.',
+        metadata={
+            'description': 'Magnitude error of the observation in '
+            'the magnitude system `magsys`. Can be '
+            'null in the case of a non-detection.'
+        },
         required=False,
         missing=None,
         default=None,
     )
     limiting_mag = fields.Number(
-        description='Limiting magnitude of the image '
-        'in the magnitude system `magsys`.',
+        metadata={
+            'description': 'Limiting magnitude of the image '
+            'in the magnitude system `magsys`.'
+        },
         required=True,
     )
 
@@ -761,89 +866,108 @@ class AssignmentSchema(_Schema):
 
     run_id = fields.Integer(required=True)
     obj_id = fields.String(
-        required=True, description='The ID of the object to observe.'
+        required=True, metadata={'description': 'The ID of the object to observe.'}
     )
     priority = ApispecEnumField(
         py_followup_priorities,
         required=True,
-        description='Priority of the request, ' '(lowest = 1, highest = 5).',
+        metadata={
+            "description": ('Priority of the request, ' '(lowest = 1, highest = 5).')
+        },
     )
-    status = fields.String(description='The status of the request')
-    comment = fields.String(description='An optional comment describing the request.')
+    status = fields.String(metadata={'description': 'The status of the request'})
+    comment = fields.String(
+        metadata={'description': 'An optional comment describing the request.'}
+    )
 
 
 class ObservingRunPost(_Schema):
     instrument_id = fields.Integer(
-        required=True, description='The ID of the instrument to be ' 'used in this run.'
+        required=True,
+        metadata={
+            "description": ('The ID of the instrument to be ' 'used in this run.')
+        },
     )
 
     # name of the PI
-    pi = fields.String(description='The PI of the observing run.')
-    observers = fields.String(description='The names of the observers')
+    pi = fields.String(metadata={'description': 'The PI of the observing run.'})
+    observers = fields.String(metadata={'description': 'The names of the observers'})
     group_id = fields.Integer(
-        description='The ID of the group this run is associated with.'
+        metadata={'description': 'The ID of the group this run is associated with.'}
     )
     calendar_date = fields.Date(
-        description='The local calendar date of the run.', required=True
+        metadata={"description": 'The local calendar date of the run.'}, required=True
     )
 
 
 class GcnHandlerPut(_Schema):
-    xml = fields.String(description='VOEvent XML content.')
+    xml = fields.String(metadata={'description': 'VOEvent XML content.'})
 
 
 class GcnEventHandlerGet(_Schema):
-    tags = fields.List(fields.Field(), description='Event tags')
-    dateobs = fields.Field(description='UTC event timestamp')
-    localizations = fields.List(fields.Field(), description='Healpix localizations')
-    notices = fields.List(fields.Field(), description='VOEvent XML notices')
-    lightcurve = fields.String(description='URL for light curve')
+    tags = fields.List(fields.Field(), metadata={'description': 'Event tags'})
+    dateobs = fields.Field(metadata={'description': 'UTC event timestamp'})
+    localizations = fields.List(
+        fields.Field(), metadata={'description': 'Healpix localizations'}
+    )
+    notices = fields.List(
+        fields.Field(), metadata={'description': 'VOEvent XML notices'}
+    )
+    lightcurve = fields.String(metadata={'description': 'URL for light curve'})
 
 
 class LocalizationHandlerGet(_Schema):
-    localization_name = fields.String(description='Localization name')
-    dateobs = fields.String(description='UTC event timestamp')
-    flat_2d = fields.List(fields.Float, description='Flattened 2D healpix map')
-    contour = fields.Field(description='GeoJSON contours of healpix map')
+    localization_name = fields.String(metadata={'description': 'Localization name'})
+    dateobs = fields.String(metadata={'description': 'UTC event timestamp'})
+    flat_2d = fields.List(
+        fields.Float, metadata={'description': 'Flattened 2D healpix map'}
+    )
+    contour = fields.Field(metadata={'description': 'GeoJSON contours of healpix map'})
 
 
 class GcnEventViewsHandlerGet(_Schema):
-    tags = fields.List(fields.Field(), description='Event list')
+    tags = fields.List(fields.Field(), metadata={'description': 'Event list'})
 
 
 class FollowupRequestPost(_Schema):
 
     obj_id = fields.String(
         required=True,
-        description="ID of the target Obj.",
+        metadata={'description': "ID of the target Obj."},
     )
 
     payload = fields.Field(
-        required=False, description="Content of the followup request."
+        required=False, metadata={'description': "Content of the followup request."}
     )
 
     status = fields.String(
         missing="pending submission",
-        description="The status of the request.",
+        metadata={'description': "The status of the request."},
         required=False,
     )
 
     allocation_id = fields.Integer(
-        required=True, description="Followup request allocation ID."
+        required=True,
+        metadata={'description': "Followup request allocation ID."},
     )
 
     target_group_ids = fields.List(
         fields.Integer,
         required=False,
-        description='IDs of groups to share the results of the f'
-        'ollowup request with.',
+        metadata={
+            'description': (
+                'IDs of groups to share the results of the f' 'ollowup request with.'
+            )
+        },
     )
 
 
 class ObservingRunGet(ObservingRunPost):
-    owner_id = fields.Integer(description='The User ID of the owner of this run.')
-    ephemeris = fields.Field(description='Observing run ephemeris data.')
-    id = fields.Integer(description='Unique identifier for the run.')
+    owner_id = fields.Integer(
+        metadata={'description': 'The User ID of the owner of this run.'}
+    )
+    ephemeris = fields.Field(metadata={'description': 'Observing run ephemeris data.'})
+    id = fields.Integer(metadata={'description': 'Unique identifier for the run.'})
 
     @pre_dump
     def serialize(self, data, **kwargs):
@@ -859,9 +983,13 @@ class ObservingRunGetWithAssignments(ObservingRunGet):
 class PhotometryRangeQuery(_Schema):
     instrument_ids = fields.List(
         fields.Integer,
-        description="IDs of the instruments to query "
-        "for photometry from. If `None`, "
-        "queries all instruments.",
+        metadata={
+            'description': (
+                "IDs of the instruments to query "
+                "for photometry from. If `None`, "
+                "queries all instruments."
+            )
+        },
         required=False,
         missing=None,
         default=None,
@@ -869,18 +997,26 @@ class PhotometryRangeQuery(_Schema):
 
     min_date = fields.DateTime(
         required=False,
-        description='Query for photometry taken after '
-        'this UT `DateTime`. For an '
-        'open-ended interval use `None`.',
+        metadata={
+            'description': (
+                'Query for photometry taken after '
+                'this UT `DateTime`. For an '
+                'open-ended interval use `None`.'
+            )
+        },
         missing=None,
         default=None,
     )
 
     max_date = fields.DateTime(
         required=False,
-        description='Query for photometry taken before '
-        'this UT `DateTime`. For an '
-        'open-ended interval use `None`.',
+        metadata={
+            'description': (
+                'Query for photometry taken before '
+                'this UT `DateTime`. For an '
+                'open-ended interval use `None`.'
+            )
+        },
         missing=None,
         default=None,
     )
@@ -890,24 +1026,37 @@ class SpectrumAsciiFileParseJSON(_Schema):
 
     wave_column = fields.Integer(
         missing=0,
-        description="The 0-based index of the ASCII column corresponding "
-        "to the wavelength values of the spectrum (default 0).",
+        metadata={
+            'description': (
+                "The 0-based index of the ASCII column corresponding "
+                "to the wavelength values of the spectrum (default 0)."
+            )
+        },
     )
     flux_column = fields.Integer(
         missing=1,
-        description="The 0-based index of the ASCII column corresponding to "
-        "the flux values of the spectrum (default 1).",
+        metadata={
+            'description': (
+                "The 0-based index of the ASCII column corresponding to "
+                "the flux values of the spectrum (default 1)."
+            )
+        },
     )
     fluxerr_column = fields.Integer(
         missing=None,
-        description="The 0-based index of the ASCII column corresponding to the flux "
-        "error values of the spectrum (default None). If a column for errors "
-        "is provided, set to the corresponding 0-based column number, "
-        "otherwise, it will be ignored.",
+        metadata={
+            'description': (
+                "The 0-based index of the ASCII column corresponding to the flux "
+                "error values of the spectrum (default None). If a column for errors "
+                "is provided, set to the corresponding 0-based column number, "
+                "otherwise, it will be ignored."
+            )
+        },
     )
 
     ascii = fields.String(
-        description="""The content of the ASCII file to be parsed.
+        metadata={
+            'description': """The content of the ASCII file to be parsed.
 
 The file can optionally contain a header which will be parsed and stored.
 
@@ -1028,80 +1177,100 @@ Many-column ASCII:
 7994.40 1.236514
 ```
 
-""",
+"""
+        },
         required=True,
     )
 
 
 class SpectrumAsciiFilePostJSON(SpectrumAsciiFileParseJSON):
     obj_id = fields.String(
-        description='The ID of the object that the spectrum is of.', required=True
+        metadata={'description': 'The ID of the object that the spectrum is of.'},
+        required=True,
     )
 
     instrument_id = fields.Integer(
-        description='The ID of the instrument that took the spectrum.', required=True
+        metadata={'description': 'The ID of the instrument that took the spectrum.'},
+        required=True,
     )
 
     type = fields.String(
         validate=validate.OneOf(ALLOWED_SPECTRUM_TYPES),
-        by_value=True,
         required=False,
-        description=f'''Type of spectrum. One of: {', '.join(f"'{t}'" for t in ALLOWED_SPECTRUM_TYPES)}.
-                            Defaults to 'f{default_spectrum_type}'.''',
+        metadata={
+            'by_value': True,
+            'description': f'''Type of spectrum. One of: {', '.join(f"'{t}'" for t in ALLOWED_SPECTRUM_TYPES)}.
+                    Defaults to 'f{default_spectrum_type}'.''',
+        },
     )
 
     label = fields.String(
-        description='User defined label to be placed in plot legends, '
-        'instead of the default <instrument>-<date taken>.',
+        metadata={
+            'description': 'User defined label to be placed in plot legends, '
+            'instead of the default <instrument>-<date taken>.'
+        },
         required=False,
     )
 
     observed_at = fields.DateTime(
-        description='The ISO UTC time the spectrum was taken.', required=True
+        metadata={'description': 'The ISO UTC time the spectrum was taken.'},
+        required=True,
     )
 
     group_ids = fields.List(
-        fields.Integer, description="The IDs of the groups to share this spectrum with."
+        fields.Integer,
+        metadata={'description': "The IDs of the groups to share this spectrum with."},
     )
 
     filename = fields.String(
-        description="The original filename (for bookkeeping purposes).",
+        metadata={'description': "The original filename (for bookkeeping purposes)."},
         required=True,
     )
     reduced_by = fields.List(
         fields.Integer,
-        description="IDs of the Users who reduced this Spectrum, or to use as points of contact given an external reducer.",
+        metadata={
+            'description': "IDs of the Users who reduced this Spectrum, or to use as points of contact given an external reducer."
+        },
         missing=[],
     )
 
     external_reducer = fields.String(
-        description="Free text provided as an external reducer",
+        metadata={'description': "Free text provided as an external reducer"},
         required=False,
         missing=None,
     )
 
     observed_by = fields.List(
         fields.Integer,
-        description="IDs of the Users who observed this Spectrum, or to use as points of contact given an external observer.",
+        metadata={
+            'description': "IDs of the Users who observed this Spectrum, or to use as points of contact given an external observer."
+        },
         missing=[],
     )
 
     external_observer = fields.String(
-        description="Free text provided as an external observer",
+        metadata={'description': "Free text provided as an external observer"},
         required=False,
         missing=None,
     )
 
     followup_request_id = fields.Integer(
         required=False,
-        description='ID of the Followup request that generated this spectrum, '
-        'if any.',
+        metadata={
+            'description': (
+                'ID of the Followup request that generated this spectrum, ' 'if any.'
+            )
+        },
     )
 
     assignment_id = fields.Integer(
         required=False,
-        description='ID of the classical assignment that generated this spectrum, '
-        'if any.',
+        metadata={
+            'description': (
+                'ID of the classical assignment that generated this spectrum, '
+                'if any.'
+            )
+        },
     )
 
 
@@ -1110,91 +1279,112 @@ class SpectrumPost(_Schema):
     wavelengths = fields.List(
         fields.Float,
         required=True,
-        description="Wavelengths of the spectrum [Angstrom].",
+        metadata={'description': "Wavelengths of the spectrum [Angstrom]."},
     )
 
     fluxes = fields.List(
         fields.Float,
         required=True,
-        description="Flux of the Spectrum [F_lambda, arbitrary units].",
+        metadata={'description': "Flux of the Spectrum [F_lambda, arbitrary units]."},
     )
 
     errors = fields.List(
         fields.Float,
-        description="Errors on the fluxes of the spectrum [F_lambda, same units as `fluxes`.]",
+        metadata={
+            'description': "Errors on the fluxes of the spectrum [F_lambda, same units as `fluxes`.]"
+        },
     )
 
     obj_id = fields.String(
         required=True,
-        description="ID of this Spectrum's Obj.",
+        metadata={'description': "ID of this Spectrum's Obj."},
     )
 
     observed_at = fields.DateTime(
-        description='The ISO UTC time the spectrum was taken.', required=True
+        metadata={'description': 'The ISO UTC time the spectrum was taken.'},
+        required=True,
     )
 
     reduced_by = fields.List(
         fields.Integer,
-        description="IDs of the Users who reduced this Spectrum, or to use as points of contact given an external reducer.",
+        metadata={
+            'description': "IDs of the Users who reduced this Spectrum, or to use as points of contact given an external reducer."
+        },
         missing=[],
     )
 
     external_reducer = fields.String(
-        description="Free text provided as an external reducer",
+        metadata={'description': "Free text provided as an external reducer"},
         required=False,
         missing=None,
     )
 
     observed_by = fields.List(
         fields.Integer,
-        description="IDs of the Users who observed this Spectrum, or to use as points of contact given an external observer.",
+        metadata={
+            'description': "IDs of the Users who observed this Spectrum, or to use as points of contact given an external observer."
+        },
         missing=[],
     )
 
     external_observer = fields.String(
-        description="Free text provided as an external observer",
+        metadata={'description': "Free text provided as an external observer"},
         required=False,
         missing=None,
     )
 
-    origin = fields.String(required=False, description="Origin of the spectrum.")
+    origin = fields.String(
+        required=False, metadata={'description': "Origin of the spectrum."}
+    )
 
     type = fields.String(
         validate=validate.OneOf(ALLOWED_SPECTRUM_TYPES),
         required=False,
-        description=f'''Type of spectrum. One of: {', '.join(f"'{t}'" for t in ALLOWED_SPECTRUM_TYPES)}.
-                        Defaults to 'f{default_spectrum_type}'.''',
+        metadata={
+            "description": f'''Type of spectrum. One of: {''.join(f"'{t}'" for t in ALLOWED_SPECTRUM_TYPES)}.
+                         Defaults to 'f{default_spectrum_type}'.'''
+        },
     )
 
     label = fields.String(
         required=False,
-        description="User defined label (can be used to replace default instrument/date labeling on plot legends).",
+        metadata={
+            'description': "User defined label (can be used to replace default instrument/date labeling on plot legends)."
+        },
     )
 
     instrument_id = fields.Integer(
         required=True,
-        description="ID of the Instrument that acquired the Spectrum.",
+        metadata={'description': "ID of the Instrument that acquired the Spectrum."},
     )
 
     group_ids = fields.Field(
         missing=[],
-        description='IDs of the Groups to share this spectrum with. Set to "all"'
-        ' to make this spectrum visible to all users.',
+        metadata={
+            'description': 'IDs of the Groups to share this spectrum with. Set to "all"'
+            ' to make this spectrum visible to all users.'
+        },
     )
 
     followup_request_id = fields.Integer(
         required=False,
-        description='ID of the Followup request that generated this spectrum, '
-        'if any.',
+        metadata={
+            'description': 'ID of the Followup request that generated this spectrum, '
+            'if any.'
+        },
     )
 
     assignment_id = fields.Integer(
         required=False,
-        description='ID of the classical assignment that generated this spectrum, '
-        'if any.',
+        metadata={
+            'description': 'ID of the classical assignment that generated this spectrum, '
+            'if any.'
+        },
     )
 
-    altdata = fields.Field(description='Miscellaneous alternative metadata.')
+    altdata = fields.Field(
+        metadata={'description': 'Miscellaneous alternative metadata.'}
+    )
 
 
 class GroupIDList(_Schema):
@@ -1203,8 +1393,10 @@ class GroupIDList(_Schema):
 
 
 class GalaxyHandlerPost(_Schema):
-    catalog_name = fields.String(description='Galaxy catalog name.')
-    catalog_data = fields.List(fields.Field(), description='Galaxy catalog data')
+    catalog_name = fields.String(metadata={"description": 'Galaxy catalog name.'})
+    catalog_data = fields.List(
+        fields.Field(), metadata={"description": 'Galaxy catalog data'}
+    )
 
 
 def register_components(spec):

--- a/skyportal/tests/api/test_photometry.py
+++ b/skyportal/tests/api/test_photometry.py
@@ -478,12 +478,20 @@ def test_retrieve_photometry_error_group_membership_posted_by_other(
         },
         token=upload_data_token,
     )
+    print(
+        "upload_data_token user's single user group id:",
+        Token.query.get(upload_data_token).created_by.single_user_group.id,
+    )
     assert status == 200
     assert data['status'] == 'success'
 
     photometry_id = data['data']['ids'][0]
     status, data = api(
         'GET', f'photometry/{photometry_id}?format=flux', token=view_only_token
+    )
+    print(
+        "view only token group ids:",
+        [g.id for g in Token.query.get(view_only_token).created_by.groups],
     )
     # `view_only_token only` belongs to `public_group`, not `public_group2`
     assert status == 400

--- a/skyportal/tests/conftest.py
+++ b/skyportal/tests/conftest.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import astroplan
 import numpy as np
 import pytest
+import sqlalchemy as sa
 
 from baselayer.app import models
 from baselayer.app.test_util import driver  # noqa: F401
@@ -15,7 +16,6 @@ from skyportal.model_util import create_token, delete_token
 from skyportal.models import (
     DBSession,
     User,
-    Role,
     Source,
     Candidate,
     GroupStream,
@@ -57,7 +57,11 @@ from skyportal.models import Obj
 # Add a "test factory" User so that all factory-generated comments have a
 # proper author, if it doesn't already exist (the user may already be in
 # there if running the test server and running tests individually)
-if not DBSession.query(User).filter(User.username == "test factory").scalar():
+if (
+    not DBSession()
+    .execute(sa.select(User).filter(User.username == "test factory"))
+    .scalar()
+):
     DBSession.add(User(username="test factory"))
     DBSession.commit()
 
@@ -66,7 +70,11 @@ if not DBSession.query(User).filter(User.username == "test factory").scalar():
 # With invitations enabled on the test configs, the driver fails to login properly
 # without this user because the authenticator looks for the user or an
 # invitation token when neither exists initially on fresh test databases.
-if not DBSession.query(User).filter(User.username == "testuser-cesium-ml-org").scalar():
+if (
+    not DBSession()
+    .execute(sa.select(User).filter(User.username == "testuser-cesium-ml-org"))
+    .scalar()
+):
     DBSession.add(
         User(username="testuser-cesium-ml-org", oauth_uid="testuser@cesium-ml.org")
     )
@@ -104,8 +112,8 @@ def test_driver_user(request):
     if 'driver' in request.node.funcargs:
         testuser = (
             DBSession()
-            .query(User)
-            .filter(User.username == "testuser-cesium-ml-org")
+            .execute(sa.select(User).filter(User.username == "testuser-cesium-ml-org"))
+            .scalars()
             .first()
         )
         webdriver = request.node.funcargs['driver']
@@ -272,11 +280,13 @@ def group_with_stream_with_users(
 def public_groupstream(public_group):
     return (
         DBSession()
-        .query(GroupStream)
-        .filter(
-            GroupStream.group_id == public_group.id,
-            GroupStream.stream_id == public_group.streams[0].id,
+        .execute(
+            sa.select(GroupStream).filter(
+                GroupStream.group_id == public_group.id,
+                GroupStream.stream_id == public_group.streams[0].id,
+            )
         )
+        .scalars()
         .first()
     )
 
@@ -285,8 +295,12 @@ def public_groupstream(public_group):
 def public_streamuser(public_stream, user):
     return (
         DBSession()
-        .query(StreamUser)
-        .filter(StreamUser.user_id == user.id, StreamUser.stream_id == public_stream.id)
+        .execute(
+            sa.select(StreamUser).filter(
+                StreamUser.user_id == user.id, StreamUser.stream_id == public_stream.id
+            )
+        )
+        .scalars()
         .first()
     )
 
@@ -295,11 +309,13 @@ def public_streamuser(public_stream, user):
 def public_streamuser_no_groups(public_stream, user_no_groups):
     return (
         DBSession()
-        .query(StreamUser)
-        .filter(
-            StreamUser.user_id == user_no_groups.id,
-            StreamUser.stream_id == public_stream.id,
+        .execute(
+            sa.select(StreamUser).filter(
+                StreamUser.user_id == user_no_groups.id,
+                StreamUser.stream_id == public_stream.id,
+            )
         )
+        .scalars()
         .first()
     )
 
@@ -389,7 +405,7 @@ def public_source_no_data(public_group):
     yield obj
     # If the obj wasn't deleted by the test using it, clean up
     DBSession().expire(obj)
-    if DBSession().query(Obj).filter(Obj.id == obj_id).first():
+    if DBSession().execute(sa.select(Obj).filter(Obj.id == obj_id)).scalars().first():
         DBSession().delete(obj)
         DBSession().commit()
 
@@ -649,7 +665,12 @@ def private_source():
 def user(public_group, public_stream):
     user = UserFactory(
         groups=[public_group],
-        roles=[models.Role.query.get("Full user")],
+        roles=[
+            DBSession()
+            .execute(sa.select(models.Role).filter(models.Role.id == "Full user"))
+            .scalars()
+            .first()
+        ],
         streams=[public_stream],
     )
     user_id = user.id
@@ -661,7 +682,12 @@ def user(public_group, public_stream):
 def user_stream2_only(public_group, public_stream2):
     user = UserFactory(
         groups=[public_group],
-        roles=[models.Role.query.get("Full user")],
+        roles=[
+            DBSession()
+            .execute(sa.select(models.Role).filter(models.Role.id == "Full user"))
+            .scalars()
+            .first()
+        ],
         streams=[public_stream2],
     )
     user_id = user.id
@@ -673,7 +699,12 @@ def user_stream2_only(public_group, public_stream2):
 def user_group2(public_group2, public_stream):
     user = UserFactory(
         groups=[public_group2],
-        roles=[models.Role.query.get("Full user")],
+        roles=[
+            DBSession()
+            .execute(sa.select(models.Role).filter(models.Role.id == "Full user"))
+            .scalars()
+            .first()
+        ],
         streams=[public_stream],
     )
     user_id = user.id
@@ -687,8 +718,12 @@ def public_groupuser(public_group, user):
     DBSession().commit()
     return (
         DBSession()
-        .query(GroupUser)
-        .filter(GroupUser.group_id == public_group.id, GroupUser.user_id == user.id)
+        .execute(
+            sa.select(GroupUser).filter(
+                GroupUser.group_id == public_group.id, GroupUser.user_id == user.id
+            )
+        )
+        .scalars()
         .first()
     )
 
@@ -697,7 +732,12 @@ def public_groupuser(public_group, user):
 def user2(public_group, public_stream):
     user = UserFactory(
         groups=[public_group],
-        roles=[models.Role.query.get("Full user")],
+        roles=[
+            DBSession()
+            .execute(sa.select(models.Role).filter(models.Role.id == "Full user"))
+            .scalars()
+            .first()
+        ],
         streams=[public_stream],
     )
     user_id = user.id
@@ -708,7 +748,13 @@ def user2(public_group, public_stream):
 @pytest.fixture()
 def user_no_groups(public_stream):
     user = UserFactory(
-        roles=[models.Role.query.get("Full user")], streams=[public_stream]
+        roles=[
+            DBSession()
+            .execute(sa.select(models.Role).filter(models.Role.id == "Full user"))
+            .scalars()
+            .first()
+        ],
+        streams=[public_stream],
     )
     user_id = user.id
     yield user
@@ -718,7 +764,12 @@ def user_no_groups(public_stream):
 @pytest.fixture()
 def user_no_groups_two_streams(public_stream, public_stream2):
     user = UserFactory(
-        roles=[models.Role.query.get("Full user")],
+        roles=[
+            DBSession()
+            .execute(sa.select(models.Role).filter(models.Role.id == "Full user"))
+            .scalars()
+            .first()
+        ],
         streams=[public_stream, public_stream2],
     )
     user_id = user.id
@@ -728,7 +779,15 @@ def user_no_groups_two_streams(public_stream, public_stream2):
 
 @pytest.fixture()
 def user_no_groups_no_streams():
-    user = UserFactory(roles=[models.Role.query.get("Full user")], streams=[])
+    user = UserFactory(
+        roles=[
+            DBSession()
+            .execute(sa.select(models.Role).filter(models.Role.id == "Full user"))
+            .scalars()
+            .first()
+        ],
+        streams=[],
+    )
     user_id = user.id
     yield user
     UserFactory.teardown(user_id)
@@ -794,7 +853,12 @@ def upload_data_token_no_groups_no_streams(user_no_groups_no_streams):
 def user_two_groups(public_group, public_group2, public_stream):
     user = UserFactory(
         groups=[public_group, public_group2],
-        roles=[models.Role.query.get("Full user")],
+        roles=[
+            DBSession()
+            .execute(sa.select(models.Role).filter(models.Role.id == "Full user"))
+            .scalars()
+            .first()
+        ],
         streams=[public_stream],
     )
     user_id = user.id
@@ -806,7 +870,12 @@ def user_two_groups(public_group, public_group2, public_stream):
 def view_only_user(public_group, public_stream):
     user = UserFactory(
         groups=[public_group],
-        roles=[models.Role.query.get("View only")],
+        roles=[
+            DBSession()
+            .execute(sa.select(models.Role).filter(models.Role.id == "View only"))
+            .scalars()
+            .first()
+        ],
         streams=[public_stream],
     )
     user_id = user.id
@@ -818,7 +887,12 @@ def view_only_user(public_group, public_stream):
 def view_only_user2(public_group, public_stream):
     user = UserFactory(
         groups=[public_group],
-        roles=[models.Role.query.get("View only")],
+        roles=[
+            DBSession()
+            .execute(sa.select(models.Role).filter(models.Role.id == "View only"))
+            .scalars()
+            .first()
+        ],
         streams=[public_stream],
     )
     user_id = user.id
@@ -830,14 +904,23 @@ def view_only_user2(public_group, public_stream):
 def group_admin_user(public_group, public_stream):
     user = UserFactory(
         groups=[public_group],
-        roles=[models.Role.query.get("Group admin")],
+        roles=[
+            DBSession()
+            .execute(sa.select(models.Role).filter(models.Role.id == "Group admin"))
+            .scalars()
+            .first()
+        ],
         streams=[public_stream],
     )
     user_id = user.id
     group_user = (
         DBSession()
-        .query(GroupUser)
-        .filter(GroupUser.group_id == public_group.id, GroupUser.user_id == user.id)
+        .execute(
+            sa.select(GroupUser).filter(
+                GroupUser.group_id == public_group.id, GroupUser.user_id == user.id
+            )
+        )
+        .scalars()
         .first()
     )
     group_user.admin = True
@@ -850,7 +933,12 @@ def group_admin_user(public_group, public_stream):
 def group_admin_user_two_groups(public_group, public_group2, public_stream):
     user = UserFactory(
         groups=[public_group, public_group2],
-        roles=[models.Role.query.get("Group admin")],
+        roles=[
+            DBSession()
+            .execute(sa.select(models.Role).filter(models.Role.id == "Group admin"))
+            .scalars()
+            .first()
+        ],
         streams=[public_stream],
     )
     user_id = user.id
@@ -862,7 +950,12 @@ def group_admin_user_two_groups(public_group, public_group2, public_stream):
 def super_admin_user(public_group, public_stream):
     user = UserFactory(
         groups=[public_group],
-        roles=[models.Role.query.get("Super admin")],
+        roles=[
+            DBSession()
+            .execute(sa.select(models.Role).filter(models.Role.id == "Super admin"))
+            .scalars()
+            .first()
+        ],
         streams=[public_stream],
     )
     user_id = user.id
@@ -874,7 +967,12 @@ def super_admin_user(public_group, public_stream):
 def super_admin_user_group2(public_group2, public_stream):
     user = UserFactory(
         groups=[public_group2],
-        roles=[models.Role.query.get("Super admin")],
+        roles=[
+            DBSession()
+            .execute(sa.select(models.Role).filter(models.Role.id == "Super admin"))
+            .scalars()
+            .first()
+        ],
         streams=[public_stream],
     )
     user_id = user.id
@@ -886,7 +984,12 @@ def super_admin_user_group2(public_group2, public_stream):
 def super_admin_user_two_groups(public_group, public_group2, public_stream):
     user = UserFactory(
         groups=[public_group, public_group2],
-        roles=[models.Role.query.get("Super admin")],
+        roles=[
+            DBSession()
+            .execute(sa.select(models.Role).filter(models.Role.id == "Super admin"))
+            .scalars()
+            .first()
+        ],
         streams=[public_stream],
     )
     user_id = user.id
@@ -1017,7 +1120,12 @@ def manage_users_token_group2(super_admin_user_group2):
 
 @pytest.fixture()
 def super_admin_token(super_admin_user):
-    role = Role.query.get("Super admin")
+    role = (
+        DBSession()
+        .execute(sa.select(models.Role).filter(models.Role.id == "Super admin"))
+        .scalars()
+        .first()
+    )
     token_id = create_token(
         ACLs=[a.id for a in role.acls],
         user_id=super_admin_user.id,
@@ -1029,7 +1137,12 @@ def super_admin_token(super_admin_user):
 
 @pytest.fixture()
 def super_admin_token_two_groups(super_admin_user_two_groups):
-    role = Role.query.get("Super admin")
+    role = (
+        DBSession()
+        .execute(sa.select(models.Role).filter(models.Role.id == "Super admin"))
+        .scalars()
+        .first()
+    )
     token_id = create_token(
         ACLs=[a.id for a in role.acls],
         user_id=super_admin_user_two_groups.id,
@@ -1192,7 +1305,12 @@ def source_notification_user(public_group):
         contact_email="test_email@gmail.com",
         contact_phone="+12345678910",
         groups=[public_group],
-        roles=[models.Role.query.get("Full user")],
+        roles=[
+            DBSession()
+            .execute(sa.select(models.Role).filter(models.Role.id == "Full user"))
+            .scalars()
+            .first()
+        ],
         preferences={"allowEmailNotifications": True, "allowSMSNotifications": True},
     )
     user_id = user.id
@@ -1223,11 +1341,13 @@ def public_taxonomy(public_group):
 def public_group_taxonomy(public_taxonomy):
     return (
         DBSession()
-        .query(GroupTaxonomy)
-        .filter(
-            GroupTaxonomy.group_id == public_taxonomy.groups[0].id,
-            GroupTaxonomy.taxonomie_id == public_taxonomy.id,
+        .execute(
+            sa.select(GroupTaxonomy).filter(
+                GroupTaxonomy.group_id == public_taxonomy.groups[0].id,
+                GroupTaxonomy.taxonomie_id == public_taxonomy.id,
+            )
         )
+        .scalars()
         .first()
     )
 
@@ -1245,11 +1365,13 @@ def public_comment(user_no_groups, public_source, public_group):
 def public_groupcomment(public_comment):
     return (
         DBSession()
-        .query(GroupComment)
-        .filter(
-            GroupComment.group_id == public_comment.groups[0].id,
-            GroupComment.comment_id == public_comment.id,
+        .execute(
+            sa.select(GroupComment).filter(
+                GroupComment.group_id == public_comment.groups[0].id,
+                GroupComment.comment_id == public_comment.id,
+            )
         )
+        .scalars()
         .first()
     )
 
@@ -1267,11 +1389,13 @@ def public_annotation(user_no_groups, public_source, public_group):
 def public_groupannotation(public_annotation):
     return (
         DBSession()
-        .query(GroupAnnotation)
-        .filter(
-            GroupAnnotation.group_id == public_annotation.groups[0].id,
-            GroupAnnotation.annotation_id == public_annotation.id,
+        .execute(
+            sa.select(GroupAnnotation).filter(
+                GroupAnnotation.group_id == public_annotation.groups[0].id,
+                GroupAnnotation.annotation_id == public_annotation.id,
+            )
         )
+        .scalars()
         .first()
     )
 
@@ -1294,11 +1418,13 @@ def public_classification(
 def public_groupclassification(public_classification):
     return (
         DBSession()
-        .query(GroupClassification)
-        .filter(
-            GroupClassification.group_id == public_classification.groups[0].id,
-            GroupClassification.classification_id == public_classification.id,
+        .execute(
+            sa.select(GroupClassification).filter(
+                GroupClassification.group_id == public_classification.groups[0].id,
+                GroupClassification.classification_id == public_classification.id,
+            )
         )
+        .scalars()
         .first()
     )
 
@@ -1317,11 +1443,13 @@ def public_source_spectrum(public_source):
 def public_source_groupphotometry(public_source_photometry_point):
     return (
         DBSession()
-        .query(GroupPhotometry)
-        .filter(
-            GroupPhotometry.group_id == public_source_photometry_point.groups[0].id,
-            GroupPhotometry.photometr_id == public_source_photometry_point.id,
+        .execute(
+            sa.select(GroupPhotometry).filter(
+                GroupPhotometry.group_id == public_source_photometry_point.groups[0].id,
+                GroupPhotometry.photometr_id == public_source_photometry_point.id,
+            )
         )
+        .scalars()
         .first()
     )
 
@@ -1330,11 +1458,13 @@ def public_source_groupphotometry(public_source_photometry_point):
 def public_source_groupspectrum(public_source_spectrum):
     return (
         DBSession()
-        .query(GroupSpectrum)
-        .filter(
-            GroupSpectrum.group_id == public_source_spectrum.groups[0].id,
-            GroupSpectrum.spectr_id == public_source_spectrum.id,
+        .execute(
+            sa.select(GroupSpectrum).filter(
+                GroupSpectrum.group_id == public_source_spectrum.groups[0].id,
+                GroupSpectrum.spectr_id == public_source_spectrum.id,
+            )
         )
+        .scalars()
         .first()
     )
 
@@ -1343,13 +1473,15 @@ def public_source_groupspectrum(public_source_spectrum):
 def public_source_followup_request_target_group(public_source_followup_request):
     return (
         DBSession()
-        .query(FollowupRequestTargetGroup)
-        .filter(
-            FollowupRequestTargetGroup.followuprequest_id
-            == public_source_followup_request.id,
-            FollowupRequestTargetGroup.group_id
-            == public_source_followup_request.target_groups[0].id,
+        .execute(
+            sa.select(FollowupRequestTargetGroup).filter(
+                FollowupRequestTargetGroup.followuprequest_id
+                == public_source_followup_request.id,
+                FollowupRequestTargetGroup.group_id
+                == public_source_followup_request.target_groups[0].id,
+            )
         )
+        .scalars()
         .first()
     )
 
@@ -1358,9 +1490,12 @@ def public_source_followup_request_target_group(public_source_followup_request):
 def public_thumbnail(public_source):
     return (
         DBSession()
-        .query(Thumbnail)
-        .filter(Thumbnail.obj_id == public_source.id)
-        .order_by(Thumbnail.id.desc())
+        .execute(
+            sa.select(Thumbnail)
+            .filter(Thumbnail.obj_id == public_source.id)
+            .order_by(Thumbnail.id.desc())
+        )
+        .scalars()
         .first()
     )
 

--- a/skyportal/tests/fixtures.py
+++ b/skyportal/tests/fixtures.py
@@ -8,6 +8,7 @@ from tempfile import mkdtemp
 
 import factory
 import numpy as np
+import sqlalchemy as sa
 from sqlalchemy import inspect
 from sqlalchemy.orm.exc import ObjectDeletedError
 
@@ -68,7 +69,11 @@ def is_already_deleted(instance, table):
     ):
         try:
             return (
-                DBSession().query(table).filter(table.id == instance.id).first() is None
+                DBSession()
+                .execute(sa.select(table).filter(table.id == instance.id))
+                .scalars()
+                .first()
+                is None
             )
         except ObjectDeletedError:
             # If instance was deleted by the test, it would have taken place in
@@ -100,7 +105,10 @@ class TelescopeFactory(factory.alchemy.SQLAlchemyModelFactory):
     @staticmethod
     def teardown(telescope_id):
         telescope = (
-            DBSession().query(Telescope).filter(Telescope.id == telescope_id).first()
+            DBSession()
+            .execute(sa.select(Telescope).filter(Telescope.id == telescope_id))
+            .scalars()
+            .first()
         )
         if telescope is not None:
             DBSession().delete(telescope)
@@ -140,8 +148,10 @@ class UserFactory(factory.alchemy.SQLAlchemyModelFactory):
         # always add the sitewide group
         sitewide_group = (
             DBSession()
-            .query(Group)
-            .filter(Group.name == cfg['misc']['public_group_name'])
+            .execute(
+                sa.select(Group).filter(Group.name == cfg['misc']['public_group_name'])
+            )
+            .scalars()
             .first()
         )
 
@@ -150,7 +160,12 @@ class UserFactory(factory.alchemy.SQLAlchemyModelFactory):
 
     @staticmethod
     def teardown(user_id):
-        user = DBSession().query(User).filter(User.id == user_id).first()
+        user = (
+            DBSession()
+            .execute(sa.select(User).filter(User.id == user_id))
+            .scalars()
+            .first()
+        )
         if user is not None:
             # If it is, delete it
             DBSession().delete(user)
@@ -275,7 +290,12 @@ class StreamFactory(factory.alchemy.SQLAlchemyModelFactory):
     @staticmethod
     def teardown(stream_id):
         # Fetch fresh instance of stream
-        stream = DBSession().query(Stream).filter(Stream.id == stream_id).first()
+        stream = (
+            DBSession()
+            .execute(sa.select(Stream).filter(Stream.id == stream_id))
+            .scalars()
+            .first()
+        )
         if stream is not None:
             # If it is, delete it
             DBSession().delete(stream)
@@ -304,7 +324,12 @@ class GroupFactory(factory.alchemy.SQLAlchemyModelFactory):
 
     @staticmethod
     def teardown(group_id):
-        group = DBSession().query(Group).filter(Group.id == group_id).first()
+        group = (
+            DBSession()
+            .execute(sa.select(Group).filter(Group.id == group_id))
+            .scalars()
+            .first()
+        )
         if group is not None:
             # If it is, delete it
             DBSession().delete(group)
@@ -319,7 +344,12 @@ class FilterFactory(factory.alchemy.SQLAlchemyModelFactory):
 
     @staticmethod
     def teardown(filter_id):
-        filter_ = DBSession().query(Filter).filter(Filter.id == filter_id).first()
+        filter_ = (
+            DBSession()
+            .execute(sa.select(Filter).filter(Filter.id == filter_id))
+            .scalars()
+            .first()
+        )
         if filter_ is not None:
             # If it is, delete it
             DBSession().delete(filter_)
@@ -416,7 +446,12 @@ class ObjFactory(factory.alchemy.SQLAlchemyModelFactory):
         comment_authors = list(map(lambda x: x.author.id, obj.comments))
         for author in comment_authors:
             UserFactory.teardown(author)
-        spectra = DBSession().query(Spectrum).filter(Spectrum.obj_id == obj.id).all()
+        spectra = (
+            DBSession()
+            .execute(sa.select(Spectrum).filter(Spectrum.obj_id == obj.id))
+            .scalars()
+            .all()
+        )
         for spectrum in spectra:
             SpectrumFactory.teardown(spectrum)
         DBSession().delete(obj)
@@ -517,7 +552,10 @@ class TaxonomyFactory(factory.alchemy.SQLAlchemyModelFactory):
     @staticmethod
     def teardown(taxonomy_id):
         taxonomy = (
-            DBSession().query(Taxonomy).filter(Taxonomy.id == taxonomy_id).first()
+            DBSession()
+            .execute(sa.select(Taxonomy).filter(Taxonomy.id == taxonomy_id))
+            .scalars()
+            .first()
         )
         if taxonomy is not None:
             DBSession().delete(taxonomy)

--- a/skyportal/tests/tools/test_offset_util.py
+++ b/skyportal/tests/tools/test_offset_util.py
@@ -4,7 +4,7 @@ import pytest
 import numpy as np
 import numpy.testing as npt
 import requests
-from requests.exceptions import HTTPError, Timeout, ConnectionError
+from requests.exceptions import HTTPError, Timeout, ConnectionError, MissingSchema
 
 from skyportal.tests import api
 from skyportal.utils.offset import (
@@ -13,7 +13,6 @@ from skyportal.utils.offset import (
     get_ztfref_url,
     _calculate_best_position_for_offset_stars,
 )
-from skyportal.utils.offset import irsa
 from skyportal.models import Photometry
 
 
@@ -187,12 +186,17 @@ def test_calculate_best_position_with_photometry(
         npt.assert_almost_equal(dec_calc_snr, dec_calc_err, decimal=10)
 
 
-ztfref_url = irsa['url_search']
+# use a bona fide URL to test to see if the ZTF search facility is working
+ztfref_url = get_ztfref_url(123.0, 33.3, 2)
+# if it's a valid URL, then we can assume that the ZTF search facility is working
 run_ztfref_test = True
 try:
-    r = requests.get(ztfref_url)
-    r.raise_for_status()
-except (HTTPError, TimeoutError, ConnectionError) as e:
+    if ztfref_url != "":
+        r = requests.get(ztfref_url)
+        r.raise_for_status()
+    else:
+        run_ztfref_test = False
+except (HTTPError, TimeoutError, ConnectionError, MissingSchema) as e:
     run_ztfref_test = False
     print(e)
 


### PR DESCRIPTION
This PR upgrades SQLAlchemy to 1.4.* from 1.3. It pins a branch of `baselayer` that has `requirements.txt` explicitly stating the dependency of `sqlalchemy>=1.4.0'. This move has a number of breaking changes. In addition to the original PR, we may opt to merge #2570 into this branch.

* Pin BL that requires SQLA v>=1.4.0

* Use SQLA 1.4-compatible registry mappers in schema

* Refactor Values construct in photometry handler

* Use select API instead of query in PhotometryHandler, PublicGroupHandler, conftest & fixtures

* use a version that eralchemy which works with SQLA1.4

* fix AttributeError on Base in schema.py

* safe alias the group logic

* fix candidate.py

* use VALUES constructor in get_obj_id_values

* use 1.4 func.jsonb_each instead of <1.4 formula

* remove legacy code

Co-authored-by: Ari Crellin-Quick <a.crellinquick@gmail.com>
Co-authored-by: Michael Coughlin <michael.w.coughlin@gmail.com>