### PR TITLE
Add @material-ui/styles peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@material-ui/icons": "4.11.2",
     "@material-ui/lab": "4.0.0-alpha.60",
     "@material-ui/pickers": "3.3.10",
+    "@material-ui/styles": "4.11.4",
     "@rjsf/core": "2.5.1",
     "@rjsf/material-ui": "2.4.0",
     "autosuggest-highlight": "3.1.1",


### PR DESCRIPTION
Webpack would not build on my machine without it, even after removing
`node_modules`.  I am not sure why it works on CI; it could be that I
have a newer version of node/npm.