### PR TITLE
fix redshift of lines 

### DIFF
--- a/skyportal/plot.py
+++ b/skyportal/plot.py
@@ -1779,6 +1779,8 @@ def make_spectrum_layout(obj, spectra, user, device, width, smoothing, smooth_nu
     # Track elements that need to be shifted with change in z / v
     shifting_elements = []
     renderers = []
+    obj_redshift = 0 if obj.redshift is None else obj.redshift
+
     for i, (name, (wavelengths, color)) in enumerate(SPEC_LINES.items()):
 
         if name in ('Tellurics-1', 'Tellurics-2'):
@@ -1812,6 +1814,8 @@ def make_spectrum_layout(obj, spectra, user, device, width, smoothing, smooth_nu
                     'flux': [f for _ in wavelengths for f in flux_values],
                 }
             )
+            if name != 'Sky Lines':
+                el_data['x'] = el_data['wavelength'] * (1.0 + obj_redshift)
             new_line = plot.line(
                 x='x',
                 y='flux',


### PR DESCRIPTION
When loading a source page that has a redshift, the spectral lines are not red-shifted when the plot is shown. The redshift is only applied after changing the redshift in the slider or input box. 

This patch fixes this by adding a couple of missing lines in `plot.py`. 
