### PR TITLE
Fix disappearing photometry/spectroscopy bug

### DIFF
--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -823,6 +823,16 @@ class SourceHandler(BaseHandler):
                     key=lambda x: x["created_at"],
                     reverse=True,
                 )
+            if include_photometry_exists:
+                source_info["photometry_exists"] = (
+                    len(
+                        Photometry.query_records_accessible_by(self.current_user)
+                        .filter(Photometry.obj_id == obj_id)
+                        .all()
+                    )
+                    > 0
+                )
+
             source_info["annotations"] = sorted(
                 Annotation.query_records_accessible_by(
                     self.current_user, options=[joinedload(Annotation.author)]

--- a/skyportal/tests/api/test_sources.py
+++ b/skyportal/tests/api/test_sources.py
@@ -53,6 +53,29 @@ def test_token_user_retrieving_source_with_phot(view_only_token, public_source):
     )
 
 
+def test_token_user_retrieving_source_with_phot_exists(view_only_token, public_source):
+    status, data = api(
+        "GET",
+        f"sources/{public_source.id}",
+        params={"includePhotometryExists": "true"},
+        token=view_only_token,
+    )
+    assert status == 200
+    assert data["status"] == "success"
+    assert all(
+        k in data["data"]
+        for k in [
+            "ra",
+            "dec",
+            "redshift",
+            "dm",
+            "created_at",
+            "id",
+            "photometry_exists",
+        ]
+    )
+
+
 def test_token_user_retrieving_source_with_thumbnails(view_only_token, public_source):
     status, data = api(
         "GET",

--- a/static/js/ducks/source.js
+++ b/static/js/ducks/source.js
@@ -148,7 +148,7 @@ export function getCommentOnSpectrumAttachment(spectrumID, commentID) {
 
 export function fetchSource(id, actionType = FETCH_LOADED_SOURCE) {
   return API.GET(
-    `/api/sources/${id}?includeComments=true&includeColorMagnitude=true&includeThumbnails=true`,
+    `/api/sources/${id}?includeComments=true&includeColorMagnitude=true&includeThumbnails=true&includePhotometryExists=true&includeSpectrumExists=true`,
     actionType
   );
 }


### PR DESCRIPTION
When PS1 cutout arrives, the photometry and spectroscopy disappears. It turns out it is because the photometry option only exist in multiple source request (despite what the docstring says). This adds it back in.

See https://github.com/ZwickyTransientFacility/scope/issues/61