### PR TITLE
Hide ability to add allocations, telescopes, and instruments to non-admins

### DIFF
--- a/static/js/components/AllocationPage.jsx
+++ b/static/js/components/AllocationPage.jsx
@@ -107,6 +107,7 @@ const AllocationList = ({ allocations }) => {
 
 const AllocationPage = () => {
   const { allocationList } = useSelector((state) => state.allocations);
+  const currentUser = useSelector((state) => state.profile);
   const classes = useStyles();
 
   return (
@@ -119,14 +120,16 @@ const AllocationPage = () => {
           </div>
         </Paper>
       </Grid>
-      <Grid item md={6} sm={12}>
-        <Paper>
-          <div className={classes.paperContent}>
-            <Typography variant="h6">Add a New Allocation</Typography>
-            <NewAllocation />
-          </div>
-        </Paper>
-      </Grid>
+      {currentUser.permissions?.includes("System admin") && (
+        <Grid item md={6} sm={12}>
+          <Paper>
+            <div className={classes.paperContent}>
+              <Typography variant="h6">Add a New Allocation</Typography>
+              <NewAllocation />
+            </div>
+          </Paper>
+        </Grid>
+      )}
     </Grid>
   );
 };

--- a/static/js/components/InstrumentPage.jsx
+++ b/static/js/components/InstrumentPage.jsx
@@ -98,6 +98,7 @@ const InstrumentList = ({ instruments, telescopes }) => {
 const InstrumentPage = () => {
   const { instrumentList } = useSelector((state) => state.instruments);
   const { telescopeList } = useSelector((state) => state.telescopes);
+  const currentUser = useSelector((state) => state.profile);
 
   const classes = useStyles();
   return (
@@ -113,14 +114,16 @@ const InstrumentPage = () => {
           </div>
         </Paper>
       </Grid>
-      <Grid item md={6} sm={12}>
-        <Paper>
-          <div className={classes.paperContent}>
-            <Typography variant="h6">Add a New Instrument</Typography>
-            <NewInstrument />
-          </div>
-        </Paper>
-      </Grid>
+      {currentUser.permissions?.includes("System admin") && (
+        <Grid item md={6} sm={12}>
+          <Paper>
+            <div className={classes.paperContent}>
+              <Typography variant="h6">Add a New Instrument</Typography>
+              <NewInstrument />
+            </div>
+          </Paper>
+        </Grid>
+      )}
     </Grid>
   );
 };

--- a/static/js/components/TelescopePage.jsx
+++ b/static/js/components/TelescopePage.jsx
@@ -86,6 +86,7 @@ const TelescopeList = ({ telescopes }) => {
 
 const TelescopePage = () => {
   const { telescopeList } = useSelector((state) => state.telescopes);
+  const currentUser = useSelector((state) => state.profile);
 
   const classes = useStyles();
   return (
@@ -98,14 +99,16 @@ const TelescopePage = () => {
           </div>
         </Paper>
       </Grid>
-      <Grid item md={6} sm={12}>
-        <Paper>
-          <div className={classes.paperContent}>
-            <Typography variant="h6">Add a New Telescope</Typography>
-            <NewTelescope />
-          </div>
-        </Paper>
-      </Grid>
+      {currentUser.permissions?.includes("System admin") && (
+        <Grid item md={6} sm={12}>
+          <Paper>
+            <div className={classes.paperContent}>
+              <Typography variant="h6">Add a New Telescope</Typography>
+              <NewTelescope />
+            </div>
+          </Paper>
+        </Grid>
+      )}
     </Grid>
   );
 };


### PR DESCRIPTION
This PR adds the requirement of admin privileges to use the Add functionality on the allocations, telescopes, and instruments pages.