### PR TITLE
Make download CSV file more useful

### DIFF
--- a/static/js/components/SourceTable.jsx
+++ b/static/js/components/SourceTable.jsx
@@ -1086,9 +1086,70 @@ const SourceTable = ({
     onFilterChange: handleTableFilterChipChange,
     onFilterDialogOpen: () => setFilterFormSubmitted(false),
     search: false,
+    download: true,
     rowsExpanded: openedRows,
     onRowExpansionChange: (_, allRowsExpanded) => {
       setOpenedRows(allRowsExpanded.map((i) => i.dataIndex));
+    },
+    onDownload: (buildHead, buildBody, columnsDownload, data) => {
+      const renderDownloadClassification = (dataIndex) => {
+        const source = sources[dataIndex];
+        const classifications = [];
+        source?.classifications.forEach((x) => {
+          classifications.push(x.classification);
+        });
+        return classifications.join(";");
+      };
+      const renderDownloadGroups = (dataIndex) => {
+        const source = sources[dataIndex];
+        const groups = [];
+        source?.groups.forEach((x) => {
+          groups.push(x.name);
+        });
+        return groups.join(";");
+      };
+
+      return (
+        buildHead([
+          {
+            name: "id",
+            download: true,
+          },
+          {
+            name: "ra",
+            download: true,
+          },
+          {
+            name: "dec",
+            download: true,
+          },
+          {
+            name: "redshift",
+            download: true,
+          },
+          {
+            name: "classification",
+            download: true,
+          },
+          {
+            name: "groups",
+            download: true,
+          },
+        ]) +
+        buildBody(
+          data.map((x) => ({
+            ...x,
+            data: [
+              x.data[0],
+              x.data[4],
+              x.data[5],
+              x.data[8],
+              renderDownloadClassification(x.index),
+              renderDownloadGroups(x.index),
+            ],
+          }))
+        )
+      );
     },
   };
 

--- a/static/js/components/SourceTable.jsx
+++ b/static/js/components/SourceTable.jsx
@@ -1109,6 +1109,30 @@ const SourceTable = ({
         return groups.join(";");
       };
 
+      const renderDownloadDateSaved = (dataIndex) => {
+        const source = sources[dataIndex];
+        return getDate(source)?.substring(0, 19);
+      };
+
+      const renderDownloadAlias = (dataIndex) => {
+        const { alias } = sources[dataIndex];
+        let alias_str = "";
+        if (alias) {
+          alias_str = Array.isArray(alias) ? alias.join(";") : alias;
+        }
+        return alias_str;
+      };
+      const renderDownloadOrigin = (dataIndex) => {
+        const { origin } = sources[dataIndex];
+        return origin;
+      };
+      const renderDownloadTNSName = (dataIndex) => {
+        const source = sources[dataIndex];
+        return source.altdata && source.altdata.tns
+          ? source.altdata.tns.name
+          : "";
+      };
+
       return (
         buildHead([
           {
@@ -1116,11 +1140,11 @@ const SourceTable = ({
             download: true,
           },
           {
-            name: "ra",
+            name: "ra [deg]",
             download: true,
           },
           {
-            name: "dec",
+            name: "dec [deg]",
             download: true,
           },
           {
@@ -1135,6 +1159,22 @@ const SourceTable = ({
             name: "groups",
             download: true,
           },
+          {
+            name: "Date saved",
+            download: true,
+          },
+          {
+            name: "Alias",
+            download: true,
+          },
+          {
+            name: "Origin",
+            download: true,
+          },
+          {
+            name: "TNS Name",
+            download: true,
+          },
         ]) +
         buildBody(
           data.map((x) => ({
@@ -1146,6 +1186,10 @@ const SourceTable = ({
               x.data[8],
               renderDownloadClassification(x.index),
               renderDownloadGroups(x.index),
+              renderDownloadDateSaved(x.index),
+              renderDownloadAlias(x.index),
+              renderDownloadOrigin(x.index),
+              renderDownloadTNSName(x.index),
             ],
           }))
         )


### PR DESCRIPTION
Currently the CSV file downloaded gets very confused by our objects (just says [object Object]).

This makes the CSV file print out relevant things similar to how the table displays in the App.

"id","ra","dec","redshift","classification","groups"
"ZTF21aaqjmps","202.5050541","13.4111859","0.0246","","Sitewide Group;Program A;Program B"
"ZTF18aabcvnq","172.0534465","25.6596908","","Time-domain Source;variable","Sitewide Group;Program A;Program B"
"ZTFe028h94k","229.9620403","34.8442757","","","Sitewide Group;Program A;Program B"
"ZTFrlh6cyjh","342.4596","51.2634","","","Sitewide Group;Program A;Program B"
"ZTFJ201825+380316","304.60791628","38.05469","","","Sitewide Group;Program A;Program B" 