### PR TITLE
Improve dark mode

### DIFF
--- a/static/js/components/GcnEvents.jsx
+++ b/static/js/components/GcnEvents.jsx
@@ -30,6 +30,12 @@ const useStyles = makeStyles((theme) => ({
       background: theme.palette.primary.main,
     },
   },
+  gcnEventLink: {
+    color:
+      theme.palette.type === "dark"
+        ? theme.palette.secondary.main
+        : theme.palette.primary.main,
+  },
 }));
 
 // Tweak responsive styling
@@ -108,7 +114,9 @@ const GcnEvents = () => {
 
   const renderDateObs = (dataIndex) => (
     <Link to={`/gcn_events/${gcnEvents[dataIndex]?.dateobs}`}>
-      <Button color="primary">{gcnEvents[dataIndex]?.dateobs}</Button>
+      <Button className={classes.gcnEventLink}>
+        {gcnEvents[dataIndex]?.dateobs}
+      </Button>
     </Link>
   );
 

--- a/static/js/components/RecentSources.jsx
+++ b/static/js/components/RecentSources.jsx
@@ -72,7 +72,10 @@ export const useSourceListStyles = makeStyles((theme) => ({
     fontSize: "1rem",
   },
   sourceNameLink: {
-    color: theme.palette.primary.main,
+    color:
+      theme.palette.type === "dark"
+        ? theme.palette.secondary.main
+        : theme.palette.primary.main,
   },
   link: {
     color: theme.palette.warning.main,
@@ -97,7 +100,8 @@ export const useSourceListStyles = makeStyles((theme) => ({
     // marginBottom: "1rem",
     transition: "all 0.3s ease",
     "&:hover": {
-      backgroundColor: theme.palette.secondary.light,
+      backgroundColor:
+        theme.palette.type === "light" ? theme.palette.secondary.light : null,
     },
     "&:hover $quickViewButton": {
       visibility: "visible",

--- a/static/js/components/SourceDesktop.jsx
+++ b/static/js/components/SourceDesktop.jsx
@@ -72,7 +72,10 @@ export const useSourceStyles = makeStyles((theme) => ({
   name: {
     fontSize: "200%",
     fontWeight: "900",
-    color: theme.palette.primary.main,
+    color:
+      theme.palette.type === "dark"
+        ? theme.palette.secondary.main
+        : theme.palette.primary.main,
     paddingBottom: "0.25em",
     display: "inline-block",
   },

--- a/static/js/components/SourceMobile.jsx
+++ b/static/js/components/SourceMobile.jsx
@@ -97,7 +97,10 @@ export const useSourceStyles = makeStyles((theme) => ({
   name: {
     fontSize: "200%",
     fontWeight: "900",
-    color: theme.palette.primary.main,
+    color:
+      theme.palette.type === "dark"
+        ? theme.palette.secondary.main
+        : theme.palette.primary.main,
     paddingBottom: "0.25em",
     display: "inline-block",
   },

--- a/static/js/components/SourceTable.jsx
+++ b/static/js/components/SourceTable.jsx
@@ -150,7 +150,10 @@ const useStyles = makeStyles((theme) => ({
     verticalAlign: "middle",
   },
   objId: {
-    color: theme.palette.primary.main,
+    color:
+      theme.palette.type === "dark"
+        ? theme.palette.secondary.main
+        : theme.palette.primary.main,
   },
   starButton: {
     verticalAlign: "middle",

--- a/static/js/components/Theme.jsx
+++ b/static/js/components/Theme.jsx
@@ -81,9 +81,6 @@ const Theme = ({ disableTransitions, children }) => {
                 : `3px solid ${grey[100]}`,
             },
           },
-          a: {
-            color: dark ? grey[600] : null,
-          },
         },
       },
     },

--- a/static/js/components/Theme.jsx
+++ b/static/js/components/Theme.jsx
@@ -37,6 +37,19 @@ const Theme = ({ disableTransitions, children }) => {
       background: dark ? { default: "#303030" } : { default: "#f0f2f5" },
     },
     overrides: {
+      MuiTypography: {
+        body1: {
+          color: dark ? grey[50] : null,
+        },
+      },
+      MuiButton: {
+        textPrimary: {
+          color: dark ? "#b1dae9" : null,
+        },
+        outlinedPrimary: {
+          color: dark ? "#b1dae9" : null,
+        },
+      },
       MuiCssBaseline: {
         "@global": {
           html: {
@@ -67,6 +80,9 @@ const Theme = ({ disableTransitions, children }) => {
                 ? `3px solid ${grey[800]}`
                 : `3px solid ${grey[100]}`,
             },
+          },
+          a: {
+            color: dark ? grey[600] : null,
           },
         },
       },

--- a/static/js/components/TopSources.jsx
+++ b/static/js/components/TopSources.jsx
@@ -48,7 +48,10 @@ const useStyles = makeStyles((theme) => ({
     flexDirection: "column",
   },
   sourceNameLink: {
-    color: theme.palette.primary.main,
+    color:
+      theme.palette.type === "dark"
+        ? theme.palette.secondary.main
+        : theme.palette.primary.main,
   },
   quickViewContainer: {
     display: "flex",


### PR DESCRIPTION
Adds styling for improving skyportal in dark mode.

before: low contrast between background and typography body text
![Screenshot (28)](https://user-images.githubusercontent.com/82007190/155028846-13d604f2-2ae4-420d-a613-bd06455bdb04.png)
after: better contrast
![Screenshot (29)](https://user-images.githubusercontent.com/82007190/155028885-c8a76757-63f0-406f-b33c-cdc08f6c6312.png)

before: links are quite dark
![Screenshot (32)](https://user-images.githubusercontent.com/82007190/155028933-0b84a1e0-2432-4ac7-8896-422bdfd66600.png)
after: lighter links
![Screenshot (31)](https://user-images.githubusercontent.com/82007190/155028949-62674cc9-460c-42b6-a694-4a51b8890b96.png)


