### PR TITLE
filter sources by annotation

### DIFF
--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -509,7 +509,7 @@ class SourceHandler(BaseHandler):
             nullable: true
             schema:
               type: string
-            description: Comma-separated string of who posted the annotations to filter
+            description: Comma separated string of origins. Only annotations from these origins are used when filtering with the annotationsFilter.
           - in: query
             name: minRedshift
             nullable: true

--- a/skyportal/tests/api/test_sources.py
+++ b/skyportal/tests/api/test_sources.py
@@ -2027,3 +2027,39 @@ def test_token_user_retrieving_source_with_period_exists(
     assert status == 200
     assert data["status"] == "success"
     assert data["data"]['period_exists']
+
+
+def test_token_user_retrieving_source_with_annotation_filter(
+    view_only_token, public_source, annotation_token
+):
+
+    status, data = api(
+        'POST',
+        f'sources/{public_source.id}/annotations',
+        data={
+            'origin': 'kowalski',
+            'data': {'period': 1.5},
+        },
+        token=annotation_token,
+    )
+    assert status == 200
+
+    status, data = api(
+        "GET",
+        "sources",
+        params={"annotationsFilter": "period:2.0:le"},
+        token=view_only_token,
+    )
+    assert status == 200
+    assert data["status"] == "success"
+    assert len(data["data"]["sources"]) > 0
+
+    status, data = api(
+        "GET",
+        "sources",
+        params={"annotationsFilter": "period:2.0:ge"},
+        token=view_only_token,
+    )
+    assert status == 200
+    assert data["status"] == "success"
+    assert len(data["data"]["sources"]) == 0


### PR DESCRIPTION
This PR enables source filtering by annotations. This is important as it allows one to identify sources by, for example, thresholding on redshift values or other numerical annotations.