### PR TITLE
Display names of users in options when uploading a spectra

### DIFF
--- a/data/db_demo.yaml
+++ b/data/db_demo.yaml
@@ -2,6 +2,8 @@ user:
   - username: testadmin
     roles:
       - Super admin
+    first_name: Jada
+    last_name: Lilleboe
     =id: testadmin
   - username: groupadmin
     roles:

--- a/static/js/components/UploadSpectrum.jsx
+++ b/static/js/components/UploadSpectrum.jsx
@@ -295,7 +295,10 @@ const UploadSpectrumForm = ({ route }) => {
           type: "integer",
           anyOf: users?.map((user) => ({
             enum: [user.id],
-            title: user.username,
+            title:
+              user?.first_name && user?.last_name
+                ? `${user.username} (${user.first_name} ${user.last_name})`
+                : `${user.username}`,
           })),
         },
         uniqueItems: true,
@@ -313,7 +316,10 @@ const UploadSpectrumForm = ({ route }) => {
           type: "integer",
           anyOf: users?.map((user) => ({
             enum: [user.id],
-            title: user.username,
+            title:
+              user?.first_name && user?.last_name
+                ? `${user.username} (${user.first_name} ${user.last_name})`
+                : `${user.username}`,
           })),
         },
         uniqueItems: true,
@@ -388,7 +394,10 @@ const UploadSpectrumForm = ({ route }) => {
                   type: "integer",
                   anyOf: users?.map((user) => ({
                     enum: [user.id],
-                    title: user.username,
+                    title:
+                      user?.first_name && user?.last_name
+                        ? `${user.username} (${user.first_name} ${user.last_name})`
+                        : `${user.username}`,
                   })),
                 },
                 uniqueItems: true,
@@ -411,7 +420,10 @@ const UploadSpectrumForm = ({ route }) => {
                   type: "integer",
                   anyOf: users?.map((user) => ({
                     enum: [user.id],
-                    title: user.username,
+                    title:
+                      user?.first_name && user?.last_name
+                        ? `${user.username} (${user.first_name} ${user.last_name})`
+                        : `${user.username}`,
                   })),
                 },
                 uniqueItems: true,
@@ -439,7 +451,10 @@ const UploadSpectrumForm = ({ route }) => {
                   type: "integer",
                   anyOf: users?.map((user) => ({
                     enum: [user.id],
-                    title: user.username,
+                    title:
+                      user?.first_name && user?.last_name
+                        ? `${user.username} (${user.first_name} ${user.last_name})`
+                        : `${user.username}`,
                   })),
                 },
                 uniqueItems: true,
@@ -462,7 +477,10 @@ const UploadSpectrumForm = ({ route }) => {
                   type: "integer",
                   anyOf: users?.map((user) => ({
                     enum: [user.id],
-                    title: user.username,
+                    title:
+                      user?.first_name && user?.last_name
+                        ? `${user.username} (${user.first_name} ${user.last_name})`
+                        : `${user.username}`,
                   })),
                 },
                 uniqueItems: true,

--- a/static/js/components/UploadSpectrum.jsx
+++ b/static/js/components/UploadSpectrum.jsx
@@ -262,6 +262,14 @@ const UploadSpectrumForm = ({ route }) => {
     });
   }
 
+  const getUserDisplay = (user) => {
+    const lastOrFirst = user?.first_name || user?.last_name;
+    const displayStr = `${user.username} ${lastOrFirst ? "(" : ""}${
+      user?.first_name ? user.first_name : ""
+    } ${user?.last_name ? user.last_name : ""}${lastOrFirst ? ")" : ""}`;
+    return displayStr;
+  };
+
   const uploadFormSchema = {
     type: "object",
     properties: {
@@ -295,10 +303,7 @@ const UploadSpectrumForm = ({ route }) => {
           type: "integer",
           anyOf: users?.map((user) => ({
             enum: [user.id],
-            title:
-              user?.first_name && user?.last_name
-                ? `${user.username} (${user.first_name} ${user.last_name})`
-                : `${user.username}`,
+            title: getUserDisplay(user),
           })),
         },
         uniqueItems: true,
@@ -316,10 +321,7 @@ const UploadSpectrumForm = ({ route }) => {
           type: "integer",
           anyOf: users?.map((user) => ({
             enum: [user.id],
-            title:
-              user?.first_name && user?.last_name
-                ? `${user.username} (${user.first_name} ${user.last_name})`
-                : `${user.username}`,
+            title: getUserDisplay(user),
           })),
         },
         uniqueItems: true,
@@ -394,10 +396,7 @@ const UploadSpectrumForm = ({ route }) => {
                   type: "integer",
                   anyOf: users?.map((user) => ({
                     enum: [user.id],
-                    title:
-                      user?.first_name && user?.last_name
-                        ? `${user.username} (${user.first_name} ${user.last_name})`
-                        : `${user.username}`,
+                    title: getUserDisplay(user),
                   })),
                 },
                 uniqueItems: true,
@@ -420,10 +419,7 @@ const UploadSpectrumForm = ({ route }) => {
                   type: "integer",
                   anyOf: users?.map((user) => ({
                     enum: [user.id],
-                    title:
-                      user?.first_name && user?.last_name
-                        ? `${user.username} (${user.first_name} ${user.last_name})`
-                        : `${user.username}`,
+                    title: getUserDisplay(user),
                   })),
                 },
                 uniqueItems: true,
@@ -451,10 +447,7 @@ const UploadSpectrumForm = ({ route }) => {
                   type: "integer",
                   anyOf: users?.map((user) => ({
                     enum: [user.id],
-                    title:
-                      user?.first_name && user?.last_name
-                        ? `${user.username} (${user.first_name} ${user.last_name})`
-                        : `${user.username}`,
+                    title: getUserDisplay(user),
                   })),
                 },
                 uniqueItems: true,
@@ -477,10 +470,7 @@ const UploadSpectrumForm = ({ route }) => {
                   type: "integer",
                   anyOf: users?.map((user) => ({
                     enum: [user.id],
-                    title:
-                      user?.first_name && user?.last_name
-                        ? `${user.username} (${user.first_name} ${user.last_name})`
-                        : `${user.username}`,
+                    title: getUserDisplay(user),
                   })),
                 },
                 uniqueItems: true,


### PR DESCRIPTION
Display a user's full name in the option for adding observers/reducers when uploading a spectra
![Screenshot (39)](https://user-images.githubusercontent.com/82007190/156675195-024f7cca-5b6e-4769-8a59-22e55f268daa.png)
![Screenshot (40)](https://user-images.githubusercontent.com/82007190/156675201-f1c51016-6071-4fd2-a453-cc5779d095c0.png)

