### PR TITLE
Add clear spectra and add all spectra buttons to spectroscopy plot

### DIFF
--- a/skyportal/plot.py
+++ b/skyportal/plot.py
@@ -1931,22 +1931,56 @@ def make_spectrum_layout(obj, spectra, user, device, width, smoothing, smooth_nu
         )
         column_checkboxes.js_on_click(callback_toggle_lines)
 
+    second_to_last_column = all_column_checkboxes[-2]
+    clear_all_spectra = Button(name="Clear Spectra", label="Clear Spectra", width=100)
+    callback_clear_all_spectra = CustomJS(
+        args={'model_dict': model_dict},
+        code="""
+            for (const[key, value] of Object.entries(model_dict)) {
+                value.visible = false
+            }
+        """,
+    )
+    clear_all_spectra.js_on_click(callback_clear_all_spectra)
+    all_column_checkboxes[-2] = column(second_to_last_column, clear_all_spectra)
+
+    third_to_last_column = all_column_checkboxes[-3]
+    add_all_spectra = Button(name="Add All Spectra", label="Add All Spectra", width=30)
+    callback_add_all_spectra = CustomJS(
+        args={'model_dict': model_dict},
+        code="""
+            for (const[key, value] of Object.entries(model_dict)) {
+                if (!key.startsWith('element_')) {
+                    value.visible = true
+                }
+            }
+        """,
+    )
+    add_all_spectra.js_on_click(callback_add_all_spectra)
+    all_column_checkboxes[-3] = column(third_to_last_column, add_all_spectra)
+
     last_column = all_column_checkboxes[-1]
-    reset_button = Button(name="Reset", label="Reset", width=30, align="end")
+    reset_checkboxes_button = Button(
+        name="Reset Checkboxes", label="Reset Checkboxes", width=30
+    )
     callback_reset_specs = CustomJS(
         args={
             'all_column_checkboxes': all_column_checkboxes,
             'last_column': last_column,
+            'second_to_last_column': second_to_last_column,
+            'third_to_last_column': third_to_last_column,
         },
         code=f"""
-            for (let i = 0; i < {len(all_column_checkboxes) - 1}; i++) {{
+            for (let i = 0; i < {len(all_column_checkboxes) - 3}; i++) {{
                 all_column_checkboxes[i].active = [];
             }}
             last_column.active = [];
+            second_to_last_column.active = [];
+            third_to_last_column.active = [];
         """,
     )
-    reset_button.js_on_click(callback_reset_specs)
-    all_column_checkboxes[-1] = column(last_column, reset_button)
+    reset_checkboxes_button.js_on_click(callback_reset_specs)
+    all_column_checkboxes[-1] = column(last_column, reset_checkboxes_button)
 
     # Move spectral lines when redshift or velocity changes
     speclines = {f'specline_{i}': line for i, line in enumerate(shifting_elements)}
@@ -1990,7 +2024,6 @@ def make_spectrum_layout(obj, spectra, user, device, width, smoothing, smooth_nu
                 """,
         ),
     )
-
     row2 = row(all_column_checkboxes)
     row3 = (
         column(z, v_exp, smooth_column)


### PR DESCRIPTION
Adds two buttons for clearing the spectra on a spectroscopy plot and adding them back in:
![ezgif com-gif-maker](https://user-images.githubusercontent.com/82007190/157144966-30ce3cf1-7ee6-4d8e-9d09-7511f704595d.gif)

