### PR TITLE
Make it possible to delete allocations from front-end

### DIFF
--- a/static/js/components/AllocationPage.jsx
+++ b/static/js/components/AllocationPage.jsx
@@ -34,12 +34,6 @@ const useStyles = makeStyles((theme) => ({
     top: 0,
   },
   allocationDeleteDisabled: {
-    cursor: "pointer",
-    fontSize: "2em",
-    position: "absolute",
-    padding: 0,
-    right: 0,
-    top: 0,
     opacity: 0,
   },
 }));

--- a/static/js/components/ShiftPage.jsx
+++ b/static/js/components/ShiftPage.jsx
@@ -33,12 +33,6 @@ const useStyles = makeStyles((theme) => ({
     top: 0,
   },
   shiftDeleteDisabled: {
-    cursor: "pointer",
-    fontSize: "2em",
-    position: "absolute",
-    padding: 0,
-    right: 0,
-    top: 0,
     opacity: 0,
   },
 }));
@@ -176,6 +170,7 @@ const ShiftPage = () => {
 };
 
 ShiftList.propTypes = {
+  // eslint-disable-next-line react/forbid-prop-types
   shifts: PropTypes.arrayOf(PropTypes.any).isRequired,
   deletePermission: PropTypes.bool.isRequired,
 };

--- a/static/js/ducks/allocation.js
+++ b/static/js/ducks/allocation.js
@@ -10,11 +10,17 @@ const FETCH_ALLOCATION_OK = "skyportal/FETCH_ALLOCATION_OK";
 
 const SUBMIT_ALLOCATION = "skyportal/SUBMIT_ALLOCATION";
 
+const DELETE_ALLOCATION = "skyportal/DELETE_ALLOCATION";
+
 export const fetchAllocation = (id) =>
   API.GET(`/api/allocation/${id}`, FETCH_ALLOCATION);
 
 export const submitAllocation = (run) =>
   API.POST(`/api/allocation`, SUBMIT_ALLOCATION, run);
+
+export function deleteAllocation(allocationID) {
+  return API.DELETE(`/api/allocation/${allocationID}`, DELETE_ALLOCATION);
+}
 
 // Websocket message handler
 messageHandler.add((actionType, payload, dispatch, getState) => {


### PR DESCRIPTION
This PR emulates the shift page so that Allocations can be removed.