### PR TITLE
Fix doc requirements

### DIFF
--- a/requirements.docs.txt
+++ b/requirements.docs.txt
@@ -6,3 +6,4 @@ notedown
 jsx-lexer
 # need a fix for SQLA1.4
 git+https://github.com/sturzaam/eralchemy@Sturzaam-patch-1#egg=eralchemy
+jinja2<3.1.0


### PR DESCRIPTION
This PR restricts jinga2 to be below 3.1.0, which breaks our docs.