### PR TITLE
Adding missing packages that broke pycurl

### DIFF
--- a/doc/setup.md
+++ b/doc/setup.md
@@ -10,8 +10,6 @@ how to install them on MacOS and Debian-based systems below.
 - NGINX (v>=1.7)
 - PostgreSQL (v>=9.6)
 - Node.JS/npm (v>=5.8.0)
-- libcurl4-gnutls-dev
-- libgnutls28-dev
 
 ## Source download, Python environment
 
@@ -36,7 +34,7 @@ These instructions assume that you have [Homebrew](http://brew.sh/) installed.
 1. Install dependencies
 
 ```
-brew install supervisor nginx postgresql node libcurl4-gnutls-dev libgnutls28-dev
+brew install supervisor nginx postgresql node
 ```
 
 2. Start the PostgreSQL server:

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -11,6 +11,11 @@ how to install them on MacOS and Debian-based systems below.
 - PostgreSQL (v>=9.6)
 - Node.JS/npm (v>=5.8.0)
 
+When installing SkyPortal on Debian-based systems, 2 additional packages are required to be able to install pycurl later on:
+
+- libcurl4-gnutls-dev
+- libgnutls28-dev
+
 ## Source download, Python environment
 
 Clone the [SkyPortal repository](https://github.com/skyportal/skyportal) and start a new

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -10,6 +10,8 @@ how to install them on MacOS and Debian-based systems below.
 - NGINX (v>=1.7)
 - PostgreSQL (v>=9.6)
 - Node.JS/npm (v>=5.8.0)
+- libcurl4-gnutls-dev
+- libgnutls28-dev
 
 ## Source download, Python environment
 
@@ -34,7 +36,7 @@ These instructions assume that you have [Homebrew](http://brew.sh/) installed.
 1. Install dependencies
 
 ```
-brew install supervisor nginx postgresql node
+brew install supervisor nginx postgresql node libcurl4-gnutls-dev libgnutls28-dev
 ```
 
 2. Start the PostgreSQL server:
@@ -58,7 +60,7 @@ brew install graphviz
 1. Install dependencies
 
 ```
-sudo apt install nginx supervisor postgresql libpq-dev npm python3-pip
+sudo apt install nginx supervisor postgresql libpq-dev npm python3-pip libcurl4-gnutls-dev libgnutls28-dev
 ```
 
 2. Configure your database permissions.


### PR DESCRIPTION
Recently, skyportal couldn't get installed properly as pycurl (package installed with pip) was broken. It seems that adding these 2 packages fixed it. I would suggest to the reviewer to make sure they aren't already installed on his distro before trying it so he can compare and verify their necessity.