### PR TITLE
Resolved issue where GcnEvent page was crashing

### DIFF
--- a/static/js/components/GcnSelectionForm.jsx
+++ b/static/js/components/GcnSelectionForm.jsx
@@ -301,16 +301,29 @@ const GcnSelectionForm = ({ gcnEvent }) => {
 
   return (
     <div>
-      <div>
-        <LocalizationPlot
-          loc={locLookUp[selectedLocalizationId]}
-          sources={gcnEventSources}
-          galaxies={gcnEventGalaxies}
-          instrument={instLookUp[selectedInstrumentId]}
-          observations={gcnEventObservations}
-          options={checkedDisplayState}
-        />
-      </div>
+      {!(selectedLocalizationId in Object.entries(locLookUp)) ? (
+        <div>
+          <LocalizationPlot
+            loc={gcnEvent.localizations[0]}
+            sources={gcnEventSources}
+            galaxies={gcnEventGalaxies}
+            instrument={instLookUp[selectedInstrumentId]}
+            observations={gcnEventObservations}
+            options={checkedDisplayState}
+          />
+        </div>
+      ) : (
+        <div>
+          <LocalizationPlot
+            loc={locLookUp[selectedLocalizationId]}
+            sources={gcnEventSources}
+            galaxies={gcnEventGalaxies}
+            instrument={instLookUp[selectedInstrumentId]}
+            observations={gcnEventObservations}
+            options={checkedDisplayState}
+          />
+        </div>
+      )}
       <div>
         <Button
           variant="outlined"


### PR DESCRIPTION
This PR aims to resolve the issue where the GCN Event page was crashing. It behaved like this:
![gcn event page crash](https://user-images.githubusercontent.com/60301767/162482703-845c55e1-87e0-4454-940d-e7dfbd6f515e.gif)
 
Now the page behaves like this
![Peek 2022-04-08 18-25](https://user-images.githubusercontent.com/60301767/162483246-395b988a-60af-49c9-83a0-d6db60c75ec9.gif)

It isn't perfect but the page does not crash anymore.
