### PR TITLE
Draft: on top spectra

### DIFF
--- a/skyportal/handlers/api/internal/plot.py
+++ b/skyportal/handlers/api/internal/plot.py
@@ -47,6 +47,7 @@ class PlotSpectroscopyHandler(BaseHandler):
         device = self.get_query_argument("device", None)
         smoothing = self.get_query_argument("smoothing", False)
         smooth_number = self.get_query_argument("smoothNumber", 10)
+        on_top_spectra_id = self.get_query_argument("onTopSpectraId", None)
         # Just return browser by default if not one of accepted types
         if device not in device_types:
             device = "browser"
@@ -60,6 +61,7 @@ class PlotSpectroscopyHandler(BaseHandler):
                 device=device,
                 smoothing=smoothing,
                 smooth_number=smooth_number,
+                on_top_spectra_id=on_top_spectra_id,
             )
         except Exception as e:
             return self.error(f'Exception in photometry plot: {e}')
@@ -72,6 +74,7 @@ class PlotSpectroscopyHandler(BaseHandler):
             device=device,
             smoothing=smoothing,
             smooth_number=smooth_number,
+            on_top_spectra_id=on_top_spectra_id,
         )
         self.verify_and_commit()
         self.success(data={'bokehJSON': json, 'url': self.request.uri})

--- a/static/js/components/SourceDesktop.jsx
+++ b/static/js/components/SourceDesktop.jsx
@@ -458,6 +458,9 @@ const SourceDesktop = ({ source }) => {
                     </Suspense>
                   )}
                 </div>
+                <div className={classes.photometryContainer}>
+                  <div id="bokeh-spectroscopy" />
+                </div>
                 <div className={classes.buttonContainer}>
                   <Link to={`/upload_spectrum/${source.id}`} role="link">
                     <Button variant="contained">

--- a/static/js/plotjs/on_top_spectra.js
+++ b/static/js/plotjs/on_top_spectra.js
@@ -1,0 +1,20 @@
+/* eslint-disable */
+// import * as Bokeh from "@bokeh/bokehjs";
+
+// import * as Models from "../components/BokehModels";
+// Bokeh.Models.register_models(Models);
+let bokehJSON;
+fetch(
+  `/api/internal/plot/spectroscopy/${sourceId}?width=800&height=600&onTopSpectraId=${this.item}`
+)
+  .then((res) => res.json())
+  .then((data) => {
+    console.log(data);
+    console.log(data.data.bokehJSON);
+    bokehJSON = data.data.bokehJSON;
+  });
+console.log(bokehJSON);
+window.Bokeh = Bokeh;
+if (bokehJSON) {
+  Bokeh.embed.embed_item(bokehJSON, "bokeh-spectroscopy");
+}


### PR DESCRIPTION
This is a first pass at letting the user choose which spectra should be on top, which will close #1844. It doesn't work yet, I need to figure out a way to refresh/rerender the plot (similar to the problem in #2836). It works if an on top spectra id is hard-coded though:
<img width="890" alt="Screen Shot 2022-04-14 at 5 24 00 PM" src="https://user-images.githubusercontent.com/82007190/163577501-b0b87887-a46f-44cf-a75c-4f62123bc441.png">
<img width="714" alt="Screen Shot 2022-04-15 at 8 32 52 AM" src="https://user-images.githubusercontent.com/82007190/163577528-83c125cc-3f10-4f80-a3a5-9e6f2c3d8e64.png">
The main idea is that there will be a dropdown and the user can select which should be on top, this is the part that doesn't work yet.
<img width="342" alt="Screen Shot 2022-04-15 at 8 39 49 AM" src="https://user-images.githubusercontent.com/82007190/163577659-b24736ed-0ca1-4d76-a72b-bd0274fc8fc5.png">

