### PR TITLE
Determine instrument tile color based on filters

### DIFF
--- a/static/js/components/LocalizationPlot.jsx
+++ b/static/js/components/LocalizationPlot.jsx
@@ -246,6 +246,22 @@ const GeoJSONGlobePlot = ({
       return gdistance < 1.57;
     };
 
+    const filtersToColor = (filters) => {
+      const filterStr = filters.join("");
+      let hash = 0;
+      for (let i = 0; i < filterStr.length; i += 1) {
+        // eslint-disable-next-line no-bitwise
+        hash = filterStr.charCodeAt(i) + ((hash << 5) - hash);
+      }
+      let color = "#";
+      for (let i = 0; i < 3; i += 1) {
+        // eslint-disable-next-line no-bitwise
+        const value = (hash >> (i * 8)) & 0xff;
+        color += `00${value.toString(16)}`.substr(-2);
+      }
+      return color;
+    };
+
     function refresh() {
       svg.selectAll("*").remove();
 
@@ -319,7 +335,10 @@ const GeoJSONGlobePlot = ({
             .append("path")
             .attr("class", field_id)
             .classed(classes.fieldStyle, true)
-            .style("fill", f.selected ? "red" : "white")
+            .style(
+              "fill",
+              f.selected ? filtersToColor(data.instrument.filters) : "white"
+            )
             .attr("d", geoGenerator)
             .on("click", () => {
               if (f.selected) {
@@ -363,7 +382,7 @@ const GeoJSONGlobePlot = ({
           .data(galaxies.features)
           .enter()
           .append("circle")
-          .attr("fill", (d) => (visibleOnSphere(d) ? "red" : "none"))
+          .attr("fill", (d) => (visibleOnSphere(d) ? "green" : "none"))
           .attr("cx", x)
           .attr("cy", y)
           .attr("r", 3)

--- a/static/js/components/LocalizationPlot.jsx
+++ b/static/js/components/LocalizationPlot.jsx
@@ -327,6 +327,7 @@ const GeoJSONGlobePlot = ({
       }
 
       if (data.instrument?.fields && data.options.instrument) {
+        const filterColor = filtersToColor(data.instrument?.filters);
         data.instrument.fields.forEach((f) => {
           const { field_id } = f.contour_summary.properties;
           const { features } = f.contour_summary;
@@ -335,10 +336,7 @@ const GeoJSONGlobePlot = ({
             .append("path")
             .attr("class", field_id)
             .classed(classes.fieldStyle, true)
-            .style(
-              "fill",
-              f.selected ? filtersToColor(data.instrument.filters) : "white"
-            )
+            .style("fill", f.selected ? filterColor : "white")
             .attr("d", geoGenerator)
             .on("click", () => {
               if (f.selected) {


### PR DESCRIPTION
Determines color for the instrument tiles based on the filters, here's the color for these filters:
<img width="382" alt="Screen Shot 2022-04-15 at 3 58 46 PM" src="https://user-images.githubusercontent.com/82007190/163631581-3ee44ac4-69a1-4838-a4eb-6c8e692121fe.png">
And with just the first 3:
<img width="382" alt="Screen Shot 2022-04-15 at 4 03 12 PM" src="https://user-images.githubusercontent.com/82007190/163631687-07f877e7-ea15-4add-b702-14f3df17061b.png">
Also I made the galaxy points green to distinguish from sources
