### PR TITLE
Fix missing bot user in Candidates handler

### DIFF
--- a/skyportal/handlers/api/candidate.py
+++ b/skyportal/handlers/api/candidate.py
@@ -1039,12 +1039,11 @@ class CandidateHandler(BaseHandler):
                 f"Failed to post candidate for object {obj.id}: {e.args[0]}"
             )
 
+        calling_user_id = self.associated_user_object.id
         if not obj_already_exists:
             IOLoop.current().run_in_executor(
                 None,
-                lambda: add_linked_thumbnails_and_push_ws_msg(
-                    obj.id, self.associated_user_object.id
-                ),
+                lambda: add_linked_thumbnails_and_push_ws_msg(obj.id, calling_user_id),
             )
 
         return self.success(data={"ids": [c.id for c in candidates]})


### PR DESCRIPTION
Problem: When a token/bot is trying to POST a candidate we get this error: 
```
ERROR:asyncio:Future exception was never retrieved
future: <Future finished exception=DetachedInstanceError("Parent instance <Token at 0x7f6ea25394f0> is not bound to a Session; lazy load operation of attribute 'created_by' cannot proceed")>
Traceback (most recent call last):
  File "/usr/lib/python3.8/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/skyportal/skyportal/handlers/api/candidate.py", line 1046, in <lambda>
    obj.id, self.associated_user_object.id
  File "/skyportal/skyportal/handlers/base.py", line 15, in associated_user_object
    return self.current_user.created_by
  File "/skyportal_env/lib/python3.8/site-packages/sqlalchemy/orm/attributes.py", line 481, in __get__
    return self.impl.get(state, dict_)
  File "/skyportal_env/lib/python3.8/site-packages/sqlalchemy/orm/attributes.py", line 941, in get
    value = self._fire_loader_callables(state, key, passive)
  File "/skyportal_env/lib/python3.8/site-packages/sqlalchemy/orm/attributes.py", line 977, in _fire_loader_callables
    return self.callable_(state, passive)
  File "/skyportal_env/lib/python3.8/site-packages/sqlalchemy/orm/strategies.py", line 861, in _load_for_state
    raise orm_exc.DetachedInstanceError(
sqlalchemy.orm.exc.DetachedInstanceError: Parent instance <Token at 0x7f6ea25394f0> is not bound to a Session; lazy load operation of attribute 'created_by' cannot proceed (Background on this error at: https://sqlalche.me/e/14/bhk3)
```

Solution: move the call to associated_user_object outside loop so it runs in the scope of the handler, rather than in the scope of where the lambda is called. 
