### PR TITLE
Fix flaky shift frontend tests

### DIFF
--- a/skyportal/tests/frontend/test_shifts.py
+++ b/skyportal/tests/frontend/test_shifts.py
@@ -7,9 +7,6 @@ import uuid
 def test_super_user_post_shift(
     public_group, super_admin_token, super_admin_user, driver
 ):
-
-    driver.get(f"/become_user/{super_admin_user.id}")
-
     name = str(uuid.uuid4())
     start_date = date.today().strftime("%Y-%m-%dT%H:%M:%S")
     end_date = (date.today() + timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%S")
@@ -29,6 +26,7 @@ def test_super_user_post_shift(
     start_date = date.today().strftime("%m/%d/%Y")
     end_date = (date.today() + timedelta(days=1)).strftime("%m/%d/%Y")
 
+    driver.get(f"/become_user/{super_admin_user.id}")
     # go to the shift page
     driver.get("/shifts")
 


### PR DESCRIPTION
Currently, the front-end tests for the shift page seem to be flaky. What happens is that from time to time, when looking for the shift we added using API calls on the front-end (more specifically the calendar), it fails and that shift can't by found on the calendar by selenium. 

What seems to be the problem ?

As of right now, we open the browser and go to `/become_user/x`, then add a shift with an API call, and then access the `/shift` page to see if that shift we added is visible. What seems to be the problem is that basically, the access to the shift page happens almost at the exact same time as the API call, so what probably happens is that the page loads at the same time/before the shift is added to the DB and/or at the same time/before the associated handler pushed the refresh shift action, so the newly added shift is not on the calendar yet.

How can we fix it ?

By moving the access to the `/become_user/x` page after the API call, it adds the necessary delay that allows the shift to be added properly to SkyPortal so it can be visible on the calendar when going to the `/shift` page right after.
Right now, we manage to run this test **100 times in a row without having a single error**. What would be interesting might be to run it more than a 100 times, or run it in the GitHub actions to see if some other tests that run after or before this one could impact its behavior, but this is unlikely to happen.