### PR TITLE
Adjustable data point size for photometry plot

### DIFF
--- a/skyportal/plot.py
+++ b/skyportal/plot.py
@@ -740,10 +740,10 @@ def photometry_plot(obj_id, user, width=600, device="browser"):
         model_dict[key] = plot.scatter(
             x='mjd',
             y='flux',
-            size=4,
             color='color',
             marker=factor_mark('instrument', markers, instruments),
             fill_color=color_dict,
+            fill_alpha=0.1,
             alpha='alpha',
             source=ColumnDataSource(df),
         )
@@ -755,10 +755,10 @@ def photometry_plot(obj_id, user, width=600, device="browser"):
         model_dict[key] = plot.scatter(
             x='mjd',
             y='flux',
-            size=4,
             color='color',
             marker=factor_mark('instrument', markers, instruments),
             fill_color=color_dict,
+            fill_alpha=0.1,
             source=ColumnDataSource(
                 data=dict(
                     mjd=[],
@@ -1011,7 +1011,7 @@ def photometry_plot(obj_id, user, width=600, device="browser"):
             y='lim_mag',
             color=color_dict,
             marker=factor_mark('instrument', markers, instruments),
-            fill_alpha=0.0,
+            fill_alpha=0.1,
             line_color=color_dict,
             alpha='alpha',
             source=ColumnDataSource(unobs_source),
@@ -1028,6 +1028,7 @@ def photometry_plot(obj_id, user, width=600, device="browser"):
             marker=factor_mark('instrument', markers, instruments),
             fill_color=color_dict,
             alpha='alpha',
+            fill_alpha=0.1,
             source=ColumnDataSource(df[df['obs']]),
         )
         renderers.append(model_dict[key])
@@ -1041,6 +1042,7 @@ def photometry_plot(obj_id, user, width=600, device="browser"):
             color=color_dict,
             marker=factor_mark('instrument', markers, instruments),
             fill_color='color',
+            fill_alpha=0.1,
             source=ColumnDataSource(
                 data=dict(
                     mjd=[],
@@ -1106,6 +1108,7 @@ def photometry_plot(obj_id, user, width=600, device="browser"):
             fill_color='white',
             line_color=color_dict,
             alpha=0.8,
+            fill_alpha=0.1,
             source=ColumnDataSource(
                 data=dict(
                     mjd=[],
@@ -1289,6 +1292,7 @@ def photometry_plot(obj_id, user, width=600, device="browser"):
                     color='color',
                     marker=factor_mark('instrument', markers, instruments),
                     fill_color=color_dict,
+                    fill_alpha=0.1,
                     alpha='alpha',
                     # visible=('a' in ph),
                     source=ColumnDataSource(df[df['obs']]),  # only visible data

--- a/skyportal/plot.py
+++ b/skyportal/plot.py
@@ -20,6 +20,7 @@ from bokeh.models import (
     CategoricalColorMapper,
     Legend,
     LegendItem,
+    Spinner,
 )
 from bokeh.models.widgets import (
     CheckboxGroup,
@@ -724,6 +725,9 @@ def photometry_plot(obj_id, user, width=600, device="browser"):
     plot.add_tools(imhover)
 
     model_dict = {}
+    spinner = Spinner(
+        title="Data point size", low=1, high=40, step=0.5, value=4, width=80
+    )
 
     legend_items = []
     for i, (label, sdf) in enumerate(split):
@@ -736,6 +740,7 @@ def photometry_plot(obj_id, user, width=600, device="browser"):
         model_dict[key] = plot.scatter(
             x='mjd',
             y='flux',
+            size=4,
             color='color',
             marker=factor_mark('instrument', markers, instruments),
             fill_color=color_dict,
@@ -744,11 +749,13 @@ def photometry_plot(obj_id, user, width=600, device="browser"):
         )
         renderers.append(model_dict[key])
         imhover.renderers.append(model_dict[key])
+        spinner.js_link('value', model_dict[key].glyph, 'size')
 
         key = f'{label}~bin{i}'
         model_dict[key] = plot.scatter(
             x='mjd',
             y='flux',
+            size=4,
             color='color',
             marker=factor_mark('instrument', markers, instruments),
             fill_color=color_dict,
@@ -769,6 +776,8 @@ def photometry_plot(obj_id, user, width=600, device="browser"):
         )
         renderers.append(model_dict[key])
         imhover.renderers.append(model_dict[key])
+
+        spinner.js_link('value', model_dict[key].glyph, 'size')
 
         key = f'{label}~obserr{str(i)}'
         y_err_x = []
@@ -877,7 +886,7 @@ def photometry_plot(obj_id, user, width=600, device="browser"):
     layout = column(
         slider,
         plot,
-        make_clear_and_add_buttons(model_dict),
+        row(make_clear_and_add_buttons(model_dict), spinner),
         row(
             make_add_filter_group_form(split, model_dict, 'flux'),
             make_custom_buttons_div('flux'),
@@ -978,6 +987,9 @@ def photometry_plot(obj_id, user, width=600, device="browser"):
     imhover = HoverTool(tooltips=tooltip_format)
     imhover.renderers = []
     plot.add_tools(imhover)
+    spinner = Spinner(
+        title="Data point size", low=1, high=40, step=0.5, value=4, width=80
+    )
 
     model_dict = {}
 
@@ -1006,6 +1018,7 @@ def photometry_plot(obj_id, user, width=600, device="browser"):
         )
         renderers.append(model_dict[key])
         imhover.renderers.append(model_dict[key])
+        spinner.js_link('value', model_dict[key].glyph, 'size')
 
         key = f'{label}~obs{i}'
         model_dict[key] = plot.scatter(
@@ -1019,6 +1032,7 @@ def photometry_plot(obj_id, user, width=600, device="browser"):
         )
         renderers.append(model_dict[key])
         imhover.renderers.append(model_dict[key])
+        spinner.js_link('value', model_dict[key].glyph, 'size')
 
         key = f'{label}~bin{i}'
         model_dict[key] = plot.scatter(
@@ -1044,6 +1058,7 @@ def photometry_plot(obj_id, user, width=600, device="browser"):
         )
         renderers.append(model_dict[key])
         imhover.renderers.append(model_dict[key])
+        spinner.js_link('value', model_dict[key].glyph, 'size')
 
         key = f'{label}~obserr{str(i)}'
         y_err_x = []
@@ -1108,6 +1123,7 @@ def photometry_plot(obj_id, user, width=600, device="browser"):
         )
         imhover.renderers.append(model_dict[key])
         renderers.append(model_dict[key])
+        spinner.js_link('value', model_dict[key].glyph, 'size')
 
         key = f'all{i}'
         model_dict[key] = ColumnDataSource(df)
@@ -1179,7 +1195,7 @@ def photometry_plot(obj_id, user, width=600, device="browser"):
     layout = column(
         top_layout,
         plot,
-        make_clear_and_add_buttons(model_dict),
+        row(make_clear_and_add_buttons(model_dict), spinner),
         row(
             make_add_filter_group_form(split, model_dict, 'mag'),
             make_custom_buttons_div('mag'),
@@ -1252,6 +1268,9 @@ def photometry_plot(obj_id, user, width=600, device="browser"):
 
         # store all the plot data
         period_model_dict = {}
+        spinner = Spinner(
+            title="Data point size", low=1, high=40, step=0.5, value=4, width=80
+        )
 
         # iterate over each filter
         legend_items = []
@@ -1277,6 +1296,7 @@ def photometry_plot(obj_id, user, width=600, device="browser"):
                 # add to hover tool
                 period_imhover.renderers.append(period_model_dict[key])
                 renderers.append(period_model_dict[key])
+                spinner.js_link('value', period_model_dict[key].glyph, 'size')
 
                 # errorbars for phases
                 key = label + '~fold' + ph + f'err{i}'
@@ -1422,7 +1442,7 @@ def photometry_plot(obj_id, user, width=600, device="browser"):
 
         period_layout = column(
             period_plot,
-            make_clear_and_add_buttons(period_model_dict),
+            row(make_clear_and_add_buttons(period_model_dict), spinner),
             period_controls,
             row(
                 make_add_filter_group_form(split, period_model_dict, 'period'),

--- a/static/js/components/SourceDesktop.jsx
+++ b/static/js/components/SourceDesktop.jsx
@@ -477,7 +477,11 @@ const SourceDesktop = ({ source }) => {
                       }
                     >
                       <Plot
-                        url={`/api/internal/plot/spectroscopy/${source.id}?width=${plotWidth}&height=600&cacheID=${specIDs}`}
+                        url={`/api/internal/plot/spectroscopy/${
+                          source.id
+                        }?width=${
+                          plotWidth !== 0 ? plotWidth : 800
+                        }&height=600&cacheID=${specIDs}`}
                       />
                     </Suspense>
                   )}


### PR DESCRIPTION
Allows the user to adjust the size of the data points on the photometry plot. With #2857 and #2778, this should close #2396
![ezgif com-gif-maker (8)](https://user-images.githubusercontent.com/82007190/164477290-b458dca3-6368-4978-a817-3b2fa270644e.gif)

