### PR TITLE
Context Manager Session

### DIFF
--- a/skyportal/facility_apis/ps1.py
+++ b/skyportal/facility_apis/ps1.py
@@ -169,7 +169,10 @@ class PS1API(FollowUpAPI):
             }
 
             url = f"{PS1_URL}/api/v0.1/panstarrs/dr2/detections.csv"
-            r = requests.get(url, params=params)
+            try:
+                r = requests.get(url, params=params, timeout=5.0)  # timeout in seconds
+            except TimeoutError:
+                req.status = 'error: timeout'
 
             if r.status_code == 200:
                 try:

--- a/skyportal/handlers/api/candidate.py
+++ b/skyportal/handlers/api/candidate.py
@@ -74,6 +74,7 @@ def add_linked_thumbnails_and_push_ws_msg(obj_id, user_id):
             )
         except Exception as e:
             log(f"Unable to add linked thumbnails to {obj_id}: {e}")
+            session.rollback()
 
 
 def update_redshift_history_if_relevant(request_data, obj, user):

--- a/skyportal/handlers/api/candidate.py
+++ b/skyportal/handlers/api/candidate.py
@@ -56,24 +56,24 @@ Session = scoped_session(sessionmaker(bind=DBSession.session_factory.kw["bind"])
 
 
 def add_linked_thumbnails_and_push_ws_msg(obj_id, user_id):
-    session = Session()
-    try:
-        user = session.query(User).get(user_id)
-        if Obj.get_if_accessible_by(obj_id, user) is None:
-            raise AccessError(
-                f"Insufficient permissions for User {user_id} to read Obj {obj_id}"
+    with Session() as session:
+        try:
+            user = session.query(User).get(user_id)
+            if Obj.get_if_accessible_by(obj_id, user) is None:
+                raise AccessError(
+                    f"Insufficient permissions for User {user_id} to read Obj {obj_id}"
+                )
+            obj = session.query(Obj).get(obj_id)
+            obj.add_linked_thumbnails(session=session)
+            flow = Flow()
+            flow.push(
+                '*', "skyportal/REFRESH_SOURCE", payload={"obj_key": obj.internal_key}
             )
-        obj = session.query(Obj).get(obj_id)
-        obj.add_linked_thumbnails(session=session)
-        flow = Flow()
-        flow.push(
-            '*', "skyportal/REFRESH_SOURCE", payload={"obj_key": obj.internal_key}
-        )
-        flow.push('*', "skyportal/REFRESH_CANDIDATE", payload={"id": obj.internal_key})
-    except Exception as e:
-        log(f"Unable to add linked thumbnails to {obj_id}: {e}")
-    finally:
-        Session.remove()
+            flow.push(
+                '*', "skyportal/REFRESH_CANDIDATE", payload={"id": obj.internal_key}
+            )
+        except Exception as e:
+            log(f"Unable to add linked thumbnails to {obj_id}: {e}")
 
 
 def update_redshift_history_if_relevant(request_data, obj, user):

--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -106,6 +106,7 @@ def add_ps1_thumbnail_and_push_ws_msg(obj_id, user_id):
             )
         except Exception as e:
             log(f"Unable to generate PS1 thumbnail URL for {obj_id}: {e}")
+            session.rollback()
 
 
 def paginate_summary_query(query, page, num_per_page, total_matches):


### PR DESCRIPTION
There are a couple of places in the skyportal code (i.e., not in baselayer) where we generate sessions. 
Right now they use try/catch/finally to make sure the session gets closed properly. 
I'm not sure if that is good enough so I'm going to replace the finally with a `with Session() as session` block. 
This may help prevent us from slowly losing DB connections from the pool. 