### PR TITLE
Add follow-up requests to demo data

### DIFF
--- a/data/db_demo.yaml
+++ b/data/db_demo.yaml
@@ -386,6 +386,7 @@ allocation:
     hours_allocated: 100
     group_id: =program_A
     instrument_id: =SEDM
+    =id: SEDM_allocation
   - pi: Michael Coughlin
     proposal_id: LT-001
     start_date: "3020-02-12T00:00:00"
@@ -734,6 +735,32 @@ photometry:
       - =ztf_public
       - =ztf_partnership
 
+followup_request:
+  - obj_id: ZTFrlh6cyjh
+    allocation_id: =SEDM_allocation
+    payload:
+      priority: 5
+      observation_type: IFU
+      start_date: 3020-09-01
+      end_date: 3022-09-01
+    =id: request_1
+  - obj_id: ZTFe028h94k
+    allocation_id: =SEDM_allocation
+    payload:
+      priority: 5
+      observation_type: IFU
+      start_date: 3020-09-01
+      end_date: 3022-09-01
+    =id: request_2
+  - obj_id: ZTFe028h94k
+    allocation_id: =SEDM_allocation
+    payload:
+      priority: 5
+      observation_type: IFU
+      start_date: 3020-09-01
+      end_date: 3022-09-01
+    =id: request_3
+
 spectrum:
   - obj_id: ZTFrlh6cyjh
     file: spec1.csv
@@ -746,6 +773,7 @@ spectrum:
       - =program_B
     =id: "spectrum1"
     units: erg/s/cm/cm/AA
+    followup_request_id: =request_1
   - obj_id: ZTFe028h94k
     file: spec2.csv
     instrument_id: =ALFOSC
@@ -760,12 +788,14 @@ spectrum:
       - =program_B
     =id: "spectrum2"
     units: erg/s/cm/cm/AA
+    followup_request_id: =request_2
   - obj_id: ZTF21aaqjmps
     file: ZTF21aaqjmps_spec.csv
     instrument_id: =SPRAT
     observed_at: "2021-04-03T02:28:19.921"
     assignment_id: 1
     units: erg/s/cm/cm/AA
+    followup_request_id: =request_3
 
 spectra/=spectrum1/annotations:
   - origin: "Kowalski"

--- a/tools/data_loader.py
+++ b/tools/data_loader.py
@@ -257,6 +257,11 @@ if __name__ == "__main__":
             except KeyError:
                 continue
 
+            if "payload" in obj:
+                date_keys = ["start_date", "end_date"]
+                for key in date_keys:
+                    if key in obj["payload"]:
+                        obj["payload"][key] = obj["payload"][key].isoformat()
             status, response = post(endpoint, data=obj)
 
             print('.' if status == 200 else 'X', end='')


### PR DESCRIPTION
This PR adds follow-up requests associated to existing spectra to the demo data to facilitate studying data base queries.