### PR TITLE
Remove ResizeObserver on source page

### DIFF
--- a/skyportal/tests/frontend/sources_and_followup_etc/test_sources.py
+++ b/skyportal/tests/frontend/sources_and_followup_etc/test_sources.py
@@ -698,6 +698,15 @@ def test_show_photometry_table(public_source, driver, user):
     )
 
 
+def test_hide_right_pane(public_source, driver, user):
+    driver.get(f"/become_user/{user.id}")
+    driver.get(f"/source/{public_source.id}")
+    driver.click_xpath('//*[@data-testid="hide-right-pane-button"]')
+    driver.wait_for_xpath_to_disappear('//*[@class="MuiCollapse-hidden"]')
+    driver.click_xpath('//*[@data-testid="show-right-pane-button"]')
+    driver.wait_for_xpath_to_disappear('//*[@class="MuiCollapse-entered"]')
+
+
 def test_javascript_sexagesimal_conversion(public_source, driver, user):
     public_source.ra = 342.0708127
     public_source.dec = 56.1130711

--- a/skyportal/tests/frontend/sources_and_followup_etc/test_sources.py
+++ b/skyportal/tests/frontend/sources_and_followup_etc/test_sources.py
@@ -702,9 +702,9 @@ def test_hide_right_pane(public_source, driver, user):
     driver.get(f"/become_user/{user.id}")
     driver.get(f"/source/{public_source.id}")
     driver.click_xpath('//*[@data-testid="hide-right-pane-button"]')
-    driver.wait_for_xpath_to_disappear('//*[@class="MuiCollapse-hidden"]')
-    driver.click_xpath('//*[@data-testid="show-right-pane-button"]')
     driver.wait_for_xpath_to_disappear('//*[@class="MuiCollapse-entered"]')
+    driver.click_xpath('//*[@data-testid="show-right-pane-button"]')
+    driver.wait_for_xpath_to_disappear('//*[@class="MuiCollapse-hidden"]')
 
 
 def test_javascript_sexagesimal_conversion(public_source, driver, user):

--- a/static/js/components/SourceDesktop.jsx
+++ b/static/js/components/SourceDesktop.jsx
@@ -165,7 +165,7 @@ const SourceDesktop = ({ source }) => {
   const [showStarList, setShowStarList] = useState(false);
   const [showPhotometry, setShowPhotometry] = useState(false);
   const [rightPaneVisible, setRightPaneVisible] = useState(true);
-  const [plotWidth, setPlotWidth] = useState(0);
+  const plotWidth = rightPaneVisible ? 800 : 1200;
 
   const { instrumentList, instrumentFormParams } = useSelector(
     (state) => state.instruments
@@ -196,14 +196,6 @@ const SourceDesktop = ({ source }) => {
     dispatch(spectraActions.fetchSourceSpectra(source.id));
   }, [source.id, dispatch]);
 
-  useEffect(() => {
-    const resizeObserver = new ResizeObserver((event) => {
-      setPlotWidth(parseInt(event[0].contentBoxSize[0].inlineSize, 10));
-    });
-
-    resizeObserver.observe(document.getElementById("photometry-container"));
-  });
-
   const z_round = source.redshift_error
     ? ceil(abs(log10(source.redshift_error)))
     : 4;
@@ -222,7 +214,10 @@ const SourceDesktop = ({ source }) => {
             </div>
           </div>
           {!rightPaneVisible && (
-            <Button onClick={() => setRightPaneVisible(true)}>
+            <Button
+              onClick={() => setRightPaneVisible(true)}
+              data-testid="show-right-pane-button"
+            >
               Show right pane
             </Button>
           )}
@@ -546,7 +541,10 @@ const SourceDesktop = ({ source }) => {
       </Grid>
       <Grid item xs={5}>
         {rightPaneVisible && (
-          <Button onClick={() => setRightPaneVisible(false)}>
+          <Button
+            onClick={() => setRightPaneVisible(false)}
+            data-testid="hide-right-pane-button"
+          >
             Hide right pane
           </Button>
         )}


### PR DESCRIPTION
Quick fix for the problem brought up in slack where the source page would freak out due to the ResizeObserver

This reverts back to having some hardcoded plot widths based on if the right pane is hidden or not. I would like to make the plot widths fully responsive but I would have to find a good solution, the ResizeObserver does not seem to work well

Once approved I'll also make a PR on fritz