### PR TITLE
Add nginx info when using Let's Encrypt certificates

### DIFF
--- a/doc/setup.md
+++ b/doc/setup.md
@@ -168,7 +168,7 @@ This also adds `testuser@cesium-ml.org` as an administrator.
 
 ### nginx configuration
 
-When running on a public server, it can be useful to use X. 509 certificates for Transport Layer Security (TLS) encryption. For example, services such as Let's Encrypt (https://letsencrypt.org/) provide free services to create such certificates when deploying publicly.
+When running a public server, you will likely want to deploy an SSL certificate (i.e., serve `https://your.url` instead of `http://your.url`). Certificates can be obtained for free from services such as Let's Encrypt (https://letsencrypt.org/).
 
 One way to pick up the certificates with SkyPortal's nginx deployment is by modifying the default nginx template configuration files which come with baselayer. In this case, in the server portion of baselayer/services/nginx/nginx.conf.template, one can add (for Let's Encrypt'):
 

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -168,7 +168,7 @@ This also adds `testuser@cesium-ml.org` as an administrator.
 
 ### Deploying secure HTTP / SSL certificate
 
-When running a public server, you will likely want to deploy an SSL certificate (i.e., serve `https://your.url` instead of `http://your.url`). Certificates can be obtained for free from services such as Let's Encrypt (https://letsencrypt.org/). For Let's Encrypt at least, the process requires verification of the service without SSL first (i.e. simply running `make run`).
+When running a public server, you will likely want to deploy an SSL certificate (i.e., serve `https://your.url` instead of `http://your.url`). Certificates can be obtained for free from services such as Let's Encrypt (https://letsencrypt.org/).
 
 Briefly, one can install certbot:
     pip install certbot-nginx

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -168,7 +168,7 @@ This also adds `testuser@cesium-ml.org` as an administrator.
 
 ### Deploying secure HTTP / SSL certificate
 
-When running a public server, you will likely want to deploy an SSL certificate (i.e., serve `https://your.url` instead of `http://your.url`). Certificates can be obtained for free from services such as Let's Encrypt (https://letsencrypt.org/).
+When running a public server, you will likely want to deploy an SSL certificate (i.e., serve `https://your.url` instead of `http://your.url`). Certificates can be obtained for free from services such as Let's Encrypt (https://letsencrypt.org/). For Let's Encrypt at least, the process requires verification of the service without SSL first to provision a certificate, and so deployment without an nginx configuration change will be first required.
 
 To have nginx pick up your SSL certificate, you'll need to modify the nginx configuration in `baselayer/services/nginx/nginx.conf.template`. For example, you would add the following for Let's Encrypt:
 
@@ -179,4 +179,4 @@ To have nginx pick up your SSL certificate, you'll need to modify the nginx conf
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 
-and restart the app.
+and restart the app with `make run`.

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -178,7 +178,7 @@ Ask `certbot` to verify the service and retrieve a new certificate:
 or similar if using https
     sudo certbot certonly --standalone --preferred-challenges https -d https://your.url
 
-To renew the certificate, one does:
+To renew and retrieve the certificate, do:
     sudo certbot renew
 
 Next, modify the nginx configuration in `baselayer/services/nginx/nginx.conf.template` to use the newly generated certificate:

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -181,7 +181,7 @@ or similar if using https
 To renew the certificate, one does:
     sudo certbot renew
 
-After receiving an SSL certificate, you'll need to modify the nginx configuration in `baselayer/services/nginx/nginx.conf.template` to use it. For example, you would add the following for Let's Encrypt:
+Next, modify the nginx configuration in `baselayer/services/nginx/nginx.conf.template` to use the newly generated certificate:
 
     listen [::]:443 ssl ipv6only=on;
     listen 443 ssl;

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -186,13 +186,16 @@ or similar if using https
 To renew and retrieve the certificate, do:
     sudo certbot renew
 
-Next, modify the nginx configuration in `baselayer/services/nginx/nginx.conf.template` to use the newly generated certificate:
+Next, modify the nginx configuration in `baselayer/services/nginx/nginx.conf.template` to use the newly generated certificate, placing it at the top of the server section:
 
-    listen [::]:443 ssl ipv6only=on;
-    listen 443 ssl;
-    ssl_certificate /etc/letsencrypt/live/{YOUR_DOMAIN_HERE}/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/{YOUR_DOMAIN_HERE}/privkey.pem;
-    include /etc/letsencrypt/options-ssl-nginx.conf;
-    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+    server {
+      listen [::]:443 ssl ipv6only=on;
+      listen 443 ssl;
+      ssl_certificate /etc/letsencrypt/live/{YOUR_DOMAIN_HERE}/fullchain.pem;
+      ssl_certificate_key /etc/letsencrypt/live/{YOUR_DOMAIN_HERE}/privkey.pem;
+      include /etc/letsencrypt/options-ssl-nginx.conf;
+      ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+      ...
+   }
 
 Finally, stop the app and run it again using `make run`.

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -173,7 +173,7 @@ When running a public server, you will likely want to deploy an SSL certificate 
 Briefly, one can install certbot:
     pip install certbot-nginx
 
-and retrieve a certificate:
+Ask `certbot` to verify the service and retrieve a new certificate:
     sudo certbot certonly --standalone --preferred-challenges http -d http://your.url
 or similar if using https
     sudo certbot certonly --standalone --preferred-challenges https -d https://your.url

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -170,6 +170,17 @@ This also adds `testuser@cesium-ml.org` as an administrator.
 
 When running a public server, you will likely want to deploy an SSL certificate (i.e., serve `https://your.url` instead of `http://your.url`). Certificates can be obtained for free from services such as Let's Encrypt (https://letsencrypt.org/). For Let's Encrypt at least, the process requires verification of the service without SSL first (i.e. simply running `make run`).
 
+Briefly, one can install certbot:
+    pip install certbot-nginx
+
+and retrieve a certificate:
+    sudo certbot certonly --standalone --preferred-challenges http -d http://your.url
+or similar if using https
+    sudo certbot certonly --standalone --preferred-challenges https -d https://your.url
+
+To renew the certificate, one does:
+    sudo certbot renew
+
 After receiving an SSL certificate, you'll need to modify the nginx configuration in `baselayer/services/nginx/nginx.conf.template` to use it. For example, you would add the following for Let's Encrypt:
 
     listen [::]:443 ssl ipv6only=on;

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -168,7 +168,7 @@ This also adds `testuser@cesium-ml.org` as an administrator.
 
 ### Deploying secure HTTP / SSL certificate
 
-When running a public server, you will likely want to deploy an SSL certificate (i.e., serve `https://your.url` instead of `http://your.url`). Certificates can be obtained for free from services such as Let's Encrypt (https://letsencrypt.org/). For Let's Encrypt at least, the process requires verification of the service without SSL first to provision a certificate, and so deployment without an nginx configuration change will be first required.
+When running a public server, you will likely want to deploy an SSL certificate (i.e., serve `https://your.url` instead of `http://your.url`). Certificates can be obtained for free from services such as Let's Encrypt (https://letsencrypt.org/). For Let's Encrypt at least, the process requires verification of the service without SSL first.
 
 After receiving an SSL certificate, you'll need to modify the nginx configuration in `baselayer/services/nginx/nginx.conf.template` to use it. For example, you would add the following for Let's Encrypt:
 

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -168,7 +168,7 @@ This also adds `testuser@cesium-ml.org` as an administrator.
 
 ### Deploying secure HTTP / SSL certificate
 
-When running a public server, you will likely want to deploy an SSL certificate (i.e., serve `https://your.url` instead of `http://your.url`). Certificates can be obtained for free from services such as Let's Encrypt (https://letsencrypt.org/). For Let's Encrypt at least, the process requires verification of the service without SSL first.
+When running a public server, you will likely want to deploy an SSL certificate (i.e., serve `https://your.url` instead of `http://your.url`). Certificates can be obtained for free from services such as Let's Encrypt (https://letsencrypt.org/). For Let's Encrypt at least, the process requires verification of the service without SSL first (i.e. simply running `make run`).
 
 After receiving an SSL certificate, you'll need to modify the nginx configuration in `baselayer/services/nginx/nginx.conf.template` to use it. For example, you would add the following for Let's Encrypt:
 

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -170,7 +170,7 @@ This also adds `testuser@cesium-ml.org` as an administrator.
 
 When running a public server, you will likely want to deploy an SSL certificate (i.e., serve `https://your.url` instead of `http://your.url`). Certificates can be obtained for free from services such as Let's Encrypt (https://letsencrypt.org/).
 
-One way to pick up the certificates with SkyPortal's nginx deployment is by modifying the default nginx template configuration files which come with baselayer. In this case, in the server portion of baselayer/services/nginx/nginx.conf.template, one can add (for Let's Encrypt'):
+To have nginx pick up your SSL certificate, you'll need to modify the nginx configuration in `baselayer/services/nginx/nginx.conf.template`. For example, you would add the following for Let's Encrypt:
 
     listen [::]:443 ssl ipv6only=on;
     listen 443 ssl;

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -190,4 +190,4 @@ Next, modify the nginx configuration in `baselayer/services/nginx/nginx.conf.tem
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 
-and restart the app with `make run`.
+Finally, stop the app and run it again using `make run`.

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -170,7 +170,7 @@ This also adds `testuser@cesium-ml.org` as an administrator.
 
 When running a public server, you will likely want to deploy an SSL certificate (i.e., serve `https://your.url` instead of `http://your.url`). Certificates can be obtained for free from services such as Let's Encrypt (https://letsencrypt.org/). For Let's Encrypt at least, the process requires verification of the service without SSL first to provision a certificate, and so deployment without an nginx configuration change will be first required.
 
-To have nginx pick up your SSL certificate, you'll need to modify the nginx configuration in `baselayer/services/nginx/nginx.conf.template`. For example, you would add the following for Let's Encrypt:
+After receiving an SSL certificate, you'll need to modify the nginx configuration in `baselayer/services/nginx/nginx.conf.template` to use it. For example, you would add the following for Let's Encrypt:
 
     listen [::]:443 ssl ipv6only=on;
     listen 443 ssl;

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -166,7 +166,7 @@ make load_demo_data
 
 This also adds `testuser@cesium-ml.org` as an administrator.
 
-### nginx configuration
+### Deploying secure HTTP / SSL certificate
 
 When running a public server, you will likely want to deploy an SSL certificate (i.e., serve `https://your.url` instead of `http://your.url`). Certificates can be obtained for free from services such as Let's Encrypt (https://letsencrypt.org/).
 

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -165,3 +165,18 @@ make load_demo_data
 ```
 
 This also adds `testuser@cesium-ml.org` as an administrator.
+
+### nginx configuration
+
+When running on a public server, it can be useful to use X. 509 certificates for Transport Layer Security (TLS) encryption. For example, services such as Let's Encrypt (https://letsencrypt.org/) provide free services to create such certificates when deploying publicly.
+
+One way to pick up the certificates with SkyPortal's nginx deployment is by modifying the default nginx template configuration files which come with baselayer. In this case, in the server portion of baselayer/services/nginx/nginx.conf.template, one can add (for Let's Encrypt'):
+
+    listen [::]:443 ssl ipv6only=on;
+    listen 443 ssl;
+    ssl_certificate /etc/letsencrypt/live/{YOUR_DOMAIN_HERE}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/{YOUR_DOMAIN_HERE}/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+and restart the App.

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -170,7 +170,12 @@ This also adds `testuser@cesium-ml.org` as an administrator.
 
 When running a public server, you will likely want to deploy an SSL certificate (i.e., serve `https://your.url` instead of `http://your.url`). Certificates can be obtained for free from services such as Let's Encrypt (https://letsencrypt.org/).
 
-Briefly, one can install certbot:
+[certbot](https://certbot.eff.org/) is software for helping you obtain a new SSL certificate from Let's Encrypt.
+To do so, it first verifies that your server is running (without SSL) at the specified domain.
+
+Start SkyPortal using `make run`.
+
+Then, install `certbot`:
     pip install certbot-nginx
 
 Ask `certbot` to verify the service and retrieve a new certificate:

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -179,4 +179,4 @@ To have nginx pick up your SSL certificate, you'll need to modify the nginx conf
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 
-and restart the App.
+and restart the app.


### PR DESCRIPTION
This PR adds some info to the docs for when using Let's Encrypt certificates.