### PR TITLE
Telescope Map : Display if telescope in Night (Astronomical)

### DIFF
--- a/data/db_demo.yaml
+++ b/data/db_demo.yaml
@@ -183,8 +183,8 @@ telescope:
     =id: Swift
   - diameter: 1.8
     elevation: 4215.0
-    lat: 19.825
-    lon: 204.5317
+    lat: 20.708424
+    lon: -156.257565
     name: PAN-STARRS 1.8m
     nickname: PS1
     skycam_link: null

--- a/skyportal/handlers/api/telescope.py
+++ b/skyportal/handlers/api/telescope.py
@@ -105,9 +105,18 @@ class TelescopeHandler(BaseHandler):
         query = Telescope.query
         if tel_name is not None:
             query = query.filter(Telescope.name == tel_name)
+
         data = query.all()
+        telescopes = []
+        for telescope in data:
+            temp = telescope.to_dict()
+            temp['is_night_astronomical'] = bool(
+                telescope.next_twilight_morning_astronomical().jd
+                < telescope.next_twilight_evening_astronomical().jd
+            )
+            telescopes.append(temp)
         self.verify_and_commit()
-        return self.success(data=data)
+        return self.success(data=telescopes)
 
     @permissions(['Manage sources'])
     def put(self, telescope_id):

--- a/static/js/components/TelescopeInfo.jsx
+++ b/static/js/components/TelescopeInfo.jsx
@@ -20,6 +20,13 @@ const useStyles = makeStyles(() => ({
     justifyItems: "left",
     alignItems: "left",
   },
+  telescope_header: {
+    display: "flex",
+    flexDirection: "row",
+    justifyItems: "center",
+    alignItems: "center",
+    gap: "0.5rem",
+  },
   h2: {
     textAlign: "left",
     fontSize: "1.4rem",
@@ -40,6 +47,18 @@ const useStyles = makeStyles(() => ({
     padding: "0",
     margin: "0",
   },
+  canObserve: {
+    height: "1rem",
+    width: "1rem",
+    backgroundColor: "#0c1445",
+    borderRadius: "50%",
+  },
+  cannotObserve: {
+    height: "1rem",
+    width: "1rem",
+    backgroundColor: "#f9d71c",
+    borderRadius: "50%",
+  },
 }));
 
 const TelescopeInfo = () => {
@@ -57,9 +76,16 @@ const TelescopeInfo = () => {
             className={classes.listItem}
             key={telescope.id}
           >
-            <h2 className={classes.h2}>
-              {telescope.name} ({telescope.nickname})
-            </h2>
+            <div className={classes.telescope_header}>
+              {telescope.is_night_astronomical ? (
+                <span className={classes.canObserve} />
+              ) : (
+                <span className={classes.cannotObserve} />
+              )}
+              <h2 className={classes.h2}>
+                {telescope.name} ({telescope.nickname})
+              </h2>
+            </div>
             {telescope.robotic ? (
               <h3 className={classes.h3}>Robotic : Yes</h3>
             ) : (

--- a/static/js/components/TelescopeMap.jsx
+++ b/static/js/components/TelescopeMap.jsx
@@ -38,6 +38,14 @@ function telescopelabel(nestedTelescope) {
     .join(" / ");
 }
 
+function telescopeCanObserve(nestedTelescope) {
+  let color = "#f9d71c";
+  if (nestedTelescope.is_night_astronomical_at_least_one) {
+    color = "#0c1445";
+  }
+  return color;
+}
+
 function TelescopeMarker({ nestedTelescope, position }) {
   return (
     <Marker
@@ -46,7 +54,10 @@ function TelescopeMarker({ nestedTelescope, position }) {
       coordinates={[nestedTelescope.lon, nestedTelescope.lat]}
       onClick={() => setCurrentTelescopes(nestedTelescope)}
     >
-      <circle r={6.5 / position.k} fill="#457B9C" />
+      <circle
+        r={6.5 / position.k}
+        fill={telescopeCanObserve(nestedTelescope)}
+      />
       <text
         id="telescopes_label"
         textAnchor="middle"
@@ -77,6 +88,8 @@ const TelescopeMap = ({ telescopes }) => {
       nestedTelescopes.push({
         lat: filteredTelescopes[i].lat,
         lon: filteredTelescopes[i].lon,
+        is_night_astronomical_at_least_one:
+          filteredTelescopes[i].is_night_astronomical,
         telescopes: [filteredTelescopes[i]],
       });
     } else {
@@ -96,11 +109,16 @@ const TelescopeMap = ({ telescopes }) => {
           ) < 2
         ) {
           nestedTelescopes[j].telescopes.push(filteredTelescopes[i]);
+          if (filteredTelescopes[i].is_night_astronomical) {
+            nestedTelescopes[j].is_night_astronomical_at_least_one = true;
+          }
           break;
         } else if (j === nestedTelescopes.length - 1) {
           nestedTelescopes.push({
             lat: filteredTelescopes[i].lat,
             lon: filteredTelescopes[i].lon,
+            is_night_astronomical_at_least_one:
+              filteredTelescopes[i].is_night_astronomical,
             telescopes: [filteredTelescopes[i]],
           });
           break;
@@ -159,16 +177,17 @@ TelescopeMap.propTypes = {
 
 TelescopeMarker.propTypes = {
   nestedTelescope: PropTypes.shape({
-    lat: PropTypes.number,
-    lon: PropTypes.number,
+    lat: PropTypes.number.isRequired,
+    lon: PropTypes.number.isRequired,
     telescopes: PropTypes.arrayOf(
       PropTypes.shape({
-        id: PropTypes.number,
-        name: PropTypes.string,
-        nickname: PropTypes.string,
-        lat: PropTypes.number,
-        lon: PropTypes.number,
+        id: PropTypes.number.isRequired,
+        name: PropTypes.string.isRequired,
+        nickname: PropTypes.string.isRequired,
+        lat: PropTypes.number.isRequired,
+        lon: PropTypes.number.isRequired,
         fixed_location: PropTypes.bool,
+        is_night_astronomical: PropTypes.bool.isRequired,
       })
     ),
   }).isRequired,

--- a/static/js/components/TelescopePageDesktop.jsx
+++ b/static/js/components/TelescopePageDesktop.jsx
@@ -26,6 +26,7 @@ const useStyles = makeStyles((theme) => ({
     direction: "row",
     justifyContent: "space-around",
     alignItems: "center",
+    marginBottom: "1rem",
   },
   selectedMenu: {
     height: "3rem",

--- a/static/js/components/TelescopePageMobile.jsx
+++ b/static/js/components/TelescopePageMobile.jsx
@@ -122,6 +122,7 @@ TelescopeList.propTypes = {
       lat: PropTypes.number.isRequired,
       lon: PropTypes.number.isRequired,
       elevation: PropTypes.number.isRequired,
+      is_night_astronomical: PropTypes.bool.isRequired,
     })
   ).isRequired,
 };


### PR DESCRIPTION
## This PR aims to change the color of the markers of telescope on the telescope map depending on one of the element of their current condition : Day or Night.

### Backend:
For this, we used 2 of the methods defined in the Telescope model: 

- `next_twilight_evening_astronomical`
- `next_twilight_morning_astronomical`

Logically, if the `next_twilight_morning_astronomical` is before the `next_twilight_evening_astronomical`, then it means we are at night (astronomical), and vice versa.

So we added a boolean `is_night_astronomical` to a telescope, so we can use it in the frontend to change the color of the marker depending on that parameter.

### Frontend:

We choose yellow (like the color of the sun) for the color of markers of telescope that are not at night, and a deep purple (like the night sky) for the color of markers of telescope that are at night.

#### Details:
When it comes to nested telescopes (nested telescopes are telescopes that are so close to each other on the map that we grouped them into one marker to avoid overlapping), we show the color associated to that parameter being true if at least one of them has it set to `true`. So a user looking at the map knows that at that location (on this marker), there is at least one of them that is in at night (astronomical).


## Preview:
![telescope_is_night](https://user-images.githubusercontent.com/49785117/166495917-4ade115c-38eb-46a6-9128-124822517903.gif)

