### PR TITLE
Add general comments to the news feed

### DIFF
--- a/skyportal/app_server.py
+++ b/skyportal/app_server.py
@@ -14,6 +14,7 @@ from skyportal.handlers.api import (
     ClassificationHandler,
     CommentHandler,
     CommentAttachmentHandler,
+    GeneralCommentHandler,
     EnumTypesHandler,
     AnnotationHandler,
     DatalabQueryHandler,
@@ -168,6 +169,7 @@ skyportal_handlers = [
         r'/api/(sources|spectra|gcn_event)/([0-9A-Za-z-_\.\+]+)/comments(/[0-9]+)/attachment.pdf',
         CommentAttachmentHandler,
     ),
+    (r'/api/comments(/[0-9]+)?', GeneralCommentHandler),
     (r'/api/gcn_event(/.*)?', GcnEventHandler),
     (
         r'/api/localization(/[0-9]+)/airmass(/[0-9]+)?',

--- a/skyportal/handlers/api/__init__.py
+++ b/skyportal/handlers/api/__init__.py
@@ -3,6 +3,7 @@ from .allocation import AllocationHandler
 from .candidate import CandidateHandler
 from .classification import ClassificationHandler, ObjClassificationHandler
 from .comment import CommentHandler, CommentAttachmentHandler
+from .general_comment import GeneralCommentHandler
 from .annotation import AnnotationHandler
 from .annotation_services import (
     IRSAQueryWISEHandler,

--- a/skyportal/handlers/api/general_comment.py
+++ b/skyportal/handlers/api/general_comment.py
@@ -1,0 +1,477 @@
+import string
+import base64
+from marshmallow.exceptions import ValidationError
+from baselayer.app.custom_exceptions import AccessError
+from baselayer.app.access import permissions, auth_or_token
+from ..base import BaseHandler
+from ...models import (
+    DBSession,
+    Comment,
+    CommentOnSpectrum,
+    CommentOnGCN,
+    GeneralComment,
+    Group,
+    User,
+    UserNotification,
+    Token,
+)
+
+
+def users_mentioned(text):
+    punctuation = string.punctuation.replace("-", "").replace("@", "")
+    usernames = []
+    for word in text.replace(",", " ").split():
+        word = word.strip(punctuation)
+        if word.startswith("@"):
+            usernames.append(word.replace("@", ""))
+    users = User.query.filter(User.username.in_(usernames)).all()
+    return users
+
+
+class GeneralCommentHandler(BaseHandler):
+    @auth_or_token
+    def get(self, comment_id=None):
+        """
+        ---
+        single:
+          description: Retrieve a comment
+          tags:
+            - comments
+            - sources
+            - spectra
+          parameters:
+            - in: path
+              name: associated_resource_type
+              required: true
+              schema:
+                type: string
+              description: |
+                 What underlying data the comment is on:
+                 "sources" or "spectra" or "gcn_event".
+            - in: path
+              name: resource_id
+              required: true
+              schema:
+                type: string
+                enum: [sources, spectra, gcn_event]
+              description: |
+                 The ID of the source, spectrum, or gcn_event
+                 that the comment is posted to.
+                 This would be a string for a source ID
+                 or an integer for a spectrum or gcn_event
+            - in: path
+              name: comment_id
+              required: true
+              schema:
+                type: integer
+          responses:
+            200:
+              content:
+                application/json:
+                  schema: SingleComment
+            400:
+              content:
+                application/json:
+                  schema: Error
+        multiple:
+          description: Retrieve all comments associated with specified resource
+          tags:
+            - comments
+            - spectra
+            - sources
+            - gcn_event
+            - general_comments
+          parameters:
+            - in: path
+              name: associated_resource_type
+              required: true
+              schema:
+                type: string
+                enum: [sources]
+              description: |
+                 What underlying data the comment is on, e.g., "sources"
+                 or "spectra" or "gcn_event".
+            - in: path
+              name: resource_id
+              required: true
+              schema:
+                type: string
+              description: |
+                 The ID of the underlying data.
+                 This would be a string for a source ID
+                 or an integer for other data types like spectrum or gcn_event.
+          responses:
+            200:
+              content:
+                application/json:
+                  schema: ArrayOfComments
+            400:
+              content:
+                application/json:
+                  schema: Error
+        """
+        if comment_id is None:
+            comments = GeneralComment.query_records_accessible_by(
+                self.current_user
+            ).all()
+
+            self.verify_and_commit()
+            return self.success(data=comments)
+
+        try:
+            comment_id = int(comment_id)
+        except (TypeError, ValueError):
+            return self.error("Must provide a valid (scalar integer) comment ID. ")
+
+        try:
+            comment = GeneralComment.get_if_accessible_by(
+                comment_id, self.current_user, raise_if_none=True
+            )
+        except AccessError:
+            return self.error('Could not find any accessible comments.', status=403)
+
+        if not comment.attachment_bytes:
+            return self.success(data=comment)
+        else:
+            return self.success(
+                data={
+                    "commentId": int(comment_id),
+                    "text": comment.text,
+                    "attachment": base64.b64decode(comment.attachment_bytes).decode(),
+                    "attachment_name": str(comment.attachment_name),
+                }
+            )
+
+    @permissions(['Comment'])
+    def post(self):
+        """
+        ---
+        description: Post a comment
+        tags:
+          - comments
+        requestBody:
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  text:
+                    type: string
+                  group_ids:
+                    type: array
+                    items:
+                      type: integer
+                    description: |
+                      List of group IDs corresponding to which groups should be
+                      able to view comment. Defaults to all of requesting user's
+                      groups.
+                  attachment:
+                    type: object
+                    properties:
+                      body:
+                        type: string
+                        format: byte
+                        description: base64-encoded file contents
+                      name:
+                        type: string
+                required:
+                  - text
+        responses:
+          200:
+            content:
+              application/json:
+                schema:
+                  allOf:
+                    - $ref: '#/components/schemas/Success'
+                    - type: object
+                      properties:
+                        data:
+                          type: object
+                          properties:
+                            comment_id:
+                              type: integer
+                              description: New comment ID
+        """
+        data = self.get_json()
+
+        comment_text = data.get("text")
+
+        group_ids = data.pop('group_ids', None)
+        if not group_ids:
+            groups = self.current_user.accessible_groups
+        else:
+            try:
+                groups = Group.get_if_accessible_by(
+                    group_ids, self.current_user, raise_if_none=True
+                )
+            except AccessError:
+                return self.error('Could not find any accessible groups.', status=403)
+
+        if 'attachment' in data:
+            if (
+                isinstance(data['attachment'], dict)
+                and 'body' in data['attachment']
+                and 'name' in data['attachment']
+            ):
+                attachment_bytes = str.encode(
+                    data['attachment']['body'].split('base64,')[-1]
+                )
+                attachment_name = data['attachment']['name']
+            else:
+                return self.error("Malformed comment attachment")
+        else:
+            attachment_bytes, attachment_name = None, None
+
+        author = self.associated_user_object
+        is_bot_request = isinstance(self.current_user, Token)
+
+        comment = GeneralComment(
+            text=comment_text,
+            attachment_bytes=attachment_bytes,
+            attachment_name=attachment_name,
+            author=author,
+            groups=groups,
+            bot=is_bot_request,
+        )
+
+        users_mentioned_in_comment = users_mentioned(comment_text)
+
+        for user in users_mentioned_in_comment:
+            DBSession().add(
+                UserNotification(
+                    user=user,
+                    text=f"*@{self.current_user.username}* mentionned you on a general comment. *{comment.text}*",
+                    notification_type="comment",
+                    url=f"/comments/{comment.id}",
+                )
+            )
+
+        DBSession().add(comment)
+        self.verify_and_commit()
+        if users_mentioned_in_comment:
+            for user_mentioned in users_mentioned_in_comment:
+                self.flow.push(user_mentioned.id, "skyportal/FETCH_NOTIFICATIONS", {})
+
+        # add comment to all users
+        self.push_all(action='skyportal/FETCH_NEWSFEED', payload={})
+
+        return self.success(data={'comment_id': comment.id})
+
+    @permissions(['Comment'])
+    def put(self, associated_resource_type, resource_id, comment_id):
+        """
+        ---
+        description: Update a comment
+        tags:
+          - comments
+        parameters:
+          - in: path
+            name: associated_resource_type
+            required: true
+            schema:
+              type: string
+              enum: [sources, spectrum, gcn_event]
+            description: |
+               What underlying data the comment is on:
+               "sources" or "spectra" or "gcn_event".
+          - in: path
+            name: resource_id
+            required: true
+            schema:
+              type: string
+              enum: [sources, spectra, gcn_event]
+            description: |
+               The ID of the source or spectrum
+               that the comment is posted to.
+               This would be a string for an object ID
+               or an integer for a spectrum or gcn_event.
+          - in: path
+            name: comment_id
+            required: true
+            schema:
+              type: integer
+        requestBody:
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/CommentNoID'
+                  - type: object
+                    properties:
+                      group_ids:
+                        type: array
+                        items:
+                          type: integer
+                        description: |
+                          List of group IDs corresponding to which groups should be
+                          able to view comment.
+        responses:
+          200:
+            content:
+              application/json:
+                schema: Success
+          400:
+            content:
+              application/json:
+                schema: Error
+        """
+
+        try:
+            comment_id = int(comment_id)
+        except (TypeError, ValueError):
+            return self.error("Must provide a valid (scalar integer) comment ID. ")
+
+        if associated_resource_type.lower() == "sources":
+            schema = Comment.__schema__()
+            try:
+                c = Comment.get_if_accessible_by(
+                    comment_id, self.current_user, mode="update", raise_if_none=True
+                )
+            except AccessError:
+                return self.error('Could not find any accessible comments.', status=403)
+            comment_resource_id_str = str(c.obj_id)
+
+        elif associated_resource_type.lower() == "spectra":
+            schema = CommentOnSpectrum.__schema__()
+            try:
+                c = CommentOnSpectrum.get_if_accessible_by(
+                    comment_id, self.current_user, mode="update", raise_if_none=True
+                )
+            except AccessError:
+                return self.error('Could not find any accessible comments.', status=403)
+            comment_resource_id_str = str(c.spectrum_id)
+
+        elif associated_resource_type.lower() == "gcn_event":
+            schema = CommentOnGCN.__schema__()
+            try:
+                c = CommentOnGCN.get_if_accessible_by(
+                    comment_id, self.current_user, mode="update", raise_if_none=True
+                )
+            except AccessError:
+                return self.error('Could not find any accessible comments.', status=403)
+            comment_resource_id_str = str(c.gcn_id)
+
+        # add more options using elif
+        else:
+            return self.error(
+                f'Unsupported associated_resource_type "{associated_resource_type}".'
+            )
+
+        data = self.get_json()
+        group_ids = data.pop("group_ids", None)
+        data['id'] = comment_id
+        attachment_bytes = data.pop('attachment_bytes', None)
+
+        try:
+            schema.load(data, partial=True)
+        except ValidationError as e:
+            return self.error(f'Invalid/missing parameters: {e.normalized_messages()}')
+
+        if attachment_bytes is not None:
+            attachment_bytes = str.encode(attachment_bytes.split('base64,')[-1])
+            c.attachment_bytes = attachment_bytes
+
+        bytes_is_none = c.attachment_bytes is None
+        name_is_none = c.attachment_name is None
+
+        if bytes_is_none ^ name_is_none:
+            return self.error(
+                'This update leaves one of attachment name or '
+                'attachment bytes null. Both fields must be '
+                'filled, or both must be null.'
+            )
+
+        if group_ids is not None:
+            try:
+                groups = Group.get_if_accessible_by(
+                    group_ids, self.current_user, raise_if_none=True
+                )
+            except AccessError:
+                return self.error('Could not find any accessible groups.', status=403)
+            c.groups = groups
+
+        if comment_resource_id_str != resource_id:
+            return self.error(
+                f'Comment resource ID does not match resource ID given in path ({resource_id})'
+            )
+
+        self.verify_and_commit()
+
+        if hasattr(c, 'obj'):  # comment on object, or object related resources
+            self.push_all(
+                action='skyportal/REFRESH_SOURCE',
+                payload={'obj_key': c.obj.internal_key},
+            )
+        if isinstance(c, CommentOnSpectrum):  # also update the spectrum
+            self.push_all(
+                action='skyportal/REFRESH_SOURCE_SPECTRA',
+                payload={'obj_internal_key': c.obj.internal_key},
+            )
+        elif isinstance(c, CommentOnGCN):  # also update the spectrum
+            self.push_all(
+                action='skyportal/REFRESH_SOURCE_GCN',
+                payload={'obj_internal_key': c.obj.internal_key},
+            )
+
+        return self.success()
+
+    @permissions(['Comment'])
+    def delete(self, comment_id=None):
+        """
+        ---
+        description: Delete a comment
+        tags:
+          - comments
+        parameters:
+          - in: path
+            name: associated_resource_type
+            required: true
+            schema:
+              type: string
+            description: |
+               What underlying data the comment is on:
+               "sources" or "spectra".
+          - in: path
+            name: resource_id
+            required: true
+            schema:
+              type: string
+              enum: [sources, spectra, gcn_event]
+            description: |
+               The ID of the source or spectrum
+               that the comment is posted to.
+               This would be a string for a source ID
+               or an integer for a spectrum or gcn_event.
+          - in: path
+            name: comment_id
+            required: true
+            schema:
+              type: integer
+        responses:
+          200:
+            content:
+              application/json:
+                schema: Success
+        """
+        try:
+            comment_id = int(comment_id)
+        except (TypeError, ValueError):
+            return self.error("Must provide a valid (scalar integer) comment ID.")
+
+        try:
+            c = GeneralComment.get_if_accessible_by(
+                comment_id, self.current_user, mode="delete", raise_if_none=True
+            )
+        except AccessError:
+            return self.error('Could not find any accessible comments.', status=403)
+
+        DBSession().delete(c)
+        self.verify_and_commit()
+
+        if isinstance(c, GeneralComment):  # also update the news feed
+            self.push_all(
+                action='skyportal/FETCH_NEWSFEED',
+                payload={},
+            )
+
+        return self.success()

--- a/skyportal/handlers/api/news_feed.py
+++ b/skyportal/handlers/api/news_feed.py
@@ -4,6 +4,7 @@ from ..base import BaseHandler
 from ...models import (
     Source,
     Comment,
+    GeneralComment,
     Classification,
     Spectrum,
     Photometry,
@@ -63,14 +64,22 @@ class NewsFeedHandler(BaseHandler):
                 )
             elif model == Comment and not include_bot_comments:
                 query = query.filter(Comment.bot.is_(False))
-            query = (
-                query.order_by(desc(model.created_at or model.saved_at))
-                .distinct(model.obj_id, model.created_at)
-                .limit(n_items)
-            )
+            elif model == GeneralComment and not include_bot_comments:
+                query = query.filter(GeneralComment.bot.is_(False))
+
+            if model == GeneralComment:
+                query = query.order_by(desc(model.created_at or model.saved_at)).limit(
+                    n_items
+                )
+            else:
+                query = (
+                    query.order_by(desc(model.created_at or model.saved_at))
+                    .distinct(model.obj_id, model.created_at)
+                    .limit(n_items)
+                )
             newest = query.all()
 
-            if model == Comment:
+            if model == Comment or model == GeneralComment:
                 for comment in newest:
                     comment.author_info = comment.construct_author_info_dict()
 
@@ -173,6 +182,25 @@ class NewsFeedHandler(BaseHandler):
                 ]
             )
 
+        if (
+            preferences.get("newsFeed", {})
+            .get("categories", {})
+            .get("general_comments", True)
+        ):
+            comments = fetch_newest(GeneralComment)
+            # Add latest general comments
+            news_feed_items.extend(
+                [
+                    {
+                        'type': 'general_comments',
+                        'time': c.created_at,
+                        'message': c.text,
+                        'author': c.author.username,
+                        'author_info': c.author_info,
+                    }
+                    for c in comments
+                ]
+            )
         news_feed_items.sort(key=lambda x: x['time'], reverse=True)
         news_feed_items = news_feed_items[:n_items]
         self.verify_and_commit()

--- a/skyportal/models/comment.py
+++ b/skyportal/models/comment.py
@@ -1,4 +1,4 @@
-__all__ = ['Comment', 'CommentOnSpectrum', 'CommentOnGCN']
+__all__ = ['Comment', 'CommentOnSpectrum', 'CommentOnGCN', 'GeneralComment']
 
 import sqlalchemy as sa
 from sqlalchemy.ext.declarative import declared_attr
@@ -59,6 +59,8 @@ class CommentMixin:
             return 'comments_on_spectra'
         if cls.__name__ == 'CommentOnGCN':
             return 'comments_on_gcns'
+        if cls.__name__ == 'GeneralComment':
+            return 'general_comments'
 
     @declared_attr
     def author(cls):
@@ -183,3 +185,16 @@ class CommentOnGCN(Base, CommentMixin):
         back_populates='comments',
         doc="The GcnEvent referred to by this comment.",
     )
+
+
+class GeneralComment(Base, CommentMixin):
+
+    __tablename__ = 'general_comments'
+
+    create = AccessibleIfRelatedRowsAreAccessible(groups='read')
+
+    read = accessible_by_groups_members & AccessibleIfRelatedRowsAreAccessible(
+        groups='read'
+    )
+
+    update = delete = AccessibleIfUserMatches('author')

--- a/skyportal/models/group_joins.py
+++ b/skyportal/models/group_joins.py
@@ -7,6 +7,7 @@ __all__ = [
     'GroupSpectrum',
     'GroupCommentOnSpectrum',
     'GroupCommentOnGCN',
+    'GroupGeneralComment',
     'GroupAnnotationOnSpectrum',
     'GroupInvitation',
     'GroupSourceNotification',
@@ -27,6 +28,7 @@ from .spectrum import Spectrum
 from .comment import CommentOnSpectrum
 from .annotation import AnnotationOnSpectrum
 from .comment import CommentOnGCN
+from .comment import GeneralComment
 from .invitation import Invitation
 from .source_notification import SourceNotification
 from .filter import Filter
@@ -90,6 +92,12 @@ GroupCommentOnGCN = join_model("group_comments_on_gcns", Group, CommentOnGCN)
 GroupCommentOnGCN.__doc__ = "Join table mapping Groups to CommentOnGCN."
 GroupCommentOnGCN.delete = GroupCommentOnGCN.update = (
     accessible_by_group_admins & GroupCommentOnGCN.read
+)
+
+GroupGeneralComment = join_model("group_general_comments", Group, GeneralComment)
+GroupGeneralComment.__doc__ = "Join table mapping Groups to GeneralComment."
+GroupGeneralComment.delete = GroupGeneralComment.update = (
+    accessible_by_group_admins & GroupGeneralComment.read
 )
 
 GroupInvitation = join_model('group_invitations', Group, Invitation)

--- a/skyportal/models/user_token.py
+++ b/skyportal/models/user_token.py
@@ -146,6 +146,13 @@ User.comments_on_gcns = relationship(
     cascade="delete",
     passive_deletes=True,
 )
+User.general_comments = relationship(
+    "GeneralComment",
+    back_populates="author",
+    foreign_keys="GeneralComment.author_id",
+    cascade="delete",
+    passive_deletes=True,
+)
 User.followup_requests = relationship(
     'FollowupRequest',
     back_populates='requester',

--- a/skyportal/tests/api/test_general_comments.py
+++ b/skyportal/tests/api/test_general_comments.py
@@ -1,0 +1,63 @@
+from skyportal.tests import api
+
+
+def test_add_and_retrieve_comment_group_id(
+    comment_token,
+    public_group,
+):
+
+    status, data = api(
+        'POST',
+        'comments',
+        data={
+            'text': 'Comment text',
+            'group_ids': [public_group.id],
+        },
+        token=comment_token,
+    )
+    assert status == 200
+    comment_id = data['data']['comment_id']
+
+    status, data = api('GET', f'comments/{comment_id}', token=comment_token)
+    assert status == 200
+    assert data['data']['text'] == 'Comment text'
+
+
+def test_delete_comment(comment_token, public_group, super_admin_token):
+
+    status, data = api(
+        'POST',
+        'comments',
+        data={'text': 'Comment text to delete'},
+        token=comment_token,
+    )
+    assert status == 200
+    comment_id = data['data']['comment_id']
+
+    status, data = api('GET', f'comments/{comment_id}', token=comment_token)
+    assert status == 200
+    assert data['data']['text'] == 'Comment text to delete'
+
+    print('comment_id', comment_id)
+
+    # try to delete using the wrong comment ID
+    status, data = api(
+        'DELETE',
+        f'comments/{comment_id}1212',
+        token=comment_token,
+    )
+    assert status == 403
+    assert "Could not find any accessible comments." in data["message"]
+
+    status, data = api(
+        'DELETE',
+        f'comments/{comment_id}',
+        token=comment_token,
+    )
+    assert status == 200
+    assert len(data['data']) == 0
+
+    status, data = api('GET', 'comments', token=comment_token)
+    print('data', data)
+    assert status == 200
+    assert data['data'] == []

--- a/static/js/ducks/comment.js
+++ b/static/js/ducks/comment.js
@@ -1,0 +1,89 @@
+import * as API from "../API";
+import store from "../store";
+
+const ADD_GENERAL_COMMENT = "skyportal/ADD_GENERAL_COMMENT";
+
+const DELETE_GENERAL_COMMENT = "skyportal/DELETE_GENERAL_COMMENT";
+
+const GET_GENERAL_COMMENT_ATTACHMENT =
+  "skyportal/GET_GENERAL_COMMENT_ATTACHMENT";
+const GET_GENERAL_COMMENT_ATTACHMENT_OK =
+  "skyportal/GET_GENERAL_COMMENT_ATTACHMENT_OK";
+
+const GET_GENERAL_COMMENT_ATTACHMENT_PREVIEW =
+  "skyportal/GET_GENERAL_COMMENT_ATTACHMENT_PREVIEW";
+const GET_GENERAL_COMMENT_ATTACHMENT_PREVIEW_OK =
+  "skyportal/GET_GENERAL_COMMENT_ATTACHMENT_PREVIEW_OK";
+
+export function addGeneralComment(formData) {
+  function fileReaderPromise(file) {
+    return new Promise((resolve) => {
+      const filereader = new FileReader();
+      filereader.readAsDataURL(file);
+      filereader.onloadend = () =>
+        resolve({ body: filereader.result, name: file.name });
+    });
+  }
+  if (formData.attachment) {
+    return (dispatch) => {
+      fileReaderPromise(formData.attachment).then((fileData) => {
+        formData.attachment = fileData;
+
+        dispatch(API.POST(`/api/comments`, ADD_GENERAL_COMMENT, formData));
+      });
+    };
+  }
+
+  return API.POST(`/api/comments`, ADD_GENERAL_COMMENT, formData);
+}
+
+export function deleteGeneralComment(commentID) {
+  return API.DELETE(`/api/comments/${commentID}`, DELETE_GENERAL_COMMENT);
+}
+
+export function getGeneralCommentAttachment(commentID) {
+  return API.GET(
+    `/api/comments/${commentID}/attachment`,
+    GET_GENERAL_COMMENT_ATTACHMENT
+  );
+}
+
+export function getGeneralCommentAttachmentPreview(commentID) {
+  return API.GET(
+    `/api/comments/${commentID}`,
+    GET_GENERAL_COMMENT_ATTACHMENT_PREVIEW
+  );
+}
+
+const reducer = (state = { source: null, loadError: false }, action) => {
+  switch (action.type) {
+    case GET_GENERAL_COMMENT_ATTACHMENT_OK: {
+      const { commentId, text, attachment, attachment_name } = action.data;
+      return {
+        ...state,
+        commentAttachment: {
+          commentId,
+          text,
+          attachment,
+          attachment_name,
+        },
+      };
+    }
+    case GET_GENERAL_COMMENT_ATTACHMENT_PREVIEW_OK: {
+      const { commentId, text, attachment, attachment_name } = action.data;
+      return {
+        ...state,
+        commentAttachment: {
+          commentId,
+          text,
+          attachment,
+          attachment_name,
+        },
+      };
+    }
+    default:
+      return state;
+  }
+};
+
+store.injectReducer("GeneralComments", reducer);


### PR DESCRIPTION
This PR aims to add the ability to comment directly on the Dashboard, on the NewsFeed component as you can see below:

![general_comment](https://user-images.githubusercontent.com/60301767/166227860-d3c5270a-411e-4717-9ae8-34313a3d2dad.gif)

The commentEntry form has been added to the NewsFeed widget where you can type your comment. 

The particularity of these comments is that they are not related to an object.