### PR TITLE
Documentation : PostgreSQL Configuration

### DIFF
--- a/doc/setup.md
+++ b/doc/setup.md
@@ -78,6 +78,14 @@ host skyportal_test skyportal 127.0.0.1/32 trust
 host all postgres 127.0.0.1/32 trust
 ```
 
+If you are deploying SkyPortal using IPv6 rather than IPv4, you should add the following lines instead:
+
+```
+host skyportal skyportal ::1/128 trust
+host skyportal_test skyportal ::1/128 trust
+host all postgres ::1/128 trust
+```
+
 In some PostgreSQL installations, the default TCP port may be different from the 5432 value assumed in our default configuration file values. To remedy this, you can either edit your config.yaml file to reflect your system's PostgreSQL default port, or update your system-wide config to use port 5432 by editing /etc/postgresql/12/main/postgresql.conf (replace "12" with your installed version number) and changing the line `port = XXXX` (where "XXXX" is whatever the system default was) to `port = 5432`.
 
 Restart PostgreSQL:


### PR DESCRIPTION
This PR adds the configuration (in the documentation) for machines where SkyPortal is deployed using IPv6 rather than IPv4.
It was discussed after merging https://github.com/skyportal/skyportal/pull/2938