### PR TITLE
Fixes link to SkyPortal logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h1 align="center">
   <br>
   <img
-    src="https://github.com/skyportal/skyportal/raw/master/static/images/skyportal_logo.png"
+    src="https://github.com/skyportal/skyportal/raw/main/static/images/skyportal_logo.png"
     alt="SkyPortal Logo"
     width="100px"
   />


### PR DESCRIPTION
The link to skyportal's logo in the readme points to the master branch that has been renamed main, so it doesnt work anymore. This extra short PR fixes that.