### PR TITLE
TimeZoneFinder telescope longitude range

### DIFF
--- a/skyportal/models/telescope.py
+++ b/skyportal/models/telescope.py
@@ -65,7 +65,7 @@ class Telescope(Base):
         except AttributeError:
             tf = timezonefinder.TimezoneFinder(in_memory=True)
             local_tz = tf.closest_timezone_at(
-                lng=self.lon, lat=self.lat, delta_degree=5
+                lng=(self.lon + 180) % 360 - 180, lat=self.lat, delta_degree=5
             )
             self._observer = astroplan.Observer(
                 longitude=self.lon * u.deg,


### PR DESCRIPTION
If any telescope has longitude > 180 the TimeZoneFinder complains that some coordinates are out of range. 
This makes sure the telescope longitude is in range for the finder.