### PR TITLE
Turn off ATLAS API endpoint

### DIFF
--- a/skyportal/facility_apis/atlas.py
+++ b/skyportal/facility_apis/atlas.py
@@ -230,6 +230,9 @@ class ATLASAPI(FollowUpAPI):
             Instrument,
         )
 
+        log(
+            f'Pending ATLAS request from {request.requester.username}: request ID {request.id}'
+        )
         raise ValueError(
             'Turning off ATLAS API endpoint until this can be made more stable.'
         )

--- a/skyportal/facility_apis/atlas.py
+++ b/skyportal/facility_apis/atlas.py
@@ -230,6 +230,10 @@ class ATLASAPI(FollowUpAPI):
             Instrument,
         )
 
+        raise ValueError(
+            'Turning off ATLAS API endpoint until this can be made more stable.'
+        )
+
         Session = scoped_session(
             sessionmaker(bind=DBSession.session_factory.kw["bind"])
         )


### PR DESCRIPTION
This PR turns off the ATLAS API endpoint for now.