### PR TITLE
Tests flagged as flaky

### DIFF
--- a/skyportal/tests/frontend/test_new_source.py
+++ b/skyportal/tests/frontend/test_new_source.py
@@ -1,7 +1,3 @@
-import pytest
-
-
-@pytest.mark.flaky(reruns=2)
 def test_new_source(
     driver, user, super_admin_token, upload_data_token, view_only_token, ztf_camera
 ):


### PR DESCRIPTION
Some tests are still flagged as flaky while they do not seem to be. For example, test_new_source.py is marked as flaky but does not seem to be flaky at all. I tried running it multiple times and it never failed.