### PR TITLE
Slightly relax line lengths

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -11,6 +11,6 @@
 # for error classes selected below.
 
 [flake8]
-max-line-length = 80
+max-line-length = 88
 select = C,E,F,W,B,B950
 ignore = E501, W503, E203


### PR DESCRIPTION
This slightly relaxes the limit on line length from 80 to 88. This gives black a bit more freedom to reformat long lines reasonably well. Note that we also allow a 10% margin of overshoot. As they say in the black docs: "try to respect --line-length, but don’t become crazy if you can’t".