### PR TITLE
Fix issue with converting Local input in form to UTC date

### DIFF
--- a/static/js/components/GcnSelectionForm.jsx
+++ b/static/js/components/GcnSelectionForm.jsx
@@ -175,8 +175,12 @@ const GcnSelectionForm = ({ gcnEvent }) => {
 
   const handleSubmit = async ({ formData }) => {
     setIsSubmitting(true);
-    formData.startDate = formData.startDate.replace("+00:00", "");
-    formData.endDate = formData.endDate.replace("+00:00", "");
+    formData.startDate = formData.startDate
+      .replace("+00:00", "")
+      .replace(".000Z", "");
+    formData.endDate = formData.endDate
+      .replace("+00:00", "")
+      .replace(".000Z", "");
     dispatch(sourcesActions.fetchGcnEventSources(gcnEvent.dateobs, formData));
     formData.includeGeoJSON = true;
     dispatch(

--- a/static/js/components/NewAPIObservation.jsx
+++ b/static/js/components/NewAPIObservation.jsx
@@ -89,8 +89,12 @@ const NewAPIObservation = () => {
   });
 
   const handleSubmit = async ({ formData }) => {
-    formData.start_date = formData.start_date.replace("+00:00", "");
-    formData.end_date = formData.end_date.replace("+00:00", "");
+    formData.start_date = formData.start_date
+      .replace("+00:00", "")
+      .replace(".000Z", "");
+    formData.end_date = formData.end_date
+      .replace("+00:00", "")
+      .replace(".000Z", "");
     await dispatch(observationActions.requestAPIObservations(formData));
   };
 

--- a/static/js/components/NewAPIQueuedObservation.jsx
+++ b/static/js/components/NewAPIQueuedObservation.jsx
@@ -90,8 +90,8 @@ const NewAPIQueuedObservation = () => {
 
   const handleSubmit = async ({ formData }) => {
     const data = {
-      startDate: formData.start_date.replace("+00:00", ""),
-      endDate: formData.end_date.replace("+00:00", ""),
+      startDate: formData.start_date.replace("+00:00", "").replace(".000Z", ""),
+      endDate: formData.end_date.replace("+00:00", "").replace(".000Z", ""),
     };
     await dispatch(
       queuedObservationActions.requestAPIQueuedObservations(

--- a/static/js/components/NewAllocation.jsx
+++ b/static/js/components/NewAllocation.jsx
@@ -25,8 +25,12 @@ const NewAllocation = () => {
     .format("YYYY-MM-DDTHH:mm:ssZ");
 
   const handleSubmit = async ({ formData }) => {
-    formData.start_date = formData.start_date.replace("+00:00", "");
-    formData.end_date = formData.end_date.replace("+00:00", "");
+    formData.start_date = formData.start_date
+      .replace("+00:00", "")
+      .replace(".000Z", "");
+    formData.end_date = formData.end_date
+      .replace("+00:00", "")
+      .replace(".000Z", "");
     const result = await dispatch(submitAllocation(formData));
     if (result.status === "success") {
       dispatch(showNotification("Allocation saved"));

--- a/static/js/components/NewShift.jsx
+++ b/static/js/components/NewShift.jsx
@@ -33,8 +33,12 @@ const NewShift = () => {
 
   const handleSubmit = async ({ formData }) => {
     if (!formData.repeatsDaily) {
-      formData.start_date = formData.start_date.replace("+00:00", "");
-      formData.end_date = formData.end_date.replace("+00:00", "");
+      formData.start_date = formData.start_date
+        .replace("+00:00", "")
+        .replace(".000Z", "");
+      formData.end_date = formData.end_date
+        .replace("+00:00", "")
+        .replace(".000Z", "");
       delete formData.repeatsDaily;
       const result = await dispatch(submitShift(formData));
       if (result.status === "success") {
@@ -52,11 +56,13 @@ const NewShift = () => {
         newFormData.start_date = startDate
           .add(i, "day")
           .format("YYYY-MM-DDTHH:mm:ssZ")
-          .replace("+00:00", "");
+          .replace("+00:00", "")
+          .replace(".000Z", "");
         newFormData.end_date = endDate
           .subtract(days - i, "day")
           .format("YYYY-MM-DDTHH:mm:ssZ")
-          .replace("+00:00", "");
+          .replace("+00:00", "")
+          .replace(".000Z", "");
         const result = dispatch(submitShift(newFormData));
         if (result.status === "success") {
           dispatch(showNotification("Shift saved"));


### PR DESCRIPTION
It seems that a recent modification to either:
- rjsf
- dayjs
- the way the calendar that open on your browser works

affect the format of the date returned by the form (or it could just be that this error was never noticed before).

Here's what happens:

A form has a default value, and when submitting it without modifying a start and end date, all is well, and the date ends in "+00:00" as expected, which we delete. But right now, it seems that modifying the date manually or via the calendar that pops up, modifies the format of the date which then ends int '.000Z'.

This PR takes care of this by also deleting '.000Z'.



