### PR TITLE
FollowupRequestPage rerendering

### DIFF
--- a/static/js/components/FollowupRequestPage.jsx
+++ b/static/js/components/FollowupRequestPage.jsx
@@ -72,7 +72,7 @@ const FollowupRequestPage = () => {
       instrumentID: selectedInstrumentId,
     };
     dispatch(followupRequestActions.fetchFollowupRequests(params));
-  }, [dispatch, fetchParams, selectedInstrumentId]);
+  }, [dispatch, selectedInstrumentId]);
 
   if (!Array.isArray(followupRequestList)) {
     return <p>Waiting for followup requests to load...</p>;


### PR DESCRIPTION
Currently the FollowupRequestPage component incorrectly rerenders with every table click. This fixes that.