### PR TITLE
For Pandas DataFrames, ensure that assignments are made on views, not copies

### DIFF
--- a/skyportal/facility_apis/atlas.py
+++ b/skyportal/facility_apis/atlas.py
@@ -150,18 +150,18 @@ def commit_photometry(json_response, altdata, request_id, instrument_id, user_id
 
         snr = df['uJy'] / df['duJy'] < 5
 
-        df['filter'].loc[cyan] = 'atlasc'
-        df['filter'].loc[orange] = 'atlaso'
-        df['mag'].loc[snr] = None
-        df['magerr'].loc[snr] = None
+        df.loc[cyan, 'filter'] = 'atlasc'
+        df.loc[orange, 'filter'] = 'atlaso'
+        df.loc[snr, 'mag'] = None
+        df.loc[snr, 'magerr'] = None
 
         iszero = df['duJy'] == 0.0
-        df['mag'].loc[iszero] = None
-        df['magerr'].loc[iszero] = None
+        df.loc[iszero, 'mag'] = None
+        df.loc[iszero, 'magerr'] = None
 
         isnan = np.isnan(df['uJy'])
-        df['mag'].loc[isnan] = None
-        df['magerr'].loc[isnan] = None
+        df.loc[isnan, 'mag'] = None
+        df.loc[isnan, 'magerr'] = None
 
         df = df.replace({np.nan: None})
 

--- a/skyportal/facility_apis/ztf.py
+++ b/skyportal/facility_apis/ztf.py
@@ -258,16 +258,16 @@ def commit_photometry(url, altdata, df_request, request_id, instrument_id, user_
         df['magerr'] = 1.0857 * df['forcediffimfluxunc'] / df['forcediffimflux']
 
         snr = df['forcediffimflux'] / df['forcediffimfluxunc'] < 5
-        df['mag'].loc[snr] = None
-        df['magerr'].loc[snr] = None
+        df.loc[snr, 'mag'] = None
+        df.loc[snr, 'magerr'] = None
 
         iszero = df['forcediffimfluxunc'] == 0.0
-        df['mag'].loc[iszero] = None
-        df['magerr'].loc[iszero] = None
+        df.loc[iszero, 'mag'] = None
+        df.loc[iszero, 'magerr'] = None
 
         isnan = np.isnan(df['forcediffimflux'])
-        df['mag'].loc[isnan] = None
-        df['magerr'].loc[isnan] = None
+        df.loc[isnan, 'mag'] = None
+        df.loc[isnan, 'magerr'] = None
 
         df = df.replace({np.nan: None})
 


### PR DESCRIPTION
See https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#why-does-assignment-fail-when-using-chained-indexing

In our case, the code was probably doing the right thing.  But the
SettingWithCopy warning is issued conservatively whenever copies *may*
be returned, and rewriting the statements the way it is done here is
safer overall.