### PR TITLE
classification shortcuts

### DIFF
--- a/skyportal/handlers/api/internal/profile.py
+++ b/skyportal/handlers/api/internal/profile.py
@@ -200,6 +200,10 @@ class ProfileHandler(BaseHandler):
         if not user_prefs:
             user_prefs = preferences
         else:
+            if "classificationShortcuts" in preferences:
+                user_prefs["classificationShortcuts"] = preferences[
+                    "classificationShortcuts"
+                ]
             user_prefs = recursive_update(user_prefs, preferences)
         user.preferences = user_prefs
 

--- a/skyportal/tests/frontend/test_profile.py
+++ b/skyportal/tests/frontend/test_profile.py
@@ -1,5 +1,9 @@
 import pytest
 import uuid
+from skyportal.tests import api
+from tdtax import taxonomy, __version__
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.common.action_chains import ActionChains
 
 
 def test_token_acls_options_rendering1(driver, user):
@@ -99,3 +103,66 @@ def test_profile_dropdown(driver, user):
     driver.wait_for_xpath("//p[contains(@data-testid, 'firstLastName')]")
     driver.wait_for_xpath("//p[contains(@data-testid, 'username')]")
     driver.wait_for_xpath("//a[contains(@data-testid, 'signOutButton')]")
+
+
+def test_add_classification_shortcut(driver, user, public_group, taxonomy_token):
+    status, data = api(
+        'POST',
+        'taxonomy',
+        data={
+            'name': "test taxonomy" + str(uuid.uuid4()),
+            'hierarchy': taxonomy,
+            'group_ids': [public_group.id],
+            'provenance': f"tdtax_{__version__}",
+            'version': __version__,
+            'isLatest': True,
+        },
+        token=taxonomy_token,
+    )
+    assert status == 200
+    driver.get(f"/become_user/{user.id}")
+    driver.get("/profile")
+    classifications_entry = driver.wait_for_xpath('//div[@id="classifications-select"]')
+    driver.scroll_to_element_and_click(classifications_entry)
+    agn_option = driver.wait_for_xpath('//li[@data-value="AGN"]')
+    driver.scroll_to_element_and_click(agn_option)
+    driver.wait_for_xpath('//span[contains(text(), "AGN")]')
+    am_cvn_option = driver.wait_for_xpath('//li[@data-value="AM CVn"]')
+    driver.scroll_to_element_and_click(am_cvn_option)
+    driver.wait_for_xpath('//span[contains(text(), "AM CVn")]')
+    ActionChains(driver).send_keys(Keys.ESCAPE).perform()
+
+    shortcut_name = str(uuid.uuid4())
+    shortcut_name_entry = driver.wait_for_xpath('//input[@name="shortcutName"]')
+    driver.scroll_to_element_and_click(shortcut_name_entry)
+    shortcut_name_entry.send_keys(shortcut_name)
+
+    add_shortcut_button = driver.wait_for_xpath(
+        '//button[@data-testid="addShortcutButton"]'
+    )
+    driver.scroll_to_element_and_click(add_shortcut_button)
+
+    driver.wait_for_xpath(f'//span[contains(text(), "{shortcut_name}")]')
+    return shortcut_name
+
+
+def test_classification_shortcut(driver, user, public_group, taxonomy_token):
+    shortcut_name = test_add_classification_shortcut(
+        driver, user, public_group, taxonomy_token
+    )
+    driver.get("/candidates")
+    shortcut_button = driver.wait_for_xpath(f'//button[@data-testid="{shortcut_name}"]')
+    driver.scroll_to_element_and_click(shortcut_button)
+    driver.wait_for_xpath('//span[contains(text(), "AGN")]')
+    driver.wait_for_xpath('//span[contains(text(), "AM CVn")]')
+
+
+def test_delete_classification_shortcut(driver, user, public_group, taxonomy_token):
+    shortcut_name = test_add_classification_shortcut(
+        driver, user, public_group, taxonomy_token
+    )
+    delete_icon = driver.wait_for_xpath(
+        '//*[@class="MuiSvgIcon-root MuiChip-deleteIcon"]'
+    )
+    driver.scroll_to_element_and_click(delete_icon)
+    driver.wait_for_xpath_to_disappear(f'//span[contains(text(), "{shortcut_name}")]')

--- a/static/js/components/ClassificationsShortcutForm.jsx
+++ b/static/js/components/ClassificationsShortcutForm.jsx
@@ -1,0 +1,172 @@
+import React, { useState } from "react";
+import { useSelector, useDispatch } from "react-redux";
+import { useForm } from "react-hook-form";
+import Input from "@material-ui/core/Input";
+import InputLabel from "@material-ui/core/InputLabel";
+import Chip from "@material-ui/core/Chip";
+import Select from "@material-ui/core/Select";
+import MenuItem from "@material-ui/core/MenuItem";
+import { makeStyles } from "@material-ui/core/styles";
+import { Button, FormControl, TextField, Typography } from "@material-ui/core";
+import UserPreferencesHeader from "./UserPreferencesHeader";
+import { allowedClasses } from "./ClassificationForm";
+import * as profileActions from "../ducks/profile";
+
+const useStyles = makeStyles(() => ({
+  chips: {
+    display: "flex",
+    flexWrap: "wrap",
+    maxWidth: "20rem",
+  },
+  form: {
+    display: "flex",
+    gap: "1rem",
+    flexWrap: "wrap",
+    paddingBottom: "1.5rem",
+  },
+  classificationsMenu: {
+    minWidth: "12rem",
+  },
+}));
+
+const ClassificationsShortcutForm = () => {
+  const classes = useStyles();
+  const profile = useSelector((state) => state.profile.preferences);
+  const { taxonomyList } = useSelector((state) => state.taxonomies);
+  const latestTaxonomyList = taxonomyList?.filter((t) => t.isLatest);
+  let classifications = [];
+  latestTaxonomyList?.forEach((taxonomy) => {
+    const currentClasses = allowedClasses(taxonomy.hierarchy)?.map(
+      (option) => option.class
+    );
+    classifications = classifications.concat(currentClasses);
+  });
+  classifications = Array.from(new Set(classifications)).sort();
+  const { handleSubmit, register, errors, reset } = useForm();
+  const dispatch = useDispatch();
+
+  const ITEM_HEIGHT = 48;
+  const MenuProps = {
+    PaperProps: {
+      style: {
+        maxHeight: ITEM_HEIGHT * 4.5,
+        width: 250,
+      },
+    },
+  };
+
+  const [selectedClassifications, setSelectedClassifications] = useState([]);
+
+  const onSubmit = (formValues) => {
+    const shortcuts = profile?.classificationShortcuts || {};
+    shortcuts[formValues.shortcutName] = selectedClassifications;
+    const prefs = {
+      classificationShortcuts: shortcuts,
+    };
+    dispatch(profileActions.updateUserPreferences(prefs));
+    setSelectedClassifications([]);
+    reset({
+      shortcutName: "",
+    });
+  };
+
+  const onDelete = (shortcutName) => {
+    const shortcuts = profile?.classificationShortcuts;
+    delete shortcuts[shortcutName];
+    const prefs = {
+      classificationShortcuts: shortcuts,
+    };
+    dispatch(profileActions.updateUserPreferences(prefs));
+  };
+
+  return (
+    <div>
+      <UserPreferencesHeader
+        title="Classifications Shortcut"
+        popupText="Select a group of preexisting classifications, give them a common name, and a shortcut button will appear on the scanning page for selecting those classifications."
+      />
+      <div className={classes.form}>
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <div className={classes.form}>
+            <div>
+              <FormControl className={classes.classificationsMenu}>
+                <InputLabel id="classifications-select-label">
+                  Classifications
+                </InputLabel>
+                <Select
+                  labelId="classifications-select-label"
+                  id="classifications-select"
+                  multiple
+                  value={selectedClassifications}
+                  onChange={(event) => {
+                    setSelectedClassifications(event.target.value);
+                  }}
+                  input={<Input id="classifications-select" />}
+                  renderValue={(selected) => (
+                    <div className={classes.chips}>
+                      {selected?.map((classification) => (
+                        <Chip key={classification} label={classification} />
+                      ))}
+                    </div>
+                  )}
+                  MenuProps={MenuProps}
+                >
+                  {classifications?.map((classification) => (
+                    <MenuItem key={classification} value={classification}>
+                      {classification}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            </div>
+            <div>
+              <InputLabel htmlFor="shortcutNameInput">Shortcut Name</InputLabel>
+              <TextField
+                inputRef={register({
+                  required: true,
+                  validate: (value) => {
+                    if (profile?.classificationShortcuts) {
+                      return !(value in profile?.classificationShortcuts);
+                    }
+                    return null;
+                  },
+                })}
+                name="shortcutName"
+                id="shortcutNameInput"
+                error={!!errors.shortcutName}
+                helperText={
+                  errors.shortcutName
+                    ? "Required/Shortcut with that name already exists"
+                    : ""
+                }
+              />
+            </div>
+          </div>
+          <Button
+            variant="contained"
+            type="submit"
+            data-testid="addShortcutButton"
+          >
+            Add Shortcut
+          </Button>
+        </form>
+        {profile?.classificationShortcuts && (
+          <div>
+            <Typography>Shortcuts</Typography>
+            {Object.keys(profile?.classificationShortcuts)?.map(
+              (shortcutName) => (
+                <Chip
+                  key={shortcutName}
+                  label={shortcutName}
+                  onDelete={() => onDelete(shortcutName)}
+                />
+              )
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ClassificationsShortcutForm;

--- a/static/js/components/FavoriteSourcesNotificationPreferences.jsx
+++ b/static/js/components/FavoriteSourcesNotificationPreferences.jsx
@@ -1,25 +1,16 @@
-import React, { useState } from "react";
+import React from "react";
 import { useSelector, useDispatch } from "react-redux";
 
 import FormGroup from "@material-ui/core/FormGroup";
 import FormControlLabel from "@material-ui/core/FormControlLabel";
 import Switch from "@material-ui/core/Switch";
-import IconButton from "@material-ui/core/IconButton";
-import HelpOutlineIcon from "@material-ui/icons/HelpOutline";
 import Typography from "@material-ui/core/Typography";
 import { makeStyles } from "@material-ui/core/styles";
-import Popover from "@material-ui/core/Popover";
 
 import * as profileActions from "../ducks/profile";
+import UserPreferencesHeader from "./UserPreferencesHeader";
 
 const useStyles = makeStyles((theme) => ({
-  header: {
-    display: "flex",
-    alignItems: "center",
-    "& > h6": {
-      marginRight: "0.5rem",
-    },
-  },
   typography: {
     padding: theme.spacing(2),
   },
@@ -29,16 +20,6 @@ const FavoriteSourcesNotificationPreferences = () => {
   const classes = useStyles();
   const profile = useSelector((state) => state.profile.preferences);
   const dispatch = useDispatch();
-
-  const [anchorEl, setAnchorEl] = useState(null);
-  const handleClick = (event) => {
-    setAnchorEl(event.currentTarget);
-  };
-  const handleClose = () => {
-    setAnchorEl(null);
-  };
-  const open = Boolean(anchorEl);
-  const id = open ? "simple-popover" : undefined;
 
   const prefToggled = (event) => {
     const prefs = {
@@ -62,33 +43,11 @@ const FavoriteSourcesNotificationPreferences = () => {
 
   return (
     <div>
-      <div className={classes.header}>
-        <Typography variant="h6" display="inline">
-          Notifications For Favorite Source Activity
-        </Typography>
-        <IconButton aria-label="help" size="small" onClick={handleClick}>
-          <HelpOutlineIcon />
-        </IconButton>
-      </div>
-      <Popover
-        id={id}
-        open={open}
-        anchorEl={anchorEl}
-        onClose={handleClose}
-        anchorOrigin={{
-          vertical: "top",
-          horizontal: "right",
-        }}
-        transformOrigin={{
-          vertical: "top",
-          horizontal: "left",
-        }}
-      >
-        <Typography className={classes.typography}>
-          Enable these to receive notifications for the selected activity types
-          regarding sources you have starred/favorited.
-        </Typography>
-      </Popover>
+      <UserPreferencesHeader
+        title="Notifications For Favorite Source Activity"
+        popupText="Enable these to receive notifications for the selected activity types
+          regarding sources you have starred/favorited."
+      />
       <FormGroup row>
         <Typography className={classes.typography}>Browser:</Typography>
         <FormControlLabel

--- a/static/js/components/FilterCandidateList.jsx
+++ b/static/js/components/FilterCandidateList.jsx
@@ -754,9 +754,9 @@ FilterCandidateList.propTypes = {
       id: PropTypes.number.isRequired,
       modified: PropTypes.string.isRequired,
       name: PropTypes.string.isRequired,
-      nickname: PropTypes.string.isRequired,
+      nickname: PropTypes.string,
       private: PropTypes.bool.isRequired,
-      description: PropTypes.string.isRequired,
+      description: PropTypes.string,
     })
   ).isRequired,
   setQueryInProgress: PropTypes.func.isRequired,

--- a/static/js/components/FilterCandidateList.jsx
+++ b/static/js/components/FilterCandidateList.jsx
@@ -128,6 +128,7 @@ const FilterCandidateList = ({
   annotationFilterList,
   setSortOrder,
 }) => {
+  console.log(userAccessibleGroups);
   const classes = useStyles();
   const theme = useTheme();
 
@@ -142,7 +143,7 @@ const FilterCandidateList = ({
     }
   }, [dispatch, availableAnnotationsInfo]);
 
-  const { scanningProfiles } = useSelector(
+  const { scanningProfiles, classificationShortcuts } = useSelector(
     (state) => state.profile.preferences
   );
 
@@ -363,6 +364,12 @@ const FilterCandidateList = ({
     setQueryInProgress(false);
   };
 
+  const handleClassificationShortcutClick = (shortcutClassifications) => {
+    setSelectedClassifications([
+      ...new Set([...selectedClassifications, ...shortcutClassifications]),
+    ]);
+  };
+
   return (
     <Paper variant="outlined">
       <div className={classes.filterListContainer}>
@@ -437,11 +444,11 @@ const FilterCandidateList = ({
             </InputLabel>
             <Controller
               labelId="classifications-select-label"
-              render={({ onChange, value }) => (
+              render={({ onChange }) => (
                 <Select
                   id="classifications-select"
                   multiple
-                  value={value}
+                  value={selectedClassifications}
                   onChange={(event) => {
                     setSelectedClassifications(event.target.value);
                     onChange(event.target.value);
@@ -480,6 +487,21 @@ const FilterCandidateList = ({
               defaultValue={selectedScanningProfile?.classifications || []}
             />
           </div>
+          {classificationShortcuts &&
+            Object.entries(classificationShortcuts)?.map(
+              ([shortcutName, shortcutClassifications]) => (
+                <Button
+                  variant="outlined"
+                  key={shortcutName}
+                  data-testid={shortcutName}
+                  onClick={() =>
+                    handleClassificationShortcutClick(shortcutClassifications)
+                  }
+                >
+                  Select {shortcutName}
+                </Button>
+              )
+            )}
           <div className={classes.formRow}>
             <InputLabel id="redshift-select-label">Redshift</InputLabel>
             <div className={classes.redshiftField}>
@@ -726,7 +748,18 @@ const FilterCandidateList = ({
   );
 };
 FilterCandidateList.propTypes = {
-  userAccessibleGroups: PropTypes.arrayOf(PropTypes.object).isRequired,
+  userAccessibleGroups: PropTypes.arrayOf(
+    PropTypes.shape({
+      single_user_group: PropTypes.bool.isRequired,
+      created_at: PropTypes.string.isRequired,
+      id: PropTypes.number.isRequired,
+      modified: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired,
+      nickname: PropTypes.string.isRequired,
+      private: PropTypes.bool.isRequired,
+      description: PropTypes.string.isRequired,
+    })
+  ).isRequired,
   setQueryInProgress: PropTypes.func.isRequired,
   setFilterGroups: PropTypes.func.isRequired,
   numPerPage: PropTypes.number.isRequired,

--- a/static/js/components/FilterCandidateList.jsx
+++ b/static/js/components/FilterCandidateList.jsx
@@ -128,7 +128,6 @@ const FilterCandidateList = ({
   annotationFilterList,
   setSortOrder,
 }) => {
-  console.log(userAccessibleGroups);
   const classes = useStyles();
   const theme = useTheme();
 

--- a/static/js/components/Group.jsx
+++ b/static/js/components/Group.jsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from "react";
 import { useNavigate, useParams, Link } from "react-router-dom";
-import PropTypes from "prop-types";
 import { useDispatch, useSelector } from "react-redux";
 import { makeStyles, useTheme } from "@material-ui/core/styles";
 import Button from "@material-ui/core/Button";
@@ -227,12 +226,6 @@ const Group = () => {
       </Dialog>
     </div>
   );
-};
-
-Group.propTypes = {
-  route: PropTypes.shape({
-    id: PropTypes.string,
-  }).isRequired,
 };
 
 export default Group;

--- a/static/js/components/NotificationPreferences.jsx
+++ b/static/js/components/NotificationPreferences.jsx
@@ -1,44 +1,16 @@
-import React, { useState } from "react";
+import React from "react";
 import { useSelector, useDispatch } from "react-redux";
 
 import FormGroup from "@material-ui/core/FormGroup";
 import FormControlLabel from "@material-ui/core/FormControlLabel";
 import Switch from "@material-ui/core/Switch";
-import IconButton from "@material-ui/core/IconButton";
-import HelpOutlineIcon from "@material-ui/icons/HelpOutline";
-import Typography from "@material-ui/core/Typography";
-import { makeStyles } from "@material-ui/core/styles";
-import Popover from "@material-ui/core/Popover";
 
 import * as profileActions from "../ducks/profile";
-
-const useStyles = makeStyles((theme) => ({
-  header: {
-    display: "flex",
-    alignItems: "center",
-    "& > h6": {
-      marginRight: "0.5rem",
-    },
-  },
-  typography: {
-    padding: theme.spacing(2),
-  },
-}));
+import UserPreferencesHeader from "./UserPreferencesHeader";
 
 const NotificationPreferences = () => {
-  const classes = useStyles();
   const profile = useSelector((state) => state.profile.preferences);
   const dispatch = useDispatch();
-
-  const [anchorEl, setAnchorEl] = useState(null);
-  const handleClick = (event) => {
-    setAnchorEl(event.currentTarget);
-  };
-  const handleClose = () => {
-    setAnchorEl(null);
-  };
-  const open = Boolean(anchorEl);
-  const id = open ? "simple-popover" : undefined;
 
   const prefToggled = (event) => {
     const prefs = {
@@ -50,33 +22,10 @@ const NotificationPreferences = () => {
 
   return (
     <div>
-      <div className={classes.header}>
-        <Typography variant="h6" display="inline">
-          SMS/Email Notification Preferences
-        </Typography>
-        <IconButton aria-label="help" size="small" onClick={handleClick}>
-          <HelpOutlineIcon />
-        </IconButton>
-      </div>
-      <Popover
-        id={id}
-        open={open}
-        anchorEl={anchorEl}
-        onClose={handleClose}
-        anchorOrigin={{
-          vertical: "top",
-          horizontal: "right",
-        }}
-        transformOrigin={{
-          vertical: "top",
-          horizontal: "left",
-        }}
-      >
-        <Typography className={classes.typography}>
-          Enable these to receive notifications regarding sources triggered by
-          other users within your groups.
-        </Typography>
-      </Popover>
+      <UserPreferencesHeader
+        title="SMS/Email Notification Preferences"
+        popupText="Enable these to receive notifications regarding sources triggered by other users within your groups."
+      />
       <FormGroup row>
         <FormControlLabel
           control={

--- a/static/js/components/ObservabilityPreferences.jsx
+++ b/static/js/components/ObservabilityPreferences.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import { useSelector, useDispatch } from "react-redux";
 
 import { makeStyles, useTheme } from "@material-ui/core/styles";
@@ -8,24 +8,10 @@ import InputLabel from "@material-ui/core/InputLabel";
 import FormControl from "@material-ui/core/FormControl";
 import Chip from "@material-ui/core/Chip";
 import Input from "@material-ui/core/Input";
-import Typography from "@material-ui/core/Typography";
-import Popover from "@material-ui/core/Popover";
-import IconButton from "@material-ui/core/IconButton";
-import HelpOutlineIcon from "@material-ui/icons/HelpOutline";
-
 import * as profileActions from "../ducks/profile";
+import UserPreferencesHeader from "./UserPreferencesHeader";
 
 const useStyles = makeStyles((theme) => ({
-  header: {
-    display: "flex",
-    alignItems: "center",
-    "& > h6": {
-      marginRight: "0.5rem",
-    },
-  },
-  typography: {
-    padding: theme.spacing(2),
-  },
   formControl: {
     marginTop: theme.spacing(1),
     minWidth: "12rem",
@@ -54,17 +40,6 @@ const ObservabilityPreferences = () => {
 
   const dispatch = useDispatch();
 
-  //   const [telescopeIDs, setTelescopeIDs] = useState([]);
-  const [anchorEl, setAnchorEl] = useState(null);
-  const handleClick = (event) => {
-    setAnchorEl(event.currentTarget);
-  };
-  const handleClose = () => {
-    setAnchorEl(null);
-  };
-  const open = Boolean(anchorEl);
-  const id = open ? "simple-popover" : undefined;
-
   const handleChange = (event) => {
     const prefs = {
       observabilityTelescopes:
@@ -82,33 +57,12 @@ const ObservabilityPreferences = () => {
 
   return (
     <div>
-      <div className={classes.header}>
-        <Typography variant="h6" display="inline">
-          Observability Preferences
-        </Typography>
-        <IconButton aria-label="help" size="small" onClick={handleClick}>
-          <HelpOutlineIcon />
-        </IconButton>
-      </div>
-      <Popover
-        id={id}
-        open={open}
-        anchorEl={anchorEl}
-        onClose={handleClose}
-        anchorOrigin={{
-          vertical: "top",
-          horizontal: "right",
-        }}
-        transformOrigin={{
-          vertical: "top",
-          horizontal: "left",
-        }}
-      >
-        <Typography className={classes.typography}>
-          The telescopes to display observability plots for on sources&apos;
-          observability pages. Leave blank to show all telescopes.
-        </Typography>
-      </Popover>
+      <UserPreferencesHeader
+        title="Observability Preferences"
+        popupText={
+          "The telescopes to display observability plots for on sources' observability pages. Leave blank to show all telescopes."
+        }
+      />
       <FormControl className={classes.formControl}>
         <InputLabel id="select-telescopes-label">Telescopes to show</InputLabel>
         <Select

--- a/static/js/components/SlackPreferences.jsx
+++ b/static/js/components/SlackPreferences.jsx
@@ -4,27 +4,14 @@ import { useSelector, useDispatch } from "react-redux";
 import FormGroup from "@material-ui/core/FormGroup";
 import FormControlLabel from "@material-ui/core/FormControlLabel";
 import Switch from "@material-ui/core/Switch";
-import IconButton from "@material-ui/core/IconButton";
 import TextField from "@material-ui/core/TextField";
 
-import HelpOutlineIcon from "@material-ui/icons/HelpOutline";
-import Typography from "@material-ui/core/Typography";
 import { makeStyles } from "@material-ui/core/styles";
-import Popover from "@material-ui/core/Popover";
 
 import * as profileActions from "../ducks/profile";
+import UserPreferencesHeader from "./UserPreferencesHeader";
 
 const useStyles = makeStyles((theme) => ({
-  header: {
-    display: "flex",
-    alignItems: "center",
-    "& > h6": {
-      marginRight: "0.5rem",
-    },
-  },
-  typography: {
-    padding: theme.spacing(2),
-  },
   textField: {
     marginLeft: theme.spacing(1),
     marginRight: theme.spacing(1),
@@ -39,7 +26,6 @@ const SlackPreferences = () => {
   const slack_preamble = useSelector((state) => state.config.slackPreamble);
   const profile = useSelector((state) => state.profile.preferences);
   const dispatch = useDispatch();
-  const [anchorEl, setAnchorEl] = useState(null);
   const [slackurl, setSlackurl] = useState(profile.slack_integration?.url);
   const [slackurlerror, setSlackurlerror] = useState(false);
 
@@ -61,15 +47,6 @@ const SlackPreferences = () => {
     }
   };
 
-  const handleClick = (event) => {
-    setAnchorEl(event.currentTarget);
-  };
-  const handleClose = () => {
-    setAnchorEl(null);
-  };
-  const open = Boolean(anchorEl);
-  const id = open ? "simple-popover" : undefined;
-
   const prefToggled = (event) => {
     const prefs = {
       slack_integration: {
@@ -82,35 +59,13 @@ const SlackPreferences = () => {
 
   return (
     <div>
-      <div className={classes.header}>
-        <Typography variant="h6" display="inline">
-          Slack Integration
-        </Typography>
-        <IconButton aria-label="help" size="small" onClick={handleClick}>
-          <HelpOutlineIcon />
-        </IconButton>
-      </div>
-      <Popover
-        id={id}
-        open={open}
-        anchorEl={anchorEl}
-        onClose={handleClose}
-        anchorOrigin={{
-          vertical: "top",
-          horizontal: "right",
-        }}
-        transformOrigin={{
-          vertical: "top",
-          horizontal: "left",
-        }}
-      >
-        <Typography className={classes.typography}>
-          You&apos;ll need to ask your site administrator to give you a unique
+      <UserPreferencesHeader
+        title="Slack Integration"
+        popupText="You'll need to ask your site administrator to give you a unique
           URL that posts to your Slack channel. Activating the Slack integration
           will allow you to see all @ mentions of this account and configure
-          other notifications below.
-        </Typography>
-      </Popover>
+          other notifications below."
+      />
       <FormGroup row>
         <FormControlLabel
           control={

--- a/static/js/components/UIPreferences.jsx
+++ b/static/js/components/UIPreferences.jsx
@@ -4,11 +4,9 @@ import { useSelector, useDispatch } from "react-redux";
 import FormGroup from "@material-ui/core/FormGroup";
 import FormControlLabel from "@material-ui/core/FormControlLabel";
 import Switch from "@material-ui/core/Switch";
-import Typography from "@material-ui/core/Typography";
-
-// import { useTheme } from '@material-ui/core/styles';
 
 import * as profileActions from "../ducks/profile";
+import UserPreferencesHeader from "./UserPreferencesHeader";
 
 const UIPreferences = () => {
   const preferences = useSelector((state) => state.profile.preferences);
@@ -72,7 +70,7 @@ const UIPreferences = () => {
 
   return (
     <div>
-      <Typography variant="h6">UI Preferences</Typography>
+      <UserPreferencesHeader title="UI Preferences" />
       <FormGroup row>
         <FormControlLabel control={themeSwitch} label="Dark mode" />
         <FormControlLabel

--- a/static/js/components/UpdateProfileForm.jsx
+++ b/static/js/components/UpdateProfileForm.jsx
@@ -24,6 +24,7 @@ import NotificationPreferences from "./NotificationPreferences";
 import FavoriteSourcesNotificationPreferences from "./FavoriteSourcesNotificationPreferences";
 import SlackPreferences from "./SlackPreferences";
 import ObservabilityPreferences from "./ObservabilityPreferences";
+import ClassificationsShortcutForm from "./ClassificationsShortcutForm";
 
 const UpdateProfileForm = () => {
   const profile = useSelector((state) => state.profile);
@@ -175,6 +176,9 @@ const UpdateProfileForm = () => {
         </CardContent>
         <CardContent>
           <ObservabilityPreferences />
+        </CardContent>
+        <CardContent>
+          <ClassificationsShortcutForm />
         </CardContent>
       </Card>
       <Dialog

--- a/static/js/components/UpdateProfileForm.jsx
+++ b/static/js/components/UpdateProfileForm.jsx
@@ -87,7 +87,7 @@ const UpdateProfileForm = () => {
             <Grid
               container
               direction="row"
-              justify="flex-start"
+              justifyContent="flex-start"
               alignItems="baseline"
               spacing={2}
             >
@@ -114,7 +114,7 @@ const UpdateProfileForm = () => {
             <Grid
               container
               direction="row"
-              justify="flex-start"
+              justifyContent="flex-start"
               alignItems="baseline"
               spacing={2}
             >
@@ -135,7 +135,7 @@ const UpdateProfileForm = () => {
             <Grid
               container
               direction="row"
-              justify="flex-start"
+              justifyContent="flex-start"
               alignItems="baseline"
               spacing={2}
             >

--- a/static/js/components/UserPreferencesHeader.jsx
+++ b/static/js/components/UserPreferencesHeader.jsx
@@ -1,0 +1,73 @@
+import React, { useState } from "react";
+import PropTypes from "prop-types";
+import { makeStyles } from "@material-ui/core/styles";
+import Typography from "@material-ui/core/Typography";
+import Popover from "@material-ui/core/Popover";
+import IconButton from "@material-ui/core/IconButton";
+import HelpOutlineIcon from "@material-ui/icons/HelpOutline";
+
+const useStyles = makeStyles((theme) => ({
+  header: {
+    display: "flex",
+    alignItems: "center",
+    "& > h6": {
+      marginRight: "0.5rem",
+    },
+  },
+  typography: {
+    padding: theme.spacing(2),
+  },
+}));
+
+const UserPreferencesHeader = ({ title, popupText }) => {
+  const classes = useStyles();
+  const [anchorEl, setAnchorEl] = useState(null);
+  const handleClick = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+  const open = Boolean(anchorEl);
+  const id = open ? "simple-popover" : undefined;
+  return (
+    <div>
+      <div className={classes.header}>
+        <Typography variant="h6" display="inline">
+          {title}
+        </Typography>
+        {popupText && (
+          <IconButton aria-label="help" size="small" onClick={handleClick}>
+            <HelpOutlineIcon />
+          </IconButton>
+        )}
+      </div>
+      <Popover
+        id={id}
+        open={open}
+        anchorEl={anchorEl}
+        onClose={handleClose}
+        anchorOrigin={{
+          vertical: "top",
+          horizontal: "right",
+        }}
+        transformOrigin={{
+          vertical: "top",
+          horizontal: "left",
+        }}
+      >
+        <Typography className={classes.typography}>{popupText}</Typography>
+      </Popover>
+    </div>
+  );
+};
+
+UserPreferencesHeader.propTypes = {
+  title: PropTypes.string.isRequired,
+  popupText: PropTypes.string,
+};
+UserPreferencesHeader.defaultProps = {
+  popupText: null,
+};
+
+export default UserPreferencesHeader;


### PR DESCRIPTION
Adds classification shortcuts for selecting classifications on the scanning page
Also, I noticed there was some duplicated code with creating the headers and help icons on the preferences page so there's a new component: UserPreferencesHeader.
![Hnet-image](https://user-images.githubusercontent.com/82007190/168503308-c3e2fc8f-dd52-4395-98fd-cae336c11e61.gif)
closes #2858 
