### PR TITLE
lon lat elevation : validation in NewTelescope.jsx and in the handler if the telescope is fixed

### DIFF
--- a/skyportal/handlers/api/telescope.py
+++ b/skyportal/handlers/api/telescope.py
@@ -45,7 +45,7 @@ class TelescopeHandler(BaseHandler):
             if data['fixed_location']:
                 if 'lat' not in data or 'lon' not in data or 'elevation' not in data:
                     return self.error(
-                        'Missing latitude, longitude or elevation, required if the telescope is fixed'
+                        'Missing latitude, longitude, or elevation; required if the telescope is fixed'
                     )
                 elif (
                     not isinstance(data['lat'], (int, float))
@@ -53,7 +53,7 @@ class TelescopeHandler(BaseHandler):
                     or not isinstance(data['elevation'], (int, float))
                 ):
                     return self.error(
-                        'Latitude, longitude and elevation must all be numbers'
+                        'Latitude, longitude, and elevation must all be numbers'
                     )
                 elif (
                     data['lat'] < -90
@@ -63,7 +63,7 @@ class TelescopeHandler(BaseHandler):
                     or data['elevation'] < 0
                 ):
                     return self.error(
-                        'Latitude must be between -90 and 90, longitude between -180 and 180 and elevation must be positive'
+                        'Latitude must be between -90 and 90, longitude between -180 and 180, and elevation must be positive'
                     )
         try:
             telescope = schema.load(data)

--- a/skyportal/handlers/api/telescope.py
+++ b/skyportal/handlers/api/telescope.py
@@ -44,8 +44,26 @@ class TelescopeHandler(BaseHandler):
         if 'fixed_location' in data:
             if data['fixed_location']:
                 if 'lat' not in data or 'lon' not in data or 'elevation' not in data:
-                    raise ValidationError(
+                    return self.error(
                         'Missing latitude, longitude or elevation, required if the telescope is fixed'
+                    )
+                elif (
+                    not isinstance(data['lat'], (int, float))
+                    or not isinstance(data['lon'], (int, float))
+                    or not isinstance(data['elevation'], (int, float))
+                ):
+                    return self.error(
+                        'Latitude, longitude and elevation must all be numbers'
+                    )
+                elif (
+                    data['lat'] < -90
+                    or data['lat'] > 90
+                    or data['lon'] < -180
+                    or data['lon'] > 180
+                    or data['elevation'] < 0
+                ):
+                    return self.error(
+                        'Latitude must be between -90 and 90, longitude between -180 and 180 and elevation must be positive'
                     )
         try:
             telescope = schema.load(data)

--- a/skyportal/handlers/api/telescope.py
+++ b/skyportal/handlers/api/telescope.py
@@ -40,7 +40,13 @@ class TelescopeHandler(BaseHandler):
         data = self.get_json()
 
         schema = Telescope.__schema__()
-
+        # check if the telescope has a fixed location
+        if 'fixed_location' in data:
+            if data['fixed_location']:
+                if 'lat' not in data or 'lon' not in data or 'elevation' not in data:
+                    raise ValidationError(
+                        'Missing latitude, longitude or elevation, required if the telescope is fixed'
+                    )
         try:
             telescope = schema.load(data)
         except ValidationError as e:

--- a/static/js/components/NewTelescope.jsx
+++ b/static/js/components/NewTelescope.jsx
@@ -29,36 +29,32 @@ const NewTelescope = () => {
   };
 
   function validate(formData, errors) {
-    console.log(formData);
     telescopeList?.forEach((telescope) => {
       if (formData.name === telescope.name) {
         errors.name.addError("Telescope name matches another, please change.");
       }
     });
     if (formData.fixed_location === true) {
-      if (formData.lon === undefined || formData.lat === undefined) {
+      if (formData.lon === undefined) {
         errors.lon.addError(
           "Longitude must be specified if telescope is fixed."
         );
-
+      } else if (formData.lon < -180 || formData.lon > 180) {
+        errors.lon.addError("Longitude must be between -180 and 180.");
+      }
+      if (formData.lat === undefined) {
         errors.lat.addError(
           "Latitude must be specified if telescope is fixed."
         );
-      } else if (
-        formData.lon < -180 ||
-        formData.lon > 180 ||
-        formData.lat < -90 ||
-        formData.lat > 90
-      ) {
-        errors.longitude.addError("Latitude must be between -180 and 180.");
-
-        errors.latitude.addError("Longitude must be between -90 and 90.");
+      } else if (formData.lat < -90 || formData.lat > 90) {
+        errors.lat.addError("Latitude must be between -90 and 90.");
       }
-
       if (formData.elevation === undefined) {
         errors.elevation.addError(
           "Elevation must be specified if telescope is fixed."
         );
+      } else if (formData.elevation < 0) {
+        errors.elevation.addError("Elevation must be positive.");
       }
     }
 

--- a/static/js/components/NewTelescope.jsx
+++ b/static/js/components/NewTelescope.jsx
@@ -29,11 +29,39 @@ const NewTelescope = () => {
   };
 
   function validate(formData, errors) {
+    console.log(formData);
     telescopeList?.forEach((telescope) => {
       if (formData.name === telescope.name) {
         errors.name.addError("Telescope name matches another, please change.");
       }
     });
+    if (formData.fixed_location === true) {
+      if (formData.lon === undefined || formData.lat === undefined) {
+        errors.lon.addError(
+          "Longitude must be specified if telescope is fixed."
+        );
+
+        errors.lat.addError(
+          "Latitude must be specified if telescope is fixed."
+        );
+      } else if (
+        formData.lon < -180 ||
+        formData.lon > 180 ||
+        formData.lat < -90 ||
+        formData.lat > 90
+      ) {
+        errors.longitude.addError("Latitude must be between -180 and 180.");
+
+        errors.latitude.addError("Longitude must be between -90 and 90.");
+      }
+
+      if (formData.elevation === undefined) {
+        errors.elevation.addError(
+          "Elevation must be specified if telescope is fixed."
+        );
+      }
+    }
+
     return errors;
   }
 


### PR DESCRIPTION
Solves issue mentionned in https://github.com/skyportal/skyportal/issues/2985, where we would encounter an error because the lon, lat, elevation field are required if the telescope has a fixed location, but that wasn't verified in both frontend and backend.