### PR TITLE
pin mathjax_full

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "geojson-prop-types": "0.2.0",
     "imports-loader": "1.2.0",
     "material-ui-phone-number": "2.2.6",
+    "mathjax-full": "3.2.0",
     "mathjs": "10.0.2",
     "moment": "2.29.3",
     "mui-datatables": "3.8.2",


### PR DESCRIPTION
the bokeh dependencies that changed recently:

```
es5-ext (0.10.53->0.10.61)
flatbush (3.3.0-> 3.3.1)
mathjax-full (3.2.0 -> 3.2.1)
nouislider (15.5.0 -> 15.6.0)
proj4 (2.7.5 -> 2.8.0)
tslib (2.3.1 -> 2.4.0)
```
It looks like pinning mathjax_full will fix broken plotting.