### PR TITLE
Configuration for the GCN Service

### DIFF
--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -526,3 +526,17 @@ spectrum_types:
 #    wavelength: [5580, 5582, 8249, 8250]
 #    transmission: [0, 1, 1, 0]
 #    description: "basic ATLAS O filter - tophat transmission"
+
+gcn_notice_types:
+  - FERMI_GBM_FLT_POS
+  - FERMI_GBM_GND_POS
+  - FERMI_GBM_FIN_POS
+  - FERMI_GBM_SUBTHRESH
+  - LVC_PRELIMINARY
+  - LVC_INITIAL
+  - LVC_UPDATE
+  - LVC_RETRACTION
+  - AMON_ICECUBE_COINC
+  - AMON_ICECUBE_HESE
+  - ICECUBE_ASTROTRACK_GOLD
+  - ICECUBE_ASTROTRACK_BRONZE

--- a/services/gcn_service/gcn_service.py
+++ b/services/gcn_service/gcn_service.py
@@ -12,26 +12,15 @@ env, cfg = load_env()
 init_db(**cfg['database'])
 
 
-@gcn.include_notice_types(
-    gcn.NoticeType.FERMI_GBM_FLT_POS,
-    gcn.NoticeType.FERMI_GBM_GND_POS,
-    gcn.NoticeType.FERMI_GBM_FIN_POS,
-    gcn.NoticeType.FERMI_GBM_SUBTHRESH,
-    gcn.NoticeType.LVC_PRELIMINARY,
-    gcn.NoticeType.LVC_INITIAL,
-    gcn.NoticeType.LVC_UPDATE,
-    gcn.NoticeType.LVC_RETRACTION,
-    # gcn.NoticeType.LVC_TEST,
-    gcn.NoticeType.AMON_ICECUBE_COINC,
-    gcn.NoticeType.AMON_ICECUBE_HESE,
-    gcn.NoticeType.ICECUBE_ASTROTRACK_GOLD,
-    gcn.NoticeType.ICECUBE_ASTROTRACK_BRONZE,
-)
 def handle(payload, root):
-
-    user_id = 1
-    with DBSession() as session:
-        post_gcnevent(payload, user_id, session)
+    notice_type = gcn.get_notice_type(root)
+    if notice_type in [
+        getattr(gcn.notice_types, notice_type)
+        for notice_type in cfg["gcn_notice_types"]
+    ]:
+        user_id = 1
+        with DBSession() as session:
+            post_gcnevent(payload, user_id, session)
 
 
 if __name__ == "__main__":

--- a/services/gcn_service/gcn_service.py
+++ b/services/gcn_service/gcn_service.py
@@ -11,13 +11,14 @@ env, cfg = load_env()
 
 init_db(**cfg['database'])
 
+notice_types = [
+    getattr(gcn.notice_types, notice_type) for notice_type in cfg["gcn_notice_types"]
+]
+
 
 def handle(payload, root):
     notice_type = gcn.get_notice_type(root)
-    if notice_type in [
-        getattr(gcn.notice_types, notice_type)
-        for notice_type in cfg["gcn_notice_types"]
-    ]:
+    if notice_type in notice_types:
         user_id = 1
         with DBSession() as session:
             post_gcnevent(payload, user_id, session)


### PR DESCRIPTION
### Currently, in the gcn_service handler, the list of GCN notice types to be ingested in skyportal is fixed. This PR makes it configurable in the config.yaml