### PR TITLE
Shift Page Bug fix : Incorrect display when changing page and going back to the Shift Page

### DIFF
--- a/static/js/components/ShiftPage.jsx
+++ b/static/js/components/ShiftPage.jsx
@@ -21,34 +21,12 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-function datestringToDate(shiftList) {
-  for (let i = 0; i < shiftList.length; i += 1) {
-    shiftList[i].start_date = new Date(`${shiftList[i].start_date}Z`);
-    shiftList[i].end_date = new Date(`${shiftList[i].end_date}Z`);
-  }
-  return shiftList;
-}
-
 const ShiftPage = ({ route }) => {
   const classes = useStyles();
   const dispatch = useDispatch();
   const currentUser = useSelector((state) => state.profile);
   const shiftList = useSelector((state) => state.shifts.shiftList);
   const currentShift = useSelector((state) => state.shift.currentShift);
-  const [events, setEvents] = React.useState([]);
-
-  if (shiftList) {
-    if (!events || events?.length !== shiftList?.length) {
-      setEvents(datestringToDate(shiftList));
-    } else if (currentShift?.shift_users && currentShift?.id) {
-      if (
-        events.find((shift) => shift.id === currentShift.id).shift_users
-          .length !== currentShift.shift_users.length
-      ) {
-        setEvents(datestringToDate(shiftList));
-      }
-    }
-  }
 
   useEffect(() => {
     if (!currentShift?.id && route) {
@@ -101,8 +79,8 @@ const ShiftPage = ({ route }) => {
     <Grid container spacing={3}>
       <Grid item md={6} sm={12}>
         <Paper elevation={1}>
-          {events ? (
-            <MyCalendar events={events} currentShift={currentShift} />
+          {shiftList ? (
+            <MyCalendar events={shiftList} currentShift={currentShift} />
           ) : (
             <CircularProgress />
           )}
@@ -111,10 +89,9 @@ const ShiftPage = ({ route }) => {
 
       <Grid item md={6} sm={12}>
         <Paper elevation={1}>
-          {currentShift &&
-            (events && Object.keys(currentShift).length > 0 ? (
-              <CurrentShiftMenu currentShift={currentShift} />
-            ) : null)}
+          {currentShift && shiftList ? (
+            <CurrentShiftMenu currentShift={currentShift} />
+          ) : null}
         </Paper>
         {permission && (
           <Paper>

--- a/static/js/ducks/shifts.js
+++ b/static/js/ducks/shifts.js
@@ -14,6 +14,15 @@ const UPDATE_SHIFT_USER = "skyportal/UPDATE_SHIFT_USER";
 
 const DELETE_SHIFT_USER = "skyportal/DELETE_SHIFT_USER";
 
+function datestringToDate(shiftList) {
+  const newShiftList = [...shiftList];
+  for (let i = 0; i < shiftList.length; i += 1) {
+    newShiftList[i].start_date = new Date(`${shiftList[i].start_date}Z`);
+    newShiftList[i].end_date = new Date(`${shiftList[i].end_date}Z`);
+  }
+  return newShiftList;
+}
+
 // eslint-disable-next-line import/prefer-default-export
 export const fetchShifts = () => API.GET("/api/shifts", FETCH_SHIFTS);
 
@@ -54,7 +63,7 @@ messageHandler.add((actionType, payload, dispatch) => {
 const reducer = (state = { shiftList: [] }, action) => {
   switch (action.type) {
     case FETCH_SHIFTS_OK: {
-      const shiftList = action.data;
+      const shiftList = datestringToDate(action.data);
       return {
         ...state,
         shiftList,


### PR DESCRIPTION
#### In production, we noticed a bug we did not have the chance to witness before as we never tried that specific scenario. 
#### *The bug behaves differently if you are on Chrome or Firefox.*

### What is the problem:
When fetching the shifts from the API, the API sends a list of shifts, and each shift has a `start_date` and `end_date` that when querying the API is returned as a `string`. What would happen is that **when injecting that list in the store and then recovering it with a useSelector on the frontend, if that useSelector runs again** (re rendering when changing page and going back to the shift page), **the result is somehow different and the date is parsed as a Date object in local, so it basically adds the offset between your local and UTC.**
**BUT, when rerendering again, ... it adds the offset again ... So we are left with shifts that quite literally 'shift' of a certain offset every time you go back to the shift page, basically showing you incorrect shifts which could lead to big time confusion.**

That is what happens on Chrome, where the date seems to be parsed and the offset accumulates

On firefox, it is parsed once, and then it breaks and tells you in the log that the dates are `invalid`.

How did I fix that:
Basically, instead of expecting a string from the `useSelector()` for the dates and then converting/parsing them to local dates in the component, I parse them to local dates directly in the reducer, before returning the new state that contains the newly queried shiftList. Therefore, the **conversion happens just once**, I have **less state variables** in the component, the calendar **doesn't break** when changing pages on firefox and the shifts **don't keep "moving"** on the calendar on chrome. 

This seems to fix all the issue I encountered. But it would be best to have the reviewer try it as well ! 