### PR TITLE
Fix invalid route message

### DIFF
--- a/skyportal/tests/frontend/test_about_page.py
+++ b/skyportal/tests/frontend/test_about_page.py
@@ -7,3 +7,8 @@ def test_skyportal_version_displayed(driver):
     driver.click_xpath("//button[contains(.,'Show BiBTeX')]")
     driver.wait_for_xpath("//*[contains(.,'Journal of Open Source Software')]")
     driver.click_xpath("//button[contains(.,'Hide BiBTeX')]")
+
+
+def test_invalid_route(driver):
+    driver.get('/invalid_route')
+    driver.wait_for_xpath("//*[contains(.,'Invalid route')]")

--- a/static/js/components/Main.jsx.template
+++ b/static/js/components/Main.jsx.template
@@ -117,7 +117,7 @@ const MainContent = ({ root }) => {
             <Route path="{{ route.path }}" element={{ "{<" }}{{ route.component }}{{ "/>}" }} />
             {%- endfor %}
 
-            <Route component={<NoMatchingRoute/>} />
+            <Route path="*" element={<NoMatchingRoute/>} />
 
           </Routes>
 


### PR DESCRIPTION
The "Invalid route" message disappeared, this puts it back in and adds a test for invalid routes.