### PR TITLE
Catch (new) Gaia exception

### DIFF
--- a/skyportal/utils/offset.py
+++ b/skyportal/utils/offset.py
@@ -14,7 +14,7 @@ import matplotlib.pyplot as plt
 import seaborn as sns
 import numpy as np
 import numpy.ma as ma
-from scipy.ndimage.filters import gaussian_filter
+from scipy.ndimage import gaussian_filter
 from joblib import Memory
 
 from astropy import units as u
@@ -58,6 +58,12 @@ class GaiaQuery:
         'Magnitude[mag]': u.mag,
         'Angular Velocity[mas/year]': u.mas / u.yr,
         'Angle[mas]': u.mas,
+        'yr': u.yr,
+        'mas.yr**-1': u.mas / u.yr,
+        'mas': u.mas,
+        'mag': u.mag,
+        'deg': u.deg,
+        'Angle[rad], Angle[rad]': u.deg,  # this is the `pos` in degrees, incorrectly reported as radians
     }
 
     def __init__(self, main_db="gaiaedr3"):

--- a/skyportal/utils/offset.py
+++ b/skyportal/utils/offset.py
@@ -83,8 +83,9 @@ class GaiaQuery:
         except (HTTPError, ConnectionResetError):
             log("Warning: main Gaia TAP+ server failed")
             self.is_backup = True
-        except:  # noqa: E722
+        except Exception as e:  # noqa: E722
             log("Warning: main Gaia TAP+ server failed in a way we didn't expect.")
+            log(f'Exception type={type(e).__name__}. Exception message={e}')
             self.is_backup = True
 
         if self.is_backup:

--- a/skyportal/utils/offset.py
+++ b/skyportal/utils/offset.py
@@ -83,6 +83,9 @@ class GaiaQuery:
         except (HTTPError, ConnectionResetError):
             log("Warning: main Gaia TAP+ server failed")
             self.is_backup = True
+        except:  # noqa: E722
+            log("Warning: main Gaia TAP+ server failed in a way we didn't expect.")
+            self.is_backup = True
 
         if self.is_backup:
             try:


### PR DESCRIPTION
During the transition from EDR2 to DR3 the main Gaia catalog used by astroquery has become unstable. We look for this but did not catch the new error that is arising. This PR attempts to fix this.

The backup Gaia catalog also changed its units reporting. This PR fixes this.