### PR TITLE
Use allocation lookup in form

### DIFF
--- a/static/js/components/FollowupRequestForm.jsx
+++ b/static/js/components/FollowupRequestForm.jsx
@@ -132,12 +132,12 @@ const FollowupRequestForm = ({
 
   const handleSelectedAllocationChange = (e) => {
     setSelectedAllocationId(e.target.value);
-    if (allocationList[e.target.value]?.default_share_group_ids?.length > 0) {
-      setSelectedGroupIds([
-        allocationList[e.target.value]?.default_share_group_ids,
-      ]);
+    if (allocationLookUp[e.target.value]?.default_share_group_ids?.length > 0) {
+      setSelectedGroupIds(
+        allocationLookUp[e.target.value]?.default_share_group_ids
+      );
     } else {
-      setSelectedGroupIds([allocationList[e.target.value]?.group_id]);
+      setSelectedGroupIds([allocationLookUp[e.target.value]?.group_id]);
     }
   };
 


### PR DESCRIPTION
This PR uses the allocation lookup in the FollowupRequestForm drop down.