### PR TITLE
Migrate to Gaia DR3 queries

### DIFF
--- a/skyportal/handlers/api/annotation_services.py
+++ b/skyportal/handlers/api/annotation_services.py
@@ -33,7 +33,7 @@ class GaiaQueryHandler(BaseHandler):
         ---
         description: |
             get Gaia parallax and magnitudes and post them as an annotation,
-            based on cross-match to the Gaia eDR3.
+            based on cross-match to the Gaia DR3.
         parameters:
           - in: path
             name: obj_id
@@ -54,7 +54,7 @@ class GaiaQueryHandler(BaseHandler):
                       The name of the catalog key, associated with a
                       catalog cross match,
                       from which the data should be retrieved.
-                      Default is "gaiaedr3.gaia_source".
+                      Default is "gaiadr3.gaia_source".
                   crossmatchRadius:
                     required: false
                     type: number
@@ -112,7 +112,7 @@ class GaiaQueryHandler(BaseHandler):
 
         author = self.associated_user_object
 
-        catalog = data.pop('catalog', cfg['catalog'] or "gaiaedr3.gaia_source")
+        catalog = data.pop('catalog', cfg['catalog'] or "gaiadr3.gaia_source")
         radius_arcsec = data.pop(
             'crossmatchRadius', cfg['cross_match.gaia.radius'] or 2.0
         )

--- a/skyportal/handlers/api/observation_plan.py
+++ b/skyportal/handlers/api/observation_plan.py
@@ -560,7 +560,7 @@ def observation_animations(
         "ztfr": "#DC3545",
         "ztfi": "#F3DC11",
         "AllWISE": "#2F5492",
-        "Gaia_EDR3": "#FF7F0E",
+        "Gaia_DR3": "#FF7F0E",
         "PS1_DR1": "#3BBED5",
         "GALEX": "#6607C2",
         "TNS": "#ED6CF6",

--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -2159,7 +2159,7 @@ class SourceOffsetsHandler(BaseHandler):
           schema:
             type: boolean
           description: |
-            Use ZTFref catalog for offset star positions, otherwise Gaia DR2
+            Use ZTFref catalog for offset star positions, otherwise Gaia DR3
         responses:
           200:
             content:
@@ -2371,7 +2371,7 @@ class SourceFinderHandler(BaseHandler):
           schema:
             type: boolean
           description: |
-            Use ZTFref catalog for offset star positions, otherwise DR2
+            Use ZTFref catalog for offset star positions, otherwise DR3
         - in: query
           name: obstime
           nullable: True

--- a/skyportal/handlers/api/unsourced_finder.py
+++ b/skyportal/handlers/api/unsourced_finder.py
@@ -37,7 +37,7 @@ class UnsourcedFinderHandler(BaseHandler):
           required: true
           schema:
             type: string
-            enum: [gaia_edr3, gaia_dr2, pos]
+            enum: [gaia_dr3, gaia_dr2, pos]
           description: |
             What is the type of the search? From gaia or by position? If `pos`
             then `ra` and `dec` should be given. If otherwise, the catalog
@@ -97,7 +97,7 @@ class UnsourcedFinderHandler(BaseHandler):
           schema:
             type: boolean
           description: |
-            Use ZTFref catalog for offset star positions, otherwise DR2.
+            Use ZTFref catalog for offset star positions, otherwise DR3.
             Defaults to True.
         - in: query
           name: obstime
@@ -141,7 +141,7 @@ class UnsourcedFinderHandler(BaseHandler):
                 schema: Error
         """
         location_type = self.get_query_argument('location_type')
-        if location_type not in ["gaia_edr3", "gaia_dr2", "pos"]:
+        if location_type not in ["gaia_dr3", "gaia_dr2", "pos"]:
             return self.error(f'Invalid argument for `location_type`: {location_type}')
 
         obstime = self.get_query_argument(
@@ -158,7 +158,7 @@ class UnsourcedFinderHandler(BaseHandler):
             if not catalog_id.isnumeric():
                 return self.error('`catalog_id` must be a number')
 
-            # database name should be something like gaiaedr3
+            # database name should be something like gaiadr3
             db_name = "".join(location_type.split("_"))
             obstime_decimalyear = Time(isoparse(obstime)).decimalyear
             query_string = f"""

--- a/skyportal/services/test_server/test_api_server.py
+++ b/skyportal/services/test_server/test_api_server.py
@@ -244,7 +244,7 @@ def atlas_request_matcher(r1, r2):
 
 def ps1_request_matcher(r1, r2):
     """
-    Helper function to help determine if two requests to the PS1 DR2 API are equivalent
+    Helper function to help determine if two requests to the PS1 DR3 API are equivalent
     """
 
     # A request matches an PS1 request if the URI and method matches

--- a/skyportal/services/test_server/test_api_server.py
+++ b/skyportal/services/test_server/test_api_server.py
@@ -244,7 +244,7 @@ def atlas_request_matcher(r1, r2):
 
 def ps1_request_matcher(r1, r2):
     """
-    Helper function to help determine if two requests to the PS1 DR3 API are equivalent
+    Helper function to help determine if two requests to the PS1 DR2 API are equivalent
     """
 
     # A request matches an PS1 request if the URI and method matches

--- a/skyportal/tests/api/test_color_mag.py
+++ b/skyportal/tests/api/test_color_mag.py
@@ -224,7 +224,7 @@ def test_add_multiple_color_mag_annotations(annotation_token, user, public_sourc
         f'sources/{public_source.id}/annotations',
         data={
             'obj_id': public_source.id,
-            'origin': 'gaiadr3.gaia_source',
+            'origin': 'gaiadr2.gaia_source',
             'data': {'MagG': 15.2, 'MagBp': 16.2, 'MagRp': 14.0, 'Plx': 20},
         },
         token=annotation_token,
@@ -260,7 +260,7 @@ def test_add_multiple_color_mag_annotations(annotation_token, user, public_sourc
     assert abs(data['data'][0]['color'] - 2.1) < 0.1
 
     # make sure the second one still exists
-    assert data['data'][1]['origin'] == 'gaiadr3.gaia_source'
+    assert data['data'][1]['origin'] == 'gaiadr2.gaia_source'
     assert abs(data['data'][1]['abs_mag'] - 11.7) < 0.1
     assert abs(data['data'][1]['color'] - 2.2) < 0.1
 

--- a/skyportal/tests/api/test_color_mag.py
+++ b/skyportal/tests/api/test_color_mag.py
@@ -8,7 +8,7 @@ def test_post_retrieve_color_mag_data(annotation_token, user, public_source):
         f'sources/{public_source.id}/annotations',
         data={
             'obj_id': public_source.id,
-            'origin': 'gaiaedr3.gaia_source',
+            'origin': 'gaiadr3.gaia_source',
             'data': {
                 'Mag_G': 15.1,
                 'Mag_Bp': 16.1,
@@ -29,7 +29,7 @@ def test_post_retrieve_color_mag_data(annotation_token, user, public_source):
     )
 
     assert status == 200
-    assert data['data'][0]['origin'] == 'gaiaedr3.gaia_source'
+    assert data['data'][0]['origin'] == 'gaiadr3.gaia_source'
     assert abs(data['data'][0]['abs_mag'] - 11.6) < 0.1
     assert abs(data['data'][0]['color'] - 2.1) < 0.1
 
@@ -39,7 +39,7 @@ def test_post_retrieve_color_mag_data(annotation_token, user, public_source):
         f'sources/{public_source.id}/annotations/{annotation_id}',
         data={
             'obj_id': public_source.id,
-            'origin': 'gaiaedr3.gaia_source',
+            'origin': 'gaiadr3.gaia_source',
             'data': {
                 'Mag_G': 15.1,
                 'Mag_Bp': 16.1,
@@ -57,7 +57,7 @@ def test_post_retrieve_color_mag_data(annotation_token, user, public_source):
     )
 
     assert status == 200
-    assert data['data'][0]['origin'] == 'gaiaedr3.gaia_source'
+    assert data['data'][0]['origin'] == 'gaiadr3.gaia_source'
     assert abs(data['data'][0]['abs_mag'] - 11.9) < 0.1
     assert abs(data['data'][0]['color'] - 2.1) < 0.1
 
@@ -67,7 +67,7 @@ def test_post_retrieve_color_mag_data(annotation_token, user, public_source):
         f'sources/{public_source.id}/annotations/{annotation_id}',
         data={
             'obj_id': public_source.id,
-            'origin': 'gaiaedr3.gaia_source',
+            'origin': 'gaiadr3.gaia_source',
             'data': {
                 'Mag_G': 15.1,
                 'Mag_Bp': 16.1,
@@ -88,7 +88,7 @@ def test_post_retrieve_color_mag_data(annotation_token, user, public_source):
     )
 
     assert status == 200
-    assert data['data'][0]['origin'] == 'gaiaedr3.gaia_source'
+    assert data['data'][0]['origin'] == 'gaiadr3.gaia_source'
     assert abs(data['data'][0]['abs_mag'] - 11.6) < 0.1
     assert abs(data['data'][0]['color'] - 2.1) < 0.1
 
@@ -101,7 +101,7 @@ def test_post_retrieve_color_mag_data(annotation_token, user, public_source):
     )
 
     assert status == 200
-    assert data['data'][0]['origin'] == 'gaiaedr3.gaia_source'
+    assert data['data'][0]['origin'] == 'gaiadr3.gaia_source'
     assert abs(data['data'][0]['abs_mag'] - 12.5) < 0.1
     assert abs(data['data'][0]['color'] - 1.8) < 0.1
 
@@ -114,7 +114,7 @@ def test_post_retrieve_color_mag_data(annotation_token, user, public_source):
     )
 
     assert status == 200
-    assert data['data']['color_magnitude'][0]['origin'] == 'gaiaedr3.gaia_source'
+    assert data['data']['color_magnitude'][0]['origin'] == 'gaiadr3.gaia_source'
     assert abs(data['data']['color_magnitude'][0]['abs_mag'] - 11.6) < 0.1
     assert abs(data['data']['color_magnitude'][0]['color'] - 2.1) < 0.1
 
@@ -126,7 +126,7 @@ def test_change_color_mag_keys(annotation_token, user, public_source):
         f'sources/{public_source.id}/annotations',
         data={
             'obj_id': public_source.id,
-            'origin': 'gaiaedr3.gaia_source',
+            'origin': 'gaiadr3.gaia_source',
             'data': {'MagG': 15.1, 'MagBp': 16.1, 'MagRp': 14.0, 'Plx': 20},
         },
         token=annotation_token,
@@ -139,7 +139,7 @@ def test_change_color_mag_keys(annotation_token, user, public_source):
     )
 
     assert status == 200
-    assert data['data'][0]['origin'] == 'gaiaedr3.gaia_source'
+    assert data['data'][0]['origin'] == 'gaiadr3.gaia_source'
     assert abs(data['data'][0]['abs_mag'] - 11.6) < 0.1
     assert abs(data['data'][0]['color'] - 2.1) < 0.1
 
@@ -149,7 +149,7 @@ def test_change_color_mag_keys(annotation_token, user, public_source):
         f'sources/{public_source.id}/annotations/{annotation_id}',
         data={
             'obj_id': public_source.id,
-            'origin': 'gaiaedr3.gaia_source',
+            'origin': 'gaiadr3.gaia_source',
             'data': {'mag_g': 15.1, 'mag_bp': 16.1, 'mag_rp': 14.0, 'plx': 20},
         },
         token=annotation_token,
@@ -161,7 +161,7 @@ def test_change_color_mag_keys(annotation_token, user, public_source):
     )
 
     assert status == 200
-    assert data['data'][0]['origin'] == 'gaiaedr3.gaia_source'
+    assert data['data'][0]['origin'] == 'gaiadr3.gaia_source'
     assert abs(data['data'][0]['abs_mag'] - 11.6) < 0.1
     assert abs(data['data'][0]['color'] - 2.1) < 0.1
 
@@ -224,7 +224,7 @@ def test_add_multiple_color_mag_annotations(annotation_token, user, public_sourc
         f'sources/{public_source.id}/annotations',
         data={
             'obj_id': public_source.id,
-            'origin': 'gaiadr2.gaia_source',
+            'origin': 'gaiadr3.gaia_source',
             'data': {'MagG': 15.2, 'MagBp': 16.2, 'MagRp': 14.0, 'Plx': 20},
         },
         token=annotation_token,
@@ -260,7 +260,7 @@ def test_add_multiple_color_mag_annotations(annotation_token, user, public_sourc
     assert abs(data['data'][0]['color'] - 2.1) < 0.1
 
     # make sure the second one still exists
-    assert data['data'][1]['origin'] == 'gaiadr2.gaia_source'
+    assert data['data'][1]['origin'] == 'gaiadr3.gaia_source'
     assert abs(data['data'][1]['abs_mag'] - 11.7) < 0.1
     assert abs(data['data'][1]['color'] - 2.2) < 0.1
 

--- a/skyportal/tests/api/test_finders.py
+++ b/skyportal/tests/api/test_finders.py
@@ -56,7 +56,7 @@ def test_unsourced_finder(upload_data_token):
         "unsourced_finder",
         params={
             "catalog_id": "3905335598144227200",
-            "location_type": "gaia_edr3",
+            "location_type": "gaia_dr3",
             "image_source": "ps1",
             "output_type": "pdf",
             "obstime": "2012-02-28",
@@ -101,7 +101,7 @@ def test_unsourced_finder(upload_data_token):
         "unsourced_finder",
         params={
             "catalog_id": "-1",
-            "location_type": "gaia_dr2",
+            "location_type": "gaia_dr3",
             "image_source": "ps1",
             "output_type": "pdf",
             "obstime": "2012-02-28",

--- a/skyportal/tests/api/test_sources.py
+++ b/skyportal/tests/api/test_sources.py
@@ -461,7 +461,7 @@ def test_starlist(upload_data_token, public_source):
     assert "starlist_str" in data["data"]
     assert isinstance(data["data"]["starlist_info"][2]["dec"], float)
 
-    # use DR2 for offsets ... it should not be identical position as DR2
+    # use DR3 for offsets ... it should not be identical position as DR3
     status, data = api(
         "GET",
         f"sources/{public_source.id}/offsets",

--- a/skyportal/tests/frontend/sources_and_followup_etc/test_source_list.py
+++ b/skyportal/tests/frontend/sources_and_followup_etc/test_source_list.py
@@ -507,7 +507,7 @@ def test_hr_diagram(
         f'sources/{source_id}/annotations',
         data={
             'obj_id': source_id,
-            'origin': 'gaiaedr3.gaia_source',
+            'origin': 'gaiadr3.gaia_source',
             'data': {'Mag_G': 11.3, 'Mag_Bp': 11.8, 'Mag_Rp': 11.0, 'Plx': 20},
         },
         token=annotation_token,

--- a/skyportal/tests/frontend/sources_and_followup_etc/test_sources.py
+++ b/skyportal/tests/frontend/sources_and_followup_etc/test_sources.py
@@ -726,7 +726,7 @@ def test_source_hr_diagram(driver, user, public_source, annotation_token):
         f'sources/{public_source.id}/annotations',
         data={
             'obj_id': public_source.id,
-            'origin': 'gaiaedr3.gaia_source',
+            'origin': 'gaiadr3.gaia_source',
             'data': {
                 'Mag_G': 11.3,
                 'Mag_Bp': 12.8,

--- a/skyportal/utils/offset.py
+++ b/skyportal/utils/offset.py
@@ -48,7 +48,7 @@ PS1_CUTOUT_TIMEOUT = 10
 class GaiaQuery:
 
     alt_tap = 'https://gaia.aip.de/tap'
-    alt_main_db = 'gaiaedr3'
+    alt_main_db = 'gaiadr3'
 
     # conversion for units in VO tables to astropy units
     unit_conversion = {
@@ -66,7 +66,7 @@ class GaiaQuery:
         'Angle[rad], Angle[rad]': u.deg,  # this is the `pos` in degrees, incorrectly reported as radians
     }
 
-    def __init__(self, main_db="gaiaedr3"):
+    def __init__(self, main_db="gaiadr3"):
         self.main_db = main_db
         self.db_connected = self._connect()
         log(
@@ -1292,7 +1292,7 @@ def get_finding_chart(
     colors = sns.color_palette("colorblind", ncolors)
 
     start_text = [-0.45, 0.99]
-    origin = "GaiaEDR3" if not used_ztfref else "ZTFref"
+    origin = "GaiaDR3" if not used_ztfref else "ZTFref"
     starlist_str = (
         f"# Note: {origin} used for offset star positions\n"
         "# Note: spacing in starlist many not copy/paste correctly in PDF\n"

--- a/skyportal/utils/offset.py
+++ b/skyportal/utils/offset.py
@@ -80,7 +80,7 @@ class GaiaQuery:
         """
         try:
             g = Gaia
-            q = f"SELECT TOP 1  * from {self.main_db}.gaia_source"
+            q = f"SELECT TOP 1 ra, dec from {self.main_db}.gaia_source"
             job = g.launch_job(q)
             _ = job.get_results()
             self.is_backup = False
@@ -98,7 +98,7 @@ class GaiaQuery:
             try:
                 self.main_db = GaiaQuery.alt_main_db
                 g = vo.dal.TAPService(GaiaQuery.alt_tap)
-                q = f"SELECT TOP 1 * from {self.alt_main_db}.gaia_source"
+                q = f"SELECT TOP 1 ra, dec from {self.alt_main_db}.gaia_source"
                 _ = g.search(q)
                 self.connection = g
                 return True

--- a/static/js/components/FindingChart.jsx
+++ b/static/js/components/FindingChart.jsx
@@ -200,7 +200,7 @@ const FindingChart = () => {
                             className={classes.items}
                           >
                             <MenuItem value="ztfref">ZTF Ref</MenuItem>
-                            <MenuItem value="gaia">Gaia EDR3</MenuItem>
+                            <MenuItem value="gaia">Gaia DR3</MenuItem>
                           </Controller>
                         </FormControl>
                       </Grid>


### PR DESCRIPTION
🛰 Use Gaia DR3 as the main catalog for astrometry & color-mag diagrams, replacing EDR3.