### PR TITLE
Add extra space up top

### DIFF
--- a/static/js/components/WidgetPrefsDialog.jsx
+++ b/static/js/components/WidgetPrefsDialog.jsx
@@ -21,6 +21,7 @@ const useStyles = makeStyles(() => ({
   },
   inputSectionDiv: {
     marginBottom: "1rem",
+    marginTop: "0.5rem",
   },
 }));
 


### PR DESCRIPTION
This PR adds more space at the top of Widget titles (partially addresses https://github.com/skyportal/skyportal/issues/3075).