### PR TITLE
Add basic queue interface

### DIFF
--- a/skyportal/facility_apis/_base.py
+++ b/skyportal/facility_apis/_base.py
@@ -66,6 +66,7 @@ class _Base:
             "remove": cls._isimplemented('remove'),
             "retrieve": cls._isimplemented('retrieve'),
             "queued": cls._isimplemented('queued'),
+            "remove_queue": cls._isimplemented('remove_queue'),
         }
 
     # subclasses should not modify this

--- a/skyportal/facility_apis/interface.py
+++ b/skyportal/facility_apis/interface.py
@@ -110,6 +110,12 @@ class FollowUpAPI(_Base):
         """Retrieve the status of planned observations."""
         raise NotImplementedError
 
+    # subclasses should implement this if desired
+    @staticmethod
+    def remove_queue():
+        """Remove a particular queue by name."""
+        raise NotImplementedError
+
     # jsonschema outlining the schema of the frontend form. See
     # https://github.com/rjsf-team/react-jsonschema-form
     # for examples.

--- a/skyportal/handlers/api/observation.py
+++ b/skyportal/handlers/api/observation.py
@@ -1153,24 +1153,30 @@ class ObservationExternalAPIHandler(BaseHandler):
           - observations
         parameters:
           - in: path
-            name: instrument_id
+            name: allocation_id
             required: true
             schema:
               type: string
             description: |
-              ID for the instrument to submit
+              ID for the allocation to retrieve
           - in: query
             name: startDate
-            required: true
+            required: false
             schema:
               type: string
             description: Filter by start date
           - in: query
             name: endDate
-            required: true
+            required: false
             schema:
               type: string
             description: Filter by end date
+          - in: query
+            name: queuesOnly
+            required: false
+            schema:
+              type: bool
+            description: Return queue only (do not commit observations)
         responses:
           200:
             content:
@@ -1182,17 +1188,19 @@ class ObservationExternalAPIHandler(BaseHandler):
                 schema: Error
         """
 
-        start_date = self.get_query_argument('startDate')
-        end_date = self.get_query_argument('endDate')
+        start_date = self.get_query_argument('startDate', None)
+        end_date = self.get_query_argument('endDate', None)
+        queues_only = self.get_query_argument('queuesOnly', False)
 
-        if start_date is None:
-            return self.error(message="Missing start_date")
+        if not queues_only:
+            if start_date is None:
+                return self.error(message="Missing start_date")
 
-        if end_date is None:
-            return self.error(message="Missing end_date")
+            if end_date is None:
+                return self.error(message="Missing end_date")
 
-        start_date = arrow.get(start_date.strip()).datetime
-        end_date = arrow.get(end_date.strip()).datetime
+            start_date = arrow.get(start_date.strip()).datetime
+            end_date = arrow.get(end_date.strip()).datetime
 
         data = {}
         data["requester_id"] = self.associated_user_object.id
@@ -1218,12 +1226,78 @@ class ObservationExternalAPIHandler(BaseHandler):
             # we now retrieve and commit to the database the
             # executed observations
             queue_names = instrument.api_class_obsplan.queued(
-                allocation, data['start_date'], data['end_date']
+                allocation,
+                data['start_date'],
+                data['end_date'],
+                queues_only=queues_only,
             )
-            self.push_notification(
-                'Planned observation ingestion in progress. Should be available soon.'
-            )
+            if not queues_only:
+                self.push_notification(
+                    'Planned observation ingestion in progress. Should be available soon.'
+                )
             return self.success(data={'queue_names': queue_names})
+        except Exception as e:
+            return self.error(f"Error in querying instrument API: {e}")
+
+    @permissions(['Upload data'])
+    def delete(self, allocation_id):
+        """
+        ---
+        description: Retrieve queued observations from external API
+        tags:
+          - observations
+        parameters:
+          - in: path
+            name: allocation_id
+            required: true
+            schema:
+              type: string
+            description: |
+              ID for the allocation to delete queue
+          - in: query
+            name: queueName
+            required: true
+            schema:
+              type: string
+            description: Queue name to remove
+        responses:
+          200:
+            content:
+              application/json:
+                schema: Success
+          400:
+            content:
+              application/json:
+                schema: Error
+        """
+
+        data = self.get_json()
+
+        if 'queueName' not in data:
+            return self.error('queueName is a required argument')
+        queue_name = data['queueName']
+
+        data["requester_id"] = self.associated_user_object.id
+        data["last_modified_by_id"] = self.associated_user_object.id
+        data['allocation_id'] = allocation_id
+
+        allocation = Allocation.get_if_accessible_by(
+            data['allocation_id'], self.current_user, raise_if_none=True
+        )
+        instrument = allocation.instrument
+
+        if instrument.api_classname_obsplan is None:
+            return self.error('Instrument has no remote observation plan API.')
+
+        if not instrument.api_class_obsplan.implements()['remove_queue']:
+            return self.error('Cannot delete queues from this Instrument.')
+
+        try:
+            # we now retrieve and commit to the database the
+            # executed observations
+            instrument.api_class_obsplan.remove_queue(
+                allocation, queue_name, self.associated_user_object.username
+            )
         except Exception as e:
             return self.error(f"Error in querying instrument API: {e}")
 

--- a/static/js/components/ObservationPage.jsx
+++ b/static/js/components/ObservationPage.jsx
@@ -3,6 +3,8 @@ import { useSelector, useDispatch } from "react-redux";
 import Typography from "@mui/material/Typography";
 import Paper from "@mui/material/Paper";
 import Grid from "@mui/material/Grid";
+import Divider from "@mui/material/Divider";
+import { ExpandMore, ExpandLess } from "@mui/icons-material";
 import makeStyles from "@mui/styles/makeStyles";
 import PropTypes from "prop-types";
 
@@ -23,8 +25,21 @@ const useStyles = makeStyles((theme) => ({
     backgroundColor: theme.palette.background.paper,
     whiteSpace: "pre-line",
   },
+  header: {
+    display: "flex",
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+  },
+  content: {
+    margin: "1rem",
+  },
   paperContent: {
     padding: "1rem",
+    marginBottom: "1rem",
+  },
+  divider: {
+    background: theme.palette.primary.main,
   },
 }));
 
@@ -94,6 +109,7 @@ const ObservationPage = () => {
   const observations = useSelector((state) => state.observations);
   const queued_observations = useSelector((state) => state.queued_observations);
   const currentUser = useSelector((state) => state.profile);
+  const [open, setOpen] = useState(false);
   const dispatch = useDispatch();
   const classes = useStyles();
 
@@ -193,26 +209,41 @@ const ObservationPage = () => {
       </Grid>
       {currentUser.permissions?.includes("System admin") && (
         <Grid item md={6} sm={12}>
-          <Paper>
-            <div className={classes.paperContent}>
-              <Typography variant="h6">Add New Observations</Typography>
-              <NewObservation />
+          <Paper
+            className={classes.paperContent}
+            onClick={() => setOpen(!open)}
+          >
+            <div className={classes.header}>
+              <Typography variant="h6"> Add New Observations </Typography>
+              {open ? <ExpandLess /> : <ExpandMore />}
             </div>
           </Paper>
-          <Paper>
-            <div className={classes.paperContent}>
-              <Typography variant="h6">
-                Add API Executed Observations
-              </Typography>
-              <NewAPIObservation />
-            </div>
-          </Paper>
-          <Paper>
-            <div className={classes.paperContent}>
-              <Typography variant="h6">Add API Queued Observations</Typography>
-              <NewAPIQueuedObservation />
-            </div>
-          </Paper>
+          {open && (
+            <Paper className={classes.paperContent}>
+              <div className={classes.content}>
+                <Typography variant="h6">Add Observations from File</Typography>
+                <NewObservation />
+              </div>
+              <br />
+              <Divider variant="middle" className={classes.divider} />
+              <br />
+              <div className={classes.content}>
+                <Typography variant="h6">
+                  Add API Executed Observations
+                </Typography>
+                <NewAPIObservation />
+              </div>
+              <br />
+              <Divider variant="middle" className={classes.divider} />
+              <br />
+              <div className={classes.content}>
+                <Typography variant="h6">
+                  Add API Queued Observations
+                </Typography>
+                <NewAPIQueuedObservation />
+              </div>
+            </Paper>
+          )}
           <Paper>
             <div className={classes.paperContent}>
               <Typography variant="h6">Queue Interaction</Typography>

--- a/static/js/components/ObservationPage.jsx
+++ b/static/js/components/ObservationPage.jsx
@@ -11,6 +11,7 @@ import QueuedObservationsTable from "./QueuedObservationsTable";
 import NewObservation from "./NewObservation";
 import NewAPIObservation from "./NewAPIObservation";
 import NewAPIQueuedObservation from "./NewAPIQueuedObservation";
+import QueueAPIDisplay from "./QueueAPIDisplay";
 
 import * as observationsActions from "../ducks/observations";
 import * as queuedObservationsActions from "../ducks/queued_observations";
@@ -210,6 +211,12 @@ const ObservationPage = () => {
             <div className={classes.paperContent}>
               <Typography variant="h6">Add API Queued Observations</Typography>
               <NewAPIQueuedObservation />
+            </div>
+          </Paper>
+          <Paper>
+            <div className={classes.paperContent}>
+              <Typography variant="h6">Queue Interaction</Typography>
+              <QueueAPIDisplay />
             </div>
           </Paper>
         </Grid>

--- a/static/js/components/QueueAPIDisplay.jsx
+++ b/static/js/components/QueueAPIDisplay.jsx
@@ -1,0 +1,199 @@
+import React, { useState, useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+// eslint-disable-next-line import/no-unresolved
+import makeStyles from "@mui/styles/makeStyles";
+import Button from "@mui/material/Button";
+import Select from "@mui/material/Select";
+import InputLabel from "@mui/material/InputLabel";
+import MenuItem from "@mui/material/MenuItem";
+
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+
+import * as queuedObservationActions from "../ducks/queued_observations";
+import * as allocationActions from "../ducks/allocations";
+import * as instrumentActions from "../ducks/instruments";
+
+dayjs.extend(utc);
+
+const useStyles = makeStyles(() => ({
+  marginTop: {
+    marginTop: "1rem",
+  },
+  select: {
+    width: "100%",
+  },
+  SelectItem: {
+    whiteSpace: "break-spaces",
+  },
+  container: {
+    width: "99%",
+    marginBottom: "1rem",
+  },
+}));
+
+const QueueAPIDisplay = () => {
+  const classes = useStyles();
+
+  const [selectedAllocationId, setSelectedAllocationId] = useState(null);
+  const [queueList, setQueueList] = useState(["None"]);
+  const [selectedQueueName, setSelectedQueueName] = useState("None");
+
+  const { instrumentList } = useSelector((state) => state.instruments);
+  const { telescopeList } = useSelector((state) => state.telescopes);
+  const { allocationList } = useSelector((state) => state.allocations);
+  const allGroups = useSelector((state) => state.groups.all);
+
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    const getAllocations = async () => {
+      // Wait for the allocations to update before setting
+      // the new default form fields, so that the allocations list can
+      // update
+
+      const result = await dispatch(
+        allocationActions.fetchAllocations({
+          apiType: "api_classname_obsplan",
+        })
+      );
+
+      const { data } = result;
+      setSelectedAllocationId(data[0]?.id);
+    };
+
+    getAllocations();
+
+    dispatch(
+      instrumentActions.fetchInstrumentForms({
+        apiType: "api_classname_obsplan",
+      })
+    );
+    dispatch(
+      allocationActions.fetchAllocations({
+        apiType: "api_classname_obsplan",
+      })
+    );
+
+    // Don't want to reset everytime the component rerenders and
+    // the defaultStartDate is updated, so ignore ESLint here
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dispatch]);
+
+  if (
+    !allGroups ||
+    allGroups.length === 0 ||
+    telescopeList.length === 0 ||
+    instrumentList.length === 0
+  ) {
+    return <h3>No telescopes/instruments available...</h3>;
+  }
+
+  if (allocationList.length === 0) {
+    return <h3>No robotic instruments available...</h3>;
+  }
+
+  const groupLookUp = {};
+  // eslint-disable-next-line no-unused-expressions
+  allGroups?.forEach((group) => {
+    groupLookUp[group.id] = group;
+  });
+
+  const telLookUp = {};
+  // eslint-disable-next-line no-unused-expressions
+  telescopeList?.forEach((tel) => {
+    telLookUp[tel.id] = tel;
+  });
+
+  const instLookUp = {};
+  // eslint-disable-next-line no-unused-expressions
+  instrumentList?.forEach((instrumentObj) => {
+    instLookUp[instrumentObj.id] = instrumentObj;
+  });
+
+  const allocationLookUp = {};
+  // eslint-disable-next-line no-unused-expressions
+  allocationList?.forEach((allocation) => {
+    allocationLookUp[allocation.id] = allocation;
+  });
+
+  const handleDelete = async () => {
+    await dispatch(
+      queuedObservationActions.deleteAPIQueue(selectedAllocationId, {
+        queueName: selectedQueueName,
+      })
+    );
+  };
+
+  const handleSelectedAllocationChange = async (e) => {
+    setSelectedAllocationId(e.target.value);
+    const response = await dispatch(
+      queuedObservationActions.requestAPIQueues(e.target.value)
+    );
+    setQueueList(response.data.queue_names);
+    if (response.data.queue_names.length > 0) {
+      setSelectedQueueName(response.data.queue_names[0]);
+    }
+  };
+
+  const handleSelectedQueueNameChange = async (e) => {
+    setSelectedQueueName(e.target.value);
+  };
+
+  return (
+    <div className={classes.container}>
+      <InputLabel id="allocationSelectLabel">Allocation</InputLabel>
+      <Select
+        inputProps={{ MenuProps: { disableScrollLock: true } }}
+        labelId="allocationSelectLabel"
+        value={selectedAllocationId}
+        onChange={handleSelectedAllocationChange}
+        name="followupRequestAllocationSelect"
+        className={classes.select}
+      >
+        {allocationList?.map((allocation) => (
+          <MenuItem
+            value={allocation.id}
+            key={allocation.id}
+            className={classes.SelectItem}
+          >
+            {`${
+              telLookUp[instLookUp[allocation.instrument_id].telescope_id].name
+            } / ${instLookUp[allocation.instrument_id].name} - ${
+              groupLookUp[allocation.group_id].name
+            } (PI ${allocation.pi})`}
+          </MenuItem>
+        ))}
+      </Select>
+      <InputLabel id="queueNameSelectLabel">Queue Name</InputLabel>
+      <Select
+        inputProps={{ MenuProps: { disableScrollLock: true } }}
+        labelId="queueNameSelectLabel"
+        value={selectedQueueName}
+        onChange={handleSelectedQueueNameChange}
+        name="followupRequestAllocationSelect"
+        className={classes.select}
+      >
+        {queueList?.map((queueName) => (
+          <MenuItem
+            value={queueName}
+            key={queueName}
+            className={classes.SelectItem}
+          >
+            {queueName}
+          </MenuItem>
+        ))}
+      </Select>
+      <Button
+        onClick={() => {
+          handleDelete();
+        }}
+        data-testid="delete-queue-button"
+      >
+        Delete queue
+      </Button>
+    </div>
+  );
+};
+
+export default QueueAPIDisplay;

--- a/static/js/components/QueueAPIDisplay.jsx
+++ b/static/js/components/QueueAPIDisplay.jsx
@@ -22,13 +22,14 @@ const useStyles = makeStyles(() => ({
   },
   select: {
     width: "100%",
+    marginBottom: "1rem",
   },
   SelectItem: {
     whiteSpace: "break-spaces",
   },
   container: {
+    marginTop: "1rem",
     width: "99%",
-    marginBottom: "1rem",
   },
 }));
 
@@ -80,6 +81,24 @@ const QueueAPIDisplay = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dispatch]);
 
+  useEffect(() => {
+    const getQueues = async () => {
+      if (selectedAllocationId && allocationList?.length > 0) {
+        const response = await dispatch(
+          queuedObservationActions.requestAPIQueues(selectedAllocationId)
+        );
+        if (response?.data?.queue_names?.length > 0) {
+          setQueueList(response.data.queue_names);
+          setSelectedQueueName(response.data.queue_names[0]);
+        } else {
+          setQueueList(["None"]);
+          setSelectedQueueName("None");
+        }
+      }
+    };
+    getQueues();
+  }, [selectedAllocationId]);
+
   if (
     !allGroups ||
     allGroups.length === 0 ||
@@ -127,13 +146,6 @@ const QueueAPIDisplay = () => {
 
   const handleSelectedAllocationChange = async (e) => {
     setSelectedAllocationId(e.target.value);
-    const response = await dispatch(
-      queuedObservationActions.requestAPIQueues(e.target.value)
-    );
-    setQueueList(response.data.queue_names);
-    if (response.data.queue_names.length > 0) {
-      setSelectedQueueName(response.data.queue_names[0]);
-    }
   };
 
   const handleSelectedQueueNameChange = async (e) => {

--- a/static/js/ducks/queued_observations.js
+++ b/static/js/ducks/queued_observations.js
@@ -21,6 +21,10 @@ const REFRESH_QUEUED_OBSERVATIONS = "skyportal/REFRESH_QUEUED_OBSERVATIONS";
 const REQUEST_API_QUEUED_OBSERVATIONS =
   "skyportal/REQUEST_API_QUEUED_OBSERVATIONS";
 
+const REQUEST_API_QUEUES = "skyportal/REQUEST_API_QUEUES";
+
+const DELETE_API_QUEUE = "skyportal/DELETE_API_QUEUE";
+
 export function fetchQueuedObservations(filterParams = {}) {
   if (!Object.keys(filterParams).includes("startDate")) {
     filterParams.startDate = dayjs().utc().format("YYYY-MM-DDTHH:mm:ssZ");
@@ -42,6 +46,22 @@ export function requestAPIQueuedObservations(id, data = {}) {
   return API.GET(
     `/api/observation/external_api/${id}`,
     REQUEST_API_QUEUED_OBSERVATIONS,
+    data
+  );
+}
+
+export function requestAPIQueues(id, data = { queuesOnly: true }) {
+  return API.GET(
+    `/api/observation/external_api/${id}`,
+    REQUEST_API_QUEUES,
+    data
+  );
+}
+
+export function deleteAPIQueue(id, data = {}) {
+  return API.DELETE(
+    `/api/observation/external_api/${id}`,
+    DELETE_API_QUEUE,
     data
   );
 }


### PR DESCRIPTION
This PR adds a basic queue interface to the observations page, where the queues can be displayed (and deleted if that capability exists).