### PR TITLE
Change sedm_endpoint from pharos to minar

### DIFF
--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -22,7 +22,7 @@ app:
     default_filters: ['ztfg', 'ztfr', 'ztfi']
 
   # this endpoint does not actually do anything -- it is just for testing
-  sedm_endpoint: http://pharos.caltech.edu/add_fritz
+  sedm_endpoint: http://minar.caltech.edu/add_fritz
   sedmv2_endpoint:
 
   lt_host: 161.72.57.3


### PR DESCRIPTION
We are retiring the 8-year-old pharos and replacing it with minar.  The web server is up and running and this should be a
seamless transition.  Please let me know when this is deployed so we don't lose SEDM requests through the cracks.