### PR TITLE
DNM: fix path to discover skyportal services in test config

### DIFF
--- a/test_config.yaml
+++ b/test_config.yaml
@@ -55,7 +55,11 @@ testing: true
 services:
   paths:
     - ./baselayer/services
-    - ./skyportal/services
+    - ./services
+  disabled:
+    - gcnserver
+    - slack
+    - external_logging
 
 test_server:
   port: 64502


### PR DESCRIPTION
The discovery path for skyportal services was incorrect. This is fixed. Also turn off some of those services, which should not directly be needed for testing.

> **Note**: it actually was correct and is needed for a lot of the testing. Will fix here but DNM now.