### PR TITLE
Improvement of the comment component

### DIFF
--- a/static/js/components/CommentList.jsx
+++ b/static/js/components/CommentList.jsx
@@ -86,10 +86,32 @@ const useStyles = makeStyles(() => ({
     marginRight: "1em",
   },
   commentMessage: {
-    maxWidth: "25em",
+    maxWidth: "35em",
     "& > p": {
       margin: "0",
     },
+    wordWrap: "break-word",
+  },
+  commentMessageShift: {
+    maxWidth: "47em",
+    "& > p": {
+      margin: "0",
+    },
+    wordWrap: "break-word",
+  },
+  compactCommentMessage: {
+    maxWidth: "34em",
+    "& > p": {
+      margin: "0",
+    },
+    wordWrap: "break-word",
+  },
+  compactCommentMessageShift: {
+    maxWidth: "44em",
+    "& > p": {
+      margin: "0",
+    },
+    wordWrap: "break-word",
   },
   commentUserName: {
     fontWeight: "bold",
@@ -330,7 +352,6 @@ const CommentList = ({
           )
         )}
       </div>
-      <br />
       {permissions.indexOf("Comment") >= 0 &&
         objID &&
         (associatedResourceType === "object" ||

--- a/static/js/components/CompactCommentList.jsx
+++ b/static/js/components/CompactCommentList.jsx
@@ -56,6 +56,11 @@ const CompactCommentList = ({
       emoji.getUnicode(name) ? emoji.getUnicode(name) : name
     );
 
+  const commentMessageStyle =
+    associatedResourceType === "shift"
+      ? styles.compactCommentMessageShift
+      : styles.compactCommentMessage;
+
   return (
     <div className={styles.compactContainer}>
       <div className={styles.commentUserAvatar}>
@@ -74,7 +79,7 @@ const CompactCommentList = ({
         <ReactMarkdown
           source={renderCommentText()}
           escapeHtml={false}
-          className={styles.commentMessage}
+          className={commentMessageStyle}
           renderers={{ text: emojiSupport }}
         />
         <div className={styles.compactButtons}>

--- a/static/js/components/RegularCommentList.jsx
+++ b/static/js/components/RegularCommentList.jsx
@@ -60,6 +60,11 @@ const RegularCommentList = ({
       emoji.getUnicode(name) ? emoji.getUnicode(name) : name
     );
 
+  const commentMessageStyle =
+    associatedResourceType === "shift"
+      ? styles.commentMessageShift
+      : styles.commentMessage;
+
   return (
     <>
       <div className={styles.commentUserAvatar}>
@@ -105,7 +110,7 @@ const RegularCommentList = ({
           <ReactMarkdown
             source={renderCommentText()}
             escapeHtml={false}
-            className={styles.commentMessage}
+            className={commentMessageStyle}
             renderers={{ text: emojiSupport }}
           />
         </div>


### PR DESCRIPTION
Currently, when we write a long comment on skyportal, we have to scroll to the side to see all of it:
![long_comment_before_changes](https://user-images.githubusercontent.com/60301767/174619449-9aa3b32a-434f-4c6d-ae42-fc10c09e6e88.gif)
 
I fixed it by going to the next line when the text does not have any space left:
![image](https://user-images.githubusercontent.com/60301767/174619630-b5adf773-5d41-4024-b2ca-a546bc0135b6.png)
