### PR TITLE
Adjusted classification Chip font size and weight

### DIFF
--- a/static/js/components/ShowClassification.jsx
+++ b/static/js/components/ShowClassification.jsx
@@ -8,6 +8,8 @@ import makeStyles from "@mui/styles/makeStyles";
 export const useStyles = makeStyles((theme) => ({
   chip: {
     margin: theme.spacing(0.5),
+    fontSize: "1.2rem",
+    fontWeight: "bold",
   },
 }));
 


### PR DESCRIPTION
This PR increases the size and weight of the classification on the source page, should close https://github.com/skyportal/skyportal/issues/3125

Before:
![image](https://user-images.githubusercontent.com/39569176/175395823-45ecb83e-03f4-470d-99b0-f1d9ac8034b1.png)

After:
![image](https://user-images.githubusercontent.com/39569176/175396315-5c855248-cbf3-42ad-af3b-b530f92948df.png)
