### PR TITLE
Updated GroupsSelect.jsx imports to MUI5

### DIFF
--- a/static/js/components/GroupsSelect.jsx
+++ b/static/js/components/GroupsSelect.jsx
@@ -1,13 +1,13 @@
 import React from "react";
 import { useSelector } from "react-redux";
 import PropTypes from "prop-types";
-import Input from "@material-ui/core/Input";
-import InputLabel from "@material-ui/core/InputLabel";
-import Select from "@material-ui/core/Select";
-import MenuItem from "@material-ui/core/MenuItem";
-import Chip from "@material-ui/core/Chip";
-import FormControl from "@material-ui/core/FormControl";
-import { makeStyles, useTheme } from "@material-ui/core/styles";
+import Input from "@mui/material/Input";
+import InputLabel from "@mui/material/InputLabel";
+import Select from "@mui/material/Select";
+import MenuItem from "@mui/material/MenuItem";
+import Chip from "@mui/material/Chip";
+import FormControl from "@mui/material/FormControl";
+import { makeStyles, useTheme } from "@mui/styles";
 
 const useStyles = makeStyles(() => ({
   chips: {
@@ -97,7 +97,7 @@ const GroupsSelect = (props) => {
 GroupsSelect.propTypes = {
   selectedGroups: PropTypes.arrayOf(
     PropTypes.shape({
-      id: PropTypes.string.isRequired,
+      id: PropTypes.number.isRequired,
       name: PropTypes.string.isRequired,
     })
   ).isRequired,


### PR DESCRIPTION
The GroupSelects component is still importing components from an older version of MUI. The result is that wherever it is used, it breaks the display of the page. This PR just updates the imports to MUI5 to solve that problem.