### PR TITLE
Use newer version of postgres in default compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
       - thumbnails:/skyportal/static/thumbnails
 
   db:
-    image: postgres:12.2
+    image: postgres:14.4
     environment:
       POSTGRES_USER: skyportal
       POSTGRES_PASSWORD: password


### PR DESCRIPTION
This PR bumps default postgres in docker-compose to 14.4, required for all of the healpix-alchemy infrastructure.