### PR TITLE
Fix ValueError has no attribute normalized_messages error

### DIFF
--- a/skyportal/handlers/api/followup_request.py
+++ b/skyportal/handlers/api/followup_request.py
@@ -223,10 +223,14 @@ class AssignmentHandler(BaseHandler):
                 assignment_id = post_assignment(
                     data, self.associated_user_object.id, session
                 )
-            except Exception as e:
+            except ValidationError as e:
                 return self.error(
                     'Error posting followup request: ' f'"{e.normalized_messages()}"'
                 )
+            except ValueError as e:
+                return self.error('Error posting followup request: ' f'"{e.args[0]}"')
+            except Exception as e:
+                return self.error('Error posting followup request: ' f'"{str(e)}"')
 
             return self.success(data={"id": assignment_id})
 


### PR DESCRIPTION
Jesper got that error when trying to create a followup request.
The issue is that ValueError gets thrown in post_assignment, but the exception handler expects a ValidationError only.