### PR TITLE
Fix group in different session bug in annotation_services

### DIFF
--- a/skyportal/handlers/api/annotation_services.py
+++ b/skyportal/handlers/api/annotation_services.py
@@ -11,13 +11,11 @@ from astroquery.irsa import Irsa
 import numpy as np
 from astroquery.vizier import Vizier
 
-from baselayer.app.custom_exceptions import AccessError
 from baselayer.app.access import auth_or_token
 from baselayer.app.env import load_env
 
 from ..base import BaseHandler
 from ...models import (
-    DBSession,
     Annotation,
     Group,
     Obj,
@@ -97,19 +95,6 @@ class GaiaQueryHandler(BaseHandler):
 
         data = self.get_json()
 
-        group_ids = data.pop('group_ids', None)
-        if not group_ids:
-            groups = self.current_user.accessible_groups
-        else:
-            try:
-                groups = Group.get_if_accessible_by(
-                    group_ids, self.current_user, raise_if_none=True
-                )
-            except AccessError:
-                return self.error(
-                    'At least some of the groups are not accessible.', status=403
-                )
-
         author = self.associated_user_object
 
         catalog = data.pop('catalog', "gaiadr3.gaia_source")
@@ -167,34 +152,50 @@ class GaiaQueryHandler(BaseHandler):
             'RUWE': 'ruwe',
         }
 
-        annotations = []
-        for index, row in df.iterrows():
-            row_dict = row.to_dict()
-            annotation_data = {}
-            for local_key, gaia_key in columns.items():
-                value = row_dict.get(gaia_key, np.nan)
-                if not np.isnan(value):
-                    annotation_data[local_key] = value
-            if annotation_data:
-                if len(df) > 1:
-                    origin = f"{catalog}-{row['ra']}-{row['dec']}"
-                else:
-                    origin = catalog
-                annotation = Annotation(
-                    data=annotation_data,
-                    obj_id=obj_id,
-                    origin=origin,
-                    author=author,
-                    groups=groups,
+        # TODO: convert the above code to the new SQLA 2.0 methods
+        with self.Session() as session:
+
+            group_ids = data.pop('group_ids', None)
+
+            if not group_ids:
+                group_ids = [g.id for g in self.current_user.accessible_groups]
+            groups = session.scalars(
+                Group.select(self.current_user).where(Group.id.in_(group_ids))
+            ).all()
+
+            if {g.id for g in groups} != set(group_ids):
+                return self.error(
+                    f'Cannot find one or more groups with IDs: {group_ids}.'
                 )
-                annotations.append(annotation)
 
-        if len(annotations) == 0:
-            return self.error("No Gaia Photometry available.")
+            annotations = []
+            for index, row in df.iterrows():
+                row_dict = row.to_dict()
+                annotation_data = {}
+                for local_key, gaia_key in columns.items():
+                    value = row_dict.get(gaia_key, np.nan)
+                    if not np.isnan(value):
+                        annotation_data[local_key] = value
+                if annotation_data:
+                    if len(df) > 1:
+                        origin = f"{catalog}-{row['ra']}-{row['dec']}"
+                    else:
+                        origin = catalog
+                    annotation = Annotation(
+                        data=annotation_data,
+                        obj_id=obj_id,
+                        origin=origin,
+                        author=author,
+                        groups=groups,
+                    )
+                    annotations.append(annotation)
 
-        DBSession().add_all(annotations)
+            if len(annotations) == 0:
+                return self.error("No Gaia Photometry available.")
+
+            session.add_all(annotations)
         try:
-            self.verify_and_commit()
+            session.commit()
         except IntegrityError:
             return self.error("Annotation already posted.")
 
@@ -264,71 +265,71 @@ class IRSAQueryWISEHandler(BaseHandler):
             return self.error('Invalid object id.')
 
         data = self.get_json()
+        with self.Session() as session:
+            group_ids = data.pop('group_ids', None)
 
-        group_ids = data.pop('group_ids', None)
-        if not group_ids:
-            groups = self.current_user.accessible_groups
-        else:
-            try:
-                groups = Group.get_if_accessible_by(
-                    group_ids, self.current_user, raise_if_none=True
-                )
-            except AccessError:
+            if not group_ids:
+                group_ids = [g.id for g in self.current_user.accessible_groups]
+            groups = session.scalars(
+                Group.select(self.current_user).where(Group.id.in_(group_ids))
+            ).all()
+
+            if {g.id for g in groups} != set(group_ids):
                 return self.error(
-                    'At least some of the groups are not accessible.', status=403
+                    f'Cannot find one or more groups with IDs: {group_ids}.'
                 )
 
-        author = self.associated_user_object
+            author = self.associated_user_object
 
-        catalog = data.pop('catalog', "allwise_p3as_psd")
-        radius_arcsec = data.pop('crossmatchRadius', 2.0)
-        candidate_coord = SkyCoord(ra=obj.ra * u.deg, dec=obj.dec * u.deg)
+            catalog = data.pop('catalog', "allwise_p3as_psd")
+            radius_arcsec = data.pop('crossmatchRadius', 2.0)
+            candidate_coord = SkyCoord(ra=obj.ra * u.deg, dec=obj.dec * u.deg)
 
-        df = Irsa.query_region(
-            coordinates=candidate_coord,
-            catalog=catalog,
-            spatial="Cone",
-            radius=radius_arcsec * u.arcsec,
-        ).to_pandas()
+            df = Irsa.query_region(
+                coordinates=candidate_coord,
+                catalog=catalog,
+                spatial="Cone",
+                radius=radius_arcsec * u.arcsec,
+            ).to_pandas()
 
-        keys = [
-            'ra',
-            'dec',
-            'w1mpro',
-            'w1sigmpro',
-            'w2mpro',
-            'w2sigmpro',
-            'w3mpro',
-            'w3sigmpro',
-            'w4mpro',
-            'w4sigmpro',
-        ]
-        annotations = []
-        for index, row in df.iterrows():
-            annotation_data = {
-                k: row.to_dict().get(k, None)
-                for k in keys
-                if not np.isnan(row.to_dict().get(k, None))
-            }
+            keys = [
+                'ra',
+                'dec',
+                'w1mpro',
+                'w1sigmpro',
+                'w2mpro',
+                'w2sigmpro',
+                'w3mpro',
+                'w3sigmpro',
+                'w4mpro',
+                'w4sigmpro',
+            ]
+            annotations = []
+            for index, row in df.iterrows():
+                annotation_data = {
+                    k: row.to_dict().get(k, None)
+                    for k in keys
+                    if not np.isnan(row.to_dict().get(k, None))
+                }
 
-            origin = f"{catalog}-{row['ra']}-{row['dec']}"
-            annotation = Annotation(
-                data=annotation_data,
-                obj_id=obj_id,
-                origin=origin,
-                author=author,
-                groups=groups,
-            )
-            annotations.append(annotation)
+                origin = f"{catalog}-{row['ra']}-{row['dec']}"
+                annotation = Annotation(
+                    data=annotation_data,
+                    obj_id=obj_id,
+                    origin=origin,
+                    author=author,
+                    groups=groups,
+                )
+                annotations.append(annotation)
 
-        if len(annotations) == 0:
-            return self.error("No WISE Photometry available.")
+            if len(annotations) == 0:
+                return self.error("No WISE Photometry available.")
 
-        DBSession().add_all(annotations)
-        try:
-            self.verify_and_commit()
-        except IntegrityError:
-            return self.error("Annotation already posted.")
+            session.add_all(annotations)
+            try:
+                session.commit()
+            except IntegrityError:
+                return self.error("Annotation already posted.")
 
         self.push_all(
             action='skyportal/REFRESH_SOURCE',
@@ -398,67 +399,68 @@ class VizierQueryHandler(BaseHandler):
 
         data = self.get_json()
 
-        group_ids = data.pop('group_ids', None)
-        if not group_ids:
-            groups = self.current_user.accessible_groups
-        else:
-            try:
-                groups = Group.get_if_accessible_by(
-                    group_ids, self.current_user, raise_if_none=True
-                )
-            except AccessError:
+        with self.Session() as session:
+            group_ids = data.pop('group_ids', None)
+
+            if not group_ids:
+                group_ids = [g.id for g in self.current_user.accessible_groups]
+            groups = session.scalars(
+                Group.select(self.current_user).where(Group.id.in_(group_ids))
+            ).all()
+
+            if {g.id for g in groups} != set(group_ids):
                 return self.error(
-                    'At least some of the groups are not accessible.', status=403
+                    f'Cannot find one or more groups with IDs: {group_ids}.'
                 )
 
-        author = self.associated_user_object
+            author = self.associated_user_object
 
-        catalog = data.pop('catalog', "VII/290")
-        radius_arcsec = data.pop('crossmatchRadius', 2.0)
-        candidate_coord = SkyCoord(ra=obj.ra * u.deg, dec=obj.dec * u.deg)
+            catalog = data.pop('catalog', "VII/290")
+            radius_arcsec = data.pop('crossmatchRadius', 2.0)
+            candidate_coord = SkyCoord(ra=obj.ra * u.deg, dec=obj.dec * u.deg)
 
-        tl = Vizier.query_region(
-            coordinates=candidate_coord,
-            catalog=catalog,
-            radius=radius_arcsec * u.arcsec,
-        )
-
-        if len(tl) == 0:
-            return self.error("No successful cross-match available.")
-
-        if len(tl) > 1:
-            return self.error("Should only have one table from that query.")
-        df = tl[0].filled(fill_value=-99).to_pandas()
-        keys = [
-            'Qpct',
-            'z',
-        ]
-        annotations = []
-        for index, row in df.iterrows():
-            annotation_data = {
-                k: row.to_dict().get(k, None)
-                for k in keys
-                if not row.to_dict().get(k, None) == -99
-            }
-
-            origin = f"{catalog}-{row['Name']}"
-            annotation = Annotation(
-                data=annotation_data,
-                obj_id=obj_id,
-                origin=origin,
-                author=author,
-                groups=groups,
+            tl = Vizier.query_region(
+                coordinates=candidate_coord,
+                catalog=catalog,
+                radius=radius_arcsec * u.arcsec,
             )
-            annotations.append(annotation)
 
-        if len(annotations) == 0:
-            return self.error("No crossmatch annotation available.")
+            if len(tl) == 0:
+                return self.error("No successful cross-match available.")
 
-        DBSession().add_all(annotations)
-        try:
-            self.verify_and_commit()
-        except IntegrityError:
-            return self.error("Annotation already posted.")
+            if len(tl) > 1:
+                return self.error("Should only have one table from that query.")
+            df = tl[0].filled(fill_value=-99).to_pandas()
+            keys = [
+                'Qpct',
+                'z',
+            ]
+            annotations = []
+            for index, row in df.iterrows():
+                annotation_data = {
+                    k: row.to_dict().get(k, None)
+                    for k in keys
+                    if not row.to_dict().get(k, None) == -99
+                }
+
+                origin = f"{catalog}-{row['Name']}"
+                annotation = Annotation(
+                    data=annotation_data,
+                    obj_id=obj_id,
+                    origin=origin,
+                    author=author,
+                    groups=groups,
+                )
+                annotations.append(annotation)
+
+            if len(annotations) == 0:
+                return self.error("No crossmatch annotation available.")
+
+            session.add_all(annotations)
+            try:
+                self.verify_and_commit()
+            except IntegrityError:
+                return self.error("Annotation already posted.")
 
         self.push_all(
             action='skyportal/REFRESH_SOURCE',
@@ -526,52 +528,55 @@ class DatalabQueryHandler(BaseHandler):
 
         data = self.get_json()
 
-        group_ids = data.pop('group_ids', None)
-        if not group_ids:
-            groups = self.current_user.accessible_groups
-        else:
-            try:
-                groups = Group.get_if_accessible_by(
-                    group_ids, self.current_user, raise_if_none=True
+        with self.Session() as session:
+            group_ids = data.pop('group_ids', None)
+
+            if not group_ids:
+                group_ids = [g.id for g in self.current_user.accessible_groups]
+            groups = session.scalars(
+                Group.select(self.current_user).where(Group.id.in_(group_ids))
+            ).all()
+
+            if {g.id for g in groups} != set(group_ids):
+                return self.error(
+                    f'Cannot find one or more groups with IDs: {group_ids}.'
                 )
-            except AccessError:
-                return self.error('Could not find any accessible groups.', status=403)
 
-        author = self.associated_user_object
+            author = self.associated_user_object
 
-        catalog = data.pop('catalog', "ls_dr8")
-        radius_arcsec = data.pop('crossmatchRadius', 2.0)
-        radius_deg = radius_arcsec / 3600.0
+            catalog = data.pop('catalog', "ls_dr8")
+            radius_arcsec = data.pop('crossmatchRadius', 2.0)
+            radius_deg = radius_arcsec / 3600.0
 
-        sql_query = f"""SELECT {catalog}.photo_z.ls_id, z_phot_median, z_phot_std, ra, dec, type, z_phot_l95, flux_z from {catalog}.photo_z
-                      INNER JOIN {catalog}.tractor
-                      ON {catalog}.tractor.ls_id = {catalog}.photo_z.ls_id
-                      where 't' = Q3C_RADIAL_QUERY(ra, dec, {obj.ra}, {obj.dec}, {radius_deg})"""
-        query = qc.query(sql=sql_query)
-        df = pd.read_table(StringIO(query), sep=",")
-        annotations = []
-        for index, row in df.iterrows():
-            ls_id = row['ls_id']
-            origin = f"{catalog}-{ls_id}"
-            row.drop(index=['ls_id'], inplace=True)
-            annotation_data = row.to_dict()
-            annotation = Annotation(
-                data=annotation_data,
-                obj_id=obj_id,
-                origin=origin,
-                author=author,
-                groups=groups,
-            )
-            annotations.append(annotation)
+            sql_query = f"""SELECT {catalog}.photo_z.ls_id, z_phot_median, z_phot_std, ra, dec, type, z_phot_l95, flux_z from {catalog}.photo_z
+                          INNER JOIN {catalog}.tractor
+                          ON {catalog}.tractor.ls_id = {catalog}.photo_z.ls_id
+                          where 't' = Q3C_RADIAL_QUERY(ra, dec, {obj.ra}, {obj.dec}, {radius_deg})"""
+            query = qc.query(sql=sql_query)
+            df = pd.read_table(StringIO(query), sep=",")
+            annotations = []
+            for index, row in df.iterrows():
+                ls_id = row['ls_id']
+                origin = f"{catalog}-{ls_id}"
+                row.drop(index=['ls_id'], inplace=True)
+                annotation_data = row.to_dict()
+                annotation = Annotation(
+                    data=annotation_data,
+                    obj_id=obj_id,
+                    origin=origin,
+                    author=author,
+                    groups=groups,
+                )
+                annotations.append(annotation)
 
-        if len(annotations) == 0:
-            return self.error("No photo z's available.")
+            if len(annotations) == 0:
+                return self.error("No photo z's available.")
 
-        DBSession().add_all(annotations)
-        try:
-            self.verify_and_commit()
-        except IntegrityError:
-            return self.error("Annotation already posted.")
+            session.add_all(annotations)
+            try:
+                session.commit()
+            except IntegrityError:
+                return self.error("Annotation already posted.")
 
         self.push_all(
             action='skyportal/REFRESH_SOURCE',


### PR DESCRIPTION
When clicking add Gaia cross match (or Wise, etc) there's a backend error that has to do with the group objects coming from a different session. This moves the `annotation_services` handler to the SQL 2.0 method style (mostly) and fixes that bug. 