### PR TITLE
Separate observer and observer_timezone

### DIFF
--- a/skyportal/tests/tools/test_timezone.py
+++ b/skyportal/tests/tools/test_timezone.py
@@ -3,7 +3,7 @@ import datetime
 
 def test_problematic_timezone(wise_18inch, xinglong_216cm):
     assert (
-        wise_18inch.observer.timezone.utcoffset(
+        wise_18inch.observer_timezone.timezone.utcoffset(
             datetime.datetime.fromisoformat('2020-11-17T00:00:00')
         ).seconds
         / 3600
@@ -11,7 +11,7 @@ def test_problematic_timezone(wise_18inch, xinglong_216cm):
     )
 
     assert (
-        xinglong_216cm.observer.timezone.utcoffset(
+        xinglong_216cm.observer_timezone.timezone.utcoffset(
             datetime.datetime.fromisoformat('2020-11-17T00:00:00')
         ).seconds
         / 3600


### PR DESCRIPTION
This PR fixes a bug where the airmass plots are not reporting UT time, but actually timezone time. This splits out the observer property into one for UT and one that is timezone cognizant, which may be useful for reporting local time on the front-end.