### PR TITLE
Sources list - Download all sources, not just the ones displayed.

### DIFF
--- a/skyportal/tests/frontend/sources_and_followup_etc/test_source_list.py
+++ b/skyportal/tests/frontend/sources_and_followup_etc/test_source_list.py
@@ -1,5 +1,6 @@
 import os
 import uuid
+import time
 
 from skyportal.tests import api
 from tdtax import taxonomy, __version__
@@ -588,9 +589,10 @@ def test_download_sources(driver, user, public_group, upload_data_token):
     # check that the download has the right number of lines
     fpath = str(os.path.abspath(pjoin(cfg['paths.downloads_folder'], 'sources.csv')))
     try_count = 1
-    while not os.path.exists(fpath) and try_count <= 3:
+    while not os.path.exists(fpath) and try_count <= 5:
         try_count += 1
-        assert os.path.exists(fpath)
+        time.sleep(1)
+    assert os.path.exists(fpath)
 
     try:
         with open(fpath) as f:

--- a/skyportal/tests/frontend/sources_and_followup_etc/test_source_list.py
+++ b/skyportal/tests/frontend/sources_and_followup_etc/test_source_list.py
@@ -1,3 +1,4 @@
+import os
 import uuid
 
 from skyportal.tests import api
@@ -5,7 +6,12 @@ from tdtax import taxonomy, __version__
 
 from datetime import datetime, timezone, timedelta
 
+from baselayer.app.config import load_config
 from dateutil import parser
+from os.path import join as pjoin
+import random
+
+cfg = load_config()
 
 
 def test_add_sources_two_groups(
@@ -532,3 +538,67 @@ def test_hr_diagram(
     driver.wait_for_xpath(f'//tr[@data-testid="groupSourceExpand_{source_id}"]')
 
     driver.wait_for_xpath(f'//div[@data-testid="hr_diagram_{source_id}"]')
+
+
+def test_download_sources(driver, user, public_group, upload_data_token):
+    # generate a list of 20 source ids:
+    source_ids = [str(uuid.uuid4()) for i in range(20)]
+    origin = str(uuid.uuid4())
+    # post 20 sources:
+    for source_id in source_ids:
+        status, data = api(
+            "POST",
+            "sources",
+            data={
+                "id": source_id,
+                # random ra value
+                "ra": random.random() * 360 - 180,
+                "dec": random.random() * 180 - 90,
+                "redshift": 3,
+                "transient": False,
+                "ra_dis": 2.3,
+                "origin": origin,
+                "group_ids": [public_group.id],
+            },
+            token=upload_data_token,
+        )
+        assert status == 200
+
+    driver.get(f"/become_user/{user.id}")
+    driver.get("/sources")
+
+    # Filter for origin
+    driver.click_xpath("//button[@data-testid='Filter Table-iconButton']")
+    alias_field = driver.wait_for_xpath(
+        "//*[@data-testid='origin-text']//input",
+    )
+    alias_field.send_keys(origin)
+    driver.click_xpath(
+        "//button[text()='Submit']",
+        scroll_parent=True,
+    )
+
+    # click the download button
+    driver.click_xpath('//button[@aria-label="Download CSV"]')
+
+    driver.wait_for_xpath('//*[contains(., "Downloading 20 sources")]')
+
+    driver.wait_for_xpath_to_disappear('//*[contains(., "Downloading 20 sources")]')
+
+    # check that the download has the right number of lines
+    fpath = str(os.path.abspath(pjoin(cfg['paths.downloads_folder'], 'sources.csv')))
+    try_count = 1
+    while not os.path.exists(fpath) and try_count <= 3:
+        try_count += 1
+        assert os.path.exists(fpath)
+
+    try:
+        with open(fpath) as f:
+            lines = f.read()
+        assert (
+            lines.split('\n')[0]
+            == '"id","ra [deg]","dec [deg]","redshift","classification","groups","Date saved","Alias","Origin","TNS Name"'
+        )
+        assert len(lines.split('\n')) == 21
+    finally:
+        os.remove(fpath)

--- a/static/js/components/ProgressIndicators.jsx
+++ b/static/js/components/ProgressIndicators.jsx
@@ -1,0 +1,64 @@
+import * as React from "react";
+import PropTypes from "prop-types";
+import CircularProgress from "@mui/material/CircularProgress";
+import Typography from "@mui/material/Typography";
+import Box from "@mui/material/Box";
+
+const CircularProgressWithLabel = ({ current, total, percentage }) => (
+  <div
+    style={{
+      display: "flex",
+      flexDirection: "column",
+      width: "100%",
+      height: "100%",
+      alignItems: "center",
+      justifyContent: "center",
+    }}
+  >
+    <CircularProgress
+      variant="determinate"
+      value={Math.round((current * 100) / total)}
+      style={{ width: "100%", height: "100%" }}
+    />
+    <Box
+      sx={{
+        top: "25%",
+        left: 0,
+        bottom: 0,
+        right: 0,
+        position: "absolute",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      {percentage ? (
+        <Typography
+          variant="caption"
+          component="div"
+          color="text.secondary"
+        >{`${Math.round((current * 100) / total)}%`}</Typography>
+      ) : (
+        <Typography
+          variant="caption"
+          component="div"
+          color="text.secondary"
+        >{`${current}/${total}`}</Typography>
+      )}
+    </Box>
+  </div>
+);
+
+CircularProgressWithLabel.defaultProps = {
+  current: 0,
+  total: 100,
+  percentage: true,
+};
+
+CircularProgressWithLabel.propTypes = {
+  current: PropTypes.number,
+  total: PropTypes.number,
+  percentage: PropTypes.bool,
+};
+
+export default CircularProgressWithLabel;

--- a/static/js/components/SourceTable.jsx
+++ b/static/js/components/SourceTable.jsx
@@ -297,6 +297,7 @@ const SourceTable = ({
   sortingCallback,
   favoritesRemoveButton = false,
   hideTitle = false,
+  downloadCallback,
 }) => {
   // sourceStatus should be one of either "saved" (default) or "requested" to add a button to agree to save the source.
   // If groupID is not given, show all data available to user's accessible groups
@@ -1113,17 +1114,15 @@ const SourceTable = ({
     onRowExpansionChange: (_, allRowsExpanded) => {
       setOpenedRows(allRowsExpanded.map((i) => i.dataIndex));
     },
-    onDownload: (buildHead, buildBody, columnsDownload, data) => {
-      const renderDownloadClassification = (dataIndex) => {
-        const source = sources[dataIndex];
+    onDownload: (buildHead, buildBody) => {
+      const renderDownloadClassification = (source) => {
         const classifications = [];
         source?.classifications.forEach((x) => {
           classifications.push(x.classification);
         });
         return classifications.join(";");
       };
-      const renderDownloadGroups = (dataIndex) => {
-        const source = sources[dataIndex];
+      const renderDownloadGroups = (source) => {
         const groups = [];
         source?.groups.forEach((x) => {
           groups.push(x.name);
@@ -1131,91 +1130,93 @@ const SourceTable = ({
         return groups.join(";");
       };
 
-      const renderDownloadDateSaved = (dataIndex) => {
-        const source = sources[dataIndex];
-        return getDate(source)?.substring(0, 19);
-      };
+      const renderDownloadDateSaved = (source) =>
+        getDate(source)?.substring(0, 19);
 
-      const renderDownloadAlias = (dataIndex) => {
-        const { alias } = sources[dataIndex];
+      const renderDownloadAlias = (source) => {
+        const alias = source?.alias;
         let alias_str = "";
         if (alias) {
           alias_str = Array.isArray(alias) ? alias.join(";") : alias;
         }
         return alias_str;
       };
-      const renderDownloadOrigin = (dataIndex) => {
-        const { origin } = sources[dataIndex];
-        return origin;
-      };
-      const renderDownloadTNSName = (dataIndex) => {
-        const source = sources[dataIndex];
-        return source.altdata && source.altdata.tns
-          ? source.altdata.tns.name
-          : "";
-      };
+      const renderDownloadTNSName = (source) =>
+        source?.altdata && source.altdata.tns ? source.altdata.tns.name : "";
 
-      return (
-        buildHead([
-          {
-            name: "id",
-            download: true,
-          },
-          {
-            name: "ra [deg]",
-            download: true,
-          },
-          {
-            name: "dec [deg]",
-            download: true,
-          },
-          {
-            name: "redshift",
-            download: true,
-          },
-          {
-            name: "classification",
-            download: true,
-          },
-          {
-            name: "groups",
-            download: true,
-          },
-          {
-            name: "Date saved",
-            download: true,
-          },
-          {
-            name: "Alias",
-            download: true,
-          },
-          {
-            name: "Origin",
-            download: true,
-          },
-          {
-            name: "TNS Name",
-            download: true,
-          },
-        ]) +
-        buildBody(
-          data.map((x) => ({
-            ...x,
-            data: [
-              x.data[0],
-              x.data[4],
-              x.data[5],
-              x.data[8],
-              renderDownloadClassification(x.index),
-              renderDownloadGroups(x.index),
-              renderDownloadDateSaved(x.index),
-              renderDownloadAlias(x.index),
-              renderDownloadOrigin(x.index),
-              renderDownloadTNSName(x.index),
-            ],
-          }))
-        )
-      );
+      downloadCallback().then((data) => {
+        const result =
+          buildHead([
+            {
+              name: "id",
+              download: true,
+            },
+            {
+              name: "ra [deg]",
+              download: true,
+            },
+            {
+              name: "dec [deg]",
+              download: true,
+            },
+            {
+              name: "redshift",
+              download: true,
+            },
+            {
+              name: "classification",
+              download: true,
+            },
+            {
+              name: "groups",
+              download: true,
+            },
+            {
+              name: "Date saved",
+              download: true,
+            },
+            {
+              name: "Alias",
+              download: true,
+            },
+            {
+              name: "Origin",
+              download: true,
+            },
+            {
+              name: "TNS Name",
+              download: true,
+            },
+          ]) +
+          buildBody(
+            data.map((x) => ({
+              ...x,
+              data: [
+                x.id,
+                x.ra,
+                x.dec,
+                x.redshift,
+                renderDownloadClassification(x),
+                renderDownloadGroups(x),
+                renderDownloadDateSaved(x),
+                renderDownloadAlias(x),
+                x.origin,
+                renderDownloadTNSName(x),
+              ],
+            }))
+          );
+        const blob = new Blob([result], {
+          type: "text/csv;charset=utf-8;",
+        });
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement("a");
+        link.href = url;
+        link.setAttribute("download", "sources.csv");
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+      });
+      return false;
     },
   };
 
@@ -1313,6 +1314,7 @@ SourceTable.propTypes = {
   sortingCallback: PropTypes.func,
   favoritesRemoveButton: PropTypes.bool,
   hideTitle: PropTypes.bool,
+  downloadCallback: PropTypes.func.isRequired,
 };
 
 SourceTable.defaultProps = {

--- a/static/js/components/SourceTable.jsx
+++ b/static/js/components/SourceTable.jsx
@@ -1145,76 +1145,79 @@ const SourceTable = ({
         source?.altdata && source.altdata.tns ? source.altdata.tns.name : "";
 
       downloadCallback().then((data) => {
-        const result =
-          buildHead([
-            {
-              name: "id",
-              download: true,
-            },
-            {
-              name: "ra [deg]",
-              download: true,
-            },
-            {
-              name: "dec [deg]",
-              download: true,
-            },
-            {
-              name: "redshift",
-              download: true,
-            },
-            {
-              name: "classification",
-              download: true,
-            },
-            {
-              name: "groups",
-              download: true,
-            },
-            {
-              name: "Date saved",
-              download: true,
-            },
-            {
-              name: "Alias",
-              download: true,
-            },
-            {
-              name: "Origin",
-              download: true,
-            },
-            {
-              name: "TNS Name",
-              download: true,
-            },
-          ]) +
-          buildBody(
-            data.map((x) => ({
-              ...x,
-              data: [
-                x.id,
-                x.ra,
-                x.dec,
-                x.redshift,
-                renderDownloadClassification(x),
-                renderDownloadGroups(x),
-                renderDownloadDateSaved(x),
-                renderDownloadAlias(x),
-                x.origin,
-                renderDownloadTNSName(x),
-              ],
-            }))
-          );
-        const blob = new Blob([result], {
-          type: "text/csv;charset=utf-8;",
-        });
-        const url = URL.createObjectURL(blob);
-        const link = document.createElement("a");
-        link.href = url;
-        link.setAttribute("download", "sources.csv");
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
+        // if there is no data, cancel download
+        if (data?.length > 0) {
+          const result =
+            buildHead([
+              {
+                name: "id",
+                download: true,
+              },
+              {
+                name: "ra [deg]",
+                download: true,
+              },
+              {
+                name: "dec [deg]",
+                download: true,
+              },
+              {
+                name: "redshift",
+                download: true,
+              },
+              {
+                name: "classification",
+                download: true,
+              },
+              {
+                name: "groups",
+                download: true,
+              },
+              {
+                name: "Date saved",
+                download: true,
+              },
+              {
+                name: "Alias",
+                download: true,
+              },
+              {
+                name: "Origin",
+                download: true,
+              },
+              {
+                name: "TNS Name",
+                download: true,
+              },
+            ]) +
+            buildBody(
+              data.map((x) => ({
+                ...x,
+                data: [
+                  x.id,
+                  x.ra,
+                  x.dec,
+                  x.redshift,
+                  renderDownloadClassification(x),
+                  renderDownloadGroups(x),
+                  renderDownloadDateSaved(x),
+                  renderDownloadAlias(x),
+                  x.origin,
+                  renderDownloadTNSName(x),
+                ],
+              }))
+            );
+          const blob = new Blob([result], {
+            type: "text/csv;charset=utf-8;",
+          });
+          const url = URL.createObjectURL(blob);
+          const link = document.createElement("a");
+          link.href = url;
+          link.setAttribute("download", "sources.csv");
+          document.body.appendChild(link);
+          link.click();
+          document.body.removeChild(link);
+        }
       });
       return false;
     },


### PR DESCRIPTION
This PR attempts to fix #3118, where the problem was that when clicking on the download button of the mui datatable of the source list, it only downloads the source currently displayed (so only the current page of the table), and not all the sources matching the filters and/or sorting selected by a user. 

In this PR, the sources are download 10 by 10 which is fine to test the feature. But this could (and probably should) more be done like 100 by 100 to limit API calls.

PREVIEW: (please click on the image to see it fullscreen, makes it easier to read)
![download_source_list](https://user-images.githubusercontent.com/49785117/177601300-5d0b3462-6924-4d8b-8cf6-bdb01eb4906a.gif)
