### PR TITLE
Check that altdata is a dictionary

### DIFF
--- a/skyportal/models/obj.py
+++ b/skyportal/models/obj.py
@@ -489,7 +489,7 @@ class Obj(Base, conesearch_alchemy.Point):
 
         # there may be a non-redshift based measurement of distance
         # for nearby sources
-        if self.altdata:
+        if isinstance(self.altdata, dict):
             if self.altdata.get("dm") is not None:
                 # see eq (24) of https://ned.ipac.caltech.edu/level5/Hogg/Hogg7.html
                 return (


### PR DESCRIPTION
This PR checks that altdata is a dictionary. It addresses the recent fritz error "AttributeError: 'str' object has no attribute 'get'"