### PR TITLE
No longer return photometry for multiple sources

### DIFF
--- a/skyportal/tests/api/test_groups.py
+++ b/skyportal/tests/api/test_groups.py
@@ -537,7 +537,7 @@ def test_non_group_admin_cannot_remove_user_from_group(
         f"groups/{public_group.id}/users/{user.id}",
         token=view_only_token2,
     )
-    assert status == 400
+    assert status == 403
 
 
 def test_cannot_add_self_to_group(public_group2, view_only_token, user):
@@ -618,7 +618,7 @@ def test_cannot_remove_user_from_single_user_group(super_admin_token, user):
         f"groups/{single_user_group.id}/users/{user.id}",
         token=super_admin_token,
     )
-    assert status == 400
+    assert status == 403
 
 
 def test_user_cannot_remove_self_from_single_user_group(view_only_token, user):
@@ -629,4 +629,4 @@ def test_user_cannot_remove_self_from_single_user_group(view_only_token, user):
         f"groups/{single_user_group.id}/users/{user.id}",
         token=view_only_token,
     )
-    assert status == 400
+    assert status == 403

--- a/skyportal/tests/api/test_obj_photometry.py
+++ b/skyportal/tests/api/test_obj_photometry.py
@@ -19,7 +19,7 @@ def test_obj_photometry(upload_data_token, public_source):
         f"sources/{obj_id}/photometry",
         token=upload_data_token,
     )
-    assert status == 400
+    assert status == 403
     assert (
         data['message']
         == f'Insufficient permissions for User {upload_data_token} to read Obj {obj_id}'

--- a/skyportal/tests/api/test_sources.py
+++ b/skyportal/tests/api/test_sources.py
@@ -1636,23 +1636,6 @@ def test_sources_hidden_photometry_not_leaked(
     assert data['status'] == 'success'
     photometry_id = data['data']['ids'][0]
 
-    # Check the photometry sent back with the source
-    status, data = api(
-        "GET",
-        "sources",
-        params={"group_ids": f"{public_group.id}", "includePhotometry": "true"},
-        token=view_only_token,
-    )
-    assert status == 200
-    assert len(data["data"]["sources"]) == 1
-    assert data["data"]["sources"][0]["id"] == obj_id
-    assert len(public_source.photometry) - 1 == len(
-        data["data"]["sources"][0]["photometry"]
-    )
-    assert photometry_id not in map(
-        lambda x: x["id"], data["data"]["sources"][0]["photometry"]
-    )
-
     # Check for single GET call as well
     status, data = api(
         "GET",

--- a/skyportal/tests/rate_limiting/test_rate_limiting.py
+++ b/skyportal/tests/rate_limiting/test_rate_limiting.py
@@ -24,9 +24,9 @@ def test_api_rate_limiting(view_only_token):
         )
         if r.status_code != 200:
             break
-    # Based on baselayer's default nginx settings of max 5r/s + bursts of 10 (no delay)
+    # Based on baselayer's default nginx settings of max 10r/s + bursts of 10 (no delay)
     # See https://www.nginx.com/blog/rate-limiting-nginx/#bursts
-    assert 11 <= n_successful_requests <= 16
+    assert 11 <= n_successful_requests <= 20
     r = requests.get(
         f'http://{localhost_external_ip}:{cfg["ports.app"]}/api/sysinfo',
         headers={'Authorization': f'token {view_only_token}'},


### PR DESCRIPTION
This PR removes an unnecessary test now that we no longer return photometry for multiple sources.