### PR TITLE
Make sensitivity_data modifiable from the front-end

### DIFF
--- a/skyportal/handlers/api/instrument.py
+++ b/skyportal/handlers/api/instrument.py
@@ -7,6 +7,7 @@ import sqlalchemy as sa
 from tornado.ioloop import IOLoop
 
 import arrow
+import ast
 from healpix_alchemy import Tile
 from regions import Regions, CircleSkyRegion, RectangleSkyRegion, PolygonSkyRegion
 from astropy import coordinates
@@ -48,6 +49,9 @@ class InstrumentHandler(BaseHandler):
         )
 
         sensitivity_data = data.get("sensitivity_data", None)
+        if isinstance(sensitivity_data, str):
+            sensitivity_data = ast.literal_eval(sensitivity_data.replace("\'", "\""))
+
         if sensitivity_data:
             filters = data.get("filters", [])
             if not set(sensitivity_data.keys()).issubset(filters):
@@ -593,6 +597,9 @@ class InstrumentHandler(BaseHandler):
 
         filters = instrument.filters
         sensitivity_data = data.get('sensitivity_data', None)
+        if isinstance(sensitivity_data, str):
+            sensitivity_data = ast.literal_eval(sensitivity_data.replace("\'", "\""))
+
         if sensitivity_data:
             if not set(sensitivity_data.keys()).issubset(filters):
                 return self.error(

--- a/static/js/components/ModifyInstrument.jsx
+++ b/static/js/components/ModifyInstrument.jsx
@@ -278,6 +278,11 @@ const ModifyInstrument = () => {
         title: "FOV Attributes",
         description: "Rectangle [width,height]; Circle [radius]",
       },
+      sensitivity_data: {
+        type: "string",
+        title:
+          "Sensitivity data (i.e. {'ztfg': {'limiting_magnitude': 20.3, 'magsys': 'ab', 'exposure_time': 30, 'zeropoint': 26.3,}}",
+      },
     },
   };
 

--- a/static/js/components/NewInstrument.jsx
+++ b/static/js/components/NewInstrument.jsx
@@ -185,6 +185,11 @@ const NewInstrument = () => {
         title: "FOV Attributes",
         description: "Rectangle [width,height]; Circle [radius]",
       },
+      sensitivity_data: {
+        type: "string",
+        title:
+          "Sensitivity data (i.e. {'ztfg': {'limiting_magnitude': 20.3, 'magsys': 'ab', 'exposure_time': 30, 'zeropoint': 26.3,}}",
+      },
     },
     required: ["name", "type", "band", "telescope_id"],
   };


### PR DESCRIPTION
This PR makes instrument's sensitivity_data modifiable from the front-end.