### PR TITLE
Telescope Handler - Don't use observer's methods if it's None.

### DIFF
--- a/skyportal/handlers/api/telescope.py
+++ b/skyportal/handlers/api/telescope.py
@@ -145,6 +145,7 @@ class TelescopeHandler(BaseHandler):
                 and telescope.lon is not None
                 and telescope.lat is not None
                 and telescope.elevation is not None
+                and telescope.observer is not None
             ):
                 try:
                     morning = telescope.next_twilight_morning_astronomical()
@@ -153,10 +154,15 @@ class TelescopeHandler(BaseHandler):
                         is_night_astronomical = bool(morning.jd < evening.jd)
                         morning = morning.iso
                         evening = evening.iso
+                    else:
+                        morning = False
+                        evening = False
+                        is_night_astronomical = False
                 except Exception:
                     morning = False
                     evening = False
                     is_night_astronomical = False
+            print(morning, evening, is_night_astronomical)
             temp['is_night_astronomical'] = is_night_astronomical
             temp['next_twilight_morning_astronomical'] = morning
             temp['next_twilight_evening_astronomical'] = evening


### PR DESCRIPTION
In the PR, we simply check don't use any of the observer's methods if it does not exist. Also, few lines after, we reset some values to False to be sure that we don't end up with astropy times rather than the intended date string.