### PR TITLE
Notification Logs

### DIFF
--- a/skyportal/models/user_notification.py
+++ b/skyportal/models/user_notification.py
@@ -147,16 +147,6 @@ def user_preferences(target, notification_setting, resource_type):
 
 
 @event.listens_for(UserNotification, 'after_insert')
-def push_frontend_notification(mapper, connection, target):
-    resource_type = notification_resource_type(target)
-    log(
-        f"Sent frontend notification to user {target.user.id}, body: {target.text}, resource_type: {resource_type}"
-    )
-    ws_flow = Flow()
-    ws_flow.push(target.user.id, "skyportal/FETCH_NOTIFICATIONS")
-
-
-@event.listens_for(UserNotification, 'after_insert')
 def send_slack_notification(mapper, connection, target):
     resource_type = notification_resource_type(target)
     notifications_prefs = user_preferences(target, "slack", resource_type)
@@ -277,6 +267,16 @@ def send_sms_notification(mapper, connection, target):
             )
         except Exception as e:
             log(f"Error sending sms notification: {e}")
+
+
+@event.listens_for(UserNotification, 'after_insert')
+def push_frontend_notification(mapper, connection, target):
+    resource_type = notification_resource_type(target)
+    log(
+        f"Sent frontend notification to user {target.user.id}, body: {target.text}, resource_type: {resource_type}"
+    )
+    ws_flow = Flow()
+    ws_flow.push(target.user.id, "skyportal/FETCH_NOTIFICATIONS")
 
 
 @event.listens_for(Classification, 'after_insert')

--- a/skyportal/models/user_notification.py
+++ b/skyportal/models/user_notification.py
@@ -147,11 +147,13 @@ def user_preferences(target, notification_setting, resource_type):
 
 
 @event.listens_for(UserNotification, 'after_insert')
-def log_frontend_notification(mapper, connection, target):
+def push_frontend_notification(mapper, connection, target):
     resource_type = notification_resource_type(target)
     log(
         f"Sent frontend notification to user {target.user.id}, body: {target.text}, resource_type: {resource_type}"
     )
+    ws_flow = Flow()
+    ws_flow.push(target.user.id, "skyportal/FETCH_NOTIFICATIONS")
 
 
 @event.listens_for(UserNotification, 'after_insert')
@@ -346,8 +348,6 @@ def add_user_notifications(mapper, connection, target):
             else:
                 users = []
 
-        ws_flow = Flow()
-
         for user in users:
             # Only notify users who have read access to the new record in question
             if (
@@ -496,5 +496,3 @@ def add_user_notifications(mapper, connection, target):
                                         url=f"/source/{target.obj_id}",
                                     )
                                 )
-
-                ws_flow.push(user.id, "skyportal/FETCH_NOTIFICATIONS")


### PR DESCRIPTION
This PR adds logs not just on errors, but on notifications in general.

Here is an example of a notification successfully sent on frontend, email, slack, but with a failure on SMS:

```
[34;1m[13:36:38 notifications] Sent frontend notification to user 1, body: New classification *AGN* for source *ZTF18aabcvnq*, resource_type: sources[0m
[34;1m[13:36:39 notifications] Sent slack notification to user 1 at slack_url: https://hooks.slack.com/services/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, body: New classification *AGN* for source *ZTF18aabcvnq*, resource_type: sources[0m
[34;1m[13:36:45 notifications] Sent email notification to user 1 at email: theophile.dulaz@gmail.com, subject: SkyPortal - New followed classification on a source, body: New classification *AGN* for source *ZTF18aabcvnq* (http://localhost:5000/sources/ZTF18aabcvnq), resource_type: sources[0m
[34;1m[13:36:46 notifications] Error sending sms notification: HTTP 400 error: Unable to create record: The number  is unverified. Trial accounts cannot send messages to unverified numbers; verify  at twilio.com/user/account/phone-numbers/verified, or purchase a Twilio number to send messages to unverified numbers.[0m
```


I logged as much information as I could. If you have any suggestions on things to add/remove, please tell me !

This PR also solves a bug with slack notification. It seems that a change made in a PR that updated baselayer's cfg.get() syntax added some incorrect code.