### PR TITLE
PhotStat minor updates

### DIFF
--- a/skyportal/handlers/api/photometry.py
+++ b/skyportal/handlers/api/photometry.py
@@ -1120,6 +1120,8 @@ class PhotometryHandler(BaseHandler):
                     sa.select(Photometry).where(Photometry.obj_id == photometry.obj_id)
                 ).all()
                 phot_stat.full_update(all_phot)
+                for phot in all_phot:
+                    session.expunge(phot)
 
             session.commit()
 

--- a/skyportal/handlers/api/photometry.py
+++ b/skyportal/handlers/api/photometry.py
@@ -1116,15 +1116,9 @@ class PhotometryHandler(BaseHandler):
                 )
             ).first()
             if phot_stat is not None:
-                all_phot = (
-                    session.scalars(
-                        Photometry.select(session.user_or_token)
-                        .where(Photometry.obj_id == photometry.obj_id)
-                        .distinct()
-                    )
-                    .unique()
-                    .all()
-                )
+                all_phot = session.scalars(
+                    sa.select(Photometry).where(Photometry.obj_id == photometry.obj_id)
+                ).all()
                 phot_stat.full_update(all_phot)
 
             session.commit()
@@ -1175,15 +1169,9 @@ class PhotometryHandler(BaseHandler):
                 )
             ).first()
             if phot_stat is not None:
-                all_phot = (
-                    session.scalars(
-                        Photometry.select(session.user_or_token)
-                        .where(Photometry.obj_id == photometry.obj_id)
-                        .distinct()
-                    )
-                    .unique()
-                    .all()
-                )
+                all_phot = session.scalars(
+                    sa.select(Photometry).where(Photometry.obj_id == photometry.obj_id)
+                ).all()
                 phot_stat.full_update(all_phot)
 
             session.commit()
@@ -1283,6 +1271,18 @@ class BulkDeletePhotometryHandler(BaseHandler):
 
             for phot in photometry_to_delete:
                 session.delete(phot)
+
+            obj_ids = {phot.obj_id for phot in photometry_to_delete}
+            for oid in obj_ids:
+                stat = session.scalars(
+                    PhotStat.select(session.user_or_token, mode="update").where(
+                        PhotStat.obj_id == oid
+                    )
+                ).first()
+                all_phot = session.scalars(
+                    sa.select(Photometry).where(Photometry.obj_id == oid)
+                ).all()
+                stat.full_update(all_phot)
 
             session.commit()
             return self.success(f"Deleted {n} photometry points.")


### PR DESCRIPTION
This PR makes some minor updates to the PhotStat infrastructure. 
- It adds a re-calculation of PhotStats when photometry bulk delete is used. 
- It makes the updates of photometry use all points (regardless of access rights) when calculating PhotStats in all cases. 
- It moves the PhotStats handler to the new select style and uses the verified session. 
- It returns a meaningful error for any failures to generate/update a phot stats through the `PhotStatsUpdateHandler`. 