### PR TITLE
Routing changes on the shift page

### DIFF
--- a/static/js/actions.js
+++ b/static/js/actions.js
@@ -15,7 +15,6 @@ import * as telescopesActions from "./ducks/telescopes";
 import * as taxonomyActions from "./ducks/taxonomies";
 import * as favoritesActions from "./ducks/favorites";
 import * as rejectedActions from "./ducks/rejected_candidates";
-import * as shiftsActions from "./ducks/shifts";
 import * as tnsrobotsActions from "./ducks/tnsrobots";
 import * as enumTypesActions from "./ducks/enum_types";
 
@@ -38,7 +37,6 @@ export default function hydrate() {
     dispatch(taxonomyActions.fetchTaxonomies());
     dispatch(favoritesActions.fetchFavorites());
     dispatch(rejectedActions.fetchRejected());
-    dispatch(shiftsActions.fetchShifts());
     dispatch(tnsrobotsActions.fetchTNSRobots());
     dispatch(enumTypesActions.fetchEnumTypes());
     dispatch(defaultObservationPlansActions.fetchDefaultObservationPlans());

--- a/static/js/components/ShiftPage.jsx
+++ b/static/js/components/ShiftPage.jsx
@@ -6,12 +6,14 @@ import Paper from "@mui/material/Paper";
 import Grid from "@mui/material/Grid";
 import Button from "@mui/material/Button";
 import CircularProgress from "@mui/material/CircularProgress";
+import { showNotification } from "baselayer/components/Notifications";
 import NewShift from "./NewShift";
 import MyCalendar from "./ShiftCalendar";
 import { CurrentShiftMenu, CommentOnShift } from "./ShiftManagement";
 import ShiftSummary from "./ShiftSummary";
 
 import { getShiftsSummary } from "../ducks/shift";
+import * as shiftsActions from "../ducks/shifts";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -35,19 +37,32 @@ const ShiftPage = ({ route }) => {
   const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
+    if (!loaded) {
+      dispatch(shiftsActions.fetchShifts()).then((data) => {
+        console.log(data);
+        if (data.status === "success" && data.data.length === 0) {
+          dispatch(showNotification("No shifts found", "warning"));
+        } else if (data.status !== "success") {
+          dispatch(showNotification("Error fetching shifts", "error"));
+        }
+      });
+    }
     if (route && loaded) {
       const shift = shiftList.find((s) => s.id === parseInt(route.id, 10));
-      if (shift)
+      if (shift) {
         dispatch({
           type: "skyportal/CURRENT_SHIFT",
           data: shift,
         });
-      dispatch(
-        getShiftsSummary({
-          shiftID: parseInt(route.id, 10),
-        })
-      );
-      setShow(false);
+        dispatch(
+          getShiftsSummary({
+            shiftID: parseInt(route.id, 10),
+          })
+        );
+        setShow(false);
+      } else {
+        dispatch(showNotification("Shift not found", "error"));
+      }
     }
   }, [loaded]);
 

--- a/static/js/components/ShiftPage.jsx
+++ b/static/js/components/ShiftPage.jsx
@@ -32,9 +32,10 @@ const ShiftPage = ({ route }) => {
   const shiftList = useSelector((state) => state.shifts.shiftList);
   const currentShift = useSelector((state) => state.shift.currentShift);
   const [show, setShow] = useState(true);
+  const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
-    if (!currentShift?.id && route) {
+    if (route && loaded) {
       const shift = shiftList.find((s) => s.id === parseInt(route.id, 10));
       if (shift)
         dispatch({
@@ -47,7 +48,14 @@ const ShiftPage = ({ route }) => {
         })
       );
       setShow(false);
-    } else if (currentShift) {
+    }
+  }, [loaded]);
+
+  useEffect(() => {
+    if (!loaded && shiftList?.length > 0) {
+      setLoaded(true);
+    }
+    if (currentShift) {
       const updatedShift = shiftList.find((s) => s.id === currentShift.id);
       // check if the shift shift_users length is different from the current shift
       if (


### PR DESCRIPTION
This PR aims to solve a problem we had on the shift page. Currently, using the routing (i.e /shifts/<shift_id>) gets you to the shift page and automatically opens the calendar on the right week and displays the shift management menu, comments and summary of the shift which id has been passed in the route. However, if you already had selected a shift (which is stored as the current shift in the redux store), this does not work.

This PR adresses that issue.