### PR TITLE
Fix group frontend tests

### DIFF
--- a/skyportal/models/user_notification.py
+++ b/skyportal/models/user_notification.py
@@ -274,10 +274,16 @@ def push_frontend_notification(mapper, connection, target):
     if 'user_id' in target.__dict__:
         user_id = target.user_id
     elif 'user' in target.__dict__:
-        user_id = target.user.id
+        if 'id' in target.user.__dict__:
+            user_id = target.user.id
+        else:
+            user_id = None
     else:
+        user_id = None
+
+    if user_id is None:
         log(
-            "Error sending push notification: user_id or user not found in notification's target"
+            "Error sending frontend notification: user_id or user.id not found in notification's target"
         )
         return
     resource_type = notification_resource_type(target)

--- a/skyportal/models/user_notification.py
+++ b/skyportal/models/user_notification.py
@@ -271,12 +271,18 @@ def send_sms_notification(mapper, connection, target):
 
 @event.listens_for(UserNotification, 'after_insert')
 def push_frontend_notification(mapper, connection, target):
+    if 'user_id' in target.__dict__:
+        user_id = target.user_id
+    elif 'user' in target.__dict__:
+        user_id = target.user.id
+    else:
+        return
     resource_type = notification_resource_type(target)
     log(
-        f"Sent frontend notification to user {target.user.id}, body: {target.text}, resource_type: {resource_type}"
+        f"Sent frontend notification to user {user_id}, body: {target.text}, resource_type: {resource_type}"
     )
     ws_flow = Flow()
-    ws_flow.push(target.user.id, "skyportal/FETCH_NOTIFICATIONS")
+    ws_flow.push(user_id, "skyportal/FETCH_NOTIFICATIONS")
 
 
 @event.listens_for(Classification, 'after_insert')

--- a/skyportal/models/user_notification.py
+++ b/skyportal/models/user_notification.py
@@ -276,6 +276,9 @@ def push_frontend_notification(mapper, connection, target):
     elif 'user' in target.__dict__:
         user_id = target.user.id
     else:
+        log(
+            "Error sending push notification: user_id or user not found in notification's target"
+        )
         return
     resource_type = notification_resource_type(target)
     log(


### PR DESCRIPTION
This PR addresses a bug introduces by a PR that added logs to the notifications. It seems that some notifications, instead of having a user object as a target, have a user_id. The code added to the user notification model did not take that into account. This fixes that issue and allows tests to pass.