### PR TITLE
Bugfix: Duplicate classification on the source page

### DIFF
--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -232,9 +232,13 @@ def get_source(
         .all(),
         key=lambda x: x.origin,
     )
-    readable_classifications = session.scalars(
-        Classification.select(user).where(Classification.obj_id == obj_id)
-    ).all()
+    readable_classifications = (
+        session.scalars(
+            Classification.select(user).where(Classification.obj_id == obj_id)
+        )
+        .unique()
+        .all()
+    )
 
     readable_classifications_json = []
     for classification in readable_classifications:


### PR DESCRIPTION
This PR addresses a bug mentioned on the beta-testing channel on slack. Users experienced difficulties with the source page where they saw the classifications being duplicated many times.