### PR TITLE
Group admission request: Notify group admins by email

### DIFF
--- a/skyportal/handlers/api/group_admission_request.py
+++ b/skyportal/handlers/api/group_admission_request.py
@@ -177,25 +177,6 @@ class GroupAdmissionRequestHandler(BaseHandler):
         )
         DBSession().add(admission_request)
 
-        group_admin_gu = (
-            GroupUser.query.filter(GroupUser.group_id == group_id)
-            .filter(GroupUser.admin.is_(True))
-            .first()
-        )
-        group_admin = (
-            User.query.get(group_admin_gu.user_id)
-            if group_admin_gu is not None
-            else None
-        )
-        if group_admin is not None:
-            DBSession().add(
-                UserNotification(
-                    user=group_admin,
-                    text=f"*@{requesting_user.username}* has requested to join *{group.name}*",
-                    url=f"/group/{group_id}",
-                )
-            )
-
         try:
             self.verify_and_commit()
         except AccessError as e:
@@ -205,8 +186,6 @@ class GroupAdmissionRequestHandler(BaseHandler):
             )
 
         self.push(action="skyportal/FETCH_USER_PROFILE")
-        if group_admin is not None:
-            self.flow.push(group_admin.id, "skyportal/FETCH_NOTIFICATIONS", {})
         return self.success(data={"id": admission_request.id})
 
     @permissions(["Upload data"])

--- a/skyportal/models/user_notification.py
+++ b/skyportal/models/user_notification.py
@@ -188,7 +188,6 @@ def send_slack_notification(mapper, connection, target):
 def send_email_notification(mapper, connection, target):
     resource_type = notification_resource_type(target)
     prefs = user_preferences(target, "email", resource_type)
-    print(prefs)
     if not prefs:
         return
 
@@ -228,7 +227,6 @@ def send_email_notification(mapper, connection, target):
 
     if subject and body and target.user.contact_email:
         try:
-            print("tried sending email")
             send_email(
                 recipients=[target.user.contact_email],
                 subject=subject,

--- a/skyportal/models/user_notification.py
+++ b/skyportal/models/user_notification.py
@@ -109,19 +109,19 @@ def user_preferences(target, notification_setting, resource_type):
             return
         if not target.user.contact_email:
             return
+        # this ensures that an email is sent regardless of the user's preferences
+        # this is useful for group_admission_requests, where we want the admins to always be notified by email
+        if resource_type in ['group_admission_request']:
+            return True
+
+    if not target.user.preferences:
+        return
+
     if notification_setting == "sms":
         if client is None:
             return
         if not target.user.contact_phone:
             return
-
-    # this ensures that an email is sent regardless of the user's preferences
-    # this is useful for grou_admission_requests, where we want the admins to always be notified by email
-    if resource_type in ['group_admission_request'] and notification_setting == "email":
-        return True
-
-    if not target.user.preferences:
-        return
 
     if notification_setting == "slack":
         if not target.user.preferences.get('slack_integration'):
@@ -526,7 +526,7 @@ def add_user_notifications(mapper, connection, target):
                                             user=user,
                                             text=f"New classification *{target.classification}* for source *{target.obj_id}*",
                                             notification_type="sources",
-                                            url=f"/sources/{target.obj_id}",
+                                            url=f"/source/{target.obj_id}",
                                         )
                                     )
                     elif is_spectra:

--- a/skyportal/models/user_notification.py
+++ b/skyportal/models/user_notification.py
@@ -97,11 +97,11 @@ def notification_resource_type(target):
 
 
 def user_preferences(target, notification_setting, resource_type):
-    if not resource_type:
+    if not isinstance(notification_setting, str):
+        return
+    if not isinstance(resource_type, str):
         return
     if not target.user:
-        return
-    if not notification_setting:
         return
 
     if notification_setting == "email":
@@ -355,13 +355,9 @@ def add_user_notifications(mapper, connection, target):
                 )
             ).all()
             for gu in group_admins_gu:
-                group_admin = (
-                    session.scalars(
-                        sa.select(User).where(User.id == gu.user_id)
-                    ).first()
-                    if gu is not None
-                    else None
-                )
+                group_admin = session.scalars(
+                    sa.select(User).where(User.id == gu.user_id)
+                ).first()
 
                 if group_admin is not None:
                     users.append(group_admin)

--- a/skyportal/tests/frontend/test_notifications.py
+++ b/skyportal/tests/frontend/test_notifications.py
@@ -85,9 +85,11 @@ def test_group_admission_requests_notifications(
     driver.get(f"/become_user/{super_admin_user.id}")
     driver.get(f"/group/{public_group2.id}")
     driver.click_xpath('//*[@data-testid="notificationsButton"]')
-    driver.wait_for_xpath('//*[text()=" has requested to join "]')
+    driver.wait_for_xpath('//*[text()="New Group Admission Request from "]')
     driver.click_xpath('//*[@data-testid="deleteAllNotificationsButton"]')
-    driver.wait_for_xpath_to_disappear('//*[text()=" has requested to join "]')
+    driver.wait_for_xpath_to_disappear(
+        '//*[text()="New Group Admission Request from "]'
+    )
 
     filter_for_value(driver, user.username, last=True)
     driver.wait_for_xpath('//div[text()="pending"]')


### PR DESCRIPTION
This PR addresses an issue posted on the beta-testing channel on Slack. Some group admins complained that they were not notified clearly enough that users asked to join their group. This ensures that they are notified by email.

However, in order to work without modifying the current notification framework too much, it adds very little code that simply "bypasses" some of the verification logic to be sure that an email is sent, regardless of the user preferences.
It would be nice for reviewers to test this new feature, as well as existing features of the notification framework to make sure that everything else still works as intended.

