### PR TITLE
verify only one PhotStat per Obj

### DIFF
--- a/skyportal/handlers/api/phot_stat.py
+++ b/skyportal/handlers/api/phot_stat.py
@@ -708,6 +708,9 @@ class PhotStatUpdateHandler(BaseHandler):
                     stmt = sa.select(Photometry).where(Photometry.obj_id == obj.id)
                     photometry = session.scalars(stmt).all()
                     obj.photstats[0].full_update(photometry)
+                    # make sure only one photstats per object
+                    for j in range(1, len(obj.photstats)):
+                        session.delete(obj.photstats[j])
             except Exception as e:
                 return self.error(
                     f'Error calculating photometry stats: {e} for object {obj.id}'

--- a/skyportal/handlers/api/photometry.py
+++ b/skyportal/handlers/api/photometry.py
@@ -613,15 +613,17 @@ def insert_new_photometry_data(
         all_phot = session.scalars(
             sa.select(Photometry).where(Photometry.obj_id == obj_id)
         ).all()
-        phot_stat = PhotStat(obj_id=obj_id)
+
+        if phot_stat is None:
+            phot_stat = PhotStat(obj_id=obj_id)
+
         phot_stat.full_update(all_phot)
-        session.add(phot_stat)
 
     else:
         for phot in params:
             phot_stat.add_photometry_point(phot)
-            session.add(phot_stat)
 
+    session.add(phot_stat)
     session.commit()  # add the updated phot_stats
     return ids, upload_id
 


### PR DESCRIPTION
Turns out there were some cases where a single `Obj` had multiple `PhotStat` associated with it. 
This closes this loophole and uses the PATCH method to delete any additional `PhotStat` rows beyond the one getting a fresh update. 