### PR TITLE
Bug: Allocation page - List of allocations only showing allocations with an obs plan API

### DIFF
--- a/static/js/components/AllocationPage.jsx
+++ b/static/js/components/AllocationPage.jsx
@@ -292,6 +292,7 @@ const AllocationPage = () => {
                 <NewAllocation />
               </div>
             </Paper>
+            <br />
             <Paper>
               <div className={classes.paperContent}>
                 <Typography variant="h6">

--- a/static/js/components/NewDefaultObservationPlan.jsx
+++ b/static/js/components/NewDefaultObservationPlan.jsx
@@ -43,7 +43,9 @@ const NewDefaultObservationPlan = () => {
   const dispatch = useDispatch();
 
   const { telescopeList } = useSelector((state) => state.telescopes);
-  const { allocationList } = useSelector((state) => state.allocations);
+  const { allocationListApiObsplan } = useSelector(
+    (state) => state.allocations
+  );
 
   const allGroups = useSelector((state) => state.groups.all);
   const [selectedAllocationId, setSelectedAllocationId] = useState(null);
@@ -60,7 +62,7 @@ const NewDefaultObservationPlan = () => {
       // update
 
       const result = await dispatch(
-        allocationActions.fetchAllocations({
+        allocationActions.fetchAllocationsApiObsplan({
           apiType: "api_classname_obsplan",
         })
       );
@@ -77,11 +79,6 @@ const NewDefaultObservationPlan = () => {
         apiType: "api_classname_obsplan",
       })
     );
-    dispatch(
-      allocationActions.fetchAllocations({
-        apiType: "api_classname_obsplan",
-      })
-    );
 
     // Don't want to reset everytime the component rerenders and
     // the defaultStartDate is updated, so ignore ESLint here
@@ -90,10 +87,10 @@ const NewDefaultObservationPlan = () => {
 
   // need to check both of these conditions as selectedAllocationId is
   // initialized to be null and useEffect is not called on the first
-  // render to update it, so it can be null even if allocationList is not
+  // render to update it, so it can be null even if allocationListApiObsplan is not
   // empty.
   if (
-    allocationList.length === 0 ||
+    allocationListApiObsplan.length === 0 ||
     !selectedAllocationId ||
     Object.keys(instrumentFormParams).length === 0
   ) {
@@ -127,7 +124,7 @@ const NewDefaultObservationPlan = () => {
 
   const allocationLookUp = {};
   // eslint-disable-next-line no-unused-expressions
-  allocationList?.forEach((allocation) => {
+  allocationListApiObsplan?.forEach((allocation) => {
     allocationLookUp[allocation.id] = allocation;
   });
 
@@ -176,7 +173,7 @@ const NewDefaultObservationPlan = () => {
         name="followupRequestAllocationSelect"
         className={classes.Select}
       >
-        {allocationList?.map((allocation) => (
+        {allocationListApiObsplan?.map((allocation) => (
           <MenuItem
             value={allocation.id}
             key={allocation.id}

--- a/static/js/ducks/allocations.js
+++ b/static/js/ducks/allocations.js
@@ -6,11 +6,18 @@ import store from "../store";
 const FETCH_ALLOCATIONS = "skyportal/FETCH_ALLOCATIONS";
 const FETCH_ALLOCATIONS_OK = "skyportal/FETCH_ALLOCATIONS_OK";
 
+const FETCH_ALLOCATIONS_API_OBSPLAN = "skyportal/FETCH_ALLOCATIONS_API_OBSPLAN";
+const FETCH_ALLOCATIONS_API_OBSPLAN_OK =
+  "skyportal/FETCH_ALLOCATIONS_API_OBSPLAN_OK";
+
 const REFRESH_ALLOCATIONS = "skyportal/REFRESH_ALLOCATIONS";
 
 // eslint-disable-next-line import/prefer-default-export
 export const fetchAllocations = (params = {}) =>
   API.GET("/api/allocation", FETCH_ALLOCATIONS, params);
+
+export const fetchAllocationsApiObsplan = (params = {}) =>
+  API.GET("/api/allocation", FETCH_ALLOCATIONS_API_OBSPLAN, params);
 
 messageHandler.add((actionType, payload, dispatch) => {
   if (actionType === REFRESH_ALLOCATIONS) {
@@ -18,13 +25,23 @@ messageHandler.add((actionType, payload, dispatch) => {
   }
 });
 
-const reducer = (state = { allocationList: [] }, action) => {
+const reducer = (
+  state = { allocationList: [], allocationListApiObsplan: [] },
+  action
+) => {
   switch (action.type) {
     case FETCH_ALLOCATIONS_OK: {
       const allocationList = action.data;
       return {
         ...state,
         allocationList,
+      };
+    }
+    case FETCH_ALLOCATIONS_API_OBSPLAN_OK: {
+      const allocationListApiObsplan = action.data;
+      return {
+        ...state,
+        allocationListApiObsplan,
       };
     }
     default:


### PR DESCRIPTION
This PR addresses an issue found by users of the instance of Skyportal I have in production. On the allocation page, the list of allocations only shows the ones with an obs plan API type. This is because in the component to create new default obs plans, a useEffect is fetching allocations with the API type, which end up replacing the list of all allocations in the store.