### PR TITLE
Issues with Allocations on the Frontend: Full allocation's list replaced by sublists in several components

### DIFF
--- a/static/js/components/FollowupRequestForm.jsx
+++ b/static/js/components/FollowupRequestForm.jsx
@@ -46,7 +46,9 @@ const FollowupRequestForm = ({
   const classes = useStyles();
   const dispatch = useDispatch();
   const { telescopeList } = useSelector((state) => state.telescopes);
-  const { allocationList } = useSelector((state) => state.allocations);
+  const { allocationListApiClassname } = useSelector(
+    (state) => state.allocations
+  );
   const allGroups = useSelector((state) => state.groups.all);
   const defaultAllocationId = useSelector(
     (state) => state.profile.preferences.followupDefault
@@ -62,9 +64,7 @@ const FollowupRequestForm = ({
       // the new default form fields, so that the allocations list can
       // update
       const result = await dispatch(
-        allocationActions.fetchAllocations({
-          apiType: "api_classname",
-        })
+        allocationActions.fetchAllocationsApiClassname()
       );
 
       const { data } = result;
@@ -101,11 +101,6 @@ const FollowupRequestForm = ({
         apiType: "api_classname",
       })
     );
-    dispatch(
-      allocationActions.fetchAllocations({
-        apiType: "api_classname",
-      })
-    );
   }, [setSelectedAllocationId, setSelectedGroupIds, dispatch]);
 
   // need to check both of these conditions as selectedAllocationId is
@@ -113,12 +108,12 @@ const FollowupRequestForm = ({
   // render to update it, so it can be null even if allocationList is not
   // empty.
   if (
-    allocationList.length === 0 ||
+    allocationListApiClassname.length === 0 ||
     !selectedAllocationId ||
     !selectedGroupIds ||
     Object.keys(instrumentFormParams).length === 0
   ) {
-    return <h3>No robotic instruments available...</h3>;
+    return <h3>No allocations with an observation plan API...</h3>;
   }
 
   if (
@@ -145,7 +140,7 @@ const FollowupRequestForm = ({
   });
 
   const allocationLookUp = {};
-  allocationList?.forEach((allocation) => {
+  allocationListApiClassname?.forEach((allocation) => {
     allocationLookUp[allocation.id] = allocation;
   });
 
@@ -200,7 +195,7 @@ const FollowupRequestForm = ({
         name="followupRequestAllocationSelect"
         className={classes.allocationSelect}
       >
-        {allocationList?.map((allocation) => (
+        {allocationListApiClassname?.map((allocation) => (
           <MenuItem
             value={allocation.id}
             key={allocation.id}

--- a/static/js/components/FollowupRequestPreferences.jsx
+++ b/static/js/components/FollowupRequestPreferences.jsx
@@ -4,6 +4,7 @@ import Select from "@mui/material/Select";
 import MenuItem from "@mui/material/MenuItem";
 import makeStyles from "@mui/styles/makeStyles";
 
+import * as allocationActions from "../ducks/allocations";
 import * as profileActions from "../ducks/profile";
 import UserPreferencesHeader from "./UserPreferencesHeader";
 
@@ -18,7 +19,9 @@ const useStyles = makeStyles(() => ({
 
 const FollowupRequestPreferences = () => {
   const { telescopeList } = useSelector((state) => state.telescopes);
-  const { allocationList } = useSelector((state) => state.allocations);
+  const { allocationListApiClassname } = useSelector(
+    (state) => state.allocations
+  );
   const allGroups = useSelector((state) => state.groups.all);
   const { instrumentList, instrumentFormParams } = useSelector(
     (state) => state.instruments
@@ -33,9 +36,13 @@ const FollowupRequestPreferences = () => {
   const dispatch = useDispatch();
 
   useEffect(() => {
-    allocationList.unshift({ id: -1, name: "Clear selection" });
-  }, [dispatch, allocationList]);
+    dispatch(allocationActions.fetchAllocationsApiClassname());
+  }, [dispatch]);
 
+  const allocationListApiClassnameOptions = [
+    { id: -1, name: "No preference" },
+    ...allocationListApiClassname,
+  ];
   const handleChange = (event) => {
     const prefs = {
       followupDefault: event.target.value === -1 ? null : event.target.value,
@@ -45,12 +52,12 @@ const FollowupRequestPreferences = () => {
   };
 
   if (
-    allocationList.length === 0 ||
+    allocationListApiClassname.length === 0 ||
     instrumentList.length === 0 ||
     telescopeList.length === 0 ||
     Object.keys(instrumentFormParams).length === 0
   ) {
-    return <h3>No robotic instruments available...</h3>;
+    return <h3>No allocations with an API...</h3>;
   }
 
   const groupLookUp = {};
@@ -67,7 +74,7 @@ const FollowupRequestPreferences = () => {
 
   const allocationLookUp = {};
   // eslint-disable-next-line no-unused-expressions
-  allocationList?.forEach((allocation) => {
+  allocationListApiClassnameOptions?.forEach((allocation) => {
     allocationLookUp[allocation.id] = allocation;
   });
 
@@ -91,14 +98,14 @@ const FollowupRequestPreferences = () => {
         name="followupRequestAllocationSelect"
         className={classes.allocationSelect}
       >
-        {allocationList?.map((allocation) => (
+        {allocationListApiClassnameOptions?.map((allocation) => (
           <MenuItem
             value={allocation.id}
             key={allocation.id}
             className={classes.SelectItem}
           >
             {allocation.id === -1 ? (
-              <div>No preference</div>
+              allocation.name
             ) : (
               <div>
                 {`${

--- a/static/js/components/NewAPIObservation.jsx
+++ b/static/js/components/NewAPIObservation.jsx
@@ -15,7 +15,9 @@ dayjs.extend(utc);
 const NewAPIObservation = () => {
   const { instrumentList } = useSelector((state) => state.instruments);
   const { telescopeList } = useSelector((state) => state.telescopes);
-  const { allocationList } = useSelector((state) => state.allocations);
+  const { allocationListApiObsplan } = useSelector(
+    (state) => state.allocations
+  );
   const allGroups = useSelector((state) => state.groups.all);
 
   const dispatch = useDispatch();
@@ -32,23 +34,13 @@ const NewAPIObservation = () => {
       // Wait for the allocations to update before setting
       // the new default form fields, so that the allocations list can
       // update
-
-      await dispatch(
-        allocationActions.fetchAllocations({
-          apiType: "api_classname_obsplan",
-        })
-      );
+      await dispatch(allocationActions.fetchAllocationsApiObsplan());
     };
 
     getAllocations();
 
     dispatch(
       instrumentActions.fetchInstrumentForms({
-        apiType: "api_classname_obsplan",
-      })
-    );
-    dispatch(
-      allocationActions.fetchAllocations({
         apiType: "api_classname_obsplan",
       })
     );
@@ -67,8 +59,8 @@ const NewAPIObservation = () => {
     return <h3>No telescopes/instruments available...</h3>;
   }
 
-  if (allocationList.length === 0) {
-    return <h3>No robotic instruments available...</h3>;
+  if (allocationListApiObsplan.length === 0) {
+    return <h3>No allocations with an observation plan API...</h3>;
   }
 
   const groupLookUp = {};
@@ -130,7 +122,7 @@ const NewAPIObservation = () => {
       },
       allocation_id: {
         type: "integer",
-        oneOf: allocationList.map((allocation) => ({
+        oneOf: allocationListApiObsplan.map((allocation) => ({
           enum: [allocation.id],
           title: `${
             telLookUp[instLookUp[allocation.instrument_id].telescope_id].name
@@ -139,7 +131,7 @@ const NewAPIObservation = () => {
           } (PI ${allocation.pi})`,
         })),
         title: "Allocation",
-        default: allocationList[0]?.id,
+        default: allocationListApiObsplan[0]?.id,
       },
     },
     required: ["start_date", "end_date", "allocation_id"],

--- a/static/js/components/NewAPIQueuedObservation.jsx
+++ b/static/js/components/NewAPIQueuedObservation.jsx
@@ -15,7 +15,9 @@ dayjs.extend(utc);
 const NewAPIQueuedObservation = () => {
   const { instrumentList } = useSelector((state) => state.instruments);
   const { telescopeList } = useSelector((state) => state.telescopes);
-  const { allocationList } = useSelector((state) => state.allocations);
+  const { allocationListApiObsplan } = useSelector(
+    (state) => state.allocations
+  );
   const allGroups = useSelector((state) => state.groups.all);
 
   const dispatch = useDispatch();
@@ -33,22 +35,13 @@ const NewAPIQueuedObservation = () => {
       // the new default form fields, so that the allocations list can
       // update
 
-      await dispatch(
-        allocationActions.fetchAllocations({
-          apiType: "api_classname_obsplan",
-        })
-      );
+      await dispatch(allocationActions.fetchAllocationsApiObsplan());
     };
 
     getAllocations();
 
     dispatch(
       instrumentActions.fetchInstrumentForms({
-        apiType: "api_classname_obsplan",
-      })
-    );
-    dispatch(
-      allocationActions.fetchAllocations({
         apiType: "api_classname_obsplan",
       })
     );
@@ -67,8 +60,8 @@ const NewAPIQueuedObservation = () => {
     return <h3>No telescopes/instruments available...</h3>;
   }
 
-  if (allocationList.length === 0) {
-    return <h3>No robotic instruments available...</h3>;
+  if (allocationListApiObsplan.length === 0) {
+    return <h3>No allocations with an observation plan API...</h3>;
   }
 
   const groupLookUp = {};
@@ -133,7 +126,7 @@ const NewAPIQueuedObservation = () => {
       },
       allocation_id: {
         type: "integer",
-        oneOf: allocationList.map((allocation) => ({
+        oneOf: allocationListApiObsplan.map((allocation) => ({
           enum: [allocation.id],
           title: `${
             telLookUp[instLookUp[allocation.instrument_id].telescope_id].name
@@ -142,7 +135,7 @@ const NewAPIQueuedObservation = () => {
           } (PI ${allocation.pi})`,
         })),
         title: "Allocation",
-        default: allocationList[0]?.id,
+        default: allocationListApiObsplan[0]?.id,
       },
     },
     required: ["start_date", "end_date", "allocation_id"],

--- a/static/js/components/NewDefaultObservationPlan.jsx
+++ b/static/js/components/NewDefaultObservationPlan.jsx
@@ -62,9 +62,7 @@ const NewDefaultObservationPlan = () => {
       // update
 
       const result = await dispatch(
-        allocationActions.fetchAllocationsApiObsplan({
-          apiType: "api_classname_obsplan",
-        })
+        allocationActions.fetchAllocationsApiObsplan()
       );
 
       const { data } = result;
@@ -94,7 +92,7 @@ const NewDefaultObservationPlan = () => {
     !selectedAllocationId ||
     Object.keys(instrumentFormParams).length === 0
   ) {
-    return <h3>No robotic instruments available...</h3>;
+    return <h3>No allocations with an observation plan API...</h3>;
   }
 
   if (

--- a/static/js/components/ObservationPlanRequestForm.jsx
+++ b/static/js/components/ObservationPlanRequestForm.jsx
@@ -259,7 +259,9 @@ const ObservationPlanRequestForm = ({ gcnevent }) => {
   const dispatch = useDispatch();
 
   const { telescopeList } = useSelector((state) => state.telescopes);
-  const { allocationList } = useSelector((state) => state.allocations);
+  const { allocationListApiObsplan } = useSelector(
+    (state) => state.allocations
+  );
 
   const { useAMPM } = useSelector((state) => state.profile.preferences);
 
@@ -298,7 +300,7 @@ const ObservationPlanRequestForm = ({ gcnevent }) => {
 
   const allocationLookUp = {};
   // eslint-disable-next-line no-unused-expressions
-  allocationList?.forEach((allocation) => {
+  allocationListApiObsplan?.forEach((allocation) => {
     allocationLookUp[allocation.id] = allocation;
   });
 
@@ -337,9 +339,7 @@ const ObservationPlanRequestForm = ({ gcnevent }) => {
       // update
 
       const result = await dispatch(
-        allocationActions.fetchAllocations({
-          apiType: "api_classname_obsplan",
-        })
+        allocationActions.fetchAllocationsApiObsplan()
       );
 
       const { data } = result;
@@ -352,11 +352,6 @@ const ObservationPlanRequestForm = ({ gcnevent }) => {
 
     dispatch(
       instrumentsActions.fetchInstrumentForms({
-        apiType: "api_classname_obsplan",
-      })
-    );
-    dispatch(
-      allocationActions.fetchAllocations({
         apiType: "api_classname_obsplan",
       })
     );
@@ -373,14 +368,14 @@ const ObservationPlanRequestForm = ({ gcnevent }) => {
 
   // need to check both of these conditions as selectedAllocationId is
   // initialized to be null and useEffect is not called on the first
-  // render to update it, so it can be null even if allocationList is not
+  // render to update it, so it can be null even if allocationListApiObsplan is not
   // empty.
   if (
-    allocationList.length === 0 ||
+    allocationListApiObsplan.length === 0 ||
     !selectedAllocationId ||
     Object.keys(instrumentFormParams).length === 0
   ) {
-    return <h3>No robotic instruments available...</h3>;
+    return <h3>No allocations with an observation plan API...</h3>;
   }
 
   if (
@@ -501,7 +496,7 @@ const ObservationPlanRequestForm = ({ gcnevent }) => {
           name="followupRequestAllocationSelect"
           className={classes.allocationSelect}
         >
-          {allocationList?.map((allocation) => (
+          {allocationListApiObsplan?.map((allocation) => (
             <MenuItem
               value={allocation.id}
               key={allocation.id}

--- a/static/js/components/QueueAPIDisplay.jsx
+++ b/static/js/components/QueueAPIDisplay.jsx
@@ -42,7 +42,9 @@ const QueueAPIDisplay = () => {
 
   const { instrumentList } = useSelector((state) => state.instruments);
   const { telescopeList } = useSelector((state) => state.telescopes);
-  const { allocationList } = useSelector((state) => state.allocations);
+  const { allocationListApiObsplan } = useSelector(
+    (state) => state.allocations
+  );
   const allGroups = useSelector((state) => state.groups.all);
 
   const dispatch = useDispatch();
@@ -54,9 +56,7 @@ const QueueAPIDisplay = () => {
       // update
 
       const result = await dispatch(
-        allocationActions.fetchAllocations({
-          apiType: "api_classname_obsplan",
-        })
+        allocationActions.fetchAllocationsApiObsplan()
       );
 
       const { data } = result;
@@ -70,11 +70,6 @@ const QueueAPIDisplay = () => {
         apiType: "api_classname_obsplan",
       })
     );
-    dispatch(
-      allocationActions.fetchAllocations({
-        apiType: "api_classname_obsplan",
-      })
-    );
 
     // Don't want to reset everytime the component rerenders and
     // the defaultStartDate is updated, so ignore ESLint here
@@ -83,7 +78,7 @@ const QueueAPIDisplay = () => {
 
   useEffect(() => {
     const getQueues = async () => {
-      if (selectedAllocationId && allocationList?.length > 0) {
+      if (selectedAllocationId && allocationListApiObsplan?.length > 0) {
         const response = await dispatch(
           queuedObservationActions.requestAPIQueues(selectedAllocationId)
         );
@@ -108,8 +103,8 @@ const QueueAPIDisplay = () => {
     return <h3>No telescopes/instruments available...</h3>;
   }
 
-  if (allocationList.length === 0) {
-    return <h3>No robotic instruments available...</h3>;
+  if (allocationListApiObsplan.length === 0) {
+    return <h3>No allocations with an observation plan API...</h3>;
   }
 
   const groupLookUp = {};
@@ -132,7 +127,7 @@ const QueueAPIDisplay = () => {
 
   const allocationLookUp = {};
   // eslint-disable-next-line no-unused-expressions
-  allocationList?.forEach((allocation) => {
+  allocationListApiObsplan?.forEach((allocation) => {
     allocationLookUp[allocation.id] = allocation;
   });
 
@@ -163,7 +158,7 @@ const QueueAPIDisplay = () => {
         name="followupRequestAllocationSelect"
         className={classes.select}
       >
-        {allocationList?.map((allocation) => (
+        {allocationListApiObsplan?.map((allocation) => (
           <MenuItem
             value={allocation.id}
             key={allocation.id}

--- a/static/js/ducks/allocations.js
+++ b/static/js/ducks/allocations.js
@@ -10,14 +10,26 @@ const FETCH_ALLOCATIONS_API_OBSPLAN = "skyportal/FETCH_ALLOCATIONS_API_OBSPLAN";
 const FETCH_ALLOCATIONS_API_OBSPLAN_OK =
   "skyportal/FETCH_ALLOCATIONS_API_OBSPLAN_OK";
 
+const FETCH_ALLOCATIONS_API_CLASSNAME =
+  "skyportal/FETCH_ALLOCATIONS_API_CLASSNAME";
+const FETCH_ALLOCATIONS_API_CLASSNAME_OK =
+  "skyportal/FETCH_ALLOCATIONS_API_CLASSNAME_OK";
+
 const REFRESH_ALLOCATIONS = "skyportal/REFRESH_ALLOCATIONS";
 
 // eslint-disable-next-line import/prefer-default-export
-export const fetchAllocations = (params = {}) =>
-  API.GET("/api/allocation", FETCH_ALLOCATIONS, params);
+export const fetchAllocations = () =>
+  API.GET("/api/allocation", FETCH_ALLOCATIONS);
 
-export const fetchAllocationsApiObsplan = (params = {}) =>
-  API.GET("/api/allocation", FETCH_ALLOCATIONS_API_OBSPLAN, params);
+export const fetchAllocationsApiObsplan = () =>
+  API.GET("/api/allocation", FETCH_ALLOCATIONS_API_OBSPLAN, {
+    apiType: "api_classname_obsplan",
+  });
+
+export const fetchAllocationsApiClassname = () =>
+  API.GET("/api/allocation", FETCH_ALLOCATIONS_API_CLASSNAME, {
+    apiType: "api_classname",
+  });
 
 messageHandler.add((actionType, payload, dispatch) => {
   if (actionType === REFRESH_ALLOCATIONS) {
@@ -26,7 +38,11 @@ messageHandler.add((actionType, payload, dispatch) => {
 });
 
 const reducer = (
-  state = { allocationList: [], allocationListApiObsplan: [] },
+  state = {
+    allocationList: [],
+    allocationListApiObsplan: [],
+    allocationListApiClassname: [],
+  },
   action
 ) => {
   switch (action.type) {
@@ -42,6 +58,13 @@ const reducer = (
       return {
         ...state,
         allocationListApiObsplan,
+      };
+    }
+    case FETCH_ALLOCATIONS_API_CLASSNAME_OK: {
+      const allocationListApiClassname = action.data;
+      return {
+        ...state,
+        allocationListApiClassname,
       };
     }
     default:


### PR DESCRIPTION
This PR continues what has been done in #3267, which only solved the problem caused by one component from the allocations page itself. This adds similar changes but to all pages of SkyPortal that can affect the allocation's list, but in general have a negative effect on each other, causing some components to display incorrect allocations.

Caution: We talked about it with @mcoughlin, so I did my best to fix what I could from what I understood of the instruments, their API, allocations and how they work with Followup requests, Observations and Observation Plans. Now it would make sense to properly run the code and play with it to see if everything still behaves as expect.