### PR TITLE
Spectroscopy plot - Height of the plot is insufficient, too much scrolling on the Source Page

### DIFF
--- a/skyportal/plot.py
+++ b/skyportal/plot.py
@@ -2488,6 +2488,12 @@ def make_spectrum_layout(
     # To form columns from the rows, zip the rows together.
     element_dicts = zip(*rows)
 
+    # we add the height of the rows to the height of the plot
+    nb_rows = len(
+        list(zip(*itertools.zip_longest(*[iter(SPEC_LINES.items())] * columns)))[0]
+    )
+    plot_height += nb_rows * 60
+
     all_column_checkboxes = []
     for column_idx, element_dict in enumerate(element_dicts):
         element_dict = [e for e in element_dict if e is not None]


### PR DESCRIPTION
On the source page, to see the options below the spectroscopy plot, you have to scroll *quite a lot*. Because of that, the UX is impacted, as you can't see both the options and how they affect the plot without having to scroll up and down every time.