### PR TITLE
SourceAnalysisPage: Better display of the plots

### DIFF
--- a/static/js/components/SourceAnalysisPage.jsx
+++ b/static/js/components/SourceAnalysisPage.jsx
@@ -27,7 +27,6 @@ const useStyles = makeStyles((theme) => ({
   root: ({ size }) => ({
     width: size,
     margin: "0.5rem auto",
-    maxHeight: "31rem",
     flexGrow: 1,
   }),
   div: {
@@ -53,13 +52,11 @@ const useStyles = makeStyles((theme) => ({
     height: "95%",
     width: "95%",
   },
-  corner: {
-    height: "60%",
-    width: "60%",
+  corner: {                                                                                                                                                                                                                                                                                                  
+    height: "70vh",
   },
   media: {
-    height: "90%",
-    width: "90%",
+    height: "70vh",
   },
   downTriangle: {
     width: 0,

--- a/static/js/components/SourceAnalysisPage.jsx
+++ b/static/js/components/SourceAnalysisPage.jsx
@@ -52,7 +52,7 @@ const useStyles = makeStyles((theme) => ({
     height: "95%",
     width: "95%",
   },
-  corner: {                                                                                                                                                                                                                                                                                                  
+  corner: {
     height: "70vh",
   },
   media: {


### PR DESCRIPTION
Currently, on the analysis page, plots img width matches the width of the page. However, unless they are ina 16/9 ratio, they are cut and we can't see the whole height of the plots, even if we scroll. It's simply cut. 
To visualize some plots correctly, you are forced to download them.

This PR addresses that issue, by making sure that the plots img height matches the height of the page instead. That way, they might appear smaller, but the user can actually see the plots whole, and doesn't have to download them to see them properly.

That way, we also know that plots stay visible and are displayed properly even when we change the size of the browser's window.

Preview
![analysis_page_2](https://user-images.githubusercontent.com/49785117/184372424-97608506-2181-4b2a-a7fd-fb575fa324aa.gif)
