### PR TITLE
Query on allocation rather than proposal ID

### DIFF
--- a/services/gcn_service/gcn_service.py
+++ b/services/gcn_service/gcn_service.py
@@ -1,5 +1,6 @@
 from gcn_kafka import Consumer
 from datetime import datetime, timedelta
+import sqlalchemy as sa
 
 from baselayer.log import make_log
 from baselayer.app.models import init_db
@@ -23,11 +24,23 @@ client_secret = cfg['gcn.client_secret']
 notice_types = [
     f'gcn.classic.voevent.{notice_type}' for notice_type in cfg["gcn.notice_types"]
 ]
-config_gcn_observation_plans = [
+config_gcn_observation_plans_all = [
     observation_plan for observation_plan in cfg["gcn.observation_plans"]
 ]
-
 log = make_log('gcnserver')
+
+with DBSession() as session:
+    config_gcn_observation_plans = []
+    for config_gcn_observation_plan in config_gcn_observation_plans_all:
+        allocation = session.scalars(
+            sa.select(Allocation).where(
+                Allocation.proposal_id
+                == config_gcn_observation_plan["allocation-proposal_id"]
+            )
+        ).first()
+        if allocation is not None:
+            config_gcn_observation_plan["allocation_id"] = allocation.id
+            config_gcn_observation_plans.append(config_gcn_observation_plan)
 
 
 def service():
@@ -70,9 +83,7 @@ def service():
                         )
 
                         gcn_observation_plan = {}
-                        gcn_observation_plan[
-                            'allocation-proposal_id'
-                        ] = allocation.proposal_id
+                        gcn_observation_plan['allocation_id'] = allocation.id
                         gcn_observation_plan['payload'] = plan.payload
                         gcn_observation_plans.append(gcn_observation_plan)
                     gcn_observation_plans = (
@@ -87,10 +98,10 @@ def service():
                         "T", ""
                     )
                     for ii, gcn_observation_plan in enumerate(gcn_observation_plans):
-                        proposal_id = gcn_observation_plan['allocation-proposal_id']
+                        allocation_id = gcn_observation_plan['allocation_id']
                         allocation = (
                             session.query(Allocation)
-                            .filter(Allocation.proposal_id == proposal_id)
+                            .filter(Allocation.id == allocation_id)
                             .first()
                         )
 
@@ -110,7 +121,7 @@ def service():
 
                             post_observation_plan(plan, user_id, session)
                         else:
-                            log(f'No allocation with proposal_id {proposal_id}')
+                            log(f'No allocation with allocation_id {allocation_id}')
         except Exception as e:
             log(f'Failed to consume gcn event: {e}')
 


### PR DESCRIPTION
This PR queries on allocation rather than proposal ID for default observation plans, relevant as not all allocations have proposal IDs specified.