### PR TITLE
Return success when grabbing observations

### DIFF
--- a/skyportal/handlers/api/observation.py
+++ b/skyportal/handlers/api/observation.py
@@ -1147,6 +1147,7 @@ class ObservationExternalAPIHandler(BaseHandler):
             self.push_notification(
                 'Observation ingestion in progress. Should be available soon.'
             )
+            return self.success()
         except Exception as e:
             return self.error(f"Error in querying instrument API: {e}")
 


### PR DESCRIPTION
This PR returns success when querying for observations (otherwise throws JSON error now).