### PR TITLE
Loading symbol for group sources

### DIFF
--- a/static/js/components/GroupSources.jsx
+++ b/static/js/components/GroupSources.jsx
@@ -69,7 +69,7 @@ const GroupSources = ({ route }) => {
     );
   }, [route.id, dispatch]);
 
-  if (!savedSourcesState.sources && !pendingSourcesState.sources) {
+  if (!savedSourcesState.sources || !pendingSourcesState.sources) {
     return (
       <div>
         <CircularProgress color="secondary" />


### PR DESCRIPTION
This PR uses a loading symbol if either saved or pending sources are still loading.