### PR TITLE
Add classification management to usage doc

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -20,6 +20,70 @@ users the same subset of permissions.
 
 - Groups membership can be managed on the `/groups/` page (click through from profile)
 
+## Managing source classifications
+
+On the frontend, classifications can be managed from an individual source page or a group sources page.
+
+### On a source page:
+
+- Scroll to Classifications, choose the desired group(s) for the classification from the Choose Group dropdown
+- Select the desired taxonomy from the Taxonomy dropdown
+- In the Classification dropdown, choose the appropriate label
+- Assign a probability in the range [0, 1] in the Probability box
+- Click SUBMIT to post the classification
+- Classifications can be deleted using the trash bin button
+
+### On a group sources page:
+
+- Click the dropdown arrow to the left of a source id
+- Under Post Classifications, select a taxonomy from the dropdown
+- Select one of the Nonstellar or Stellar variable categories
+- The resulting dropdown contains sliders for each classification that can be dragged to the desired probability among [0, 0.25, 0.5, 0.75, 1]
+- If Normalize Probabilities is toggled, probabilities on a given level of the taxonomy will be scaled to sum to unity
+- Click SUBMIT CLASSIFICATIONS when finished
+
+### Programmatic access:
+
+- The API allows classifications to be managed using HTTP requests (see <https://skyportal.io/docs/api.html>).
+- The `GET` request allows existing classifications for a source with id `source_id` to be retrieved:
+```
+status, data = api(
+        'GET',
+        f'sources/{source_id}/classifications',
+        token=classification_token
+    )
+```
+- The `POST` request uploads new classifications for multiple sources using the following structure:
+```
+data = {
+         'classifications': [
+             {
+                 'obj_id': public_source.id,
+                 'classification': 'Algol',
+                 'taxonomy_id': taxonomy_id,
+                 'probability': 1.0,
+                 'group_ids': [public_group.id],
+             },
+             {
+                 'obj_id': public_source.id,
+                 'classification': 'Time-domain Source',
+                 'taxonomy_id': taxonomy_id,
+                 'probability': 1.0,
+                 'group_ids': [public_group.id],
+             },
+         ]
+     }
+```
+```
+status, data = api(
+         'POST',
+         'classification',
+         data=post_data,
+         token=classification_token,
+     )
+```
+- Classifications can be modified and deleted with the `PUT` and `DELETE` requests, respectively. These requests require the integer classification ID provided by the `GET` request. Both requests are made to the endpoint `'classification/{classification_id}'`.
+
 ## Important Makefile targets
 
 Run `make` to get a list of Makefile targets.  Here are some commonly


### PR DESCRIPTION
This PR adds a documentation section on classification management (via the frontend and API) to the Usage page (see #3431).