### PR TITLE
mount new persistent data directory for analysis results & fixup Docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,3 +9,24 @@ config.yaml
 test_config.yaml
 github_deploy_key.enc
 dbdata
+dask-worker-space
+webdriver-console
+cache
+
+# Git
+.git
+.gitignore
+.gitattributes
+.github
+
+# Docker
+Dockerfile
+docker-compose.yml
+.dockerignore
+
+
+# macOS
+.DS_Store
+
+# Visual Studio Code
+.vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && \
 RUN python3 -m venv /skyportal_env && \
     \
     bash -c "source /skyportal_env/bin/activate && \
-    pip install --upgrade pip==21.3.1 wheel numpy"
+    pip install --upgrade pip==22.2.2 wheel numpy"
 
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
@@ -40,7 +40,10 @@ RUN bash -c "\
     chown -R skyportal.skyportal /skyportal && \
     \
     mkdir -p /skyportal/static/thumbnails && \
-    chown -R skyportal.skyportal /skyportal/static/thumbnails"
+    chown -R skyportal.skyportal /skyportal/static/thumbnails && \
+    \
+    mkdir -p /skyportal/persistentdata/analysis && \
+    chown -R skyportal.skyportal /skyportal/persistentdata/analysis"
 
 USER skyportal
 

--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -602,6 +602,6 @@ health_monitor:
   startup_grace_seconds: 30
 
 analysis_services:
-  analysis_folder: analysis_data
+  analysis_folder: persistentdata/analysis
   sn_analysis_service:
     port: 6801

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,6 +7,9 @@ services:
       - "9000:5000"
       - "9001:5001"
     volumes:
+      # allow the data files to be mounted across containers
+      # if need be with the :z flag
+      # cf. https://stackoverflow.com/a/35222815
       - thumbnails:/skyportal/static/thumbnails:z
       - persistentdata:/skyportal/persistentdata:z
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,19 +7,22 @@ services:
       - "9000:5000"
       - "9001:5001"
     volumes:
-      - thumbnails:/skyportal/static/thumbnails
+      - thumbnails:/skyportal/static/thumbnails:z
+      - persistentdata:/skyportal/persistentdata:z
 
   db:
     image: postgres:14.4
+    container_name: postgres14.4
     environment:
       POSTGRES_USER: skyportal
       POSTGRES_PASSWORD: password
       POSTGRES_DB: skyportal
       PGDATA: /var/lib/postgresql/data/pgdata
     volumes:
-      - dbdata:/var/lib/postgresql/data/pgdata
+      - ./data/dbdata:/var/lib/postgresql/data:z
     restart: on-failure:3
 
 volumes:
   dbdata:
   thumbnails:
+  persistentdata:


### PR DESCRIPTION
* Update `.dockerignore` so we do not send more data into a new docker image than is needed
* Update `Dockerfile` to point to the newly mounted `/skyportal/persistentdata` directory
* Update `config.yaml.defaults` for the analysis data to be written to  `/skyportal/persistentdata`
* Make sure that `docker-compose.yaml` is up to date.

To make SP docker images
```bash
make docker-local
```
(On ARM architectures on Mac you may need to run `export DOCKER_DEFAULT_PLATFORM=linux/amd64` first)
