### PR TITLE
set group_id for GCN

### DIFF
--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -594,6 +594,8 @@ ports:
 gcn:
   server: gcn.nasa.gov
   # you can obtain a client_id and client_secret at https://gcn.nasa.gov/quickstart
+  # you can set a group_id to remember the last GCN the app ingested from the stream
+  group_id:
   client_id:
   client_secret:
   notice_types:

--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -595,7 +595,7 @@ gcn:
   server: gcn.nasa.gov
   # you can obtain a client_id and client_secret at https://gcn.nasa.gov/quickstart
   # you can set a group_id to remember the last GCN the app ingested from the stream
-  group_id:
+  client_group_id:
   client_id:
   client_secret:
   notice_types:

--- a/services/gcn_service/gcn_service.py
+++ b/services/gcn_service/gcn_service.py
@@ -56,12 +56,12 @@ def service():
         log('No notice_types configured to poll gcn events (config: gcn.notice_types')
         return
 
-    group_id = cfg['gcn.group_id']
-    if group_id is None or group_id == '':
-        group_id = str(uuid.uuid4())
+    client_group_id = cfg.get('gcn.client_group_id')
+    if client_group_id is None or client_group_id == '':
+        client_group_id = str(uuid.uuid4())
 
     config = {
-        'group.id': group_id,
+        'group.id': client_group_id,
         'auto.offset.reset': 'earliest',
         'enable.auto.commit': False,
     }

--- a/services/gcn_service/gcn_service.py
+++ b/services/gcn_service/gcn_service.py
@@ -1,6 +1,7 @@
 from gcn_kafka import Consumer
 from datetime import datetime, timedelta
 import sqlalchemy as sa
+import uuid
 
 from baselayer.log import make_log
 from baselayer.app.models import init_db
@@ -27,6 +28,7 @@ notice_types = [
 config_gcn_observation_plans_all = [
     observation_plan for observation_plan in cfg["gcn.observation_plans"]
 ]
+
 log = make_log('gcnserver')
 
 with DBSession() as session:
@@ -53,9 +55,22 @@ def service():
     if notice_types is None or notice_types == '' or notice_types == []:
         log('No notice_types configured to poll gcn events (config: gcn.notice_types')
         return
+
+    group_id = cfg['gcn.group_id']
+    if group_id is None or group_id == '':
+        group_id = str(uuid.uuid4())
+
+    config = {
+        'group.id': group_id,
+        'auto.offset.reset': 'earliest',
+        'enable.auto.commit': False,
+    }
     try:
         consumer = Consumer(
-            client_id=client_id, client_secret=client_secret, domain=cfg['gcn.server']
+            config=config,
+            client_id=client_id,
+            client_secret=client_secret,
+            domain=cfg['gcn.server'],
         )
     except Exception as e:
         log(f'Failed to initiate consumer to poll gcn events: {e}')
@@ -69,6 +84,7 @@ def service():
         try:
             for message in consumer.consume():
                 payload = message.value()
+                consumer.commit(message)
                 user_id = 1
                 with DBSession() as session:
                     default_observation_plans = session.query(
@@ -127,6 +143,7 @@ def service():
                             post_observation_plan(plan, user_id, session)
                         else:
                             log(f'No allocation with allocation_id {allocation_id}')
+
         except Exception as e:
             log(f'Failed to consume gcn event: {e}')
 


### PR DESCRIPTION
This PR allows one to set a group_id for GCN which will remember the last entry committed from the kafka stream.