### PR TITLE
Pin confluent-kafka

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -71,7 +71,6 @@ selenium==4.4.3
 selenium-requests==2.0.0
 afterglowpy==0.7.3
 gcn-kafka==0.2.3
-# dependency of gcn-kafka: pinning to understand memory effects on GCNEvents
-confluent_kafka==1.9.2
+confluent_kafka==1.9.2 # dependency of gcn-kafka: pinning to understand memory effects on GCNEvents
 iminuit==2.15.2
 watchdog==2.1.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-confluent_kafka==1.9.2
 numpy==1.22.3
 scipy==1.9.0
 pandas==1.4.3
@@ -72,5 +71,7 @@ selenium==4.4.3
 selenium-requests==2.0.0
 afterglowpy==0.7.3
 gcn-kafka==0.2.3
+# dependency of gcn-kafka: pinning to understand memory effects on GCNEvents
+confluent_kafka==1.9.2
 iminuit==2.15.2
 watchdog==2.1.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+confluent_kafka==1.9.2
 numpy==1.22.3
 scipy==1.9.0
 pandas==1.4.3


### PR DESCRIPTION
This PR pins confluent-kafka to the latest version, suggested by Leo to understand gcn memory requirements.