### PR TITLE
Use cache in source.py grab_query_results

### DIFF
--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -1048,6 +1048,7 @@ def get_sources(
                 include_thumbnails=False,
                 # include detection stats here as it is a query column,
                 include_detection_stats=include_detection_stats,
+                use_cache=True,
                 current_user=user,
             )
         except ValueError as e:


### PR DESCRIPTION
This PR attempts to address #3516 by setting `use_cache=True` in the call to `grab_query_results` in source.py. While I have not been able to replicate the duplicate source download issue in my local instance of SkyPortal, I have tested this change locally and downloads continue to work as expected.