### PR TITLE
Use public ZTFRef stars if Gaia servers are down (after retry)

### DIFF
--- a/skyportal/tests/utils/test_ztf_gaia_backup.py
+++ b/skyportal/tests/utils/test_ztf_gaia_backup.py
@@ -1,0 +1,22 @@
+from skyportal.utils.offset import get_astrometry_backup_from_ztf
+
+
+def test_get_astrometry_backup_from_ztf():
+
+    # This is a source in the ZTF Catalog
+    source_ra, source_dec = 123.2254682, 43.9976326
+    rez = get_astrometry_backup_from_ztf(source_ra, source_dec, max_offset_arcsec=60)
+    rez.sort("dist")
+    # We should find a number of sources, with the first one being near
+    # the known source
+    assert rez["dist"][0] < 0.1 / 3600.0
+
+
+def test_get_astrometry_outside_footprint():
+
+    # This is a source in the ZTF Catalog
+    source_ra, source_dec = 123, -75
+    rez = get_astrometry_backup_from_ztf(source_ra, source_dec, max_offset_arcsec=60)
+    # We should find no sources here since this is in the Southern Hemisphere
+    # expect to get None
+    assert len(rez) == 0

--- a/skyportal/utils/offset.py
+++ b/skyportal/utils/offset.py
@@ -868,6 +868,7 @@ def get_nearby_offset_stars(
     if r is None:
         if use_ztfref_as_gaia_backup:
             r = get_astrometry_backup_from_ztf(source_ra, source_dec)
+            use_ztfref = True
         else:
             return default_return
     if len(r) == 0:


### PR DESCRIPTION
This PR catches errors when the Gaia and backup Gaia DBs are down. It also retries the query just in case it's a temporary issue.