### PR TITLE
Clarify text upon photometry upload

### DIFF
--- a/static/js/components/UploadPhotometry.jsx
+++ b/static/js/components/UploadPhotometry.jsx
@@ -330,7 +330,8 @@ const UploadPhotometryForm = () => {
                       as={
                         <Select labelId="instrumentSelectLabel">
                           <MenuItem value="multiple" key={0}>
-                            Use instrument_id column
+                            Use instrument_id column (for one or more
+                            instruments)
                           </MenuItem>
                           {sortedInstrumentList.map((instrument) => (
                             <MenuItem value={instrument.id} key={instrument.id}>

--- a/static/js/components/UploadPhotometry.jsx
+++ b/static/js/components/UploadPhotometry.jsx
@@ -330,7 +330,7 @@ const UploadPhotometryForm = () => {
                       as={
                         <Select labelId="instrumentSelectLabel">
                           <MenuItem value="multiple" key={0}>
-                            Multiple (requires instrument_id column below)
+                            Use instrument_id column
                           </MenuItem>
                           {sortedInstrumentList.map((instrument) => (
                             <MenuItem value={instrument.id} key={instrument.id}>


### PR DESCRIPTION
This PR clarifies the text upon photometry upload, where it was said instrument_id in the upload file is for multiple instruments, where its really possible for one or more instrument.