### PR TITLE
improve mobile plot experience slightly

### DIFF
--- a/static/js/components/SourceMobile.jsx
+++ b/static/js/components/SourceMobile.jsx
@@ -240,7 +240,7 @@ export const useSourceStyles = makeStyles((theme) => ({
 }));
 
 const SourceMobile = WidthProvider(
-  withOrientationChange(({ source, isLandscape, width }) => {
+  withOrientationChange(({ source, isLandscape }) => {
     const matches = useMediaQuery("(min-width: 475px)");
     const centroidPlotSize = matches ? "21.875rem" : "17rem";
     const hrDiagramSize = matches ? 300 : 200;
@@ -295,7 +295,7 @@ const SourceMobile = WidthProvider(
       device = isLandscape ? "tablet_landscape" : "tablet_portrait";
     }
 
-    const plotWidth = isBrowser ? 800 : width - 100;
+    const plotWidth = isBrowser ? 800 : 300;
 
     return (
       <div className={classes.source}>

--- a/static/js/components/SourceMobile.jsx
+++ b/static/js/components/SourceMobile.jsx
@@ -244,6 +244,7 @@ const SourceMobile = WidthProvider(
     const matches = useMediaQuery("(min-width: 475px)");
     const centroidPlotSize = matches ? "21.875rem" : "17rem";
     const hrDiagramSize = matches ? 300 : 200;
+    const plotWidth = matches ? 800 : 300;
 
     const classes = useSourceStyles();
 
@@ -294,8 +295,6 @@ const SourceMobile = WidthProvider(
     } else if (isTablet) {
       device = isLandscape ? "tablet_landscape" : "tablet_portrait";
     }
-
-    const plotWidth = isBrowser ? 800 : 300;
 
     return (
       <div className={classes.source}>


### PR DESCRIPTION
Change plot width to fixed size instead of using unreliable react-grid-layout width for the time being, to slighltly improve mobile experience while using plots. 
<img width="314" alt="Screen Shot 2022-10-07 at 3 39 56 PM" src="https://user-images.githubusercontent.com/82007190/194649083-dd508a4b-58fb-4dc3-bca8-06b691a7d544.png">
<img width="314" alt="Screen Shot 2022-10-07 at 3 40 08 PM" src="https://user-images.githubusercontent.com/82007190/194649120-fa31c300-2259-48aa-a7d8-62a2bcf025a7.png">
addresses part of #2966 
