### PR TITLE
fix interface between thumbnails and post_alert

### DIFF
--- a/skyportal/handlers/api/thumbnail.py
+++ b/skyportal/handlers/api/thumbnail.py
@@ -639,9 +639,9 @@ def check_thumbnail_file(thumbnail, user_id, session):
 
         # Post a new one from alerts
         post_alert(
-            obj_id=thumbnail.obj_id,
+            object_id=thumbnail.obj_id,
             candid=0,
-            groups='all',
+            group_ids='all',
             program_id_selector={1},
             user_id=user_id,
             session=session,


### PR DESCRIPTION
I have not correctly copied the input names from `post_alerts` on fritz. 
It is very hard to develop across different repos. 
But I think we really got it this time! 