### PR TITLE
Update classification slider scaling

### DIFF
--- a/static/js/components/MultipleClassificationsForm.jsx
+++ b/static/js/components/MultipleClassificationsForm.jsx
@@ -110,17 +110,17 @@ const MultipleClassificationsForm = ({
   });
   const sortedClassifications = getSortedClasses(currentClassifications);
 
-  const normalizeProbabilities = useSelector(
-    (state) => state.classifications.normalizeProbabilities
+  const scaleProbabilities = useSelector(
+    (state) => state.classifications.scaleProbabilities
   );
 
-  const [normalizeProbabilitiesChecked, setNormalizeProbabilitiesChecked] =
-    useState(normalizeProbabilities);
+  const [scaleProbabilitiesChecked, setScaleProbabilitiesChecked] =
+    useState(scaleProbabilities);
 
-  const handleNormalizeProbabilitiesSwitchChange = (event) => {
-    setNormalizeProbabilitiesChecked(event.target.checked);
+  const handleScaleProbabilitiesSwitchChange = (event) => {
+    setScaleProbabilitiesChecked(event.target.checked);
     dispatch(
-      ClassificationsActions.setNormalizeProbabilities(event.target.checked)
+      ClassificationsActions.setScaleProbabilities(event.target.checked)
     );
   };
 
@@ -182,7 +182,6 @@ const MultipleClassificationsForm = ({
         newFormState[selectedTaxonomy.id][subclass.class]?.probability || 0;
       // New probability is the min of the parent and child probabilities
       // No child probabilities may be greater than the parent probability
-      console.log("currentProbability", currentProbability);
       const newProbability = Math.min(newValue, currentProbability) || 0;
 
       newFormState[selectedTaxonomy.id][subclass.class] = {
@@ -201,7 +200,7 @@ const MultipleClassificationsForm = ({
     };
 
     // Probability normalization
-    if (normalizeProbabilitiesChecked) {
+    if (scaleProbabilitiesChecked) {
       // Update higher-level classification probabilities to be
       // the max of the subclasses' probabilities.
       path?.forEach((ancestor, i) => {
@@ -413,12 +412,12 @@ const MultipleClassificationsForm = ({
         <FormControlLabel
           control={
             <Switch
-              checked={normalizeProbabilities || false}
-              onChange={handleNormalizeProbabilitiesSwitchChange}
+              checked={scaleProbabilities || false}
+              onChange={handleScaleProbabilitiesSwitchChange}
               inputProps={{ "aria-label": "controlled" }}
             />
           }
-          label="Normalize probabilities"
+          label="Scale parent/child probabilities"
         />
       </div>
       {selectedTaxonomy?.hierarchy?.subclasses?.map((category) => (

--- a/static/js/ducks/classifications.js
+++ b/static/js/ducks/classifications.js
@@ -1,7 +1,7 @@
 import store from "../store";
 
 const SET_TAXONOMY = "skyportal/SET_TAXONOMY";
-const SET_NORMALIZE_PROBABILITIES = "skyportal/SET_NORMALIZE_PROBABILITIES";
+const SET_SCALE_PROBABILITIES = "skyportal/SET_SCALE_PROBABILITIES";
 
 // eslint-disable-next-line import/prefer-default-export
 export const setTaxonomy = (taxonomy) => ({
@@ -10,9 +10,9 @@ export const setTaxonomy = (taxonomy) => ({
 });
 
 // eslint-disable-next-line import/prefer-default-export
-export const setNormalizeProbabilities = (normalizeProbabilities) => ({
-  type: SET_NORMALIZE_PROBABILITIES,
-  normalizeProbabilities,
+export const setScaleProbabilities = (scaleProbabilities) => ({
+  type: SET_SCALE_PROBABILITIES,
+  scaleProbabilities,
 });
 
 const reducer = (state = { rotateLogo: false }, action) => {
@@ -24,11 +24,11 @@ const reducer = (state = { rotateLogo: false }, action) => {
         taxonomy,
       };
     }
-    case SET_NORMALIZE_PROBABILITIES: {
-      const { normalizeProbabilities } = action;
+    case SET_SCALE_PROBABILITIES: {
+      const { scaleProbabilities } = action;
       return {
         ...state,
-        normalizeProbabilities,
+        scaleProbabilities,
       };
     }
     default:


### PR DESCRIPTION
This PR simplifies the behavior of the classification slider scaling on group source pages and resolves #2366 with a slight variation on the requested behavior:

- Parent classifications are updated such that their probability is ≥ the maximum of their children's probabilities.
- Sibling classification probabilities are not updated.
- Child classifications are updated such that their probabilities are ≤ their parent's probability. This is slightly different from the issue's request not to update children at all. I think it is appropriate to avoid parent classifications having a probability that is less than their children's probabilities.

This new behavior no longer normalizes the probabilities, so the toggle is now named 'Scale parent/child probabilities'. The benefit of these changes is that the slider behavior is more predictable, decreasing the likelihood that the classifying user will experience an unwanted update of probabilities.

![skyportal_classification_sliders](https://user-images.githubusercontent.com/42810347/198684704-404370e1-492c-4492-af41-6803941cee47.gif)
