### PR TITLE
Exptime, max_airmass and max_fwhm parameters for SEDM follow-up requests

### DIFF
--- a/skyportal/facility_apis/sedm.py
+++ b/skyportal/facility_apis/sedm.py
@@ -142,6 +142,9 @@ def convert_request_to_sedm(request, method_value='new'):
         'username': request.requester.username,
         'ra': request.obj.ra,
         'dec': request.obj.dec,
+        'exptime': request.payload['exposure_time'],
+        'max_airmass': request.payload['maximum_airmass'],
+        'max_fwhm': request.payload['maximum_fwhm'],
     }
 
     return payload
@@ -312,6 +315,25 @@ class SEDMAPI(FollowUpAPI):
                 "enum": _observation_types,
                 "title": "Mode",
                 "default": "IFU",
+            },
+            "exposure_time": {
+                "title": "Exposure Time (Photometry) [s]",
+                "type": "number",
+                "default": 0,
+            },
+            "maximum_airmass": {
+                "title": "Maximum Airmass (1-3)",
+                "type": "number",
+                "default": 2.8,
+                "minimum": 1,
+                "maximum": 3,
+            },
+            "maximum_fwhm": {
+                "title": "Maximum FWHM (1-10)",
+                "type": "number",
+                "default": 5,
+                "minimum": 1,
+                "maximum": 10,
             },
             "priority": {
                 "type": "number",

--- a/skyportal/facility_apis/sedm.py
+++ b/skyportal/facility_apis/sedm.py
@@ -331,7 +331,7 @@ class SEDMAPI(FollowUpAPI):
             "maximum_fwhm": {
                 "title": "Maximum FWHM (1-10)",
                 "type": "number",
-                "default": 5,
+                "default": 10,
                 "minimum": 1,
                 "maximum": 10,
             },


### PR DESCRIPTION
Added three new parameters for SEDM follow-up request api
- exposure_time : Exposure time in seconds for photometry observations only, single value, float, same for all filters
- maximum_airmass : Maximum airmass constraint for any observation, between 1 and 3, default 2.8
- maximum_fwhm : Maximum FWHM constraint for any observation, between 1 and 10, default 10