### PR TITLE
pin shapley to 1.8.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -79,3 +79,4 @@ confluent_kafka==1.9.2 # dependency of gcn-kafka: pinning to understand memory e
 iminuit==2.15.2
 watchdog==2.1.9
 PyAstronomy==0.18.0
+shapely==1.8.0


### PR DESCRIPTION
This makes it possible to read the geopandas maps using the latest numpy. 