### PR TITLE
Add galactic longitude and latitude to group source column options

### DIFF
--- a/static/js/components/SourceTable.jsx
+++ b/static/js/components/SourceTable.jsx
@@ -681,6 +681,16 @@ const SourceTable = ({
     return <div key={`${source.id}_dec_sex`}>{dec_to_dms(source.dec)}</div>;
   };
 
+  const renderGalLon = (dataIndex) => {
+    const source = sources[dataIndex];
+    return <div key={`${source.id}_gal_lon`}>{source.gal_lon.toFixed(6)}</div>;
+  };
+
+  const renderGalLat = (dataIndex) => {
+    const source = sources[dataIndex];
+    return <div key={`${source.id}_gal_lat`}>{source.gal_lat.toFixed(6)}</div>;
+  };
+
   const renderClassification = (dataIndex) => {
     const source = sources[dataIndex];
 
@@ -1080,6 +1090,28 @@ const SourceTable = ({
         sortThirdClickReset: true,
         display: displayedColumns.includes("Dec (dd:mm:ss)"),
         customBodyRenderLite: renderDecSex,
+      },
+    },
+    {
+      name: "l",
+      label: "l (deg)",
+      options: {
+        filter: false,
+        sort: true,
+        sortThirdClickReset: true,
+        display: displayedColumns.includes("l (deg)"),
+        customBodyRenderLite: renderGalLon,
+      },
+    },
+    {
+      name: "b",
+      label: "b (deg)",
+      options: {
+        filter: false,
+        sort: true,
+        sortThirdClickReset: true,
+        display: displayedColumns.includes("b (deg)"),
+        customBodyRenderLite: renderGalLat,
       },
     },
     {

--- a/static/js/components/SourceTable.jsx
+++ b/static/js/components/SourceTable.jsx
@@ -1486,6 +1486,8 @@ SourceTable.propTypes = {
       id: PropTypes.string,
       ra: PropTypes.number,
       dec: PropTypes.number,
+      gal_lon: PropTypes.number,
+      gal_lat: PropTypes.number,
       origin: PropTypes.string,
       alias: PropTypes.arrayOf(PropTypes.string),
       redshift: PropTypes.number,


### PR DESCRIPTION
This PR adds the galactic longitude and latitude to the list of displayable columns on the group sources page. The new columns are not shown by default. See below for an example of this change:

<img width="180" alt="Screen Shot 2022-12-02 at 1 08 12 PM" src="https://user-images.githubusercontent.com/42810347/205367997-3c2bb8da-72f2-4873-a97a-c3f9cdc1f89e.png">          <img width="600" alt="Screen Shot 2022-12-02 at 1 13 08 PM" src="https://user-images.githubusercontent.com/42810347/205368282-e0e36116-5284-429f-86f8-c99d1425fcd1.png">

