### PR TITLE
Remove jsonschema-to-openapi

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ mocpy==0.11.0
 obspy==1.4.0
 conesearch-alchemy==1.0.0
 regions==0.6
-jsonschema==3.2.0
+jsonschema==4.17.3
 jsonpath_ng==1.5.3
 pytest-rerunfailures==10.2
 timezonefinder==6.1.9
@@ -45,7 +45,6 @@ scp==0.14.4
 requests_toolbelt==0.10.1
 sendgrid==6.9.7
 twilio==7.15.4
-jsonschema-to-openapi==0.2.1
 responses==0.21.0
 numba==0.56.4
 pyvo==1.4

--- a/skyportal/facility_apis/_base.py
+++ b/skyportal/facility_apis/_base.py
@@ -1,4 +1,3 @@
-from jsonschema_to_openapi.convert import convert
 from copy import deepcopy
 
 
@@ -26,11 +25,6 @@ class _ListenerBase:
         base['title'] = cls.__name__
         base['additionalProperties'] = False
         return base
-
-    @classmethod
-    def openapi_spec(cls):
-        """OpenAPI representation of the user-contributed JSONSchema."""
-        return convert(cls.complete_schema())
 
     @classmethod
     def get_acl_id(cls):


### PR DESCRIPTION
This PR removes jsonschema-to-openapi, which provides unused functionality (with an unmaintained package).