### PR TITLE
Filter sources labelled by current user

### DIFF
--- a/static/js/components/SourceTableFilterForm.jsx
+++ b/static/js/components/SourceTableFilterForm.jsx
@@ -216,6 +216,19 @@ const SourceTableFilterForm = ({ handleFilterSubmit }) => {
 
   const validate = (formData) => {
     let valid = true;
+    if (
+      formData.currentUserLabeller === true &&
+      formData.hasBeenLabelled === false &&
+      formData.hasNotBeenLabelled === false
+    ) {
+      dispatch(
+        showNotification(
+          "Please specify whether to filter for labelled or not labelled sources by the current user",
+          "error"
+        )
+      );
+      valid = false;
+    }
     if (formData.gcneventid !== "" || formData.localizationid !== "") {
       if (formData.startDate === "" || formData.endDate === "") {
         dispatch(

--- a/static/js/components/SourceTableFilterForm.jsx
+++ b/static/js/components/SourceTableFilterForm.jsx
@@ -996,6 +996,25 @@ const SourceTableFilterForm = ({ handleFilterSubmit }) => {
                 />
               }
             />
+            <FormControlLabel
+              label="by me"
+              labelPlacement="start"
+              control={
+                <Controller
+                  render={({ field: { onChange, value } }) => (
+                    <Checkbox
+                      color="primary"
+                      type="checkbox"
+                      onChange={(event) => onChange(event.target.checked)}
+                      checked={value}
+                    />
+                  )}
+                  name="currentUserLabeller"
+                  control={control}
+                  defaultValue={false}
+                />
+              }
+            />
           </div>
         </div>
         <div className={classes.formItem}>

--- a/static/js/components/SourceTableFilterForm.jsx
+++ b/static/js/components/SourceTableFilterForm.jsx
@@ -142,6 +142,11 @@ const SourceTableFilterForm = ({ handleFilterSubmit }) => {
     []
   );
 
+  const [byMe, setByMe] = useState(false);
+  const handleChange = (event) => {
+    setByMe(event.target.checked);
+  };
+
   const maxNumDaysUsingLocalization = useSelector(
     (state) => state.config.maxNumDaysUsingLocalization
   );
@@ -980,7 +985,10 @@ const SourceTableFilterForm = ({ handleFilterSubmit }) => {
                     <Checkbox
                       color="primary"
                       type="checkbox"
-                      onChange={(event) => onChange(event.target.checked)}
+                      onChange={(event) => {
+                        onChange(event.target.checked);
+                        handleChange(event);
+                      }}
                       checked={value}
                     />
                   )}
@@ -999,7 +1007,10 @@ const SourceTableFilterForm = ({ handleFilterSubmit }) => {
                     <Checkbox
                       color="primary"
                       type="checkbox"
-                      onChange={(event) => onChange(event.target.checked)}
+                      onChange={(event) => {
+                        onChange(event.target.checked);
+                        handleChange(event);
+                      }}
                       checked={value}
                     />
                   )}
@@ -1012,6 +1023,7 @@ const SourceTableFilterForm = ({ handleFilterSubmit }) => {
             <FormControlLabel
               label="by me"
               labelPlacement="start"
+              disabled={!byMe}
               control={
                 <Controller
                   render={({ field: { onChange, value } }) => (
@@ -1020,6 +1032,7 @@ const SourceTableFilterForm = ({ handleFilterSubmit }) => {
                       type="checkbox"
                       onChange={(event) => onChange(event.target.checked)}
                       checked={value}
+                      disabled={!byMe}
                     />
                   )}
                   name="currentUserLabeller"


### PR DESCRIPTION
This PR allows users to filter sources by whether the user has personally labelled or not labelled a source. This will allow users to easily pick up where they left off in the labelling process regardless of how their progress compares to other users.

A new 'by me' checkbox is added in the 'Which have been...' part of the filter table to facilitate this change (see below). Users will get an error if they select 'by me' without also selecting one of 'labelled' or 'not labelled'. If 'by me' is not checked, the filter will return the sources labelled or not labelled by any user, as it currently does.

<img width="350" alt="Screen Shot 2023-01-04 at 4 11 58 PM" src="https://user-images.githubusercontent.com/42810347/210659896-d819cfa8-807a-44b2-8ab0-e6f7e9e651f3.png">
