### PR TITLE
bump version numbers to sync with baselayer requirements

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -61,7 +61,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'skyportal'
-copyright = '2020, The SkyPortal Team'
+copyright = '2020–2023, The SkyPortal Team'
 author = 'The SkyPortal Team'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -6,12 +6,12 @@ SkyPortal requires the following software to be installed.  We show
 how to install them on MacOS and Debian-based systems below.
 
 - Python 3.8 or later
-- Supervisor (v>=3.0b2)
+- Supervisor (v>=4.2.1)
 - NGINX (v>=1.7)
 - PostgreSQL (v>=14.0)
-- Node.JS/npm (v>=5.8.0)
+- Node.JS/npm (v>=16.14.0/8.3.2)
 
-When installing SkyPortal on Debian-based systems, 2 additional packages are required to be able to install pycurl later on:
+When installing SkyPortal on Debian-based systems, 2 additional packages are required to be able to install `pycurl` later on:
 
 - libcurl4-gnutls-dev
 - libgnutls28-dev


### PR DESCRIPTION
Sync some of the system dependencies in the docs to those in baselayer (c.f. `baselayer/tools/check_app_environment.py). Bump copyright dates to 2023.