### PR TITLE
Dockerfile - Uncommented SNID and STDPipe dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-# lines to uncomment if you want to use the image analysis feature
-# RUN apt-get update && \
-#     apt-get install -y sextractor scamp psfex
+# lines to comment if you do not want to use the image analysis feature
+RUN apt-get update && \
+    apt-get install -y sextractor scamp psfex
 
 RUN apt-get update && \
     apt-get install -y curl build-essential software-properties-common && \
@@ -25,15 +25,16 @@ RUN python3 -m venv /skyportal_env && \
     pip install --upgrade pip==22.2.2 wheel numpy"
 
 
-# lines to uncomment if you want to use the image analysis feature
-# RUN git clone https://github.com/Theodlz/snid-install-ubuntu.git && \
-#     cd snid-install-ubuntu && chmod +x install.sh && bash ./install.sh
+# lines to uncomment if you do not want to use the image analysis feature
+RUN git clone https://github.com/Theodlz/snid-install-ubuntu.git && \
+    cd snid-install-ubuntu && chmod +x install.sh && bash ./install.sh
 
-# RUN python3 -m venv /skyportal_env && \
-#     bash -c "source /skyportal_env/bin/activate && \
-#     git clone https://github.com/karpov-sv/stdpipe.git && \
-#     cd stdpipe && pip install -e . && \
-#     pip install astroscrappy"
+# lines to uncomment if you do not want to use the image analysis feature
+RUN python3 -m venv /skyportal_env && \
+    bash -c "source /skyportal_env/bin/activate && \
+    git clone https://github.com/karpov-sv/stdpipe.git && \
+    cd stdpipe && pip install -e . && \
+    pip install astroscrappy"
 
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8


### PR DESCRIPTION
As having SNID and STDPipe installed in SP does not cause any problem with existing features, and facilitates SP's deployment and testing (as well as its maintenance by avoiding a duplicate Dockerfile in the extension folder of Fritz), it seems like a good decision to uncomment the dependencies install lines from the Dockerfile.