### PR TITLE
Fix issue with Docker workflow on push

### DIFF
--- a/.github/workflows/test_docker_build.yaml
+++ b/.github/workflows/test_docker_build.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   test:
-    if: contains(github.event.pull_request.labels.*.name, 'docker')
+    if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'docker')
     name: Test Docker build
     runs-on: ubuntu-latest
     timeout-minutes: 30


### PR DESCRIPTION
#3862 introduced a bug by only triggering action on label, and not running it on push. This PR attempts to make both conditions work.