### PR TITLE
fail_timeout

### DIFF
--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -445,6 +445,11 @@ server:
   # The max size of a request body in megabytes (M)
   max_body_size: 10
 
+  # nginx parameter which sets both the time in seconds before which
+  # the server is considered unavailable and the subsequent period of
+  # time the server will be unavailable
+  fail_timeout: 20
+
   # Rate limit: number of requests per second (see https://www.nginx.com/blog/rate-limiting-nginx/)
   rate_limit: 5
   # Rate limit burst size (https://www.nginx.com/blog/rate-limiting-nginx/#bursts)


### PR DESCRIPTION
This PR adds fail_timeout to the skyportal config.