### PR TITLE
Upload-only Analysis

### DIFF
--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -673,6 +673,7 @@ health_monitor:
 
 analysis_services:
   analysis_folder: persistentdata/analysis
+  max_analysis_per_obj_per_user: 50
   sn_analysis_service:
     port: 6801
   ngsf_analysis_service:

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "redux-thunk": "2.4.2",
     "regl": "2.1.0",
     "semver": "7.3.7",
+    "sprintf-js": "1.1.2",
     "style-loader": "2.0.0",
     "styled-components": "5.3.5",
     "timezone": "1.0.23",

--- a/services/sn_analysis_service/app.py
+++ b/services/sn_analysis_service/app.py
@@ -5,7 +5,6 @@ import base64
 import traceback
 import json
 
-# import PIL
 import joblib
 import numpy as np
 import matplotlib

--- a/services/sn_analysis_service/app.py
+++ b/services/sn_analysis_service/app.py
@@ -5,6 +5,7 @@ import base64
 import traceback
 import json
 
+# import PIL
 import joblib
 import numpy as np
 import matplotlib

--- a/skyportal/app_server.py
+++ b/skyportal/app_server.py
@@ -8,6 +8,7 @@ from baselayer.log import make_log
 from skyportal.handlers import BecomeUserHandler, LogoutHandler
 from skyportal.handlers.api import (
     ACLHandler,
+    AnalysisUploadHandler,
     AnalysisServiceHandler,
     AnalysisHandler,
     AnalysisProductsHandler,
@@ -202,6 +203,7 @@ skyportal_handlers = [
     (r'/api/allocation/report(/[0-9]+)', AllocationReportHandler),
     (r'/api/allocation(/.*)?', AllocationHandler),
     (r'/api/analysis_service(/.*)?', AnalysisServiceHandler),
+    (r'/api/(obj)/([0-9A-Za-z-_]+)/analysis_upload(/[0-9]+)?', AnalysisUploadHandler),
     (r'/api/(obj)/([0-9A-Za-z-_]+)/analysis(/[0-9]+)?', AnalysisHandler),
     (r'/api/(obj)/analysis(/[0-9]+)?', AnalysisHandler),
     (

--- a/skyportal/app_server.py
+++ b/skyportal/app_server.py
@@ -8,7 +8,7 @@ from baselayer.log import make_log
 from skyportal.handlers import BecomeUserHandler, LogoutHandler
 from skyportal.handlers.api import (
     ACLHandler,
-    AnalysisUploadHandler,
+    AnalysisUploadOnlyHandler,
     AnalysisServiceHandler,
     AnalysisHandler,
     AnalysisProductsHandler,
@@ -203,7 +203,10 @@ skyportal_handlers = [
     (r'/api/allocation/report(/[0-9]+)', AllocationReportHandler),
     (r'/api/allocation(/.*)?', AllocationHandler),
     (r'/api/analysis_service(/.*)?', AnalysisServiceHandler),
-    (r'/api/(obj)/([0-9A-Za-z-_]+)/analysis_upload(/[0-9]+)?', AnalysisUploadHandler),
+    (
+        r'/api/(obj)/([0-9A-Za-z-_]+)/analysis_upload(/[0-9]+)?',
+        AnalysisUploadOnlyHandler,
+    ),
     (r'/api/(obj)/([0-9A-Za-z-_]+)/analysis(/[0-9]+)?', AnalysisHandler),
     (r'/api/(obj)/analysis(/[0-9]+)?', AnalysisHandler),
     (

--- a/skyportal/handlers/api/__init__.py
+++ b/skyportal/handlers/api/__init__.py
@@ -1,7 +1,7 @@
 from .acls import ACLHandler, UserACLHandler
 from .allocation import AllocationHandler, AllocationReportHandler
 from .analysis import (
-    AnalysisUploadHandler,
+    AnalysisUploadOnlyHandler,
     AnalysisServiceHandler,
     AnalysisHandler,
     AnalysisProductsHandler,

--- a/skyportal/handlers/api/__init__.py
+++ b/skyportal/handlers/api/__init__.py
@@ -1,6 +1,7 @@
 from .acls import ACLHandler, UserACLHandler
 from .allocation import AllocationHandler, AllocationReportHandler
 from .analysis import (
+    AnalysisUploadHandler,
     AnalysisServiceHandler,
     AnalysisHandler,
     AnalysisProductsHandler,

--- a/skyportal/handlers/api/analysis.py
+++ b/skyportal/handlers/api/analysis.py
@@ -755,6 +755,16 @@ class AnalysisHandler(BaseHandler):
                     message=f'Could not access Analysis Service ID: {analysis_service_id}.',
                     status=403,
                 )
+
+            if analysis_service.upload_only:
+                return self.error(
+                    message=(
+                        f'Analysis Service ID: {analysis_service_id} is of type upload_only.'
+                        ' Please use the analysis_upload endpoint.'
+                    ),
+                    status=403,
+                )
+
             input_data_types = analysis_service.input_data_types.copy()
 
             analysis_parameters = data.get('analysis_parameters', {})
@@ -1310,3 +1320,176 @@ class AnalysisProductsHandler(BaseHandler):
                 )
 
             return self.error("No data found for this Analysis.", status=404)
+
+
+class AnalysisUploadHandler(BaseHandler):
+    @permissions(['Run Analyses'])
+    def post(self, analysis_resource_type, resource_id, analysis_service_id):
+        """
+        ---
+        description: Upload an upload_only analysis result
+        tags:
+          - analysis
+        parameters:
+          - in: path
+            name: analysis_resource_type
+            required: true
+            schema:
+              type: string
+            description: |
+               What underlying data the analysis is on:
+               must be "obj" (more to be added in the future)
+          - in: path
+            name: resource_id
+            required: true
+            schema:
+              type: string
+            description: |
+               The ID of the underlying data.
+               This would be a string for an object ID.
+          - in: path
+            name: analysis_service_id
+            required: true
+            schema:
+              type: string
+            description: the analysis service id to be used
+        requestBody:
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  results:
+                    type: object
+                    description: Results data of this analysis
+                  show_parameters:
+                    type: boolean
+                    description: Whether to render the parameters of this analysis
+                  show_plots:
+                    type: boolean
+                    description: Whether to render the plots of this analysis
+                  show_corner:
+                    type: boolean
+                    description: Whether to render the corner plots of this analysis
+                  group_ids:
+                    type: array
+                    items:
+                      type: integer
+                    description: |
+                      List of group IDs corresponding to which groups should be
+                      able to view analysis results. Defaults to all of requesting user's
+                      groups.
+        responses:
+          200:
+            content:
+              application/json:
+                schema:
+                  allOf:
+                    - $ref: '#/components/schemas/Success'
+                    - type: object
+                      properties:
+                        data:
+                          type: object
+                          properties:
+                            analysis_id:
+                              type: integer
+                              description: New analysis ID
+        """
+        # allowable resources now are [obj]. Can be extended in the future.
+        if analysis_resource_type.lower() not in ['obj']:
+            return self.error("Invalid analysis resource type", status=403)
+
+        try:
+            data = self.get_json()
+        except Exception as e:
+            return self.error(f'Error parsing JSON: {e}')
+
+        with self.Session() as session:
+
+            stmt = AnalysisService.select(self.current_user).where(
+                AnalysisService.id == analysis_service_id
+            )
+            analysis_service = session.scalars(stmt).first()
+            if analysis_service is None:
+                return self.error(
+                    message=f'Could not access Analysis Service ID: {analysis_service_id}.',
+                    status=403,
+                )
+            if not analysis_service.upload_only:
+                return self.error(
+                    message=f'Analysis Service ID: {analysis_service_id} is not of type upload_only.',
+                    status=403,
+                )
+
+            # analysis_parameters = data.get('analysis_parameters', {})
+            group_ids = data.pop('group_ids', None)
+            if not group_ids:
+                group_ids = [g.id for g in self.current_user.accessible_groups]
+
+            groups = session.scalars(
+                Group.select(self.current_user).where(Group.id.in_(group_ids))
+            ).all()
+            if {g.id for g in groups} != set(group_ids):
+                return self.error(
+                    f'Cannot find one or more groups with IDs: {group_ids}.'
+                )
+
+            data["groups"] = groups
+            author = self.associated_user_object
+            data["author"] = author
+
+            status_message = data.get("message", "")
+
+            if analysis_resource_type.lower() == 'obj':
+                obj_id = resource_id
+                stmt = Obj.select(self.current_user).where(Obj.id == obj_id)
+                obj = session.scalars(stmt).first()
+                if obj is None:
+                    return self.error(f'Obj {obj_id} not found', status=404)
+                data["obj_id"] = obj_id
+                data["obj"] = obj
+
+                invalid_after = datetime.datetime.utcnow() + datetime.timedelta(
+                    seconds=10
+                )
+                analysis = ObjAnalysis(
+                    obj=obj,
+                    author=author,
+                    groups=groups,
+                    analysis_service=analysis_service,
+                    show_parameters=data.get('show_parameters', True),
+                    show_plots=data.get('show_plots', True),
+                    show_corner=data.get('show_corner', True),
+                    analysis_parameters={},
+                    status='completed',
+                    status_message=status_message,
+                    handled_by_url="/",
+                    invalid_after=invalid_after,
+                    last_activity=datetime.datetime.utcnow(),
+                )
+            else:
+                return self.error(
+                    f'analysis_resource_type must be one of {", ".join(["obj"])}',
+                    status=404,
+                )
+            session.add(analysis)
+            try:
+                session.commit()
+            except IntegrityError as e:
+                return self.error(f'Analysis already exists: {str(e)}')
+            except Exception as e:
+                return self.error(f'Unexpected error creating analysis: {str(e)}')
+
+            results = data.get("analysis", {})
+            if len(results.keys()) > 0:
+                analysis._data = results
+                analysis.save_data()
+                log(
+                    f"Saved upload_only analysis data at {analysis.filename}. Message: {analysis.status_message}"
+                )
+            else:
+                log(
+                    f"Note: empty analysis upload_only results. Message: {analysis.status_message}"
+                )
+            session.commit()
+            return self.success(data={"id": analysis.id})

--- a/skyportal/handlers/api/analysis.py
+++ b/skyportal/handlers/api/analysis.py
@@ -1421,7 +1421,6 @@ class AnalysisUploadHandler(BaseHandler):
                     status=403,
                 )
 
-            # analysis_parameters = data.get('analysis_parameters', {})
             group_ids = data.pop('group_ids', None)
             if not group_ids:
                 group_ids = [g.id for g in self.current_user.accessible_groups]
@@ -1484,12 +1483,9 @@ class AnalysisUploadHandler(BaseHandler):
             if len(results.keys()) > 0:
                 analysis._data = results
                 analysis.save_data()
-                log(
-                    f"Saved upload_only analysis data at {analysis.filename}. Message: {analysis.status_message}"
-                )
+                message = f"Saved upload_only analysis data at {analysis.filename}. Message: {analysis.status_message}"
             else:
-                log(
-                    f"Note: empty analysis upload_only results. Message: {analysis.status_message}"
-                )
+                message = f"Note: empty analysis upload_only results. Message: {analysis.status_message}"
+            log(message)
             session.commit()
-            return self.success(data={"id": analysis.id})
+            return self.success(data={"id": analysis.id, "message": message})

--- a/skyportal/handlers/api/analysis.py
+++ b/skyportal/handlers/api/analysis.py
@@ -798,10 +798,7 @@ class AnalysisHandler(BaseHandler):
                     f'Cannot find one or more groups with IDs: {group_ids}.'
                 )
 
-            data["groups"] = groups
             author = self.associated_user_object
-            data["author"] = author
-
             inputs = {"analysis_parameters": analysis_parameters}
 
             if analysis_resource_type.lower() == 'obj':
@@ -810,8 +807,6 @@ class AnalysisHandler(BaseHandler):
                 obj = session.scalars(stmt).first()
                 if obj is None:
                     return self.error(f'Obj {obj_id} not found', status=404)
-                data["obj_id"] = obj_id
-                data["obj"] = obj
 
                 # make sure the user has not exceeded the maximum number of analyses
                 # for this object. This will help save space on the disk
@@ -1348,7 +1343,7 @@ class AnalysisProductsHandler(BaseHandler):
             return self.error("No data found for this Analysis.", status=404)
 
 
-class AnalysisUploadHandler(BaseHandler):
+class AnalysisUploadOnlyHandler(BaseHandler):
     @permissions(['Run Analyses'])
     def post(self, analysis_resource_type, resource_id, analysis_service_id):
         """
@@ -1459,10 +1454,7 @@ class AnalysisUploadHandler(BaseHandler):
                     f'Cannot find one or more groups with IDs: {group_ids}.'
                 )
 
-            data["groups"] = groups
             author = self.associated_user_object
-            data["author"] = author
-
             status_message = data.get("message", "")
 
             if analysis_resource_type.lower() == 'obj':
@@ -1471,8 +1463,6 @@ class AnalysisUploadHandler(BaseHandler):
                 obj = session.scalars(stmt).first()
                 if obj is None:
                     return self.error(f'Obj {obj_id} not found', status=404)
-                data["obj_id"] = obj_id
-                data["obj"] = obj
 
                 # make sure the user has not exceeded the maximum number of analyses
                 # for this object. This will help save space on the disk

--- a/skyportal/handlers/api/webhook.py
+++ b/skyportal/handlers/api/webhook.py
@@ -108,7 +108,7 @@ class AnalysisWebhookHandler(BaseHandler):
             analysis.duration = (analysis.last_activity - last_active).total_seconds()
             session.commit()
         except Exception as e:
-            log(f'Troubling accessing Analysis with token {token} {e}.')
+            log(f'Trouble accessing Analysis with token {token} {e}.')
             return self.error("Invalid token", status=403)
 
         data = self.get_json()

--- a/skyportal/models/analysis.py
+++ b/skyportal/models/analysis.py
@@ -403,7 +403,7 @@ class AnalysisMixin:
         else:
             reg = RE_NO_SLASHES
 
-        if not reg.match(string):
+        if string is None or not reg.match(string):
             raise ValueError(f'Illegal characters in string "{string}". ')
 
     @hybrid_property

--- a/skyportal/models/analysis.py
+++ b/skyportal/models/analysis.py
@@ -403,8 +403,10 @@ class AnalysisMixin:
         else:
             reg = RE_NO_SLASHES
 
-        if string is None or not reg.match(string):
-            raise ValueError(f'Illegal characters in string "{string}". ')
+        if string is None:
+            raise ValueError("String cannot be None.")
+        if not reg.match(string):
+            raise ValueError(f'Illegal characters in string "{string}".')
 
     @hybrid_property
     def data(self):

--- a/skyportal/tests/api/test_analysis.py
+++ b/skyportal/tests/api/test_analysis.py
@@ -972,3 +972,79 @@ def test_retrieve_data_products(
         )
         assert status == 404
         assert data["message"].find("No data found") != -1
+
+
+def test_upload_analysis(
+    analysis_service_token, analysis_token, public_group, public_source, view_only_token
+):
+    name = str(uuid.uuid4())
+
+    post_data = {
+        'name': name,
+        'display_name': "test analysis service name",
+        'description': "A test analysis service description",
+        'version': "1.0",
+        'contact_name': "Vesto Slipher",
+        'contact_email': "vs@ls.st",
+        'url': "http://example.com",
+        'authentication_type': "none",
+        'analysis_type': 'meta_analysis',
+        'upload_only': True,
+        'group_ids': [public_group.id],
+    }
+
+    status, data = api(
+        'POST', 'analysis_service', data=post_data, token=analysis_service_token
+    )
+    assert status == 200
+    assert data['status'] == 'success'
+
+    analysis_service_id = data['data']['id']
+
+    # this should fail because the analysis service is not a "upload_only" service
+    status, data = api(
+        'POST',
+        f'obj/{public_source.id}/analysis/{analysis_service_id}',
+        token=analysis_token,
+    )
+    assert status == 403
+    assert data["message"].find("analysis_upload endpoint") != -1
+
+    # this should succeed
+    params = {
+        "show_parameters": True,
+        "analysis": {
+            "results": {"format": "json", "data": {"external_provenance_id": "3xwsk3a"}}
+        },
+    }
+    status, data = api(
+        'POST',
+        f'obj/{public_source.id}/analysis_upload/{analysis_service_id}',
+        token=analysis_token,
+        data=params,
+    )
+    assert status == 200
+    assert data['status'] == 'success'
+
+    # this should succeed but we should be warned that we didn't
+    # provide any analysis results
+    params = {"show_parameters": True}
+    status, data = api(
+        'POST',
+        f'obj/{public_source.id}/analysis_upload/{analysis_service_id}',
+        token=analysis_token,
+        data=params,
+    )
+    assert status == 200
+    assert data['status'] == 'success'
+    assert data["data"]["message"].find("empty analysis upload_only results") != -1
+
+    # this should fail because the user's token does not have
+    # analysis persmissions
+    status, data = api(
+        'POST',
+        f'obj/{public_source.id}/analysis_upload/{analysis_service_id}',
+        token=view_only_token,
+        data=params,
+    )
+    assert status == 401


### PR DESCRIPTION
This PR enabled an upload-only endpoint for analysis services. 

After creation of an analysis service (with the parameter `upload_only`=True), this analysis service id can be used for authenticated uploads of analysis results from an external 3rd party. It is the responsibility of the 3rd party to maintain any provenance for the analysis (ie. what specific data was used to run the analysis), to delete outdated versions of the analysis on a given `obj`, and to avoid leaking sensitive data available to the 3rd party but not available to the groups that a specific analysis is attached to. By default we place a cap of 50 completed analyses per object per user/token.

As an example, a 3rd party analysis on the object named `MySourceName` using service number `service_id` can be uploaded as such:

```python
params={
  "show_parameters": True,
  "analysis": {
    "plots": ...,
    "inference_data": ...,
    "results": {
      "format": "json",
      "data": {
        "external_provenance": {
          "hash": "23baef56",
          "spectrum_ids": [34, 68, 125],
          "model": "jsbFitter23"
        },
        "classification": "DY Per",
        "classification_proba": 0.94
      }
    }
  }
}
url = f"http://<url>:5000/api/obj/MySourceName/analysis_upload/{service_id}"
r = requests.post(url, headers={'Authorization':   'token uuid'}, json=params)
```
here the uuid is the token with `Run Analyses` permission.


