### PR TITLE
bump arviz version; fix some marshmallow warnings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -70,7 +70,7 @@ simsurvey==0.7.5
 noaodatalab==2.20.0
 black==22.8.0
 click==8.1.3
-arviz==0.12.1
+arviz==0.14.0
 corner==2.2.1
 penquins==2.2.0
 selenium==4.8.0

--- a/skyportal/models/schema.py
+++ b/skyportal/models/schema.py
@@ -345,7 +345,7 @@ class PhotBaseFlexible:
             )
         },
         load_default=None,
-        default=None,
+        dump_default=None,
         required=False,
     )
 
@@ -637,7 +637,7 @@ class PhotBase:
             )
         },
         load_default=None,
-        default=None,
+        dump_default=None,
     )
     dec = fields.Number(
         metadata={
@@ -645,19 +645,19 @@ class PhotBase:
             'of the photometric aperture [deg].'
         },
         load_default=None,
-        default=None,
+        dump_default=None,
     )
 
     ra_unc = fields.Number(
         metadata={'description': 'Uncertainty on RA [arcsec].'},
         load_default=None,
-        default=None,
+        dump_default=None,
     )
 
     dec_unc = fields.Number(
         metadata={'description': 'Uncertainty on dec [arcsec].'},
         load_default=None,
-        default=None,
+        dump_default=None,
     )
 
     alert_id = fields.Integer(
@@ -670,7 +670,7 @@ class PhotBase:
             )
         },
         load_default=None,
-        default=None,
+        dump_default=None,
     )
 
     altdata = fields.Dict(
@@ -683,7 +683,7 @@ class PhotBase:
             )
         },
         load_default=None,
-        default=None,
+        dump_default=None,
     )
 
     @post_load
@@ -712,7 +712,7 @@ class PhotometryFlux(_Schema, PhotBase):
         },
         required=False,
         load_default=None,
-        default=None,
+        dump_default=None,
     )
 
     fluxerr = fields.Number(
@@ -884,7 +884,7 @@ class PhotometryMag(_Schema, PhotBase):
         },
         required=False,
         load_default=None,
-        default=None,
+        dump_default=None,
     )
     magerr = fields.Number(
         metadata={
@@ -894,7 +894,7 @@ class PhotometryMag(_Schema, PhotBase):
         },
         required=False,
         load_default=None,
-        default=None,
+        dump_default=None,
     )
     limiting_mag = fields.Number(
         metadata={
@@ -1394,7 +1394,7 @@ class PhotometryRangeQuery(_Schema):
         },
         required=False,
         load_default=None,
-        default=None,
+        dump_default=None,
     )
 
     min_date = fields.DateTime(
@@ -1407,7 +1407,7 @@ class PhotometryRangeQuery(_Schema):
             )
         },
         load_default=None,
-        default=None,
+        dump_default=None,
     )
 
     max_date = fields.DateTime(
@@ -1420,7 +1420,7 @@ class PhotometryRangeQuery(_Schema):
             )
         },
         load_default=None,
-        default=None,
+        dump_default=None,
     )
 
 


### PR DESCRIPTION
fix the `RemovedInMarshmallow4Warning: The 'default' argument to fields is deprecated. Use 'dump_default' instead.` warning