### PR TITLE
Let labelling checkbox remain unchecked after classification deletion

### DIFF
--- a/skyportal/handlers/api/classification.py
+++ b/skyportal/handlers/api/classification.py
@@ -473,7 +473,6 @@ class ClassificationHandler(BaseHandler):
                     nullable: true
                     description: |
                       Add label associated with classification.
-                required:
         responses:
           200:
             content:
@@ -610,7 +609,6 @@ class ObjClassificationHandler(BaseHandler):
                     nullable: true
                     description: |
                       Add label associated with classification.
-                required:
         responses:
           200:
             content:

--- a/skyportal/handlers/api/classification.py
+++ b/skyportal/handlers/api/classification.py
@@ -493,17 +493,12 @@ class ClassificationHandler(BaseHandler):
                 )
 
             data = self.get_json()
+            add_label = data.get('label', True)
 
             obj_key = c.obj.internal_key
             obj_id = c.obj.id
             group_ids = [group.id for group in c.groups]
             session.delete(c)
-
-            # labelling
-            add_label = True
-            if 'label' in data:
-                if data['label'] is False:
-                    add_label = False
 
             if add_label:
                 for group_id in group_ids:
@@ -629,12 +624,7 @@ class ObjClassificationHandler(BaseHandler):
             )
 
             data = self.get_json()
-
-            # labelling
-            add_label = True
-            if 'label' in data:
-                if data['label'] is False:
-                    add_label = False
+            add_label = data.get('label', True)
 
             for c in classifications:
                 obj_key = c.obj.internal_key


### PR DESCRIPTION
This PR allows the labelling checkbox to remain unchecked after deleting one or all of a source's classifications. This will make it easier to replace classifications in an active learning group without marking the sources as labelled.