### PR TITLE
MAXI events

### DIFF
--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -647,6 +647,7 @@ gcn:
     # - AMON_ICECUBE_HESE
     - ICECUBE_ASTROTRACK_GOLD
     - ICECUBE_ASTROTRACK_BRONZE
+    - MAXI_UNKNOWN
 
   observation_plans:
     - allocation-proposal_id: ZTF-001


### PR DESCRIPTION
This PR adds MAXI_UNKNOWN to GCN ingestion list (low rate, but interesting objects).