### PR TITLE
Add plugins to SourceAnnotationButtons.jsx

### DIFF
--- a/static/js/components/SourceAnnotationButtonPlugins.jsx
+++ b/static/js/components/SourceAnnotationButtonPlugins.jsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+const SourceAnnotationButtonPlugins = () => <></>;
+
+export default SourceAnnotationButtonPlugins;

--- a/static/js/components/SourceAnnotationButtons.jsx
+++ b/static/js/components/SourceAnnotationButtons.jsx
@@ -5,6 +5,8 @@ import { useDispatch } from "react-redux";
 import CircularProgress from "@mui/material/CircularProgress";
 import Button from "./Button";
 
+import SourceAnnotationButtonPlugins from "./SourceAnnotationButtonPlugins";
+
 import * as sourceActions from "../ducks/source";
 
 const SourceAnnotationButtons = ({ source }) => {
@@ -137,6 +139,7 @@ const SourceAnnotationButtons = ({ source }) => {
           Photoz
         </Button>
       )}
+      <SourceAnnotationButtonPlugins source={source} />
     </div>
   );
 };


### PR DESCRIPTION
This PR adds a placeholder component for plugins to `SourceAnnotationButtons.jsx` and imports these plugins to the same. The intent is to allow additional buttons to appear for specific instances of SkyPortal (e.g. a 'Kowalski' button for Fritz).