### PR TITLE
Social auth timeout

### DIFF
--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -468,6 +468,7 @@ server:
     debug_login: True
     google_oauth2_key:
     google_oauth2_secret:
+    google_oauth2_timeout: 15
 
 services:
   dask: False


### PR DESCRIPTION
This PR adds the social auth timeout (see https://github.com/cesium-ml/baselayer/pull/353).