### PR TITLE
RadioGroup js_on_change to active

### DIFF
--- a/skyportal/plot.py
+++ b/skyportal/plot.py
@@ -1463,7 +1463,7 @@ def make_period_controls(
         ),
     )
     phase_selection.js_on_event(
-        'button_click',
+        'active',
         CustomJS(
             args={
                 'textinput': period_textinput,


### PR DESCRIPTION
This PR sets js_on_change for RadioGroup to be active. See https://docs.bokeh.org/en/latest/docs/examples/models/buttons.html.