### PR TITLE
Comments attachments: Better fits file preview

### DIFF
--- a/skyportal/handlers/api/comment.py
+++ b/skyportal/handlers/api/comment.py
@@ -1,6 +1,5 @@
 import string
 import base64
-import io
 from marshmallow.exceptions import ValidationError
 import os
 import sqlalchemy as sa
@@ -1195,9 +1194,11 @@ class CommentAttachmentHandler(BaseHandler):
                     else:
                         return self.error(f'Comment file missing: {data_path}')
 
-                if preview and attachment_name.lower().endswith(("fit", "fits")):
+                if preview and attachment_name.lower().endswith(
+                    ("fit", "fits", "fit.fz", "fits.fz")
+                ):
                     try:
-                        attachment = get_fits_preview(io.BytesIO(attachment))
+                        attachment = get_fits_preview(attachment_name, attachment)
                         attachment_name = os.path.splitext(attachment_name)[0] + ".png"
                     except Exception as e:
                         log(f'Cannot render {attachment_name} as image: {str(e)}')

--- a/static/js/components/CommentAttachmentPreview.jsx
+++ b/static/js/components/CommentAttachmentPreview.jsx
@@ -171,6 +171,7 @@ const CommentAttachmentPreview = ({
     "json",
     "fit",
     "fits",
+    "fz",
   ].includes(fileType.toLowerCase());
 
   let jsonFile = {};


### PR DESCRIPTION
In this PR, we try to provide users with a better preview of fits file, as well as fits.fz files (currently missing)
Here is an example:

| Before | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/49785117/219990179-0ef872e3-6aed-4272-a61b-f8dd8e2671ca.png) | ![image](https://user-images.githubusercontent.com/49785117/219989890-2c0e6707-0fe3-40db-ab93-7106d283be4c.png) |

*Details: I used [ZScaleInterval](https://github.com/spacetelescope/stsci.numdisplay/blob/master/lib/stsci/numdisplay/zscale.py) followed by a [SinhStretch](https://docs.astropy.org/en/stable/visualization/normalization.html#combining-stretches-and-matplotlib-normalization) to achieve this result.*