### PR TITLE
mathjs: 11.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "imports-loader": "4.0.1",
     "material-ui-phone-number": "3.0.0",
     "mathjax-full": "3.2.2",
-    "mathjs": "11.3.2",
+    "mathjs": "11.5.1",
     "moment": "2.29.4",
     "mui-datatables": "4.2.2",
     "nouislider": "15.6.1",


### PR DESCRIPTION
This PR bumps mathjs to 11.5.1.