### PR TITLE
Vega zoom bugfix

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,9 +98,9 @@
     "timezone": "1.0.23",
     "underscore.template": "0.1.7",
     "use-count-up": "3.0.1",
-    "vega": "5.22.1",
-    "vega-embed": "6.21.0",
-    "vega-lite": "5.2.0"
+    "vega": "5.24.0",
+    "vega-embed": "6.21.3",
+    "vega-lite": "5.6.1"
   },
   "devDependencies": {
     "@babel/core": "7.20.12",


### PR DESCRIPTION
Updating Vega, Vega-embed and Vega-lite to the latest versions seem to fix the issue mentioned in https://github.com/skyportal/skyportal/issues/4036