### PR TITLE
Gcn event service: Non Async ingestion | Notifications: Async Ingestion

### DIFF
--- a/services/gcn_service/gcn_service.py
+++ b/services/gcn_service/gcn_service.py
@@ -69,7 +69,7 @@ def service():
                 if payload.find(b'Broker: Unknown topic or partition') != -1:
                     continue
                 with DBSession() as session:
-                    post_gcnevent_from_xml(payload, user_id, session)
+                    post_gcnevent_from_xml(payload, user_id, session, False)
 
         except Exception as e:
             log(f'Failed to consume gcn event: {e}')

--- a/skyportal/handlers/api/observation_plan.py
+++ b/skyportal/handlers/api/observation_plan.py
@@ -1,3 +1,10 @@
+from datetime import datetime, timedelta
+import functools
+import io
+import random
+import tempfile
+import time
+
 import astropy
 from astropy.coordinates import EarthLocation
 from astropy.time import Time
@@ -8,7 +15,7 @@ from astroplan import (
     Observer,
     is_event_observable,
 )
-from datetime import datetime, timedelta
+import asyncio
 import geopandas
 import healpy as hp
 import humanize
@@ -21,9 +28,7 @@ from sqlalchemy.orm import joinedload, undefer
 from sqlalchemy.orm import sessionmaker, scoped_session
 import urllib
 import numpy as np
-import io
 from tornado.ioloop import IOLoop
-import functools
 import ligo.skymap
 from ligo.skymap.tool.ligo_skymap_plot_airmass import main as plot_airmass
 from ligo.skymap import plot  # noqa: F401
@@ -36,14 +41,11 @@ import pandas as pd
 import simsurvey
 from simsurvey.utils import model_tools
 from simsurvey.models import AngularTimeSeriesSource
-import tempfile
 from ligo.skymap.distance import parameters_to_marginal_moments
 from ligo.skymap.bayestar import rasterize
 from ligo.skymap import plot  # noqa: F401 F811
-import random
 import afterglowpy
 import sncosmo
-import time
 
 from baselayer.app.access import auth_or_token
 from baselayer.app.env import load_env
@@ -209,6 +211,11 @@ def post_survey_efficiency_analysis(
     )
 
     if asynchronous:
+        try:
+            loop = asyncio.get_event_loop()
+        except Exception:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
         simsurvey_analysis = functools.partial(
             observation_simsurvey,
             observations,


### PR DESCRIPTION
This PR is a 2nd attempt to reduce (or get rid of) the flakiness experienced in production, where some events have missing localizations.

In production, we notice a warning that says: 

"Attribute history events accumulated on `N` previously clean instances within inner-flush event handlers have been reset, and will not result in database updates."

This happens when we try committing the session right after adding the localization to it. Turns out, that adding notification preferences on events recreates this bug locally. And that both locally and in prod, `N` corresponds exactly to the number of UserNotifications being added to the session. 

Moreover, while testing skymap ingestion locally (with LVC stream catching up to a few days, which means a LOT of alerts at once), we notice that the number of sessions used by the different async child processes spawned by the gcnevent ingestion method creates non desirable behavior, where sessions are being shared between the processes. We've been suspecting this limitation of the connection pool of sqlalchemy for a bit (see https://davidcaron.dev/sqlalchemy-multiple-threads-and-processes/), and there is no obvious way to avoid it, other than avoiding to have too many processes using sessions at once (as they end up overlapping and sharing sessions, meaning that if one commits or closes the other can't proceed and you get an error).
Therefore, we add a simple flag to allow a fully synchronous ingestion of events, which is used by the microservice which risks to ingest multiple events at once.

Last but not least, processing the notifications in separate session - here inside of an async process - prevented us from getting the error mentioned above in this PR's description. Running this async makes a lot of sense, as otherwise whatever commit triggered the creation of notifications might have to wait for it to finis, which can take a while. Here at least it is independent of whatever triggered it, which is a very good thing as it prevents the parent process from having a rollback and being canceled if the child process encounters an error. However one might argue that might cause the same issue as the async  event ingestion that creates too many db connections. The plan for a following PR would be to add a queue (as a microservice) to process user notifications being sent to slack, email, ... instead of DB triggers.
