### PR TITLE
GcnEvent ingestion: avoid creating more sessions when running async

### DIFF
--- a/skyportal/tests/frontend/sources_and_followup_etc/test_source_list.py
+++ b/skyportal/tests/frontend/sources_and_followup_etc/test_source_list.py
@@ -255,7 +255,7 @@ def test_filter_by_classification(
     driver.get("/sources")
 
     # Filter for classification
-    driver.click_xpath("//button[@data-testid='Filter Table-iconButton']")
+    driver.click_xpath("//button[@data-testid='Filter Table-iconButton']", timeout=30)
     driver.click_xpath(
         "//div[@data-testid='classifications-select']",
         scroll_parent=True,

--- a/skyportal/tests/frontend/sources_and_followup_etc/test_sources.py
+++ b/skyportal/tests/frontend/sources_and_followup_etc/test_sources.py
@@ -251,8 +251,7 @@ def test_analysis_with_file_input_start(
     driver.click_xpath('//div[@data-testid="analysisServiceSelect"]')
 
     # look for an element list with a text with the uuid name of the analysis service
-    driver.wait_for_xpath(f'//li[text()="{name}"]')
-    driver.click_xpath(f'//li[text()="{name}"]')
+    driver.click_xpath(f'//li[text()="{name}"]', timeout=30)
 
     # look for an input element with id root_image_data
     image_data = driver.wait_for_xpath('//input[@id="root_image_data"]')


### PR DESCRIPTION
This PR builds on top of the previous PR merged on main, which allowed non async ingestion of event. Here, we make sure than when not running async, only one session is used instead of spawning 2 other sessions in the 2 methods we call. That way, we avoid using too many connection from the queue pool.

This PR also contains an attempt to reduce the flakiness of 2 test that are not running well on main.