### PR TITLE
User-specific OpenAI preferences

### DIFF
--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -698,7 +698,7 @@ analysis_services:
       frequency_penalty: 0.0
       model: gpt-3.5-turbo
       presence_penalty: 1.0
-      prompt: Using markdown (with appropriate URL links), in one human-readable paragraph please summarize the following comments about this astronomical source. If classification and/or redshift are given, then note those in the summary. This summary will be primarily read by professional astronomers to help them with their work.
+      prompt: Using markdown (including URL links), in one succinct (less than 250 words) paragraph written in the 3rd person summarize the following comments about this astronomical source.  If classifications and/or the redshift are given, then note those in the summary. This summary should be most useful to expert astrophysicists who already know the definitions and meaning of all classifications.
     embeddings_store:
       summary:
         location: pinecone

--- a/requirements.txt
+++ b/requirements.txt
@@ -84,5 +84,5 @@ watchdog==2.2.1
 PyAstronomy==0.18.0
 shapely==1.8.1
 stdpipe==0.1
-openai[embeddings]==0.27.0
+openai[embeddings]==0.27.2
 pinecone-client==2.2.1

--- a/skyportal/handlers/api/analysis.py
+++ b/skyportal/handlers/api/analysis.py
@@ -1071,9 +1071,11 @@ class AnalysisHandler(BaseHandler):
                     .get("OpenAI", {})
                     .get('active', False)
                 ):
-                    analysis_parameters["openai_api_key"] = user.preferences["summary"][
-                        "OpenAI"
-                    ]["apikey"]
+                    user_pref_openai = user.preferences["summary"]["OpenAI"].copy()
+                    analysis_parameters["openai_api_key"] = user_pref_openai["apikey"]
+                    user_pref_openai.pop("apikey", None)
+                    user_pref_openai.pop("active", None)
+                    analysis_parameters["summary_parameters"] = user_pref_openai
 
             group_ids = data.pop('group_ids', None)
             if not group_ids:

--- a/skyportal/handlers/api/config_handler.py
+++ b/skyportal/handlers/api/config_handler.py
@@ -62,16 +62,19 @@ class ConfigHandler(BaseHandler):
                               type: object
                               description: allowed classifications classes.
         """
+        openai_summary_parameters = cfg[
+            "analysis_services.openai_analysis_service.summary"
+        ]
+        openai_summary_apikey_set = openai_summary_parameters.get("api_key") is not None
+        openai_summary_parameters.pop("api_key", None)
 
         return self.success(
             data={
                 "slackPreamble": cfg["slack.expected_url_preamble"],
                 "invitationsEnabled": cfg["invitations.enabled"],
                 "cosmology": str(cosmo),
-                "openai_summary_apikey_set": cfg[
-                    "analysis_services.openai_analysis_service.summary.api_key"
-                ]
-                is not None,
+                "openai_summary_apikey_set": openai_summary_apikey_set,
+                "openai_summary_parameters": openai_summary_parameters,
                 "cosmoref": cosmo.__doc__,
                 "allowedSpectrumTypes": ALLOWED_SPECTRUM_TYPES,
                 "defaultSpectrumType": default_spectrum_type,

--- a/skyportal/handlers/api/internal/profile.py
+++ b/skyportal/handlers/api/internal/profile.py
@@ -4,7 +4,6 @@ import phonenumbers
 from phonenumbers.phonenumberutil import NumberParseException
 from validate_email import validate_email
 from sqlalchemy.exc import IntegrityError
-
 from baselayer.app.access import auth_or_token
 from baselayer.app.config import recursive_update
 from ...base import BaseHandler
@@ -209,7 +208,6 @@ class ProfileHandler(BaseHandler):
                     user.contact_email = None
 
             preferences = data.get("preferences", {})
-
             # Do not save blank fields (empty strings)
             for k, v in preferences.items():
                 if isinstance(v, dict):

--- a/skyportal/tests/frontend/test_openai_prefs.py
+++ b/skyportal/tests/frontend/test_openai_prefs.py
@@ -1,0 +1,44 @@
+import uuid
+
+from skyportal.tests import api
+
+
+def test_openai_prefs(driver, user, upload_data_token):
+    driver.get(f'/become_user/{user.id}')
+    driver.get('/profile')
+    openai_toggle = driver.wait_for_xpath('//*[@data-testid="OpenAI_toggle"]')
+
+    if not openai_toggle.is_selected():
+        driver.scroll_to_element_and_click(openai_toggle)
+
+    dummy_api_key = f"sk-{str(uuid.uuid4())}"
+
+    apikey_input = driver.wait_for_xpath('//input[@name="openai_apikey"]')
+    driver.scroll_to_element_and_click(apikey_input)
+    apikey_input.send_keys(dummy_api_key)
+
+    openai_prefs = driver.wait_for_xpath('//*[@data-testid="UpdateOpenAI"]')
+    driver.scroll_to_element_and_click(openai_prefs)
+
+    dummy_gpt_model = f"gpt-{str(uuid.uuid4())}"
+    model_input = driver.wait_for_xpath('//input[@name="root_model"]')
+    driver.scroll_to_element_and_click(model_input)
+    model_input.clear()
+    model_input.send_keys(dummy_gpt_model)
+
+    driver.click_xpath(
+        "//form[@class='rjsf']/div/button[text()='Submit']", scroll_parent=True
+    )
+
+    status, data = api('GET', 'internal/profile', token=upload_data_token)
+    assert status == 200
+    assert data['data']['preferences']['summary']["OpenAI"]["model"] == dummy_gpt_model
+    assert data['data']['preferences']['summary']["OpenAI"]["apikey"] == dummy_api_key
+    assert data['data']['preferences']['summary']["OpenAI"]["active"]
+
+    # uncheck the toggle
+    openai_toggle.click()
+
+    status, data = api('GET', 'internal/profile', token=upload_data_token)
+    assert status == 200
+    assert not data['data']['preferences']['summary']["OpenAI"]["active"]

--- a/static/js/components/AnalysisForm.jsx
+++ b/static/js/components/AnalysisForm.jsx
@@ -62,7 +62,6 @@ const AnalysisForm = ({ obj_id }) => {
   const uniqueAnalysisServiceList = uniqueNames.map((name) =>
     analysisServiceList.find((item) => item.name === name)
   );
-
   const allGroups = useSelector((state) => state.groups.all);
   const [selectedAnalysisServiceId, setSelectedAnalysisServiceId] =
     useState(null);
@@ -245,7 +244,7 @@ const AnalysisForm = ({ obj_id }) => {
         >
           {uniqueAnalysisServiceList?.map(
             (analysisService) =>
-              analysisService.display_on_resource_dropdown && (
+              analysisService.display_on_resource_dropdown !== false && (
                 <MenuItem
                   value={analysisService.id}
                   key={analysisService.id}

--- a/static/js/components/CustomizeOpenAIParameters.jsx
+++ b/static/js/components/CustomizeOpenAIParameters.jsx
@@ -225,6 +225,7 @@ const CustomizeOpenAIParameters = () => {
             schema={formSchema}
             validator={validator}
             uiSchema={uiSchema}
+            data-testid="UpdateOpenAIform"
             onSubmit={handleAISubmit}
             customValidate={validate}
           />

--- a/static/js/components/CustomizeOpenAIParameters.jsx
+++ b/static/js/components/CustomizeOpenAIParameters.jsx
@@ -130,7 +130,7 @@ const CustomizeOpenAIParameters = () => {
     temperature: {
       "ui:widget": "updown",
       "ui:help":
-        "What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.",
+        "What sampling temperature to use, between 0 and 1. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.",
     },
     top_p: {
       "ui:widget": "updown",
@@ -143,7 +143,7 @@ const CustomizeOpenAIParameters = () => {
     max_tokens: {
       "ui:widget": "range",
       "ui:help":
-        "The maximum number of tokens to generate. Must be between 1 and 2048.",
+        "The maximum number of tokens to generate in the summary. For reference, 100 tokens is about 75 words. Must be between 10 and 1000.",
     },
     frequency_penalty: {
       "ui:widget": "updown",
@@ -156,11 +156,7 @@ const CustomizeOpenAIParameters = () => {
         "Number between -2.0 and 2.0. Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to talk about new topics.",
     },
   };
-  // Since we are editing exsiting follow-up requests,
-  // it makes more sense to set default form values to current request data
   Object.keys(formSchema.properties).forEach((key) => {
-    // Set the form value for "key" to the value in the existing request's
-    // payload, which is the form data sent to the external follow-up API
     formSchema.properties[key].default = default_openai_summary_parameters[key];
   });
 
@@ -176,7 +172,7 @@ const CustomizeOpenAIParameters = () => {
     if (formData.top_p < 0.0 || formData.top_p > 1.0) {
       errors.top_p.addError("top_p must be between 0.0 and 1.0");
     }
-    if (formData.frequency_penalty < 0.0 || formData.frequency_penalty > 1.0) {
+    if (formData.frequency_penalty < -2.0 || formData.frequency_penalty > 2.0) {
       errors.frequency_penalty.addError(
         "frequency_penalty must be between 0.0 and 1.0"
       );
@@ -188,7 +184,7 @@ const CustomizeOpenAIParameters = () => {
         "must be an Open AI gpt model. See https://platform.openai.com/docs/models/overview for more information."
       );
     }
-    if (formData.presence_penalty < 0.0 || formData.presence_penalty > 1.0) {
+    if (formData.presence_penalty < -2.0 || formData.presence_penalty > 2.0) {
       errors.presence_penalty.addError(
         "presence_penalty must be between 0.0 and 1.0"
       );

--- a/static/js/components/CustomizeOpenAIParameters.jsx
+++ b/static/js/components/CustomizeOpenAIParameters.jsx
@@ -165,8 +165,8 @@ const CustomizeOpenAIParameters = () => {
       errors.temperature.addError("Temperature must be between 0.0 and 1.0");
     }
 
-    if (formData.max_tokens < 1 || formData.max_tokens > 2048) {
-      errors.max_tokens.addError("max_tokens must be between 1 and 2048");
+    if (formData.max_tokens < 10 || formData.max_tokens > 1000) {
+      errors.max_tokens.addError("max_tokens must be between 10 and 1000");
     }
 
     if (formData.top_p < 0.0 || formData.top_p > 1.0) {
@@ -174,7 +174,7 @@ const CustomizeOpenAIParameters = () => {
     }
     if (formData.frequency_penalty < -2.0 || formData.frequency_penalty > 2.0) {
       errors.frequency_penalty.addError(
-        "frequency_penalty must be between 0.0 and 1.0"
+        "frequency_penalty must be between -2 and 2"
       );
     }
     if (
@@ -186,7 +186,7 @@ const CustomizeOpenAIParameters = () => {
     }
     if (formData.presence_penalty < -2.0 || formData.presence_penalty > 2.0) {
       errors.presence_penalty.addError(
-        "presence_penalty must be between 0.0 and 1.0"
+        "presence_penalty must be between -2 and 2"
       );
     }
 

--- a/static/js/components/CustomizeOpenAIParameters.jsx
+++ b/static/js/components/CustomizeOpenAIParameters.jsx
@@ -1,0 +1,237 @@
+import React, { useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import EditOutlinedIcon from "@mui/icons-material/EditOutlined";
+import IconButton from "@mui/material/IconButton";
+import Tooltip from "@mui/material/Tooltip";
+
+import Dialog from "@mui/material/Dialog";
+import DialogContent from "@mui/material/DialogContent";
+import makeStyles from "@mui/styles/makeStyles";
+// eslint-disable-next-line import/no-unresolved
+import Form from "@rjsf/mui";
+import validator from "@rjsf/validator-ajv8";
+import DialogTitle from "@mui/material/DialogTitle";
+import * as profileActions from "../ducks/profile";
+
+const useStyles = makeStyles(() => ({
+  dialog: {
+    position: "fixed",
+  },
+  tooltip: {
+    fontSize: "1rem",
+    maxWidth: "30rem",
+  },
+}));
+
+const CustomizeOpenAIParameters = () => {
+  const dispatch = useDispatch();
+  const [aiopen, setAIOpen] = useState(false);
+  const classes = useStyles();
+
+  const site_openai_summary_parameters = useSelector(
+    (state) => state.config.openai_summary_parameters
+  );
+  const user_openai_summary_parameters = useSelector(
+    (state) => state.profile.preferences.summary.OpenAI
+  );
+
+  const default_openai_summary_parameters = {
+    ...site_openai_summary_parameters,
+    ...user_openai_summary_parameters,
+  };
+
+  const handleAIClickOpen = () => {
+    setAIOpen(true);
+  };
+
+  const handleAIClose = () => {
+    setAIOpen(false);
+  };
+
+  const handleAISubmit = ({ formData }) => {
+    const prefs = {
+      summary: {
+        OpenAI: {
+          active: user_openai_summary_parameters.active,
+          ...formData,
+        },
+      },
+    };
+    dispatch(profileActions.updateUserPreferences(prefs));
+    handleAIClose();
+  };
+
+  const formSchema = {
+    type: "object",
+    properties: {
+      model: {
+        type: "string",
+        title: "model",
+        examples: [
+          "gpt-4",
+          "gpt-3.5-turbo",
+          "text-davinci-003",
+          "davinci",
+          "gpt-4-32k",
+        ],
+      },
+      prompt: {
+        type: "string",
+        title: "prompt",
+      },
+      temperature: {
+        type: "number",
+        title: "Temperature",
+        minimum: 0.0,
+        maximum: 1.0,
+        multipleOf: 0.05,
+      },
+      max_tokens: {
+        type: "integer",
+        title: "max_tokens",
+        minimum: 10,
+        maximum: 1000,
+        multipleOf: 10,
+      },
+      top_p: {
+        type: "number",
+        title: "top_p",
+        minimum: 0.0,
+        maximum: 1.0,
+        multipleOf: 0.05,
+      },
+      frequency_penalty: {
+        type: "number",
+        title: "frequency_penalty",
+        minimum: -2.0,
+        maximum: 2.0,
+        multipleOf: 0.05,
+      },
+      presence_penalty: {
+        type: "number",
+        title: "presence_penalty",
+        minimum: -2.0,
+        maximum: 2.0,
+        multipleOf: 0.05,
+      },
+    },
+    required: [
+      "temperature",
+      "max_tokens",
+      "top_p",
+      "frequency_penalty",
+      "model",
+      "presence_penalty",
+      "prompt",
+    ],
+  };
+
+  const uiSchema = {
+    temperature: {
+      "ui:widget": "updown",
+      "ui:help":
+        "What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.",
+    },
+    top_p: {
+      "ui:widget": "updown",
+      "ui:help":
+        "An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered.",
+    },
+    prompt: {
+      "ui:widget": "textarea",
+    },
+    max_tokens: {
+      "ui:widget": "range",
+      "ui:help":
+        "The maximum number of tokens to generate. Must be between 1 and 2048.",
+    },
+    frequency_penalty: {
+      "ui:widget": "updown",
+      "ui:help":
+        "Number between -2.0 and 2.0. Positive values penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim.",
+    },
+    presence_penalty: {
+      "ui:widget": "updown",
+      "ui:help":
+        "Number between -2.0 and 2.0. Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to talk about new topics.",
+    },
+  };
+  // Since we are editing exsiting follow-up requests,
+  // it makes more sense to set default form values to current request data
+  Object.keys(formSchema.properties).forEach((key) => {
+    // Set the form value for "key" to the value in the existing request's
+    // payload, which is the form data sent to the external follow-up API
+    formSchema.properties[key].default = default_openai_summary_parameters[key];
+  });
+
+  const validate = (formData, errors) => {
+    if (formData.temperature < 0.0 || formData.temperature > 1.0) {
+      errors.temperature.addError("Temperature must be between 0.0 and 1.0");
+    }
+
+    if (formData.max_tokens < 1 || formData.max_tokens > 2048) {
+      errors.max_tokens.addError("max_tokens must be between 1 and 2048");
+    }
+
+    if (formData.top_p < 0.0 || formData.top_p > 1.0) {
+      errors.top_p.addError("top_p must be between 0.0 and 1.0");
+    }
+    if (formData.frequency_penalty < 0.0 || formData.frequency_penalty > 1.0) {
+      errors.frequency_penalty.addError(
+        "frequency_penalty must be between 0.0 and 1.0"
+      );
+    }
+    if (
+      !(formData.model.includes("gpt") || formData.model.includes("davinci"))
+    ) {
+      errors.model.addError(
+        "must be an Open AI gpt model. See https://platform.openai.com/docs/models/overview for more information."
+      );
+    }
+    if (formData.presence_penalty < 0.0 || formData.presence_penalty > 1.0) {
+      errors.presence_penalty.addError(
+        "presence_penalty must be between 0.0 and 1.0"
+      );
+    }
+
+    if (formData.prompt.length < 10) {
+      errors.prompt.addError("prompt must be at least 10 characters long");
+    }
+
+    return errors;
+  };
+
+  return (
+    <div>
+      <Tooltip
+        title="Expert mode: click here to edit the OpenAI summary settings."
+        placement="right"
+        classes={{ tooltip: classes.tooltip }}
+      >
+        <IconButton
+          primary
+          size="small"
+          type="submit"
+          onClick={handleAIClickOpen}
+          data-testid="UpdateOpenAI"
+        >
+          <EditOutlinedIcon />
+        </IconButton>
+      </Tooltip>
+      <Dialog open={aiopen} onClose={handleAIClose} className={classes.dialog}>
+        <DialogTitle>Edit OpenAI Summary Settings</DialogTitle>
+        <DialogContent>
+          <Form
+            schema={formSchema}
+            validator={validator}
+            uiSchema={uiSchema}
+            onSubmit={handleAISubmit}
+            customValidate={validate}
+          />
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+};
+
+export default CustomizeOpenAIParameters;

--- a/static/js/components/FollowupRequestPreferences.jsx
+++ b/static/js/components/FollowupRequestPreferences.jsx
@@ -29,8 +29,10 @@ const FollowupRequestPreferences = () => {
   const defaultAllocationId = useSelector(
     (state) => state.profile.preferences.followupDefault
   );
-  const [selectedAllocationId, setSelectedAllocationId] =
-    useState(defaultAllocationId);
+  // set the default allocation to be -1 if nothing is in the user preferences
+  const [selectedAllocationId, setSelectedAllocationId] = useState(
+    defaultAllocationId || -1
+  );
 
   const classes = useStyles();
   const dispatch = useDispatch();

--- a/static/js/components/NotificationSettingsSelect.jsx
+++ b/static/js/components/NotificationSettingsSelect.jsx
@@ -107,7 +107,6 @@ const NotificationSettingsSelect = ({ notificationResourceType }) => {
     if (!valueSMS) {
       const valSMS =
         profile?.notifications[notificationResourceType]?.sms?.time_slot;
-      console.log("valSMS", valSMS);
       if (valSMS?.length > 0) {
         setValueSMS(valSMS);
         if (valSMS[0] > valSMS[1]) {

--- a/static/js/components/OpenAIPreferences.jsx
+++ b/static/js/components/OpenAIPreferences.jsx
@@ -10,6 +10,7 @@ import makeStyles from "@mui/styles/makeStyles";
 
 import * as profileActions from "../ducks/profile";
 import UserPreferencesHeader from "./UserPreferencesHeader";
+import CustomizeOpenAIParameters from "./CustomizeOpenAIParameters";
 
 const useStyles = makeStyles((theme) => ({
   textField: {
@@ -82,6 +83,7 @@ const OpenAIPreferences = () => {
           }
           label={profile.summary?.OpenAI?.active ? "Active" : "Inactive"}
         />
+        {profile.summary?.OpenAI?.active && <CustomizeOpenAIParameters />}
       </FormGroup>
       {profile.summary?.OpenAI?.active && (
         <div>

--- a/static/js/components/OpenAIPreferences.jsx
+++ b/static/js/components/OpenAIPreferences.jsx
@@ -88,7 +88,7 @@ const OpenAIPreferences = () => {
       {profile.summary?.OpenAI?.active && (
         <div>
           <TextField
-            name="apikey"
+            name="openai_apikey"
             label="OpenAI API KEY"
             className={classes.textField}
             fullWidth

--- a/static/js/components/OpenAIPreferences.jsx
+++ b/static/js/components/OpenAIPreferences.jsx
@@ -81,11 +81,11 @@ const OpenAIPreferences = () => {
               data-testid="OpenAI_toggle"
             />
           }
-          label={profile.summary?.OpenAI?.active ? "Active" : "Inactive"}
+          label={profile?.summary?.OpenAI?.active ? "Active" : "Inactive"}
         />
-        {profile.summary?.OpenAI?.active && <CustomizeOpenAIParameters />}
+        {profile?.summary?.OpenAI?.active && <CustomizeOpenAIParameters />}
       </FormGroup>
-      {profile.summary?.OpenAI?.active && (
+      {profile?.summary?.OpenAI?.active && (
         <div>
           <TextField
             name="openai_apikey"

--- a/static/js/components/StartBotSummary.jsx
+++ b/static/js/components/StartBotSummary.jsx
@@ -150,70 +150,7 @@ const StartBotSummary = ({ obj_id }) => {
   };
 
   const OptionalParameters = {};
-  const RequiredParameters = [];
-  if (
-    analysisServiceLookUp[selectedAnalysisServiceId]
-      ?.optional_analysis_parameters
-  ) {
-    const keys = Object.keys(
-      analysisServiceLookUp[selectedAnalysisServiceId]
-        .optional_analysis_parameters
-    );
-    keys.forEach((key) => {
-      const params =
-        analysisServiceLookUp[selectedAnalysisServiceId]
-          ?.optional_analysis_parameters[key];
 
-      if (Array.isArray(params)) {
-        if (["True", "False"].every((val) => params.includes(val))) {
-          OptionalParameters[key] = { type: "boolean" };
-        } else {
-          OptionalParameters[key] = { type: "string", enum: params };
-          RequiredParameters.push(key);
-        }
-      } else if (typeof params === "object") {
-        if (params?.type === "number") {
-          OptionalParameters[key] = {
-            type: "number",
-            title: key,
-          };
-        } else if (params?.type === "file") {
-          OptionalParameters[key] = {
-            type: "string",
-            format: "data-url",
-            title: key,
-            description: key, // we set a description by default for file as the title doesn't show up in the rjsf form
-          };
-        } else if (params?.type === "string") {
-          OptionalParameters[key] = {
-            type: "string",
-            title: key,
-          };
-        }
-
-        if (params?.default) {
-          OptionalParameters[key].default = params.default;
-        }
-
-        if (params?.description) {
-          OptionalParameters[key].description = params.description;
-        }
-
-        if (params?.title) {
-          OptionalParameters[key].title = params.title;
-        }
-
-        if (params?.required) {
-          if (["True", "true", "t"].includes(params.required)) {
-            RequiredParameters.push(key);
-          }
-        }
-      } else {
-        OptionalParameters[key] = { type: "string", enum: params };
-        RequiredParameters.push(key);
-      }
-    });
-  }
   const AnalysisSelectionFormSchema = {
     type: "object",
     properties: {


### PR DESCRIPTION
This PR allows each user to customize which OpenAI chat model and parameters are used in source summaries. The default remains the site-wide parameters set in `config.yaml` but those will be overridden if set by the end user.

![Kapture 2023-03-19 at 08 35 10](https://user-images.githubusercontent.com/480799/226186984-75afc073-741b-4820-ad09-8d1570881efd.gif)

Small other fixes are in this PR, including removing a console message and cleaning up the view in the start AI summary dialog.
