### PR TITLE
Follow-up requests: missing SEDM defaults + re-submit on failure

### DIFF
--- a/skyportal/facility_apis/_base.py
+++ b/skyportal/facility_apis/_base.py
@@ -61,6 +61,7 @@ class _Base:
             "retrieve": cls._isimplemented('retrieve'),
             "queued": cls._isimplemented('queued'),
             "remove_queue": cls._isimplemented('remove_queue'),
+            "prepare_payload": cls._isimplemented('prepare_payload'),
         }
 
     # subclasses should not modify this

--- a/skyportal/facility_apis/interface.py
+++ b/skyportal/facility_apis/interface.py
@@ -116,6 +116,18 @@ class FollowUpAPI(_Base):
         """Remove a particular queue by name."""
         raise NotImplementedError
 
+    # subclasses should implement this if desired
+    @staticmethod
+    def prepare_payload(payload, existing_payload=None):
+        """Format the payload for submission to the facility.
+
+        Parameters
+        ----------
+        payload: dict
+            The payload to format.
+        """
+        raise NotImplementedError
+
     # jsonschema outlining the schema of the frontend form. See
     # https://github.com/rjsf-team/react-jsonschema-form
     # for examples.

--- a/skyportal/facility_apis/sedm.py
+++ b/skyportal/facility_apis/sedm.py
@@ -394,6 +394,8 @@ class SEDMAPI(FollowUpAPI):
                                 "title": "Exposure Time (Photometry) [s]",
                                 "type": "number",
                                 "default": -1,
+                                "minimum": -1,
+                                "maximum": 3600,
                             },
                             "maximum_airmass": {
                                 "title": "Maximum Airmass (1-3)",

--- a/skyportal/facility_apis/sedm.py
+++ b/skyportal/facility_apis/sedm.py
@@ -146,10 +146,43 @@ def convert_request_to_sedm(request, method_value='new'):
         'username': request.requester.username,
         'ra': request.obj.ra,
         'dec': request.obj.dec,
-        'exptime': request.payload['exposure_time'],
-        'maxairmass': request.payload['maximum_airmass'],
-        'max_fwhm': request.payload['maximum_fwhm'],
+        'exptime': request.payload.get('exposure_time', -1),
+        'maxairmass': request.payload.get('maximum_airmass', 2.8),
+        'max_fwhm': request.payload.get('maximum_fwhm', 10),
     }
+
+    return payload
+
+
+def prepare_payload_sedm(payload, existing_payload=None):
+    """Format a payload for SEDM.
+
+    Parameters
+    ----------
+    payload: dict
+        The payload to format.
+
+    Returns
+    -------
+    formatted_payload: dict
+        The formatted payload.
+    """
+
+    payload["exposure_time"] = payload.get(
+        "exposure_time",
+        -1 if existing_payload is None else existing_payload["exposure_time"],
+    )
+    payload["maximum_airmass"] = payload.get(
+        "maximum_airmass",
+        2.8 if existing_payload is None else existing_payload["maximum_airmass"],
+    )
+    payload["maximum_fwhm"] = payload.get(
+        "maximum_fwhm",
+        10 if existing_payload is None else existing_payload["maximum_fwhm"],
+    )
+
+    if "advanced" in payload:
+        del payload["advanced"]
 
     return payload
 
@@ -282,6 +315,10 @@ class SEDMAPI(FollowUpAPI):
             payload={"obj_key": request.obj.internal_key},
         )
 
+    @staticmethod
+    def prepare_payload(payload, existing_payload=None):
+        return prepare_payload_sedm(payload, existing_payload)
+
     _observation_types = [
         '3-shot (gri)',
         '4-shot (ugri)',
@@ -321,25 +358,6 @@ class SEDMAPI(FollowUpAPI):
                 "title": "Mode",
                 "default": "IFU",
             },
-            "exposure_time": {
-                "title": "Exposure Time (Photometry) [s]",
-                "type": "number",
-                "default": 0,
-            },
-            "maximum_airmass": {
-                "title": "Maximum Airmass (1-3)",
-                "type": "number",
-                "default": 2.8,
-                "minimum": 1,
-                "maximum": 3,
-            },
-            "maximum_fwhm": {
-                "title": "Maximum FWHM (1-10)",
-                "type": "number",
-                "default": 10,
-                "minimum": 1,
-                "maximum": 10,
-            },
             "priority": {
                 "type": "number",
                 "default": 1.0,
@@ -359,8 +377,48 @@ class SEDMAPI(FollowUpAPI):
                 "title": "End Date (UT)",
                 "default": (datetime.utcnow().date() + timedelta(days=7)).isoformat(),
             },
+            "advanced": {
+                "type": "boolean",
+                "title": "Show Advanced Options",
+                "default": False,
+            },
         },
-        "dependencies": {"observation_type": {"oneOf": _dependencies}},
+        "dependencies": {
+            "observation_type": {"oneOf": _dependencies},
+            "advanced": {
+                "oneOf": [
+                    {
+                        "properties": {
+                            "advanced": {"enum": [True]},
+                            "exposure_time": {
+                                "title": "Exposure Time (Photometry) [s]",
+                                "type": "number",
+                                "default": -1,
+                            },
+                            "maximum_airmass": {
+                                "title": "Maximum Airmass (1-3)",
+                                "type": "number",
+                                "default": 2.8,
+                                "minimum": 1,
+                                "maximum": 3,
+                            },
+                            "maximum_fwhm": {
+                                "title": "Maximum FWHM (1-10)",
+                                "type": "number",
+                                "default": 10,
+                                "minimum": 1,
+                                "maximum": 10,
+                            },
+                        },
+                        "required": [
+                            "exposure_time",
+                            "maximum_airmass",
+                            "maximum_fwhm",
+                        ],
+                    },
+                ]
+            },
+        },
         "required": ["observation_type", 'priority', "start_date", "end_date"],
     }
 

--- a/skyportal/handlers/api/followup_request.py
+++ b/skyportal/handlers/api/followup_request.py
@@ -410,6 +410,10 @@ def post_followup_request(data, session, refresh_source=True):
     except AttributeError:
         formSchema = instrument.api_class.form_json_schema
 
+    # if the instrument has a "prepare_payload" method, call it
+    if instrument.api_class.implements()['prepare_payload']:
+        data['payload'] = instrument.api_class.prepare_payload(data['payload'])
+
     # validate the payload
     jsonschema.validate(data['payload'], formSchema)
 
@@ -678,14 +682,18 @@ class FollowupRequestHandler(BaseHandler):
             )
 
         with self.Session() as session:
+            try:
+                data["requester_id"] = self.associated_user_object.id
+                data["last_modified_by_id"] = self.associated_user_object.id
+                data['allocation_id'] = int(data['allocation_id'])
 
-            data["requester_id"] = self.associated_user_object.id
-            data["last_modified_by_id"] = self.associated_user_object.id
-            data['allocation_id'] = int(data['allocation_id'])
+                followup_request_id = post_followup_request(data, session)
 
-            followup_request_id = post_followup_request(data, session)
-
-            return self.success(data={"id": followup_request_id})
+                return self.success(data={"id": followup_request_id})
+            except ValidationError as e:
+                return self.error(
+                    f'Error submitting follow-up request: {e.normalized_messages()}'
+                )
 
     @permissions(["Upload data"])
     def put(self, request_id):
@@ -750,9 +758,15 @@ class FollowupRequestHandler(BaseHandler):
                 data["last_modified_by_id"] = self.associated_user_object.id
 
                 api = followup_request.instrument.api_class
+                existing_status = followup_request.status
 
-                if not api.implements()['update']:
-                    return self.error('Cannot update requests on this instrument.')
+                if existing_status == 'failed to submit':
+                    if not api.implements()['submit']:
+                        return self.error('Cannot submit requests on this instrument.')
+
+                else:
+                    if not api.implements()['update']:
+                        return self.error('Cannot update requests on this instrument.')
 
                 group_ids = data.pop('target_group_ids', None)
                 if group_ids is not None:
@@ -767,20 +781,44 @@ class FollowupRequestHandler(BaseHandler):
                     FollowupRequest.__schema__().load(data, partial=True)
                 except ValidationError as e:
                     return self.error(
-                        f'Error parsing followup request update: "{e.normalized_messages()}"'
+                        f'Error parsing followup request submit/update: "{e.normalized_messages()}"'
+                    )
+
+                # if the instrument has a "prepare_payload" method, call it
+                if followup_request.instrument.api_class.implements()[
+                    'prepare_payload'
+                ]:
+                    data[
+                        'payload'
+                    ] = followup_request.instrument.api_class.prepare_payload(
+                        data['payload'], followup_request.payload
                     )
 
                 for k in data:
                     setattr(followup_request, k, data[k])
 
-                followup_request.instrument.api_class.update(followup_request, session)
-            session.commit()
+                if existing_status == 'failed to submit':
+                    try:
+                        followup_request.instrument.api_class.submit(
+                            followup_request, session, refresh_source=True
+                        )
+                        session.commit()
+                    except Exception as e:
+                        return self.error(f'Failed to submit follow-up request: {e}')
+                else:
+                    try:
+                        followup_request.instrument.api_class.update(
+                            followup_request, session
+                        )
+                        session.commit()
+                    except Exception as e:
+                        return self.error(f'Failed to update follow-up request: {e}')
 
-            self.push_all(
-                action="skyportal/REFRESH_SOURCE",
-                payload={"obj_key": followup_request.obj.internal_key},
-            )
-            return self.success()
+                self.push_all(
+                    action="skyportal/REFRESH_SOURCE",
+                    payload={"obj_key": followup_request.obj.internal_key},
+                )
+                return self.success()
 
     @permissions(["Upload data"])
     def delete(self, request_id):

--- a/static/js/components/EditFollowupRequestDialog.jsx
+++ b/static/js/components/EditFollowupRequestDialog.jsx
@@ -49,7 +49,9 @@ const EditFollowupRequestDialog = ({
   Object.keys(formSchema.properties).forEach((key) => {
     // Set the form value for "key" to the value in the existing request's
     // payload, which is the form data sent to the external follow-up API
-    formSchema.properties[key].default = followupRequest.payload[key];
+    if (followupRequest.payload[key]) {
+      formSchema.properties[key].default = followupRequest.payload[key];
+    }
   });
 
   // we do the same for formSchema.dependencies, where each key is a value that has dependencies, under a key called "oneOf"
@@ -57,7 +59,10 @@ const EditFollowupRequestDialog = ({
   Object.keys(formSchema.dependencies).forEach((key) => {
     formSchema.dependencies[key].oneOf.forEach((oneOf) => {
       Object.keys(oneOf.properties).forEach((oneOfKey) => {
-        if (!formSchema.properties[oneOfKey]) {
+        if (
+          !formSchema.properties[oneOfKey] &&
+          followupRequest.payload[oneOfKey]
+        ) {
           oneOf.properties[oneOfKey].default =
             followupRequest.payload[oneOfKey];
         }

--- a/static/js/components/EditFollowupRequestDialog.jsx
+++ b/static/js/components/EditFollowupRequestDialog.jsx
@@ -52,6 +52,19 @@ const EditFollowupRequestDialog = ({
     formSchema.properties[key].default = followupRequest.payload[key];
   });
 
+  // we do the same for formSchema.dependencies, where each key is a value that has dependencies, under a key called "oneOf"
+  // in the oneOf.properties, if any key isnt in formSchema.properties, we set the their default value to the value in the existing request's payload
+  Object.keys(formSchema.dependencies).forEach((key) => {
+    formSchema.dependencies[key].oneOf.forEach((oneOf) => {
+      Object.keys(oneOf.properties).forEach((oneOfKey) => {
+        if (!formSchema.properties[oneOfKey]) {
+          oneOf.properties[oneOfKey].default =
+            followupRequest.payload[oneOfKey];
+        }
+      });
+    });
+  });
+
   const validate = (formData, errors) => {
     if (
       formData.start_date &&

--- a/static/js/components/FollowupRequestLists.jsx
+++ b/static/js/components/FollowupRequestLists.jsx
@@ -111,6 +111,18 @@ const FollowupRequestLists = ({
     setIsGetting(null);
   };
 
+  const [isSubmitting, setIsSubmitting] = useState(null);
+  const handleSubmit = async (followupRequest) => {
+    setIsSubmitting(followupRequest.id);
+    const json = {
+      allocation_id: followupRequest.allocation.id,
+      obj_id: followupRequest.obj_id,
+      payload: followupRequest.payload,
+    };
+    await dispatch(Actions.editFollowupRequest(json, followupRequest.id));
+    setIsSubmitting(null);
+  };
+
   if (
     instrumentList.length === 0 ||
     followupRequests.length === 0 ||
@@ -149,6 +161,8 @@ const FollowupRequestLists = ({
     if (!(instrument_id in instrumentFormParams)) {
       return columns;
     }
+    const implementSubmit =
+      instrumentFormParams[instrument_id].methodsImplemented.submit;
     const implementsDelete =
       instrumentFormParams[instrument_id].methodsImplemented.delete;
     const implementsEdit =
@@ -215,6 +229,10 @@ const FollowupRequestLists = ({
         const isDone =
           followupRequest.status === "Photometry committed to database";
 
+        const isSubmitted = followupRequest.status === "submitted";
+
+        const isFailed = followupRequest.status === "failed to submit";
+
         return (
           <div className={classes.actionButtons}>
             {implementsDelete && isDeleting === followupRequest.id ? (
@@ -236,7 +254,7 @@ const FollowupRequestLists = ({
                 </Button>
               </div>
             )}
-            {!isDone && (
+            {!isDone && isSubmitted && (
               <div>
                 {implementsGet && isGetting === followupRequest.id ? (
                   <div>
@@ -254,6 +272,29 @@ const FollowupRequestLists = ({
                       data-testid={`getRequest_${followupRequest.id}`}
                     >
                       Retrieve
+                    </Button>
+                  </div>
+                )}
+              </div>
+            )}
+            {isFailed && (
+              <div>
+                {implementSubmit && isSubmitting === followupRequest.id ? (
+                  <div>
+                    <CircularProgress />
+                  </div>
+                ) : (
+                  <div>
+                    <Button
+                      primary
+                      onClick={() => {
+                        handleSubmit(followupRequest);
+                      }}
+                      size="small"
+                      type="submit"
+                      data-testid={`submitRequest_${followupRequest.id}`}
+                    >
+                      Submit
                     </Button>
                   </div>
                 )}


### PR DESCRIPTION
This PR addresses Don and Jesper's comments about the SEDM new fields that needs to be optional and always have default value. 

Moreover, this makes it possible to resubmit if the previous submission has a  "failed to submit" status. This is useful for example if you created a followup requests with an allocation that was missing credentials which you fixed right after, or if the instrument's API wasn't available for a sec... That way, you can retry submitting your request without having to delete it and input all the values again.