### PR TITLE
remove 60s single frame exposure for SEDMv2

### DIFF
--- a/skyportal/facility_apis/sedmv2.py
+++ b/skyportal/facility_apis/sedmv2.py
@@ -68,10 +68,10 @@ def validate_request_to_sedmv2(request):
 
     if (request.payload["observation_type"] == "variable") and (
         request.payload["frame_exposure_time"]
-        not in [1, 2, 3, 5, 10, 15, 20, 25, 30, 60]
+        not in [1, 2, 3, 5, 10, 15, 20, 25, 30]
     ):
         raise ValueError(
-            'frame_exposure_time must be [1, 2, 3, 5, 10, 15, 20, 25, 30, 60]'
+            'frame_exposure_time must be [1, 2, 3, 5, 10, 15, 20, 25, 30]'
         )
 
 
@@ -365,7 +365,7 @@ class SEDMV2API(FollowUpAPI):
                             },
                             "frame_exposure_time": {
                                 "title": "Exposure time per frame (s)",
-                                "enum": [1, 2, 3, 5, 10, 15, 20, 25, 30, 60],
+                                "enum": [1, 2, 3, 5, 10, 15, 20, 25, 30],
                                 "default": 10,
                             },
                         },

--- a/skyportal/facility_apis/sedmv2.py
+++ b/skyportal/facility_apis/sedmv2.py
@@ -67,12 +67,9 @@ def validate_request_to_sedmv2(request):
         raise ValueError('too must be Y or N')
 
     if (request.payload["observation_type"] == "variable") and (
-        request.payload["frame_exposure_time"]
-        not in [1, 2, 3, 5, 10, 15, 20, 25, 30]
+        request.payload["frame_exposure_time"] not in [1, 2, 3, 5, 10, 15, 20, 25, 30]
     ):
-        raise ValueError(
-            'frame_exposure_time must be [1, 2, 3, 5, 10, 15, 20, 25, 30]'
-        )
+        raise ValueError('frame_exposure_time must be [1, 2, 3, 5, 10, 15, 20, 25, 30]')
 
 
 class SEDMV2API(FollowUpAPI):


### PR DESCRIPTION
Remove the 60s single frame option from SEDMv2 follow-up requests. It is not a valid option within the software for the imaging mode.