### PR TITLE
Custom Engine args

### DIFF
--- a/skyportal/app_server.py
+++ b/skyportal/app_server.py
@@ -627,10 +627,15 @@ def make_app(cfg, baselayer_handlers, baselayer_settings, process=None, env=None
     )
 
     app = CustomApplication(handlers, **settings)
+
+    default_engine_args = {'pool_size': 10, 'max_overflow': 15, 'pool_recycle': 3600}
+    database_cfg = cfg['database']
+    if database_cfg.get('engine_args', {}) in [None, '', {}]:
+        database_cfg['engine_args'] = default_engine_args
+
     init_db(
-        **cfg['database'],
+        **database_cfg,
         autoflush=False,
-        engine_args={'pool_size': 10, 'max_overflow': 15, 'pool_recycle': 3600},
     )
 
     # If tables are found in the database, new tables will only be added

--- a/skyportal/app_server.py
+++ b/skyportal/app_server.py
@@ -632,6 +632,11 @@ def make_app(cfg, baselayer_handlers, baselayer_settings, process=None, env=None
     database_cfg = cfg['database']
     if database_cfg.get('engine_args', {}) in [None, '', {}]:
         database_cfg['engine_args'] = default_engine_args
+    else:
+        database_cfg['engine_args'] = {
+            **default_engine_args,
+            **database_cfg['engine_args'],
+        }
 
     init_db(
         **database_cfg,


### PR DESCRIPTION
It is already possible in baselayer to specify the engine args of the database (pool size, overflow, ...) in the config, but a piece of code in SP specified other values than the default ones in a way that creates issues when specifying them in the config. 

This PR addresses that issue by using the SP default values (that are a little higher than the baselayer ones) if not provided in the config, and otherwise uses the ones specified in the config.