### PR TITLE
Bugfix: make load_demo_data

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -86,3 +86,4 @@ shapely==1.8.1
 stdpipe==0.1
 openai[embeddings]==0.27.2
 pinecone-client==2.2.1
+simplejson>=3.17.2,<=3.18.4


### PR DESCRIPTION
It seems that a recent release of simple-json breaks some of the json compliant verification we do in the data loader method. 

It's very probable that we could just change some code on our side rather than pin a version, but given that its still a little unclear what needs to chance, it is best to pin a version while we modify the code to allow unit tests and the app to still function.