### PR TITLE
GCN Bugfix: Summary won't open

### DIFF
--- a/skyportal/facility_apis/ztf.py
+++ b/skyportal/facility_apis/ztf.py
@@ -944,8 +944,9 @@ class ZTFMMAAPI(MMAAPI):
             "subprogram_name": {
                 "type": "string",
                 "enum": ["GW", "GRB", "Neutrino", "SolarSystem", "Other"],
-                "default": "GRB",
+                "default": "GW",
             },
+            "filters": {"type": "string", "default": "ztfg,ztfr,ztfg"},
         }
         form_json_schema["required"] = form_json_schema["required"] + [
             "subprogram_name",

--- a/skyportal/tests/flaky/test_frontend_flaky.py
+++ b/skyportal/tests/flaky/test_frontend_flaky.py
@@ -674,7 +674,7 @@ def test_observationplan_request(driver, user, super_admin_token, public_group):
     )
     driver.click_xpath(f"//div[@data-testid='{instrument_name}-requests-header']")
     driver.wait_for_xpath(
-        f'//div[contains(@data-testid, "{instrument_name}_observationplanRequestsTable")]//div[contains(., "ztfg,ztfr,ztfi")]',
+        f'//div[contains(@data-testid, "{instrument_name}_observationplanRequestsTable")]//div[contains(., "ztfg,ztfr,ztfg")]',
         timeout=15,
     )
     driver.wait_for_xpath(

--- a/static/js/components/AddGcnTag.jsx
+++ b/static/js/components/AddGcnTag.jsx
@@ -37,7 +37,7 @@ const AddGcnTag = ({ gcnEvent }) => {
   useEffect(() => {
     setInvalid(
       // eslint-disable-next-line no-restricted-globals
-      gcnEvent.tags.includes(tag)
+      gcnEvent?.tags?.includes(tag)
     );
   }, [gcnEvent, setInvalid, tag]);
 

--- a/static/js/components/GcnTags.jsx
+++ b/static/js/components/GcnTags.jsx
@@ -94,9 +94,11 @@ const GcnTags = ({ gcnEvent, show_title = false }) => {
   };
 
   const gcnTags = [];
-  gcnEvent.tags?.forEach((tag) => {
-    gcnTags.push(tag);
-  });
+  if (gcnEvent?.tags) {
+    gcnEvent.tags.forEach((tag) => {
+      gcnTags.push(tag);
+    });
+  }
   const gcnTagsUnique = [...new Set(gcnTags)];
 
   const localizationTags = [];

--- a/static/js/components/NewDefaultObservationPlan.jsx
+++ b/static/js/components/NewDefaultObservationPlan.jsx
@@ -180,13 +180,6 @@ const NewDefaultObservationPlan = () => {
         dispatch(
           showNotification("Successfully created default observation plan")
         );
-      } else {
-        dispatch(
-          showNotification(
-            `Failed to create default observation plan: ${response.message}`,
-            "error"
-          )
-        );
       }
     });
   };

--- a/static/js/components/NewDefaultObservationPlan.jsx
+++ b/static/js/components/NewDefaultObservationPlan.jsx
@@ -9,6 +9,7 @@ import validator from "@rjsf/validator-ajv8";
 import CircularProgress from "@mui/material/CircularProgress";
 import makeStyles from "@mui/styles/makeStyles";
 
+import { showNotification } from "baselayer/components/Notifications";
 import GcnNoticeTypesSelect from "./GcnNoticeTypesSelect";
 import GcnTagsSelect from "./GcnTagsSelect";
 import LocalizationTagsSelect from "./LocalizationTagsSelect";
@@ -172,9 +173,22 @@ const NewDefaultObservationPlan = () => {
       default_plan_name,
     };
 
-    await dispatch(
+    dispatch(
       defaultObservationPlansActions.submitDefaultObservationPlan(json)
-    );
+    ).then((response) => {
+      if (response.status === "success") {
+        dispatch(
+          showNotification("Successfully created default observation plan")
+        );
+      } else {
+        dispatch(
+          showNotification(
+            `Failed to create default observation plan: ${response.message}`,
+            "error"
+          )
+        );
+      }
+    });
   };
 
   const { formSchema, uiSchema } =


### PR DESCRIPTION
In the GCN Summary component, we fetch groups and users and until those are fetched, we can't open the component. 
This PR removes this component, as anyway groups are hydrated when loading SP, and we shouldn't fetched all users but only the group_users of the selected group.