### PR TITLE
WIP: Find fields with gwemopt configurable + minor quality of life improvements

### DIFF
--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -20,6 +20,7 @@ app:
 
   observation_plan:
     default_filters: ['ztfg', 'ztfr', 'ztfi']
+    use_skyportal_fields: True
 
   heasarc_endpoint: https://heasarc.gsfc.nasa.gov
 
@@ -660,7 +661,7 @@ gcn:
         schedule_strategy: tiling
         galaxy_catalog: CLU_mini
         exposure_time: 300
-        filters: g,r,g
+        filters: ztfg,ztfr,ztfg
         maximum_airmass: 2
         integrated_probability: 90
         minimum_time_difference: 30

--- a/skyportal/handlers/api/gcn.py
+++ b/skyportal/handlers/api/gcn.py
@@ -80,6 +80,7 @@ from ...utils.gcn import (
     get_skymap_properties,
     get_skymap_metadata,
     get_tags,
+    get_notice_aliases,
     get_trigger,
     get_skymap,
     get_contour,
@@ -137,6 +138,9 @@ def post_gcnevent_from_xml(
     dateobs = get_dateobs(root)
     trigger_id = get_trigger(root)
     notice_type = gcn.get_notice_type(root)
+    aliases = get_notice_aliases(
+        root, notice_type
+    )  # we try to get the aliases from the notice if possible
 
     if trigger_id is not None:
         event = session.scalars(
@@ -148,7 +152,9 @@ def post_gcnevent_from_xml(
         ).first()
 
     if event is None:
-        event = GcnEvent(dateobs=dateobs, sent_by_id=user_id, trigger_id=trigger_id)
+        event = GcnEvent(
+            dateobs=dateobs, sent_by_id=user_id, trigger_id=trigger_id, aliases=aliases
+        )
         session.add(event)
         session.commit()
         dateobs = event.dateobs
@@ -165,7 +171,6 @@ def post_gcnevent_from_xml(
 
     event_id = event.id
 
-    notice_id = None
     gcn_notice = GcnNotice(
         content=payload,
         ivorn=root.attrib['ivorn'],
@@ -1122,6 +1127,17 @@ class GcnEventHandler(BaseHandler):
                         reverse=True,
                     ),
                     "gcn_notices": [notice.to_dict() for notice in event.gcn_notices],
+                    # sort the properties by created_at date descending
+                    "properties": sorted(
+                        (
+                            {
+                                **s.to_dict(),
+                            }
+                            for s in event.properties
+                        ),
+                        key=lambda x: x["created_at"],
+                        reverse=True,
+                    ),
                 }
 
                 return self.success(data=data)
@@ -1947,6 +1963,8 @@ def add_gcn_summary(
                 coroutine = get_sources(
                     user_id=user.id,
                     session=session,
+                    group_ids=[group.id],
+                    user_accessible_group_ids=[g.id for g in user.accessible_groups],
                     first_detected_date=start_date,
                     last_detected_date=end_date,
                     localization_dateobs=dateobs,
@@ -1992,6 +2010,7 @@ def add_gcn_summary(
                         "redshift": redshifts,
                     }
                 )
+                df = df.fillna("--")
                 sources_text.append(
                     tabulate(df, headers='keys', tablefmt='psql', showindex=False)
                     + "\n"
@@ -2059,6 +2078,7 @@ def add_gcn_summary(
                                 column='obj_id',
                                 value=[p["obj_id"] for p in photometry],
                             )
+                        df_phot = df_phot.fillna("--")
                         sources_text.append(
                             tabulate(
                                 df_phot,
@@ -2123,6 +2143,7 @@ def add_gcn_summary(
                         "redshift": redshifts,
                     }
                 )
+                df = df.fillna("--")
                 galaxies_text.append(
                     tabulate(df, headers='keys', tablefmt='psql', showindex=False)
                     + "\n"
@@ -2220,6 +2241,7 @@ def add_gcn_summary(
                                     for obs in observations
                                 ],
                             )
+                        df_obs = df_obs.fillna("--")
                         observations_text.append(
                             tabulate(
                                 df_obs,
@@ -2271,6 +2293,7 @@ def add_gcn_summary(
         except Exception:
             pass
         log(f"Unable to create GCN summary: {e}")
+        raise e
     finally:
         session.close()
         Session.remove()

--- a/skyportal/handlers/api/gcn.py
+++ b/skyportal/handlers/api/gcn.py
@@ -1994,8 +1994,8 @@ def add_gcn_summary(
                 for source in sources:
                     ids.append(source['id'] if 'id' in source else None)
                     aliases.append(source['alias'] if 'alias' in source else None)
-                    ras.append(source['ra'] if 'ra' in source else None)
-                    decs.append(source['dec'] if 'dec' in source else None)
+                    ras.append(np.round(source['ra'], 4) if 'ra' in source else None)
+                    decs.append(np.round(source['dec'], 4) if 'dec' in source else None)
                     redshift = source['redshift'] if 'redshift' in source else None
                     if 'redshift_error' in source and redshift is not None:
                         if source['redshift_error'] is not None:
@@ -2012,7 +2012,13 @@ def add_gcn_summary(
                 )
                 df = df.fillna("--")
                 sources_text.append(
-                    tabulate(df, headers='keys', tablefmt='psql', showindex=False)
+                    tabulate(
+                        df,
+                        headers='keys',
+                        tablefmt='psql',
+                        showindex=False,
+                        floatfmt=".4f",
+                    )
                     + "\n"
                 )
                 # now, create a photometry table per source
@@ -2145,7 +2151,13 @@ def add_gcn_summary(
                 )
                 df = df.fillna("--")
                 galaxies_text.append(
-                    tabulate(df, headers='keys', tablefmt='psql', showindex=False)
+                    tabulate(
+                        df,
+                        headers='keys',
+                        tablefmt='psql',
+                        showindex=False,
+                        floatfmt=".4f",
+                    )
                     + "\n"
                 )
             contents.extend(galaxies_text)

--- a/skyportal/handlers/api/gcn_tach.py
+++ b/skyportal/handlers/api/gcn_tach.py
@@ -228,7 +228,7 @@ def post_aliases(dateobs, tach_id, user_id):
             if not gcn_event.aliases:  # empty list or None
                 gcn_event.aliases = new_gcn_aliases
             else:
-                gcn_aliases = gcn_event.aliases
+                gcn_aliases = [alias for alias in gcn_event.aliases]
                 for new_gcn_alias in new_gcn_aliases:
                     if new_gcn_alias not in gcn_aliases:
                         gcn_aliases.append(new_gcn_alias)

--- a/skyportal/handlers/api/observation_plan.py
+++ b/skyportal/handlers/api/observation_plan.py
@@ -47,7 +47,7 @@ from ligo.skymap import plot  # noqa: F401 F811
 import afterglowpy
 import sncosmo
 
-from baselayer.app.access import auth_or_token
+from baselayer.app.access import auth_or_token, permissions
 from baselayer.app.env import load_env
 from baselayer.app.flow import Flow
 from baselayer.log import make_log
@@ -354,7 +354,7 @@ def post_observation_plans(plans, user_id, session, asynchronous=True):
     for observation_plan_request in observation_plan_requests:
         flow.push(
             '*',
-            "skyportal/REFRESH_GCN_EVENT",
+            "skyportal/REFRESH_GCNEVENT_OBSERVATION_PLAN_REQUESTS",
             payload={"gcnEvent_dateobs": observation_plan_request.gcnevent.dateobs},
         )
 
@@ -435,7 +435,7 @@ def post_observation_plan(plan, user_id, session, asynchronous=True):
 
     flow.push(
         '*',
-        "skyportal/REFRESH_GCN_EVENT",
+        "skyportal/REFRESH_GCNEVENT_OBSERVATION_PLAN_REQUESTS",
         payload={"gcnEvent_dateobs": dateobs},
     )
 
@@ -449,7 +449,7 @@ def post_observation_plan(plan, user_id, session, asynchronous=True):
 
     flow.push(
         '*',
-        "skyportal/REFRESH_GCN_EVENT",
+        "skyportal/REFRESH_GCNEVENT_OBSERVATION_PLAN_REQUESTS",
         payload={"gcnEvent_dateobs": observation_plan_request.gcnevent.dateobs},
     )
 
@@ -457,7 +457,7 @@ def post_observation_plan(plan, user_id, session, asynchronous=True):
 
 
 class ObservationPlanRequestHandler(BaseHandler):
-    @auth_or_token
+    @permissions(['Manage observation plans'])
     def post(self):
         """
         ---
@@ -608,7 +608,7 @@ class ObservationPlanRequestHandler(BaseHandler):
             )
             return self.success(data=observation_plan_requests)
 
-    @auth_or_token
+    @permissions(['Manage observation plans'])
     def delete(self, observation_plan_request_id):
         """
         ---
@@ -652,7 +652,7 @@ class ObservationPlanRequestHandler(BaseHandler):
             session.commit()
 
             self.push_all(
-                action="skyportal/REFRESH_GCN_EVENT",
+                action="skyportal/REFRESH_GCNEVENT_OBSERVATION_PLAN_REQUESTS",
                 payload={"gcnEvent_dateobs": dateobs},
             )
 
@@ -660,7 +660,7 @@ class ObservationPlanRequestHandler(BaseHandler):
 
 
 class ObservationPlanManualRequestHandler(BaseHandler):
-    @auth_or_token
+    @permissions(['Manage observation plans'])
     def post(self):
         """
         ---
@@ -777,7 +777,7 @@ class ObservationPlanManualRequestHandler(BaseHandler):
 
 
 class ObservationPlanSubmitHandler(BaseHandler):
-    @auth_or_token
+    @permissions(['Manage observation plans'])
     def post(self, observation_plan_request_id):
         """
         ---
@@ -844,7 +844,7 @@ class ObservationPlanSubmitHandler(BaseHandler):
                 pass  # this is not a critical error, we can continue
 
             self.push_all(
-                action="skyportal/REFRESH_GCN_EVENT",
+                action="skyportal/REFRESH_GCNEVENT_OBSERVATION_PLAN_REQUESTS",
                 payload={"gcnEvent_dateobs": observation_plan_request.gcnevent.dateobs},
             )
 
@@ -852,7 +852,7 @@ class ObservationPlanSubmitHandler(BaseHandler):
 
             return self.success(data=observation_plan_request)
 
-    @auth_or_token
+    @permissions(['Manage observation plans'])
     def delete(self, observation_plan_request_id):
         """
         ---
@@ -899,7 +899,7 @@ class ObservationPlanSubmitHandler(BaseHandler):
             finally:
                 session.commit()
             self.push_all(
-                action="skyportal/REFRESH_GCN_EVENT",
+                action="skyportal/REFRESH_GCNEVENT_OBSERVATION_PLAN_REQUESTST",
                 payload={"gcnEvent_dateobs": observation_plan_request.gcnevent.dateobs},
             )
 
@@ -1228,7 +1228,7 @@ class ObservationPlanMovieHandler(BaseHandler):
 
 
 class ObservationPlanTreasureMapHandler(BaseHandler):
-    @auth_or_token
+    @permissions(['Manage observation plans'])
     def post(self, observation_plan_request_id):
         """
         ---
@@ -1327,7 +1327,7 @@ class ObservationPlanTreasureMapHandler(BaseHandler):
             self.push_notification('TreasureMap upload succeeded')
             return self.success()
 
-    @auth_or_token
+    @permissions(['Manage observation plans'])
     def delete(self, observation_plan_request_id):
         """
         ---
@@ -1526,7 +1526,7 @@ class ObservationPlanGeoJSONHandler(BaseHandler):
 
 
 class ObservationPlanFieldsHandler(BaseHandler):
-    @auth_or_token
+    @permissions(['Manage observation plans'])
     def delete(self, observation_plan_request_id):
         """
         ---
@@ -1597,7 +1597,7 @@ class ObservationPlanFieldsHandler(BaseHandler):
                 session.commit()
 
             self.push_all(
-                action="skyportal/REFRESH_GCN_EVENT",
+                action="skyportal/REFRESH_GCNEVENT_OBSERVATION_PLAN_REQUESTS",
                 payload={"gcnEvent_dateobs": dateobs},
             )
 
@@ -1946,7 +1946,7 @@ class ObservationPlanAirmassChartHandler(BaseHandler):
 
 
 class ObservationPlanCreateObservingRunHandler(BaseHandler):
-    @auth_or_token
+    @permissions(['Manage observation plans'])
     def post(self, observation_plan_request_id):
         """
         ---
@@ -2760,7 +2760,7 @@ class ObservationPlanSimSurveyPlotHandler(BaseHandler):
 
 
 class DefaultObservationPlanRequestHandler(BaseHandler):
-    @auth_or_token
+    @permissions(['Manage observation plans'])
     def post(self):
         """
         ---
@@ -2940,7 +2940,7 @@ class DefaultObservationPlanRequestHandler(BaseHandler):
 
             return self.success(data=default_observation_plan_data)
 
-    @auth_or_token
+    @permissions(['Manage observation plans'])
     def delete(self, default_observation_plan_id):
         """
         ---

--- a/skyportal/model_util.py
+++ b/skyportal/model_util.py
@@ -18,6 +18,7 @@ all_acl_ids = [
     'Manage telescopes',
     'Manage Analysis Services',
     'Manage Recurring APIs',
+    'Manage observation plans',
     'Manage GCNs',
     'Upload data',
     'Run Analyses',

--- a/skyportal/tests/api/test_gcn.py
+++ b/skyportal/tests/api/test_gcn.py
@@ -387,7 +387,7 @@ def test_gcn_summary_sources(
     photometry_table = table[idx + 1 :]
 
     assert (
-        len(sources_table) >= 6
+        len(sources_table) >= 4
     )  # other sources have probably been added in previous tests
     assert "id" in sources_table[1]
     assert "alias" in sources_table[1]
@@ -1353,7 +1353,7 @@ def test_gcn_tach(
     assert n_times < 25
 
     data = data['data']
-    assert len(data['aliases']) == 0
+    assert len(data['aliases']) == 1
 
     status, data = api('POST', f'gcn_event/{dateobs}/tach', token=view_only_token)
     assert status == 401
@@ -1365,13 +1365,13 @@ def test_gcn_tach(
     for n_times in range(30):
         status, data = api('GET', f"gcn_event/{dateobs}", token=super_admin_token)
         if data['status'] == 'success':
-            if len(data['data']['aliases']) > 0:
+            if len(data['data']['aliases']) > 1:
                 aliases = data['data']['aliases']
                 break
             time.sleep(1)
 
     assert n_times < 29
-    assert len(aliases) == 1
+    assert len(aliases) == 2
     assert 'GRB180116A' in aliases
 
     status, data = api('GET', f"gcn_event/{dateobs}/tach", token=super_admin_token)
@@ -1379,7 +1379,7 @@ def test_gcn_tach(
     assert status == 200
     assert data['status'] == 'success'
     data = data['data']
-    assert len(data['aliases']) == 1
+    assert len(data['aliases']) == 2
     assert len(data['circulars']) == 3
     assert data['tach_id'] is not None
 

--- a/skyportal/tests/frontend/test_gcn.py
+++ b/skyportal/tests/frontend/test_gcn.py
@@ -93,7 +93,9 @@ def test_gcn_tach(
     driver.wait_for_xpath(right_panel_button)
     driver.click_xpath(right_panel_button)
 
-    update_aliases = driver.wait_for_xpath('//*[@data-testid="update-aliases"]')
+    update_aliases = driver.wait_for_xpath(
+        '//*[@data-testid="update-aliases"]', timeout=30
+    )
     driver.scroll_to_element_and_click(update_aliases, scroll_parent=True)
     driver.wait_for_xpath('//*[contains(., "GRB180116A")]', timeout=60)
     assert len(driver.find_elements(By.XPATH, '//*[@name="aliases-chips"]/*')) == 2

--- a/skyportal/tests/frontend/test_gcn.py
+++ b/skyportal/tests/frontend/test_gcn.py
@@ -96,7 +96,7 @@ def test_gcn_tach(
     update_aliases = driver.wait_for_xpath('//*[@data-testid="update-aliases"]')
     driver.scroll_to_element_and_click(update_aliases, scroll_parent=True)
     driver.wait_for_xpath('//*[contains(., "GRB180116A")]', timeout=60)
-    assert len(driver.find_elements(By.XPATH, '//*[@name="aliases-chips"]/*')) == 1
+    assert len(driver.find_elements(By.XPATH, '//*[@name="aliases-chips"]/*')) == 2
 
     driver.wait_for_xpath('//a[contains(text(), "GRB 180116A: Fermi GBM Detection")]')
 

--- a/skyportal/utils/gcn.py
+++ b/skyportal/utils/gcn.py
@@ -154,6 +154,30 @@ def get_tags(root):
         yield from instruments
 
 
+def get_notice_aliases(root, notice_type):
+    aliases = []
+    try:
+        # we try to find aliases in the notice itself, which the user can update on the frontend by fetching data from TACH
+        if notice_type in [
+            gcn.NoticeType.FERMI_GBM_FIN_POS,
+            gcn.NoticeType.FERMI_GBM_FLT_POS,
+            gcn.NoticeType.FERMI_GBM_GND_POS,
+        ]:
+            url = root.find("./What/Param[@name='LightCurve_URL']").attrib['value']
+            alias = url.split('/triggers/')[1].split('/')[1].split('/')[0]
+            aliases.append(f"FERMI#{alias}")
+
+        # we try the LVC convention
+        graceid = root.find("./What/Param[@name='GraceID']")
+        if graceid is not None:
+            aliases.append(f"LVC#{graceid.attrib['value']}")
+    except Exception as e:
+        print(f"Could not find aliases in notice: {str(e)}")
+        pass
+
+    return aliases
+
+
 def get_skymap_url(root, notice_type, timeout=10):
     url = None
     available = False

--- a/static/js/components/GcnAliases.jsx
+++ b/static/js/components/GcnAliases.jsx
@@ -47,7 +47,9 @@ const GcnAliases = ({ gcnEvent }) => {
             clickable
             onClick={() => {
               window.open(
-                `https://heasarc.gsfc.nasa.gov/wsgi-scripts/tach/gcn_v2/tach.wsgi/?event=${alias}`,
+                `https://heasarc.gsfc.nasa.gov/wsgi-scripts/tach/gcn_v2/tach.wsgi/?event=${
+                  alias.split("#")[1] || alias
+                }`,
                 "_blank"
               );
             }}

--- a/static/js/components/GcnEventAllocationTriggers.jsx
+++ b/static/js/components/GcnEventAllocationTriggers.jsx
@@ -140,7 +140,12 @@ const GcnEventAllocationTriggers = ({
       triggers.find(
         (trigger) => trigger.allocation_id === parseInt(allocation_id, 10)
       ) || null;
-
+    if (instruments_triggered[allocationLookUp[allocation_id]] === undefined) {
+      instruments_triggered[allocationLookUp[allocation_id]] = {
+        triggered: "not_set",
+        allocation_triggered: [],
+      };
+    }
     if (
       t?.triggered === true &&
       instruments_triggered[allocationLookUp[allocation_id]]?.triggered ===

--- a/static/js/components/GcnEventPage.jsx
+++ b/static/js/components/GcnEventPage.jsx
@@ -57,9 +57,6 @@ const useStyles = makeStyles((theme) => ({
     "& > .MuiPaper-root": {
       width: "100%",
       height: "100%",
-      [theme.breakpoints.up("md")]: {
-        width: "50%",
-      },
     },
   },
   sidePanelContent: {
@@ -524,196 +521,199 @@ const GcnEventPage = ({ route }) => {
             </IconButton>
           </DialogTitle>
           <div className={styles.sidePanelContent}>
-            {/* event properties */}
-            <div className={styles.columnItem}>
-              <Accordion defaultExpanded>
-                <AccordionSummary
-                  expandIcon={<ExpandMoreIcon />}
-                  aria-controls="gcnEvent-content"
-                  id="info-header"
-                >
-                  <Typography className={styles.accordionHeading}>
-                    Event Properties
-                  </Typography>
-                </AccordionSummary>
-                <AccordionDetails>
-                  <GcnProperties properties={gcnEvent.properties} />
-                </AccordionDetails>
-              </Accordion>
-            </div>
-            {/* localization properties */}
-            <div className={styles.columnItem}>
-              <Accordion defaultExpanded>
-                <AccordionSummary
-                  expandIcon={<ExpandMoreIcon />}
-                  aria-controls="gcnEvent-content"
-                  id="info-header"
-                >
-                  <Typography className={styles.accordionHeading}>
-                    Localization Properties
-                  </Typography>
-                </AccordionSummary>
-                <AccordionDetails>
-                  <GcnLocalizationsTable
-                    localizations={gcnEvent.localizations}
-                  />
-                </AccordionDetails>
-              </Accordion>
-            </div>
-            <div className={styles.columnItem}>
-              <Accordion defaultExpanded>
-                <AccordionSummary
-                  expandIcon={<ExpandMoreIcon />}
-                  aria-controls="gcnEvent-content"
-                  id="lightcurve-header"
-                >
-                  <Typography className={styles.accordionHeading}>
-                    Light curve
-                  </Typography>
-                </AccordionSummary>
-                <AccordionDetails>
-                  <div className={styles.gcnEventContainer}>
-                    {route?.dateobs === gcnEvent?.dateobs && route?.dateobs ? (
-                      <>
-                        {gcnEvent?.lightcurve && (
-                          <div>
-                            <img src={gcnEvent.lightcurve} alt="loading..." />
-                          </div>
-                        )}
-                      </>
-                    ) : (
-                      <p> Fetching event... </p>
-                    )}
-                  </div>
-                </AccordionDetails>
-              </Accordion>
-            </div>
-            <div className={styles.columnItem}>
-              <Accordion defaultExpanded>
-                <AccordionSummary
-                  expandIcon={<ExpandMoreIcon />}
-                  aria-controls="gcnEvent-content"
-                  id="gcnnotices-header"
-                >
-                  <Typography className={styles.accordionHeading}>
-                    GCN Notices
-                  </Typography>
-                </AccordionSummary>
-                <AccordionDetails>
-                  <div className={styles.gcnEventContainer}>
-                    {gcnEvent.gcn_notices?.map((gcn_notice) => (
-                      <li
-                        key={gcn_notice.ivorn}
-                        className={styles.noticeListElement}
-                      >
-                        <div className={styles.noticeListElementHeader}>
-                          <Chip
-                            size="small"
-                            label={gcn_notice.ivorn}
-                            key={gcn_notice.ivorn}
-                            className={styles.noticeListElementIVORN}
-                          />
-                          <DownloadXMLButton gcn_notice={gcn_notice} />
-                        </div>
-                        {gcn_notice?.has_localization &&
-                          gcn_notice?.localization_ingested === false && (
-                            <Button
-                              secondary
-                              onClick={() => {
-                                dispatch(
-                                  showNotification(
-                                    `Starting ingestion attempt for localization from notice ${gcn_notice.id}. Please wait...`,
-                                    "warning"
-                                  )
-                                );
-                                dispatch(
-                                  postLocalizationFromNotice({
-                                    dateobs: gcn_notice.dateobs,
-                                    noticeID: gcn_notice.id,
-                                  })
-                                ).then((response) => {
-                                  if (response.status === "success") {
-                                    dispatch(
-                                      showNotification(
-                                        `Localization successfully ingested from notice ${gcn_notice.id}. Please wait for the contour to be generated. Default observation plans will be created shortly.`
-                                      )
-                                    );
-                                  } else {
-                                    dispatch(
-                                      showNotification(
-                                        `Error ingesting localization from notice ${gcn_notice.id}. It might not be available yet.`,
-                                        "error"
-                                      )
-                                    );
-                                  }
-                                });
-                              }}
-                              data-testid="ingest-localization-from-notice"
-                            >
-                              Ingest Localization
-                            </Button>
+            <Grid container spacing={2}>
+              {/* event properties */}
+              <Grid item xs={12}>
+                <Accordion defaultExpanded>
+                  <AccordionSummary
+                    expandIcon={<ExpandMoreIcon />}
+                    aria-controls="gcnEvent-content"
+                    id="info-header"
+                  >
+                    <Typography className={styles.accordionHeading}>
+                      Event Properties
+                    </Typography>
+                  </AccordionSummary>
+                  <AccordionDetails>
+                    <GcnProperties properties={gcnEvent.properties} />
+                  </AccordionDetails>
+                </Accordion>
+              </Grid>
+              {/* localization properties */}
+              <Grid item xs={12}>
+                <Accordion defaultExpanded>
+                  <AccordionSummary
+                    expandIcon={<ExpandMoreIcon />}
+                    aria-controls="gcnEvent-content"
+                    id="info-header"
+                  >
+                    <Typography className={styles.accordionHeading}>
+                      Localization Properties
+                    </Typography>
+                  </AccordionSummary>
+                  <AccordionDetails>
+                    <GcnLocalizationsTable
+                      localizations={gcnEvent.localizations}
+                    />
+                  </AccordionDetails>
+                </Accordion>
+              </Grid>
+              <Grid item sm={12} lg={6}>
+                <Accordion defaultExpanded>
+                  <AccordionSummary
+                    expandIcon={<ExpandMoreIcon />}
+                    aria-controls="gcnEvent-content"
+                    id="lightcurve-header"
+                  >
+                    <Typography className={styles.accordionHeading}>
+                      Light curve
+                    </Typography>
+                  </AccordionSummary>
+                  <AccordionDetails>
+                    <div className={styles.gcnEventContainer}>
+                      {route?.dateobs === gcnEvent?.dateobs &&
+                      route?.dateobs ? (
+                        <>
+                          {gcnEvent?.lightcurve && (
+                            <div>
+                              <img src={gcnEvent.lightcurve} alt="loading..." />
+                            </div>
                           )}
-                        <div className={styles.noticeListDivider} />
-                      </li>
-                    ))}
-                  </div>
-                </AccordionDetails>
-              </Accordion>
-            </div>
-            <div className={styles.columnItem}>
-              <Accordion defaultExpanded>
-                <AccordionSummary
-                  expandIcon={<ExpandMoreIcon />}
-                  aria-controls="gcnEvent-content"
-                  id="gcnnotices-header"
-                >
-                  <Typography className={styles.accordionHeading}>
-                    GCN Aliases
-                  </Typography>
-                </AccordionSummary>
-                <AccordionDetails>
-                  <div className={styles.gcnEventContainer}>
-                    <GcnAliases gcnEvent={gcnEvent} />
-                  </div>
-                  {permission && (
-                    <Button
-                      secondary
-                      onClick={() => handleUpdateAliasesCirculars()}
-                      data-testid="update-aliases"
-                    >
-                      Update
-                    </Button>
-                  )}
-                </AccordionDetails>
-              </Accordion>
-            </div>
-            <div className={styles.columnItem}>
-              <Accordion defaultExpanded>
-                <AccordionSummary
-                  expandIcon={<ExpandMoreIcon />}
-                  aria-controls="gcnEvent-content"
-                  id="gcncirculars-header"
-                >
-                  <Typography className={styles.accordionHeading}>
-                    GCN Circulars
-                  </Typography>
-                </AccordionSummary>
-                <AccordionDetails>
-                  <div className={styles.gcnEventContainer}>
-                    <GcnCirculars gcnEvent={gcnEvent} />
-                  </div>
-                  {permission && (
-                    <Button
-                      secondary
-                      onClick={() => handleUpdateAliasesCirculars()}
-                      data-testid="update-circulars"
-                    >
-                      Update
-                    </Button>
-                  )}
-                </AccordionDetails>
-              </Accordion>
-            </div>
+                        </>
+                      ) : (
+                        <p> Fetching event... </p>
+                      )}
+                    </div>
+                  </AccordionDetails>
+                </Accordion>
+              </Grid>
+              <Grid item sm={12} lg={6}>
+                <Accordion defaultExpanded>
+                  <AccordionSummary
+                    expandIcon={<ExpandMoreIcon />}
+                    aria-controls="gcnEvent-content"
+                    id="gcnnotices-header"
+                  >
+                    <Typography className={styles.accordionHeading}>
+                      GCN Notices
+                    </Typography>
+                  </AccordionSummary>
+                  <AccordionDetails>
+                    <div className={styles.gcnEventContainer}>
+                      {gcnEvent.gcn_notices?.map((gcn_notice) => (
+                        <li
+                          key={gcn_notice.ivorn}
+                          className={styles.noticeListElement}
+                        >
+                          <div className={styles.noticeListElementHeader}>
+                            <Chip
+                              size="small"
+                              label={gcn_notice.ivorn}
+                              key={gcn_notice.ivorn}
+                              className={styles.noticeListElementIVORN}
+                            />
+                            <DownloadXMLButton gcn_notice={gcn_notice} />
+                          </div>
+                          {gcn_notice?.has_localization &&
+                            gcn_notice?.localization_ingested === false && (
+                              <Button
+                                secondary
+                                onClick={() => {
+                                  dispatch(
+                                    showNotification(
+                                      `Starting ingestion attempt for localization from notice ${gcn_notice.id}. Please wait...`,
+                                      "warning"
+                                    )
+                                  );
+                                  dispatch(
+                                    postLocalizationFromNotice({
+                                      dateobs: gcn_notice.dateobs,
+                                      noticeID: gcn_notice.id,
+                                    })
+                                  ).then((response) => {
+                                    if (response.status === "success") {
+                                      dispatch(
+                                        showNotification(
+                                          `Localization successfully ingested from notice ${gcn_notice.id}. Please wait for the contour to be generated. Default observation plans will be created shortly.`
+                                        )
+                                      );
+                                    } else {
+                                      dispatch(
+                                        showNotification(
+                                          `Error ingesting localization from notice ${gcn_notice.id}. It might not be available yet.`,
+                                          "error"
+                                        )
+                                      );
+                                    }
+                                  });
+                                }}
+                                data-testid="ingest-localization-from-notice"
+                              >
+                                Ingest Localization
+                              </Button>
+                            )}
+                          <div className={styles.noticeListDivider} />
+                        </li>
+                      ))}
+                    </div>
+                  </AccordionDetails>
+                </Accordion>
+              </Grid>
+              <Grid item sm={12} lg={6}>
+                <Accordion defaultExpanded>
+                  <AccordionSummary
+                    expandIcon={<ExpandMoreIcon />}
+                    aria-controls="gcnEvent-content"
+                    id="gcnnotices-header"
+                  >
+                    <Typography className={styles.accordionHeading}>
+                      GCN Aliases
+                    </Typography>
+                  </AccordionSummary>
+                  <AccordionDetails>
+                    <div className={styles.gcnEventContainer}>
+                      <GcnAliases gcnEvent={gcnEvent} />
+                    </div>
+                    {permission && (
+                      <Button
+                        secondary
+                        onClick={() => handleUpdateAliasesCirculars()}
+                        data-testid="update-aliases"
+                      >
+                        Update
+                      </Button>
+                    )}
+                  </AccordionDetails>
+                </Accordion>
+              </Grid>
+              <Grid item sm={12} lg={6}>
+                <Accordion defaultExpanded>
+                  <AccordionSummary
+                    expandIcon={<ExpandMoreIcon />}
+                    aria-controls="gcnEvent-content"
+                    id="gcncirculars-header"
+                  >
+                    <Typography className={styles.accordionHeading}>
+                      GCN Circulars
+                    </Typography>
+                  </AccordionSummary>
+                  <AccordionDetails>
+                    <div className={styles.gcnEventContainer}>
+                      <GcnCirculars gcnEvent={gcnEvent} />
+                    </div>
+                    {permission && (
+                      <Button
+                        secondary
+                        onClick={() => handleUpdateAliasesCirculars()}
+                        data-testid="update-circulars"
+                      >
+                        Update
+                      </Button>
+                    )}
+                  </AccordionDetails>
+                </Accordion>
+              </Grid>
+            </Grid>
           </div>
         </Drawer>
       </React.Fragment>

--- a/static/js/components/GcnLocalizationsTable.jsx
+++ b/static/js/components/GcnLocalizationsTable.jsx
@@ -1,11 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import Accordion from "@mui/material/Accordion";
-import AccordionSummary from "@mui/material/AccordionSummary";
-import AccordionDetails from "@mui/material/AccordionDetails";
 import Chip from "@mui/material/Chip";
-import Typography from "@mui/material/Typography";
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import {
   createTheme,
   ThemeProvider,
@@ -229,26 +224,15 @@ const GcnLocalizationsTable = ({ localizations }) => {
 
   return (
     <div className={classes.container}>
-      <Accordion className={classes.accordion} key="localizations_table_div">
-        <AccordionSummary
-          expandIcon={<ExpandMoreIcon />}
-          aria-controls="gcn-localizations"
-          data-testid="gcn-localizations-header"
-        >
-          <Typography variant="subtitle1">Property Lists</Typography>
-        </AccordionSummary>
-        <AccordionDetails data-testid="gcn-localizations-Table">
-          <StyledEngineProvider injectFirst>
-            <ThemeProvider theme={getMuiTheme(theme)}>
-              <MUIDataTable
-                data={localizations}
-                options={options}
-                columns={getDataTableColumns()}
-              />
-            </ThemeProvider>
-          </StyledEngineProvider>
-        </AccordionDetails>
-      </Accordion>
+      <StyledEngineProvider injectFirst>
+        <ThemeProvider theme={getMuiTheme(theme)}>
+          <MUIDataTable
+            data={localizations}
+            options={options}
+            columns={getDataTableColumns()}
+          />
+        </ThemeProvider>
+      </StyledEngineProvider>
     </div>
   );
 };

--- a/static/js/components/GcnProperties.jsx
+++ b/static/js/components/GcnProperties.jsx
@@ -1,10 +1,5 @@
 import React from "react";
 import PropTypes from "prop-types";
-import Accordion from "@mui/material/Accordion";
-import AccordionSummary from "@mui/material/AccordionSummary";
-import AccordionDetails from "@mui/material/AccordionDetails";
-import Typography from "@mui/material/Typography";
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import {
   createTheme,
   ThemeProvider,
@@ -137,26 +132,15 @@ const GcnProperties = ({ properties }) => {
 
   return (
     <div className={classes.container}>
-      <Accordion className={classes.accordion} key="properties_table_div">
-        <AccordionSummary
-          expandIcon={<ExpandMoreIcon />}
-          aria-controls="gcn-properties"
-          data-testid="gcn-properties-header"
-        >
-          <Typography variant="subtitle1">Property Lists</Typography>
-        </AccordionSummary>
-        <AccordionDetails data-testid="gcn-properties-Table">
-          <StyledEngineProvider injectFirst>
-            <ThemeProvider theme={getMuiTheme(theme)}>
-              <MUIDataTable
-                data={propertiesWithUniqueKeys}
-                options={options}
-                columns={getDataTableColumns()}
-              />
-            </ThemeProvider>
-          </StyledEngineProvider>
-        </AccordionDetails>
-      </Accordion>
+      <StyledEngineProvider injectFirst>
+        <ThemeProvider theme={getMuiTheme(theme)}>
+          <MUIDataTable
+            data={propertiesWithUniqueKeys}
+            options={options}
+            columns={getDataTableColumns()}
+          />
+        </ThemeProvider>
+      </StyledEngineProvider>
     </div>
   );
 };

--- a/static/js/components/GcnSelectionForm.jsx
+++ b/static/js/components/GcnSelectionForm.jsx
@@ -354,6 +354,7 @@ const GcnSelectionForm = ({
   const [sourceFilteringState, setSourceFilteringState] = useState({
     startDate: null,
     endDate: null,
+    localizationName: null,
     localizationCumprob: null,
   });
 

--- a/static/js/components/GcnSelectionForm.jsx
+++ b/static/js/components/GcnSelectionForm.jsx
@@ -336,6 +336,7 @@ const GcnSelectionForm = ({
   );
 
   const gcnEvent = useSelector((state) => state.gcnEvent);
+  const groups = useSelector((state) => state.groups.userAccessible);
   const [selectedFields, setSelectedFields] = useState([]);
 
   const [selectedInstrumentId, setSelectedInstrumentId] = useState(null);
@@ -397,7 +398,24 @@ const GcnSelectionForm = ({
 
   useEffect(() => {
     const setDefaults = async () => {
-      setSelectedInstrumentId(instrumentList[0]?.id);
+      // reorder the instrument list by instrument id, and also make sure that the instrument called ZTF is first
+      const orderedInstrumentList = [...instrumentList];
+      orderedInstrumentList.sort((i1, i2) => {
+        if (i1.name === "ZTF") {
+          return -1;
+        }
+        if (i2.name === "ZTF") {
+          return 1;
+        }
+        if (i1.id > i2.id) {
+          return 1;
+        }
+        if (i2.id > i1.id) {
+          return -1;
+        }
+        return 0;
+      });
+      setSelectedInstrumentId(orderedInstrumentList[0]?.id);
       setSelectedLocalizationId(gcnEvent.localizations[0]?.id);
       setSelectedLocalizationName(gcnEvent.localizations[0]?.localization_name);
     };
@@ -620,7 +638,19 @@ const GcnSelectionForm = ({
           enum: ["sources", "galaxies", "observations"],
         },
         uniqueItems: true,
+        default: ["sources"],
         title: "Query list",
+      },
+      group_ids: {
+        type: "array",
+        items: {
+          type: "number",
+          enum: groups.map((group) => group.id),
+          enumNames: groups.map((group) => group.name),
+        },
+        uniqueItems: true,
+        default: [groups[0]?.id],
+        title: "Groups",
       },
     },
     required: ["startDate", "endDate", "localizationCumprob", "queryList"],
@@ -641,7 +671,8 @@ const GcnSelectionForm = ({
         localizationRejectSources: 12,
       },
       {
-        queryList: 12,
+        queryList: 6,
+        group_ids: 6,
       },
     ],
   };

--- a/static/js/components/GcnSummary.jsx
+++ b/static/js/components/GcnSummary.jsx
@@ -478,24 +478,24 @@ const GcnSummary = ({ dateobs }) => {
                     <FormControlLabel
                       control={
                         <Checkbox
-                          label="No Text"
+                          label="Table(s) Only"
                           checked={noText}
                           onChange={(e) => setNoText(e.target.checked)}
                         />
                       }
-                      label="No Text"
+                      label="Table(s) Only"
                     />
                     <FormControlLabel
                       control={
                         <Checkbox
-                          label="Photometry in Window"
+                          label="Photometry in Window (only between start and end dates)"
                           checked={photometryInWindow}
                           onChange={(e) =>
                             setPhotometryInWindow(e.target.checked)
                           }
                         />
                       }
-                      label="Photometry in Window"
+                      label="Photometry in Window (only between start and end dates)"
                     />
                   </div>
                   <div className={classes.buttons}>

--- a/static/js/components/GcnTags.jsx
+++ b/static/js/components/GcnTags.jsx
@@ -99,6 +99,19 @@ const GcnTags = ({ gcnEvent, show_title = false }) => {
       gcnTags.push(tag);
     });
   }
+  // we want to look through the gcnEvent?.aliases. If one starts by LVC#, we grab what is after the #
+  // and use it later as a link for the LVC tag
+  let graceid =
+    gcnEvent?.aliases?.find((alias) => alias.startsWith("LVC#")) || null;
+  if (graceid) {
+    [, graceid] = graceid.split("#");
+  }
+  // same for Fermi
+  let fermiid =
+    gcnEvent?.aliases?.find((alias) => alias.startsWith("FERMI#")) || null;
+  if (fermiid) {
+    [, fermiid] = fermiid.split("#");
+  }
   const gcnTagsUnique = [...new Set(gcnTags)];
 
   const localizationTags = [];
@@ -141,7 +154,48 @@ const GcnTags = ({ gcnEvent, show_title = false }) => {
               </>
             }
           >
-            <Chip className={styles[tag]} size="small" label={tag} key={tag} />
+            {/* eslint-disable-next-line no-nested-ternary */}
+            {graceid && tag === "LVC" ? (
+              <Chip
+                className={styles[tag]}
+                size="small"
+                label={tag}
+                key={tag}
+                component="a"
+                clickable
+                target="_blank"
+                href={
+                  graceid
+                    ? `https://gracedb.ligo.org/superevents/${graceid}/view/`
+                    : null
+                }
+              />
+            ) : fermiid && tag === "Fermi" ? (
+              <Chip
+                className={styles[tag]}
+                size="small"
+                label={tag}
+                key={tag}
+                component="a"
+                clickable
+                target="_blank"
+                href={
+                  fermiid
+                    ? `http://heasarc.gsfc.nasa.gov/FTP/fermi/data/gbm/triggers/${gcnEvent?.dateobs.slice(
+                        0,
+                        4
+                      )}/${fermiid}/quicklook/`
+                    : null
+                }
+              />
+            ) : (
+              <Chip
+                className={styles[tag]}
+                size="small"
+                label={tag}
+                key={tag}
+              />
+            )}
           </Tooltip>
         ))}
         {localizationTagsUnique.map((tag) => (
@@ -169,6 +223,7 @@ GcnTags.propTypes = {
   gcnEvent: PropTypes.shape({
     dateobs: PropTypes.string,
     tags: PropTypes.arrayOf(PropTypes.string).isRequired,
+    aliases: PropTypes.arrayOf(PropTypes.string).isRequired,
     localizations: PropTypes.arrayOf(
       PropTypes.shape({
         id: PropTypes.number,

--- a/static/js/components/ObservationPlanRequestForm.jsx
+++ b/static/js/components/ObservationPlanRequestForm.jsx
@@ -366,7 +366,15 @@ const ObservationPlanRequestForm = ({ dateobs }) => {
       if (!allocationListApiObsplan || allocationListApiObsplan?.length === 0) {
         dispatch(allocationActions.fetchAllocationsApiObsplan()).then(
           (response) => {
+            if (response.status !== "success") {
+              showNotification(
+                "Error fetching allocations, please try refreshing the page",
+                "error"
+              );
+              return;
+            }
             const { data } = response;
+            data.sort((a, b) => a.instrument_id - b.instrument_id);
             setSelectedAllocationId(data[0]?.id);
             setSelectedGroupIds([data[0]?.group_id]);
             setSelectedLocalizationId(gcnEvent.localizations[0]?.id);
@@ -376,8 +384,12 @@ const ObservationPlanRequestForm = ({ dateobs }) => {
         allocationListApiObsplan?.length > 0 &&
         !selectedAllocationId
       ) {
-        setSelectedAllocationId(allocationListApiObsplan[0]?.id);
-        setSelectedGroupIds([allocationListApiObsplan[0]?.group_id]);
+        const sortedAllocationListApiObsplan = [...allocationListApiObsplan];
+        sortedAllocationListApiObsplan.sort(
+          (a, b) => a.instrument_id - b.instrument_id
+        );
+        setSelectedAllocationId(sortedAllocationListApiObsplan[0]?.id);
+        setSelectedGroupIds([sortedAllocationListApiObsplan[0]?.group_id]);
         setSelectedLocalizationId(gcnEvent.localizations[0]?.id);
       }
     };

--- a/static/js/components/ObservationPlanRequestLists.jsx
+++ b/static/js/components/ObservationPlanRequestLists.jsx
@@ -274,8 +274,7 @@ const ObservationPlanRequestLists = ({ dateobs }) => {
 
   const gcnEvent = useSelector((state) => state.gcnEvent);
 
-  const [observationPlanRequestList, setObservationPlanRequestList] =
-    useState(null);
+  const observationPlanRequestList = gcnEvent?.observation_plans || [];
 
   const [
     observationPlanRequestFetchedForLocalization,
@@ -293,14 +292,7 @@ const ObservationPlanRequestLists = ({ dateobs }) => {
     ) {
       const fetchObservationPlanRequestList = async () => {
         setObservationPlanRequestFetchedForLocalization(selectedLocalizationId);
-        dispatch(
-          GET(
-            `/api/gcn_event/${gcnEvent.id}/observation_plan_requests`,
-            "skyportal/FETCH_GCNEVENT_OBSERVATION_PLAN_REQUESTS"
-          )
-        ).then((response) => {
-          setObservationPlanRequestList(response.data);
-        });
+        dispatch(Actions.fetchObservationPlanRequests(gcnEvent.id));
       };
       fetchObservationPlanRequestList();
     }

--- a/static/js/components/SourceTable.jsx
+++ b/static/js/components/SourceTable.jsx
@@ -699,7 +699,6 @@ const SourceTable = ({
   const [queryInProgress, setQueryInProgress] = useState(false);
 
   const gcnEvent = useSelector((state) => state.gcnEvent);
-  const localization = useSelector((state) => state.localization);
 
   const sourcesingcn = useSelector((state) => state.sourcesingcn.sourcesingcn);
 
@@ -709,7 +708,7 @@ const SourceTable = ({
       if (includeGcnStatus) {
         dispatch(
           sourcesingcnActions.fetchSourcesInGcn(gcnEvent.dateobs, {
-            localizationName: localization.localization_name,
+            localizationName: sourceInGcnFilter?.localizationName,
             sourcesIdList: sources.map((s) => s.id),
           })
         );
@@ -1277,7 +1276,7 @@ const SourceTable = ({
         {statusIcon}
         <ConfirmSourceInGCN
           dateobs={gcnEvent.dateobs}
-          localization_name={localization.localization_name}
+          localization_name={sourceInGcnFilter.localizationName}
           localization_cumprob={sourceInGcnFilter.localizationCumprob}
           source_id={source.id}
           start_date={sourceInGcnFilter.startDate}
@@ -1957,6 +1956,7 @@ SourceTable.propTypes = {
   sourceInGcnFilter: PropTypes.shape({
     startDate: PropTypes.string,
     endDate: PropTypes.string,
+    localizationName: PropTypes.string,
     localizationCumprob: PropTypes.number,
   }),
 };

--- a/static/js/ducks/gcnEvent.js
+++ b/static/js/ducks/gcnEvent.js
@@ -74,6 +74,15 @@ const FETCH_GCNEVENT_CATALOG_QUERIES =
 const FETCH_GCNEVENT_CATALOG_QUERIES_OK =
   "skyportal/FETCH_GCNEVENT_CATALOG_QUERIES_OK";
 
+const FETCH_GCNEVENT_OBSERVATION_PLAN_REQUESTS =
+  "skyportal/FETCH_GCNEVENT_OBSERVATION_PLAN_REQUESTS";
+
+const FETCH_GCNEVENT_OBSERVATION_PLAN_REQUESTS_OK =
+  "skyportal/FETCH_GCNEVENT_OBSERVATION_PLAN_REQUESTS_OK";
+
+const REFRESH_GCNEVENT_OBSERVATION_PLAN_REQUESTS =
+  "skyportal/REFRESH_GCNEVENT_OBSERVATION_PLAN_REQUESTS";
+
 export const fetchGcnEvent = (dateobs) =>
   API.GET(`/api/gcn_event/${dateobs}`, FETCH_GCNEVENT);
 
@@ -143,6 +152,13 @@ export function deleteCommentOnGcnEvent(gcnEventID, commentID) {
   return API.DELETE(
     `/api/gcn_event/${gcnEventID}/comments/${commentID}`,
     DELETE_COMMENT_ON_GCNEVENT
+  );
+}
+
+export function fetchObservationPlanRequests(gcnEventID) {
+  return API.GET(
+    `/api/gcn_event/${gcnEventID}/observation_plan_requests`,
+    FETCH_GCNEVENT_OBSERVATION_PLAN_REQUESTS
   );
 }
 
@@ -324,11 +340,23 @@ messageHandler.add((actionType, payload, dispatch, getState) => {
       dispatch(fetchGcnTrigger({ dateobs: gcnEvent.dateobs }));
     }
   }
+  if (actionType === REFRESH_GCNEVENT_OBSERVATION_PLAN_REQUESTS) {
+    const loaded_gcnevent_key = gcnEvent?.dateobs;
+    if (loaded_gcnevent_key === payload.gcnEvent_dateobs) {
+      dispatch(fetchObservationPlanRequests(gcnEvent?.id));
+    }
+  }
 });
 
 const reducer = (state = null, action) => {
   switch (action.type) {
     case FETCH_GCNEVENT_OK: {
+      if (action.data?.dateobs === state?.dateobs) {
+        return {
+          ...state,
+          ...action.data,
+        };
+      }
       return action.data;
     }
     case GET_COMMENT_ON_GCNEVENT_ATTACHMENT_OK: {
@@ -377,6 +405,12 @@ const reducer = (state = null, action) => {
       return {
         ...state,
         catalog_queries: action.data,
+      };
+    }
+    case FETCH_GCNEVENT_OBSERVATION_PLAN_REQUESTS_OK: {
+      return {
+        ...state,
+        observation_plans: action.data,
       };
     }
     default:


### PR DESCRIPTION
This PR makes it possible to choose which method to use to get the fields to observe when creating an obs plan: Postgres query, or gwemopt code. This is because currently in production, the Postgres query does not return in time, as the queries involving instrument field tiles and localization tiles do not scale well as the localization tiles table grows larger.

Also, we add several minor changes that improve the user experience and make many GCN-related features more practical to use (this is based on multiple astronomers' feedback).