### PR TITLE
Source Page classification: Avoid errors when config colors aren't fetched yet.

### DIFF
--- a/static/js/components/ShowClassification.jsx
+++ b/static/js/components/ShowClassification.jsx
@@ -237,8 +237,9 @@ const ClassificationRow = ({ classifications }) => {
           size="small"
           className={classes.chip}
           style={{
-            backgroundColor:
-              classifications_classes[classification.classification],
+            backgroundColor: classifications_classes
+              ? classifications_classes[classification.classification]
+              : "#999999",
           }}
         />
       </Tooltip>


### PR DESCRIPTION
It seems that if the classifications and source are fetched before the config, the page crashed. This minor change should fix that.