### PR TITLE
Notification Queue: Multi-threading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ data/gitlog.txt
 # test results
 test-results/
 webdriver-console/
+
+persistentdata/

--- a/.gitignore
+++ b/.gitignore
@@ -49,4 +49,5 @@ data/gitlog.txt
 test-results/
 webdriver-console/
 
+# persistent data (e.g. analysis, localizations, comment attachements, etc.)
 persistentdata/

--- a/services/observation_plan_queue/observation_plan_queue.py
+++ b/services/observation_plan_queue/observation_plan_queue.py
@@ -34,7 +34,7 @@ queue = []
 def service(queue):
     while True:
         if len(queue) == 0:
-            time.sleep(5)
+            time.sleep(1)
             continue
         plans, survey_efficiencies, combine_plans, user_id = queue.pop(0)
 
@@ -177,15 +177,14 @@ def api(queue):
 
 if __name__ == "__main__":
     try:
-        port = cfg["ports"]["observation_plan_queue"]
         t = Thread(target=service, args=(queue,))
         t2 = Thread(target=api, args=(queue,))
         t.start()
         t2.start()
 
         while True:
-            log(f"Current queue length: {len(queue)}")
-            time.sleep(60)
+            log(f"Current obsplan queue length: {len(queue)}")
+            time.sleep(120)
     except Exception as e:
         log(f"Error starting observation plan queue: {str(e)}")
         raise e

--- a/skyportal/models/user_notification.py
+++ b/skyportal/models/user_notification.py
@@ -116,11 +116,7 @@ def add_user_notifications(mapper, connection, target):
 def post_notification(notifications_microservice_url, request_body):
 
     resp = requests.post(notifications_microservice_url, json=request_body, timeout=2)
-    if resp.status_code == 200:
-        log(
-            f'Notification requested for {request_body["target_class_name"]} with ID {request_body["target_id"]}'
-        )
-    else:
+    if resp.status_code != 200:
         log(
             f'Notification request failed for {request_body["target_class_name"]} with ID {request_body["target_id"]}: {resp.content}'
         )


### PR DESCRIPTION
In this PR, we make sure that the handler pushing to the queue, and the service processing it run on different threads. Using only asyncio means that right now both are running on the same thread, in the same event loop. Because of that, we may end up having timeouts when pushing a notification, which could impact every feature that needs might trigger notifications (many).

By reducing delays in general, this PR also should help with the flakiness of some tests.

---------------------------------------------------------

Here are 2 tests who's flakiness is more persistent, and should be addressed in later PRs:
- test_analysis_with_file_input -> unknown origin
- test_gcn_tach -> frontend issue, page crashes here but not locally

*Both are frontend tests*