### PR TITLE
GCN Notifications frontend: Nicer display

### DIFF
--- a/static/js/components/GcnLocalizationsTable.jsx
+++ b/static/js/components/GcnLocalizationsTable.jsx
@@ -112,10 +112,13 @@ const GcnLocalizationsTable = ({ localizations }) => {
     if (loc?.properties?.length > 0) {
       uniquePropertyNames.forEach((name) => {
         if (Object.keys(loc.properties[0].data).includes(name)) {
-          // if it is a numerical value, we want to round it to 4 decimals
-          // but if the number is something like 0.000000001, we want to show it as 0.1e-8
           if (typeof loc.properties[0].data[name] === "number") {
             if (
+              loc.properties[0].data[name] > 10000 ||
+              loc.properties[0].data[name] < -10000
+            ) {
+              newProperty[name] = loc.properties[0].data[name].toExponential(4);
+            } else if (
               loc.properties[0].data[name] > 0.0001 ||
               loc.properties[0].data[name] < -0.0001
             ) {

--- a/static/js/components/GcnLocalizationsTable.jsx
+++ b/static/js/components/GcnLocalizationsTable.jsx
@@ -91,9 +91,16 @@ const GcnLocalizationsTable = ({ localizations }) => {
   }
   let propertyNames = [];
   if (localizations.length > 0) {
-    propertyNames = (localizations || [])
-      .map((loc) => Object.keys(loc?.properties[0].data))
-      .flat();
+    (localizations || []).forEach((loc) => {
+      if (loc?.properties?.length > 0) {
+        if (loc.properties[0].data) {
+          // append the keys of the properties object to the propertyNames array
+          propertyNames = propertyNames.concat(
+            Object.keys(loc.properties[0].data)
+          );
+        }
+      }
+    });
   }
 
   const uniquePropertyNames = [...new Set(propertyNames)];
@@ -102,28 +109,34 @@ const GcnLocalizationsTable = ({ localizations }) => {
     const newProperty = {
       ...loc,
     };
-    uniquePropertyNames.forEach((name) => {
-      if (Object.keys(loc.properties[0].data).includes(name)) {
-        // if it is a numerical value, we want to round it to 4 decimals
-        // but if the number is something like 0.000000001, we want to show it as 0.1e-8
-        if (typeof loc.properties[0].data[name] === "number") {
-          if (
-            loc.properties[0].data[name] > 0.0001 ||
-            loc.properties[0].data[name] < -0.0001
-          ) {
-            newProperty[name] = loc.properties[0].data[name].toFixed(4);
-          } else if (loc.properties[0].data[name] === 0) {
-            newProperty[name] = 0;
+    if (loc?.properties?.length > 0) {
+      uniquePropertyNames.forEach((name) => {
+        if (Object.keys(loc.properties[0].data).includes(name)) {
+          // if it is a numerical value, we want to round it to 4 decimals
+          // but if the number is something like 0.000000001, we want to show it as 0.1e-8
+          if (typeof loc.properties[0].data[name] === "number") {
+            if (
+              loc.properties[0].data[name] > 0.0001 ||
+              loc.properties[0].data[name] < -0.0001
+            ) {
+              newProperty[name] = loc.properties[0].data[name].toFixed(4);
+            } else if (loc.properties[0].data[name] === 0) {
+              newProperty[name] = 0;
+            } else {
+              newProperty[name] = loc.properties[0].data[name].toExponential(4);
+            }
           } else {
-            newProperty[name] = loc.properties[0].data[name].toExponential(4);
+            newProperty[name] = loc.properties[0].data[name];
           }
         } else {
-          newProperty[name] = loc.properties[0].data[name];
+          newProperty[name] = null;
         }
-      } else {
+      });
+    } else {
+      uniquePropertyNames.forEach((name) => {
         newProperty[name] = null;
-      }
-    });
+      });
+    }
     return newProperty;
   });
 

--- a/static/js/components/GcnProperties.jsx
+++ b/static/js/components/GcnProperties.jsx
@@ -86,10 +86,13 @@ const GcnProperties = ({ properties }) => {
     const newProperty = { created_at: property.created_at };
     uniquePropertyNames.forEach((name) => {
       if (Object.keys(property.data).includes(name)) {
-        // if it is a numerical value, we want to round it to 4 decimals
-        // but if the number is something like 0.000000001, we want to show it as 0.1e-8
         if (typeof property.data[name] === "number") {
-          if (property.data[name] > 0.0001 || property.data[name] < -0.0001) {
+          if (property.data[name] > 10000 || property.data[name] < -10000) {
+            newProperty[name] = property.data[name].toExponential(4);
+          } else if (
+            property.data[name] > 0.0001 ||
+            property.data[name] < -0.0001
+          ) {
             newProperty[name] = property.data[name].toFixed(4);
           } else if (property.data[name] === 0) {
             newProperty[name] = 0;

--- a/static/js/components/GcnPropertiesSelect.jsx
+++ b/static/js/components/GcnPropertiesSelect.jsx
@@ -57,23 +57,18 @@ const useStyles = makeStyles(() => ({
 const GcnPropertiesSelect = (props) => {
   const classes = useStyles();
   const dispatch = useDispatch();
-  const { selectedGcnProperties, setSelectedGcnProperties, conversions } =
-    props;
+  const {
+    selectedGcnProperties,
+    setSelectedGcnProperties,
+    conversions,
+    comparators,
+  } = props;
 
   let gcnProperties = [];
   gcnProperties = gcnProperties.concat(
     useSelector((state) => state.gcnProperties)
   );
   gcnProperties.sort();
-
-  const comparators = {
-    lt: "<",
-    le: "<=",
-    eq: "=",
-    ne: "!=",
-    ge: ">",
-    gt: ">=",
-  };
 
   useEffect(() => {
     dispatch(gcnPropertiesActions.fetchGcnProperties());
@@ -240,6 +235,7 @@ GcnPropertiesSelect.propTypes = {
   selectedGcnProperties: PropTypes.arrayOf(PropTypes.string).isRequired,
   setSelectedGcnProperties: PropTypes.func.isRequired,
   conversions: PropTypes.oneOfType([PropTypes.object]).isRequired,
+  comparators: PropTypes.oneOfType([PropTypes.object]).isRequired,
 };
 
 export default GcnPropertiesSelect;

--- a/static/js/components/GcnPropertiesSelect.jsx
+++ b/static/js/components/GcnPropertiesSelect.jsx
@@ -57,7 +57,8 @@ const useStyles = makeStyles(() => ({
 const GcnPropertiesSelect = (props) => {
   const classes = useStyles();
   const dispatch = useDispatch();
-  const { selectedGcnProperties, setSelectedGcnProperties } = props;
+  const { selectedGcnProperties, setSelectedGcnProperties, conversions } =
+    props;
 
   let gcnProperties = [];
   gcnProperties = gcnProperties.concat(
@@ -84,6 +85,19 @@ const GcnPropertiesSelect = (props) => {
 
   const handleSubmitProperties = async () => {
     const filterData = getValues();
+    if (
+      filterData.property === "" ||
+      filterData.propertyComparator === "" ||
+      filterData.propertyComparatorValue === ""
+    ) {
+      return;
+    }
+    if (Object.keys(conversions).includes(filterData.property)) {
+      // we have a unit conversion to do
+      filterData.propertyComparatorValue = conversions[
+        filterData.property
+      ].FrontendToBackend(filterData.propertyComparatorValue);
+    }
     const propertiesFilter = `${filterData.property}: ${filterData.propertyComparatorValue}: ${filterData.propertyComparator}`;
     const selectedGcnPropertiesCopy = [...selectedGcnProperties];
     selectedGcnPropertiesCopy.push(propertiesFilter);
@@ -122,7 +136,11 @@ const GcnPropertiesSelect = (props) => {
                         key={gcnProperty}
                         className={classes.selectItem}
                       >
-                        {`${gcnProperty}`}
+                        {`${gcnProperty}${
+                          Object.keys(conversions).includes(gcnProperty)
+                            ? ` (${conversions[gcnProperty].frontendUnit})`
+                            : ""
+                        }`}
                       </MenuItem>
                     ))}
                   </Select>
@@ -221,6 +239,7 @@ const GcnPropertiesSelect = (props) => {
 GcnPropertiesSelect.propTypes = {
   selectedGcnProperties: PropTypes.arrayOf(PropTypes.string).isRequired,
   setSelectedGcnProperties: PropTypes.func.isRequired,
+  conversions: PropTypes.oneOfType([PropTypes.object]).isRequired,
 };
 
 export default GcnPropertiesSelect;

--- a/static/js/components/NotificationGcnEvent.jsx
+++ b/static/js/components/NotificationGcnEvent.jsx
@@ -26,6 +26,15 @@ const conversions = {
   },
 };
 
+const comparators = {
+  lt: "<",
+  le: "<=",
+  eq: "=",
+  ne: "!=",
+  ge: ">",
+  gt: ">=",
+};
+
 const useStyles = makeStyles((theme) => ({
   pref: {
     display: "flex",
@@ -275,11 +284,37 @@ const NotificationGcnEvent = () => {
                   <div className={classes.formSubGroupDivider} />
                   <p>
                     Properties:{" "}
-                    {(
-                      profile.notifications.gcn_events?.properties[
-                        selectedNotification
-                      ]?.gcn_properties || []
-                    ).join(", ")}
+                    <ul>
+                      {(
+                        profile.notifications.gcn_events?.properties[
+                          selectedNotification
+                        ]?.gcn_properties || []
+                      ).map((prop) => (
+                        <li
+                          key={prop}
+                          style={{
+                            display: "flex",
+                            alignItems: "center",
+                            flexDirection: "row",
+                            gap: "0.5rem",
+                          }}
+                        >
+                          <p>{prop.split(":")[0].trim()}</p>
+                          <p>{comparators[prop.split(":")[2].trim()]}</p>
+                          <p>
+                            {conversions[prop.split(":")[0].trim()]
+                              ? conversions[
+                                  prop.split(":")[0].trim()
+                                ].BackendToFrontend(prop.split(":")[1].trim())
+                              : prop.split(":")[1].trim()}
+                          </p>
+                          <p>
+                            {conversions[prop.split(":")[0].trim()]
+                              ?.frontendUnit || ""}{" "}
+                          </p>
+                        </li>
+                      ))}
+                    </ul>
                   </p>
                   <div className={classes.formSubGroupDivider} />
                   <p>
@@ -293,11 +328,37 @@ const NotificationGcnEvent = () => {
                   <div className={classes.formSubGroupDivider} />
                   <p>
                     Localization Properties:{" "}
-                    {(
-                      profile.notifications.gcn_events?.properties[
-                        selectedNotification
-                      ]?.localization_properties || []
-                    ).join(", ")}
+                    <ul>
+                      {(
+                        profile.notifications.gcn_events?.properties[
+                          selectedNotification
+                        ]?.localization_properties || []
+                      ).map((prop) => (
+                        <li
+                          key={prop}
+                          style={{
+                            display: "flex",
+                            alignItems: "center",
+                            flexDirection: "row",
+                            gap: "0.5rem",
+                          }}
+                        >
+                          <p>{prop.split(":")[0].trim()}</p>
+                          <p>{comparators[prop.split(":")[2].trim()]}</p>
+                          <p>
+                            {conversions[prop.split(":")[0].trim()]
+                              ? conversions[
+                                  prop.split(":")[0].trim()
+                                ].BackendToFrontend(prop.split(":")[1].trim())
+                              : prop.split(":")[1].trim()}
+                          </p>
+                          <p>
+                            {conversions[prop.split(":")[0].trim()]
+                              ?.frontendUnit || ""}{" "}
+                          </p>
+                        </li>
+                      ))}
+                    </ul>
                   </p>
                 </div>
               )}
@@ -362,6 +423,7 @@ const NotificationGcnEvent = () => {
                       selectedGcnProperties={selectedGcnProperties}
                       setSelectedGcnProperties={setSelectedGcnProperties}
                       conversions={conversions}
+                      comparators={comparators}
                     />
                   </div>
                 </div>

--- a/static/js/components/NotificationGcnEvent.jsx
+++ b/static/js/components/NotificationGcnEvent.jsx
@@ -17,6 +17,15 @@ import LocalizationTagsSelect from "./LocalizationTagsSelect";
 import LocalizationPropertiesSelect from "./LocalizationPropertiesSelect";
 import * as profileActions from "../ducks/profile";
 
+const conversions = {
+  FAR: {
+    backendUnit: "Hz",
+    frontendUnit: "Per year",
+    BackendToFrontend: (val) => parseFloat(val) * (365.25 * 24 * 60 * 60),
+    FrontendToBackend: (val) => parseFloat(val) / (365.25 * 24 * 60 * 60),
+  },
+};
+
 const useStyles = makeStyles((theme) => ({
   pref: {
     display: "flex",
@@ -352,6 +361,7 @@ const NotificationGcnEvent = () => {
                     <GcnPropertiesSelect
                       selectedGcnProperties={selectedGcnProperties}
                       setSelectedGcnProperties={setSelectedGcnProperties}
+                      conversions={conversions}
                     />
                   </div>
                 </div>


### PR DESCRIPTION
In this PR, we display some values nicely in more readable units (like FAR), and allow users to also enter these values in these units. For the backend, however, everything stays the same.

----

This PR also contains a frontend bugfix to try to help with the flakiness of the gcn tach test