### PR TITLE
Localization plot: Mollweide projection and bugfix

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "d3": "7.4.4",
     "d3-array": "3.2.2",
     "d3-geo": "3.1.0",
+    "d3-geo-projection": "4.0.0",
     "d3-geo-zoom": "1.4.4",
     "data-uri-to-buffer": "4.0.1",
     "dayjs": "1.11.5",

--- a/static/js/components/GcnEventPage.jsx
+++ b/static/js/components/GcnEventPage.jsx
@@ -44,7 +44,6 @@ import GcnProperties from "./GcnProperties";
 import GcnTags from "./GcnTags";
 import Reminders from "./Reminders";
 
-import * as localizationActions from "../ducks/localization";
 import { postLocalizationFromNotice } from "../ducks/localization";
 import withRouter from "./withRouter";
 
@@ -193,14 +192,10 @@ const GcnEventPage = ({ route }) => {
   const dispatch = useDispatch();
   const [selectedLocalizationName, setSelectedLocalizationName] =
     useState(null);
-  const [fetchingCachedLocalization, setFetchingCachedLocalization] =
-    useState(false);
   const currentUser = useSelector((state) => state.profile);
   const permission =
     currentUser.permissions?.includes("System admin") ||
     currentUser.permissions?.includes("Manage GCNs");
-
-  const cachedLocalization = useSelector((state) => state.localization.cached);
 
   const [leftPanelVisible, setLeftPanelVisible] = useState(false);
   const [rightPanelVisible, setRightPanelVisible] = useState(false);
@@ -228,31 +223,6 @@ const GcnEventPage = ({ route }) => {
       fetchGcnEvent(route?.dateobs);
     }
   }, [route, dispatch]);
-
-  // if there is no cached localization, then we need to fetch it
-  useEffect(() => {
-    if (!gcnEvent || fetchingCachedLocalization) {
-      return;
-    }
-    if (
-      !cachedLocalization ||
-      cachedLocalization?.dateobs !== gcnEvent?.dateobs
-    ) {
-      if (
-        fetchingCachedLocalization === false &&
-        gcnEvent?.localizations?.length > 0
-      ) {
-        dispatch(
-          localizationActions.fetchLocalization(
-            gcnEvent?.dateobs,
-            gcnEvent.localizations[0]?.localization_name
-          )
-        ).then(() => {
-          setFetchingCachedLocalization(false);
-        });
-      }
-    }
-  }, [gcnEvent, dispatch]);
 
   const isBig = useMediaQuery(theme.breakpoints.up("sm"));
   const isSmall = useMediaQuery(theme.breakpoints.down("sm"));

--- a/static/js/components/ObservationPlanRequestLists.jsx
+++ b/static/js/components/ObservationPlanRequestLists.jsx
@@ -39,6 +39,9 @@ const useStyles = makeStyles(() => ({
   container: {
     margin: "1rem 0",
   },
+  localization: {
+    minWidth: "250px",
+  },
 }));
 
 // Tweak responsive styling
@@ -85,7 +88,7 @@ const getMuiTheme = (theme) =>
     },
   });
 
-const ObservationPlanGlobe = ({ observationplanRequest, loc }) => {
+const ObservationPlanGlobe = ({ observationplanRequest }) => {
   const dispatch = useDispatch();
 
   const displayOptions = [
@@ -135,18 +138,18 @@ const ObservationPlanGlobe = ({ observationplanRequest, loc }) => {
       ) : (
         <div>
           <LocalizationPlot
-            loc={loc}
             observations={obsList}
             options={displayOptionsDefault}
-            height={300}
-            width={300}
+            height={550}
+            width={550}
             type="obsplan"
+            projection="mollweide"
           />
           <Button
             secondary
             onClick={() => handleDeleteObservationPlanFields(obsList)}
           >
-            Delete selected fields from observation plan
+            Delete selected fields
           </Button>
         </div>
       )}
@@ -155,11 +158,6 @@ const ObservationPlanGlobe = ({ observationplanRequest, loc }) => {
 };
 
 ObservationPlanGlobe.propTypes = {
-  loc: PropTypes.shape({
-    id: PropTypes.number,
-    dateobs: PropTypes.string,
-    localization_name: PropTypes.string,
-  }).isRequired,
   observationplanRequest: PropTypes.shape({
     id: PropTypes.number,
     requester: PropTypes.shape({
@@ -698,9 +696,8 @@ const ObservationPlanRequestLists = ({ dateobs }) => {
         requestsGroupedByInstId[instrument_id][dataIndex];
 
       return (
-        <div>
+        <div className={classes.localization}>
           <ObservationPlanGlobe
-            loc={locLookUp[selectedLocalizationId]}
             observationplanRequest={observationplanRequest}
           />
         </div>

--- a/static/js/ducks/localization.js
+++ b/static/js/ducks/localization.js
@@ -18,7 +18,6 @@ export const POST_LOCALIZATION_FROM_NOTICE =
   "skyportal/POST_LOCALIZATION_FROM_NOTICE";
 
 const typeEnum = {
-  cached: FETCH_LOCALIZATION,
   analysis: FETCH_LOCALIZATION_ANALYSIS,
   obsplan: FETCH_LOCALIZATION_OBSPLAN,
 };
@@ -26,7 +25,7 @@ const typeEnum = {
 export const fetchLocalization = (
   dateobs,
   localization_name,
-  type = "cached"
+  type = "analysis"
 ) =>
   API.GET(
     `/api/localization/${dateobs}/name/${localization_name}`,
@@ -40,35 +39,18 @@ export function postLocalizationFromNotice({ dateobs, noticeID }) {
   );
 }
 
-const reducer = (
-  state = { cached: null, analysis: null, obsplan: null },
-  action
-) => {
+const reducer = (state = { analysisLoc: null, obsplanLoc: null }, action) => {
   switch (action.type) {
-    case FETCH_LOCALIZATION_OK: {
-      return {
-        ...state,
-        cached: action.data,
-        analysis:
-          state.analysis === null || action.data?.id !== state.analysis?.id
-            ? action.data
-            : state.analysis,
-        obsplan:
-          state.obsplan === null || action.data?.id !== state.obsplan?.id
-            ? action.data
-            : state.obsplan,
-      };
-    }
     case FETCH_LOCALIZATION_ANALYSIS_OK: {
       return {
         ...state,
-        analysis: action.data,
+        analysisLoc: action.data,
       };
     }
     case FETCH_LOCALIZATION_OBSPLAN_OK: {
       return {
         ...state,
-        obsplan: action.data,
+        obsplanLoc: action.data,
       };
     }
     default:


### PR DESCRIPTION
This PR adds:
- a projection dropdown to switch between mollweide and orthographic, which can be easily extended to more projections.
- Default to mollweide in the obsplan list for better visibility.
- Fixed bug where changing localization wouldn't load the newly selected one.
