### PR TITLE
GCN Table and GCN Candidate filtering: Search by dateobs

### DIFF
--- a/static/js/components/FilterCandidateList.jsx
+++ b/static/js/components/FilterCandidateList.jsx
@@ -722,7 +722,6 @@ const FilterCandidateList = ({
               {gcnEvents?.events ? (
                 <>
                   <div className={classes.gcnFormRow}>
-                    {/* gcn event filtering based on localization */}
                     <Controller
                       render={({ field: { value } }) => (
                         <Autocomplete

--- a/static/js/components/GcnEvents.jsx
+++ b/static/js/components/GcnEvents.jsx
@@ -209,6 +209,16 @@ const GcnEvents = () => {
     setFilterFormSubmitted(true);
   };
 
+  const handleSearchChange = async (searchText) => {
+    const params = {
+      ...fetchParams,
+      pageNumber: 1,
+      partialdateobs: searchText,
+    };
+    setFetchParams(params);
+    await dispatch(gcnEventsActions.fetchGcnEvents(params));
+  };
+
   const handleTableChange = (action, tableState) => {
     if (action === "changePage" || action === "changeRowsPerPage") {
       handlePageChange(
@@ -370,7 +380,8 @@ const GcnEvents = () => {
     pagination: true,
     count: totalMatches,
     onTableChange: handleTableChange,
-    search: false, // Disable search for now (not implemented yet)
+    search: true, // Disable search for now (not implemented yet)
+    onSearchChange: handleSearchChange,
     download: false, // Disable download button for now (not implemented yet)
     filter: true,
     customFilterDialogFooter: customFilterDisplay,


### PR DESCRIPTION
Previously, it was impossible to search events by date in the gcn event list, and we could only filter candidates by the last 10 events. In this PR, we make it possible to search events by typing partial dateobs strings in both components.

This will be followed by a (less urgent) PR where the code added to the candidate list will be reused in all other components where we need a dropdown to select events.