### PR TITLE
Plotting preferences: Temporarely deactivate all origins fetching

### DIFF
--- a/skyportal/tests/frontend/test_profile.py
+++ b/skyportal/tests/frontend/test_profile.py
@@ -201,6 +201,7 @@ def test_delete_classification_shortcut(driver, user, public_group, taxonomy_tok
     driver.wait_for_xpath_to_disappear(f'//span[contains(text(), "{shortcut_name}")]')
 
 
+@pytest.mark.skip(reason="Filtering on the origin has been disabled temporarily")
 def test_set_automatically_visible_photometry(
     driver, user, upload_data_token, public_source, ztf_camera, public_group
 ):
@@ -258,6 +259,7 @@ def test_set_automatically_visible_photometry(
     assert data['data']['preferences']['automaticallyVisibleOrigins'] == ['Muphoten']
 
 
+@pytest.mark.skip(reason="Filtering on the origin has been disabled temporarily")
 def test_photometry_buttons_form(
     driver, user, upload_data_token, public_source, ztf_camera, public_group
 ):

--- a/static/js/components/OriginSelect.jsx
+++ b/static/js/components/OriginSelect.jsx
@@ -3,16 +3,16 @@ import PropTypes from "prop-types";
 import { useSelector, useDispatch } from "react-redux";
 import SelectWithChips from "./SelectWithChips";
 
-import * as photometryActions from "../ducks/photometry";
+// import * as photometryActions from "../ducks/photometry";
 
 const OriginSelect = ({ onOriginSelectChange, initValue, parent }) => {
   const dispatch = useDispatch();
 
   useEffect(() => {
-    const fetchOrigins = async () => {
-      await dispatch(photometryActions.fetchAllOrigins());
-    };
-    fetchOrigins();
+    // const fetchOrigins = async () => {
+    //   await dispatch(photometryActions.fetchAllOrigins());
+    // };
+    // fetchOrigins(); //TODO: uncomment this line when the API is fixed. For now this times out.
   }, [dispatch]);
 
   const originsList = ["Clear selections"].concat(


### PR DESCRIPTION
In this PR, we temporarely prevent the frontend from fetching ALL unique origins from the photometry table, which times out and puts too much load on the database.

This PR will be followed by a second PR, where we change the feature entirely to avoid running that query.