### PR TITLE
TNS Submission bugfix

### DIFF
--- a/skyportal/handlers/api/tns.py
+++ b/skyportal/handlers/api/tns.py
@@ -235,7 +235,7 @@ class ObjTNSHandler(BaseHandler):
                 return self.error('Missing TNS information.')
 
             tns_headers = {
-                'User-Agent': f'tns_marker{"tns_id":{tnsrobot.bot_id},"type":"bot", "name":"{tnsrobot.bot_name}"}'
+                'User-Agent': f'tns_marker{{"tns_id":{tnsrobot.bot_id},"type":"bot", "name":"{tnsrobot.bot_name}"}}'
             }
 
             time_first = mag_first = magerr_first = filt_first = instrument_first = None
@@ -456,7 +456,7 @@ class SpectrumTNSHandler(BaseHandler):
                 spec_dict["external_observer"] = external_observer.external_observer
 
             tns_headers = {
-                'User-Agent': f'tns_marker{"tns_id":{tnsrobot.bot_id},"type":"bot", "name":"{tnsrobot.bot_name}"}'
+                'User-Agent': f'tns_marker{{"tns_id":{tnsrobot.bot_id},"type":"bot", "name":"{tnsrobot.bot_name}"}}'
             }
 
             tns_prefix, tns_name = get_IAUname(

--- a/skyportal/handlers/api/tns.py
+++ b/skyportal/handlers/api/tns.py
@@ -315,7 +315,7 @@ class ObjTNSHandler(BaseHandler):
                 "reporter": reporters,
                 "discovery_datetime": astropy.time.Time(
                     time_first, format='mjd'
-                ).datetime,
+                ).datetime.strftime('%Y-%m-%d %H:%M:%S.%f'),
                 "at_type": 1,  # allow other options?
                 "proprietary_period_groups": [tnsrobot.source_group_id],
                 "proprietary_period": proprietary_period,


### PR DESCRIPTION
In an f-string, one needs to double the curly brackets if they are part of the string and not just to add variables in the string. This seems to be missing in the handler to submit sources to TNS.