### PR TITLE
Annotations info caching

### DIFF
--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -477,6 +477,7 @@ services:
 misc:
   days_to_keep_unsaved_candidates: 7
   minutes_to_keep_candidate_query_cache: 60
+  minutes_to_keep_annotations_info_query_cache: 360
   minutes_to_keep_localization_instrument_query_cache: 1440
   max_items_in_localization_instrument_query_cache: 100
   public_group_name: "Sitewide Group"

--- a/skyportal/handlers/api/internal/annotations_info.py
+++ b/skyportal/handlers/api/internal/annotations_info.py
@@ -1,8 +1,26 @@
 from collections import defaultdict
+
+import numpy as np
 from sqlalchemy import func, literal
+
 from baselayer.app.access import auth_or_token
-from ...base import BaseHandler
+from baselayer.app.env import load_env
+from baselayer.log import make_log
+
 from ....models import Annotation
+from ....utils.cache import Cache, dict_to_bytes
+from ...base import BaseHandler
+
+_, cfg = load_env()
+
+cache_dir = "cache/annotations_info"
+cache = Cache(
+    cache_dir=cache_dir,
+    max_age=cfg.get("misc.minutes_to_keep_annotations_info_query_cache", 360)
+    * 60,  # defaults to 6 hours
+)
+
+log = make_log('api/annotations_info')
 
 
 class AnnotationsInfoHandler(BaseHandler):
@@ -32,29 +50,46 @@ class AnnotationsInfoHandler(BaseHandler):
         # filters to apply on the auto-annotations column on the scanning page.
         # For example, if given that an annotation field is numeric we should
         # have min/max fields on the form.
-        annotations = func.jsonb_each(Annotation.data).table_valued("key", "value")
 
-        with self.Session() as session:
-            # Objs are read-public, so no need to check that annotations belong to an unreadable obj
-            # Instead, just check for annotation group membership
-            results = session.execute(
-                Annotation.select(session.user_or_token, columns=[Annotation.origin])
-                .add_columns(
-                    annotations.c.key,
-                    func.jsonb_typeof(annotations.c.value).label("type"),
+        try:
+            cached = cache['annotations_info']
+            if cached is not None:
+                data = np.load(cached, allow_pickle=True)
+                return self.success(data=data.item())
+            else:
+                annotations = func.jsonb_each(Annotation.data).table_valued(
+                    "key", "value"
                 )
-                .outerjoin(annotations, literal(True))
-                .distinct()
-            ).all()
+                with self.Session() as session:
+                    # Objs are read-public, so no need to check that annotations belong to an unreadable obj
+                    # Instead, just check for annotation group membership
+                    results = session.execute(
+                        Annotation.select(
+                            session.user_or_token, columns=[Annotation.origin]
+                        )
+                        .add_columns(
+                            annotations.c.key,
+                            func.jsonb_typeof(annotations.c.value).label("type"),
+                        )
+                        .outerjoin(annotations, literal(True))
+                        .distinct()
+                    ).all()
 
-            # Restructure query results so that records are grouped by origin in a
-            # nice, nested dictionary
-            grouped = defaultdict(list)
-            keys_seen = defaultdict(set)
-            for annotation in results:
-                if annotation.key not in keys_seen[annotation.origin]:
-                    grouped[annotation.origin].append({annotation.key: annotation.type})
+                    # Restructure query results so that records are grouped by origin in a
+                    # nice, nested dictionary
+                    grouped = defaultdict(list)
+                    keys_seen = defaultdict(set)
+                    for annotation in results:
+                        if annotation.key not in keys_seen[annotation.origin]:
+                            grouped[annotation.origin].append(
+                                {annotation.key: annotation.type}
+                            )
 
-                keys_seen[annotation.origin].add(annotation.key)
+                        keys_seen[annotation.origin].add(annotation.key)
 
-            return self.success(data=grouped)
+                    cache['annotations_info'] = dict_to_bytes(grouped)
+                    return self.success(data=grouped)
+
+        except Exception as e:
+            log(f"Failed to get annotations info: {e}")
+            return self.error(f"Failed to get annotations info: {e}")

--- a/skyportal/tests/frontend/test_scanning_page.py
+++ b/skyportal/tests/frontend/test_scanning_page.py
@@ -1,11 +1,13 @@
-import uuid
 import datetime
+import time
+import uuid
+
 import pytest
 from selenium.webdriver import ActionChains
+from tdtax import __version__, taxonomy
 
 from skyportal.tests import api
 
-from tdtax import taxonomy, __version__
 from .test_profile import test_add_classification_shortcut
 
 
@@ -277,6 +279,9 @@ def test_submit_annotations_sorting(
     )
     assert status == 200
 
+    # origins are cached, so we wait for the cache to invalidate (2 seconds in test config)
+    time.sleep(2)
+
     driver.get(f"/become_user/{view_only_user.id}")
     driver.get("/candidates")
     driver.click_xpath(
@@ -346,6 +351,9 @@ def test_submit_annotations_filtering(
         token=annotation_token,
     )
     assert status == 200
+
+    # origins are cached, so we wait for the cache to invalidate (2 seconds in test config)
+    time.sleep(2)
 
     driver.get(f"/become_user/{view_only_user.id}")
     driver.get("/candidates")
@@ -616,6 +624,9 @@ def test_add_scanning_profile(
         token=annotation_token,
     )
     assert status == 200
+
+    # origins are cached, so we wait for the cache to invalidate (2 seconds in test config)
+    time.sleep(2)
 
     driver.get(f"/become_user/{user.id}")
     driver.get("/candidates")

--- a/skyportal/utils/cache.py
+++ b/skyportal/utils/cache.py
@@ -23,6 +23,19 @@ def array_to_bytes(array):
     return b.getvalue()
 
 
+def dict_to_bytes(dictionary):
+    """Convert dict to bytes (for use w/ caching infrastructure).
+
+    Parameters
+    ----------
+    dictionary : dict
+        Dictionary to be converted to bytes
+    """
+    b = io.BytesIO()
+    np.save(b, dictionary, allow_pickle=True)
+    return b.getvalue()
+
+
 class Cache:
     def __init__(self, cache_dir, max_items=None, max_age=None):
         """

--- a/static/js/components/CandidateList.jsx
+++ b/static/js/components/CandidateList.jsx
@@ -727,8 +727,10 @@ const CandidateList = () => {
 
   useEffect(() => {
     // Grab the available annotation fields for filtering
-    dispatch(candidatesActions.fetchAnnotationsInfo());
-  }, [dispatch]);
+    if (!availableAnnotationsInfo) {
+      dispatch(candidatesActions.fetchAnnotationsInfo());
+    }
+  }, [dispatch, availableAnnotationsInfo]);
 
   useEffect(() => {
     if (defaultScanningProfile?.sortingOrder) {

--- a/static/js/components/CandidatesPreferences.jsx
+++ b/static/js/components/CandidatesPreferences.jsx
@@ -1,5 +1,5 @@
-import React, { useState, useEffect } from "react";
-import { useSelector, useDispatch } from "react-redux";
+import React, { useState } from "react";
+import { useSelector } from "react-redux";
 import PropTypes from "prop-types";
 
 import IconButton from "@mui/material/IconButton";
@@ -18,7 +18,6 @@ import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import Button from "./Button";
 
-import * as candidatesActions from "../ducks/candidates";
 import { allowedClasses } from "./ClassificationForm";
 import ScanningProfilesList from "./ScanningProfilesList";
 import CandidatesPreferencesForm from "./CandidatesPreferencesForm";
@@ -48,14 +47,6 @@ const CandidatesPreferences = ({
     (state) => state.candidates.annotationsInfo
   );
   const classes = useStyles();
-  const dispatch = useDispatch();
-
-  useEffect(() => {
-    // Grab the available annotation fields for filtering
-    if (!availableAnnotationsInfo) {
-      dispatch(candidatesActions.fetchAnnotationsInfo());
-    }
-  }, [dispatch, availableAnnotationsInfo]);
 
   const userAccessibleGroups = useSelector(
     (state) => state.groups.userAccessible

--- a/static/js/components/FilterCandidateList.jsx
+++ b/static/js/components/FilterCandidateList.jsx
@@ -136,12 +136,6 @@ const FilterCandidateList = ({
     (state) => state.candidates.annotationsInfo
   );
   const dispatch = useDispatch();
-  useEffect(() => {
-    // Grab the available annotation fields for filtering
-    if (!availableAnnotationsInfo) {
-      dispatch(candidatesActions.fetchAnnotationsInfo());
-    }
-  }, [dispatch, availableAnnotationsInfo]);
 
   const { scanningProfiles, useAMPM } = useSelector(
     (state) => state.profile.preferences

--- a/test_config.yaml
+++ b/test_config.yaml
@@ -14,6 +14,7 @@ server:
 misc:
   photometry_detection_threshold_nsigma: 3.0
   minutes_to_keep_candidate_query_cache: 0.033333 # 2 seconds
+  minutes_to_keep_annotations_info_query_cache: 0.033333 # 2 seconds
   allow_nonadmins_delete_objs: True
 
 twilio:


### PR DESCRIPTION
In this PR, we cache the result of the annotations info caching.

The annotation page is heavily used, and this query is expected to pretty much always return the same output. Especially now that it has a tendency to time out, it makes sense to cache it given that the results will almost always be the same. We cache it for 6 hours by default, as the only time the output might change is overnight when a new Kowalski filter has been added.

Also, we modify the frontend to remove repetitive calls to that endpoint.

In this PR, we also add a `dict_to_bytes` method to the cache utils, which might come in handy when one needs to cache something other than a list/array.