### PR TITLE
Frontend Search Summary Query

### DIFF
--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -483,6 +483,7 @@ services:
 misc:
   days_to_keep_unsaved_candidates: 7
   minutes_to_keep_candidate_query_cache: 60
+  minutes_to_keep_annotations_info_query_cache: 360
   minutes_to_keep_localization_instrument_query_cache: 1440
   max_items_in_localization_instrument_query_cache: 100
   public_group_name: "Sitewide Group"

--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -155,6 +155,8 @@ app:
       component: ShiftNoId
     - path: "/shifts/:id"
       component: ShiftWithId
+    - path: "/summary_search"
+      component: SummarySearch
     - path: "/taxonomies"
       component: TaxonomyPage
 
@@ -197,6 +199,10 @@ app:
         - name: Shifts
           icon: SubwayRounded
           url: /shifts
+
+        - name: Summary Search
+          icon: Troubleshoot
+          url: /summary_search
 
         - name: About
           icon: Info

--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -483,7 +483,6 @@ services:
 misc:
   days_to_keep_unsaved_candidates: 7
   minutes_to_keep_candidate_query_cache: 60
-  minutes_to_keep_annotations_info_query_cache: 360
   minutes_to_keep_localization_instrument_query_cache: 1440
   max_items_in_localization_instrument_query_cache: 100
   public_group_name: "Sitewide Group"
@@ -706,7 +705,7 @@ analysis_services:
       # Get a global key at:
       #   https://platform.openai.com/account/api-keys
       api_key:
-      temperature: 0.2
+      temperature: 0.3
       max_tokens: 350
       top_p: 1.0
       frequency_penalty: 0.0
@@ -743,3 +742,17 @@ colors:
       "GRB": "#f89406",
       "AMON": "#3a87ad",
     }
+
+  summary_sources:
+  - score: 0.9
+    fw: bold
+    col: green
+  - score: 0.8
+    fw: bold
+    col: black
+  - score: 0.7
+    fw: normal
+    col: black
+  - score: 0.0
+    fw: normal
+    col: grey

--- a/skyportal/handlers/api/config_handler.py
+++ b/skyportal/handlers/api/config_handler.py
@@ -85,6 +85,7 @@ class ConfigHandler(BaseHandler):
                 "image_analysis": True if 'image_analysis' in cfg else False,
                 "allowedRecurringAPIMethods": ALLOWED_RECURRING_API_METHODS,
                 "classificationsClasses": cfg["colors.classifications"],
+                "summary_sourcesClasses": cfg["colors.summary_sources"],
                 "gcnTagsClasses": cfg["colors.gcnTags"],
             }
         )

--- a/skyportal/handlers/api/summary_query.py
+++ b/skyportal/handlers/api/summary_query.py
@@ -111,7 +111,7 @@ else:
 
 class SummaryQueryHandler(BaseHandler):
     @auth_or_token
-    def get(self):
+    def post(self):
         """
         ---
         description: Get a list of sources with summaries matching the query

--- a/skyportal/tests/api/test_query.py
+++ b/skyportal/tests/api/test_query.py
@@ -5,7 +5,7 @@ def test_bad_queries(view_only_token):
 
     # no query
     query_data = {}
-    status, data = api('GET', 'summary_query', data=query_data, token=view_only_token)
+    status, data = api('POST', 'summary_query', data=query_data, token=view_only_token)
     assert status == 400
     assert data["message"].find("Missing required query string") != -1
 
@@ -15,12 +15,12 @@ def test_bad_queries(view_only_token):
         'z_min': 0.2,
         'z_max': 0.1,
     }
-    status, data = api('GET', 'summary_query', data=query_data, token=view_only_token)
+    status, data = api('POST', 'summary_query', data=query_data, token=view_only_token)
     assert status == 400
     assert data["message"].find("z_min must be <= z_max") != -1
 
     # bad k
     query_data = {'q': 'Test query. This is my test query on the sources?', "k": 101}
-    status, data = api('GET', 'summary_query', data=query_data, token=view_only_token)
+    status, data = api('POST', 'summary_query', data=query_data, token=view_only_token)
     assert status == 400
     assert data["message"].find("k must be 1<=k<=100") != -1

--- a/skyportal/tests/api/test_summary_query.py
+++ b/skyportal/tests/api/test_summary_query.py
@@ -5,7 +5,7 @@ def test_bad_queries(view_only_token):
 
     # no query
     query_data = {}
-    status, data = api('GET', 'summary_query', data=query_data, token=view_only_token)
+    status, data = api('POST', 'summary_query', data=query_data, token=view_only_token)
     assert status == 400
     assert data["message"].find("Missing required query string") != -1
 
@@ -15,12 +15,12 @@ def test_bad_queries(view_only_token):
         'z_min': 0.2,
         'z_max': 0.1,
     }
-    status, data = api('GET', 'summary_query', data=query_data, token=view_only_token)
+    status, data = api('POST', 'summary_query', data=query_data, token=view_only_token)
     assert status == 400
     assert data["message"].find("z_min must be <= z_max") != -1
 
     # bad k
     query_data = {'q': 'Test query. This is my test query on the sources?', "k": 101}
-    status, data = api('GET', 'summary_query', data=query_data, token=view_only_token)
+    status, data = api('POST', 'summary_query', data=query_data, token=view_only_token)
     assert status == 400
     assert data["message"].find("k must be 1<=k<=100") != -1

--- a/static/js/components/ShowSummaries.jsx
+++ b/static/js/components/ShowSummaries.jsx
@@ -52,7 +52,7 @@ const ShowSummaries = ({ summaries = [] }) => {
           <div className={styles.compactWrap}>
             <ReactMarkdown
               escapeHtml={false}
-              renderers={{ text: emojiSupport }}
+              components={{ text: emojiSupport }}
             >
               {renderCommentText()}
             </ReactMarkdown>

--- a/static/js/components/SummarySearch.jsx
+++ b/static/js/components/SummarySearch.jsx
@@ -1,0 +1,276 @@
+import React, { useState } from "react";
+
+import { useSelector, useDispatch } from "react-redux";
+import Chip from "@mui/material/Chip";
+import makeStyles from "@mui/styles/makeStyles";
+import Paper from "@mui/material/Paper";
+import Grid from "@mui/material/Grid";
+import Box from "@mui/material/Box";
+import { Link } from "react-router-dom";
+import ReactMarkdown from "react-markdown";
+import emoji from "emoji-dictionary";
+
+import Typography from "@mui/material/Typography";
+import CircularProgress from "@mui/material/CircularProgress";
+
+// eslint-disable-next-line import/no-unresolved
+import Form from "@rjsf/mui";
+import validator from "@rjsf/validator-ajv8";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+import { allowedClasses } from "./ClassificationForm";
+import Button from "./Button";
+
+import * as summaryActions from "../ducks/summary";
+
+const useStyles = makeStyles((theme) => ({
+  chip: {
+    margin: theme.spacing(0.5),
+    fontSize: "1.2rem",
+    fontWeight: "bold",
+  },
+  source: {},
+  commentListContainer: {
+    height: "15rem",
+    overflowY: "scroll",
+    padding: "0.5rem 0",
+  },
+  tableGrid: {
+    width: "100%",
+  },
+  parameterinline: {
+    marginRight: "16px",
+    display: "flex",
+  },
+}));
+
+const SummarySearch = () => {
+  const classes = useStyles();
+  const dispatch = useDispatch();
+  const [queryResult, setQueryResult] = useState(null);
+  const [runningQuery, setRunningQuery] = useState(false);
+  const [formData, setFormData] = useState({});
+
+  // Get unique classification names, in alphabetical order
+  const { taxonomyList } = useSelector((state) => state.taxonomies);
+  const latestTaxonomyList = taxonomyList?.filter((t) => t.isLatest);
+  let classifications = [];
+  latestTaxonomyList?.forEach((taxonomy) => {
+    const currentClasses = allowedClasses(taxonomy.hierarchy)?.map(
+      (option) => option.class
+    );
+    classifications = classifications.concat(currentClasses);
+  });
+  classifications = Array.from(new Set(classifications)).sort();
+
+  const handleSubmit = ({ fd }) => {
+    setRunningQuery(true);
+    setQueryResult(null);
+    dispatch(summaryActions.fetchSummaryQuery(fd)).then((response) => {
+      if (response.status === "success") {
+        setQueryResult(response.data);
+      }
+    });
+    setRunningQuery(false);
+  };
+
+  const emojiSupport = (textComment) =>
+    textComment.value.replace(/:\w+:/gi, (name) =>
+      emoji.getUnicode(name) ? emoji.getUnicode(name) : name
+    );
+
+  const formSchema = {
+    type: "object",
+    properties: {
+      q: {
+        type: "string",
+        title: "Query",
+      },
+      k: {
+        type: "integer",
+        title: "(Optional) Number of sources to return",
+        default: 5,
+        minimum: 1,
+        maximum: 25,
+        multipleOf: 1,
+      },
+      classificationTypes: {
+        type: ["array", "null"],
+        title: "(Optional) Return sources only with these classifications",
+        items: {
+          type: "string",
+          enum: classifications,
+        },
+        uniqueItems: true,
+      },
+      z_min: {
+        type: ["number", "null"],
+        title: "(Optional) Min redshift (can be null)",
+      },
+      z_max: {
+        type: ["number", "null"],
+        title: "(Optional) Max redshift (can be null)",
+      },
+    },
+    required: ["q", "k"],
+  };
+
+  const uiSchema = {
+    q: {
+      "ui:widget": "textarea",
+      "ui:autofocus": true,
+      "ui:placeholder": "What sources are associated with NGC galaxies?",
+      "ui:help": "Natural language query of the sources summaries.",
+    },
+    z_min: {
+      "ui:placeholder": "0.0",
+    },
+    z_max: {},
+    k: {
+      "ui:widget": "updown",
+    },
+  };
+
+  const validate = (fd, errors) => {
+    if (fd.z_min && fd.z_max && fd.z_min > fd.z_max) {
+      errors.z_min.addError("Min redshift must be less than max redshift");
+      errors.z_max.addError("Min redshift must be less than max redshift");
+    }
+
+    if (fd.z_max && fd.z_max < 0) {
+      errors.z_max.addError("Max redshift must be greater than 0");
+    }
+
+    if (fd.q.length < 10) {
+      errors.q.addError("Query must be at least 10 characters long");
+    }
+
+    if (!fd.q.includes("?")) {
+      errors.q.addError("Query must be in the form of a question.");
+    }
+
+    return errors;
+  };
+
+  const onClear = () => {
+    setFormData({});
+  };
+
+  return (
+    <Grid
+      container
+      spacing={3}
+      columns={12}
+      direction="column"
+      alignItems="center"
+      justifyContent="center"
+    >
+      <Grid item sx={12}>
+        <div className={classes.source}>
+          <Typography variant="h6" gutterBottom>
+            Summary Search
+          </Typography>
+        </div>
+      </Grid>
+      <Grid item sx={8}>
+        <Paper elevation={1}>
+          <Form
+            schema={formSchema}
+            validator={validator}
+            uiSchema={uiSchema}
+            data-testid="searchform"
+            onSubmit={handleSubmit}
+            formData={formData}
+            onChange={({ fd }) => setFormData(fd)}
+            customValidate={validate}
+          >
+            <div>
+              <Button primary disabled={runningQuery} type="submit">
+                Submit
+              </Button>
+              <Button
+                secondary
+                disabled={runningQuery}
+                type="button"
+                onClick={onClear}
+              >
+                Clear
+              </Button>
+            </div>
+          </Form>
+        </Paper>
+      </Grid>
+      <Grid item sx={12}>
+        {runningQuery ? <CircularProgress /> : null}
+        {!runningQuery && queryResult ? (
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableCell>Name</TableCell>
+                <TableCell>Score</TableCell>
+                <TableCell>Summary</TableCell>
+                <TableCell>Redshift</TableCell>
+                <TableCell>Classification(s)</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {queryResult.query_results?.map((source) => {
+                let fw = "normal";
+                let col = "grey";
+                if (source.score > 0.9) {
+                  fw = "bold";
+                  col = "green";
+                } else if (source.score > 0.8) {
+                  fw = "bold";
+                  col = "black";
+                } else if (source.score > 0.7) {
+                  fw = "normal";
+                  col = "black";
+                }
+                return (
+                  <TableRow key={`query_${source.id}`}>
+                    <TableCell>
+                      <Link
+                        to={`/source/${source.id}`}
+                        role="link"
+                        key={source.id}
+                      >
+                        {source.id}
+                      </Link>
+                    </TableCell>
+                    <TableCell>
+                      <Box component="span" fontWeight={fw} color={col}>
+                        {source.score}
+                      </Box>
+                    </TableCell>
+                    <TableCell>
+                      <ReactMarkdown components={{ text: emojiSupport }}>
+                        {source?.metadata?.summary}
+                      </ReactMarkdown>
+                    </TableCell>
+                    <TableCell>{source?.metadata?.redshift}</TableCell>
+                    <TableCell>
+                      {source?.metadata?.class?.map((cl) => (
+                        <Chip
+                          label={`${cl}`}
+                          key={`${source.id}_${cl}tb`}
+                          size="small"
+                          className={classes.chip}
+                        />
+                      ))}
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        ) : null}
+      </Grid>
+    </Grid>
+  );
+};
+
+export default SummarySearch;

--- a/static/js/components/SummarySearch.jsx
+++ b/static/js/components/SummarySearch.jsx
@@ -60,6 +60,9 @@ const useStyles = makeStyles((theme) => ({
 
 const SummarySearch = () => {
   const classes = useStyles();
+  const summary_sources_classes = useSelector(
+    (state) => state.config.summary_sourcesClasses
+  );
   const dispatch = useDispatch();
   const [queryResult, setQueryResult] = useState(null);
   const [runningQuery, setRunningQuery] = useState(false);
@@ -119,7 +122,6 @@ const SummarySearch = () => {
                 default: 5,
                 minimum: 1,
                 maximum: 25,
-                multipleOf: 1,
               },
               classificationTypes: {
                 type: ["array", "null"],
@@ -274,16 +276,17 @@ const SummarySearch = () => {
               {queryResult.query_results?.map((source) => {
                 let fw = "normal";
                 let col = "grey";
-                if (source.score > 0.9) {
-                  fw = "bold";
-                  col = "green";
-                } else if (source.score > 0.8) {
-                  fw = "bold";
-                  col = "black";
-                } else if (source.score > 0.7) {
-                  fw = "normal";
-                  col = "black";
-                }
+                // set the font weight and color based on the score
+                // using the summary_sources_classes list
+                summary_sources_classes.every((tc) => {
+                  if (source.score >= tc.score) {
+                    fw = tc.fw;
+                    col = tc.col;
+                    return false;
+                  }
+                  return true;
+                });
+
                 return (
                   <TableRow key={`query_${source.id}`}>
                     <TableCell>

--- a/static/js/ducks/summary.js
+++ b/static/js/ducks/summary.js
@@ -1,0 +1,8 @@
+import * as API from "../API";
+
+const FETCH_MATCHING_SUMMARIES = "skyportal/FETCH_MATCHING_SUMMARIES";
+
+// eslint-disable-next-line import/prefer-default-export
+export function fetchSummaryQuery(formData) {
+  return API.POST(`/api/summary_query`, FETCH_MATCHING_SUMMARIES, formData);
+}


### PR DESCRIPTION
This PR adds the ability to query the summary vector database with a natural language query, by adding a new frontend page `/summary_search`.
![Kapture 2023-05-03 at 09 38 19](https://user-images.githubusercontent.com/480799/235982964-c2c67b05-9569-400e-8003-77f364f06039.gif)

Changes the API from GET to POST and updates the tests.

TODO:
- [ ] Add front end tests for the new page