### PR TITLE
Sources in GCN Table: Various user requests

### DIFF
--- a/skyportal/handlers/api/sources_confirmed_in_gcn.py
+++ b/skyportal/handlers/api/sources_confirmed_in_gcn.py
@@ -199,11 +199,11 @@ class SourcesConfirmedInGCNHandler(BaseHandler):
 
                 if len(sources_id_list) == 0:
                     stmt = SourcesConfirmedInGCN.select(session.user_or_token).where(
-                        Localization.dateobs == dateobs
+                        SourcesConfirmedInGCN.dateobs == dateobs
                     )
                 else:
                     stmt = SourcesConfirmedInGCN.select(session.user_or_token).where(
-                        Localization.dateobs == dateobs,
+                        SourcesConfirmedInGCN.dateobs == dateobs,
                         SourcesConfirmedInGCN.obj_id.in_(sources_id_list),
                     )
                 sources_in_gcn = session.scalars(stmt).all()

--- a/static/js/components/ConfirmSourceInGCN.jsx
+++ b/static/js/components/ConfirmSourceInGCN.jsx
@@ -302,7 +302,7 @@ const ConfirmSourceInGCN = ({
             maxWidth="md"
           >
             <DialogTitle onClose={handleClose}>
-              Confirm/Reject Source {source_id} in GCN {dateobs}
+              Highlight/Reject Source {source_id} in GCN {dateobs}
             </DialogTitle>
             <DialogContent dividers>
               <div className={classes.dialogContent}>
@@ -345,7 +345,7 @@ const ConfirmSourceInGCN = ({
                       />
                     </div>
                     <div>
-                      <Button onClick={handleConfirm}>CONFIRM</Button>
+                      <Button onClick={handleConfirm}>HIGHLIGHT</Button>
                       <Button onClick={handleReject}>REJECT</Button>
                       <Button onClick={handleUndefined}>UNDEFINED</Button>
                     </div>

--- a/static/js/components/SourceTable.jsx
+++ b/static/js/components/SourceTable.jsx
@@ -1864,89 +1864,115 @@ const SourceTable = ({
       downloadCallback().then((data) => {
         // if there is no data, cancel download
         if (data?.length > 0) {
+          const head = [
+            {
+              name: "id",
+              download: true,
+            },
+            {
+              name: "ra [deg]",
+              download: true,
+            },
+            {
+              name: "dec [deg]",
+              download: true,
+            },
+            {
+              name: "redshift",
+              download: true,
+            },
+            {
+              name: "classification",
+              download: true,
+            },
+            {
+              name: "probability",
+              download: true,
+            },
+            {
+              name: "annotation origin",
+              download: true,
+            },
+            {
+              name: "annotation origin key-value pair count",
+              download: true,
+            },
+            {
+              name: "annotation key",
+              download: true,
+            },
+            {
+              name: "annotation value",
+              download: true,
+            },
+            {
+              name: "groups",
+              download: true,
+            },
+            {
+              name: "Date saved",
+              download: true,
+            },
+            {
+              name: "Alias",
+              download: true,
+            },
+            {
+              name: "Origin",
+              download: true,
+            },
+            {
+              name: "TNS Name",
+              download: true,
+            },
+          ];
+          if (includeGcnStatus) {
+            head.push({
+              name: "GCN Status",
+              download: true,
+            });
+            head.push({
+              name: "GCN Status Explanation",
+              download: true,
+            });
+            head.push({
+              name: "GCN Notes",
+              download: true,
+            });
+          }
+
+          const formatDataFunc = (x) => {
+            const formattedData = [
+              x.id,
+              x.ra,
+              x.dec,
+              x.redshift,
+              renderDownloadClassification(x),
+              renderDownloadProbability(x),
+              renderDownloadAnnotationOrigin(x),
+              renderDownloadAnnotationOriginKeyValuePairCount(x),
+              renderDownloadAnnotationKey(x),
+              renderDownloadAnnotationValue(x),
+              renderDownloadGroups(x),
+              renderDownloadDateSaved(x),
+              renderDownloadAlias(x),
+              x.origin,
+              renderDownloadTNSName(x),
+            ];
+            if (includeGcnStatus) {
+              formattedData.push(x.gcn ? x.gcn.status : "");
+              formattedData.push(x.gcn ? x.gcn.explanation : "");
+              formattedData.push(x.gcn ? x.gcn.notes : "");
+            }
+            return formattedData;
+          };
+
           const result =
-            buildHead([
-              {
-                name: "id",
-                download: true,
-              },
-              {
-                name: "ra [deg]",
-                download: true,
-              },
-              {
-                name: "dec [deg]",
-                download: true,
-              },
-              {
-                name: "redshift",
-                download: true,
-              },
-              {
-                name: "classification",
-                download: true,
-              },
-              {
-                name: "probability",
-                download: true,
-              },
-              {
-                name: "annotation origin",
-                download: true,
-              },
-              {
-                name: "annotation origin key-value pair count",
-                download: true,
-              },
-              {
-                name: "annotation key",
-                download: true,
-              },
-              {
-                name: "annotation value",
-                download: true,
-              },
-              {
-                name: "groups",
-                download: true,
-              },
-              {
-                name: "Date saved",
-                download: true,
-              },
-              {
-                name: "Alias",
-                download: true,
-              },
-              {
-                name: "Origin",
-                download: true,
-              },
-              {
-                name: "TNS Name",
-                download: true,
-              },
-            ]) +
+            buildHead(head) +
             buildBody(
               data.map((x) => ({
                 ...x,
-                data: [
-                  x.id,
-                  x.ra,
-                  x.dec,
-                  x.redshift,
-                  renderDownloadClassification(x),
-                  renderDownloadProbability(x),
-                  renderDownloadAnnotationOrigin(x),
-                  renderDownloadAnnotationOriginKeyValuePairCount(x),
-                  renderDownloadAnnotationKey(x),
-                  renderDownloadAnnotationValue(x),
-                  renderDownloadGroups(x),
-                  renderDownloadDateSaved(x),
-                  renderDownloadAlias(x),
-                  x.origin,
-                  renderDownloadTNSName(x),
-                ],
+                data: formatDataFunc(x),
               }))
             );
           const blob = new Blob([result], {

--- a/static/js/components/SourceTable.jsx
+++ b/static/js/components/SourceTable.jsx
@@ -27,6 +27,7 @@ import CheckIcon from "@mui/icons-material/Check";
 import ClearIcon from "@mui/icons-material/Clear";
 import InfoIcon from "@mui/icons-material/Info";
 import QuestionMarkIcon from "@mui/icons-material/QuestionMark";
+import PriorityHigh from "@mui/icons-material/PriorityHigh";
 import CircularProgress from "@mui/material/CircularProgress";
 import Divider from "@mui/material/Divider";
 import ListItem from "@mui/material/ListItem";
@@ -1315,7 +1316,7 @@ const SourceTable = ({
     const source = sources[dataIndex];
     let statusIcon = null;
     if (sourcesingcn.filter((s) => s.obj_id === source.id).length === 0) {
-      statusIcon = <QuestionMarkIcon size="small" color="primary" />;
+      statusIcon = <PriorityHigh size="small" color="primary" />;
     } else if (
       sourcesingcn.filter((s) => s.obj_id === source.id)[0].confirmed === true
     ) {
@@ -1324,6 +1325,8 @@ const SourceTable = ({
       sourcesingcn.filter((s) => s.obj_id === source.id)[0].confirmed === false
     ) {
       statusIcon = <ClearIcon size="small" color="secondary" />;
+    } else {
+      statusIcon = <QuestionMarkIcon size="small" color="primary" />;
     }
 
     return (


### PR DESCRIPTION
In this PR we:
- Fix the download of sources from the source table on the gcn page [issue #4231]
- Stop hiding the table when there are no sources, so that additional filters can be reset without having to requery sources [issue #4231]
- Increase the default nb of sources in the table to 100 [issue #4230]
- Rename "confirmed" to "highlight" in the component to confirm/reject sources in gcn [issue #4228]