### PR TITLE
WIP - GCN Notification: No DB Trigger

### DIFF
--- a/services/gcn_service/gcn_service.py
+++ b/services/gcn_service/gcn_service.py
@@ -19,6 +19,7 @@ from skyportal.handlers.api.gcn import (
 )
 from skyportal.models import DBSession, GcnEvent
 from skyportal.utils.gcn import get_dateobs, get_skymap_metadata, get_trigger
+from skyportal.utils.notifications import post_notification
 
 env, cfg = load_env()
 
@@ -173,20 +174,34 @@ def poll_events():
                             session,
                             post_skymap=False,
                             asynchronous=False,
+                            notify=False,
                         )
                     except Exception as e:
                         log(f'Failed to ingest gcn_event from {message.topic()}: {e}')
                         continue
 
                     # skymap ingestion if available or cone
+                    notified_on_skymap = False
                     status, metadata = get_skymap_metadata(root, notice_type, 15)
                     if status in ['available', 'cone']:
                         log(
                             f'Ingesting skymap for gcn_event: {dateobs}, notice_id: {notice_id}'
                         )
                         try:
-                            post_skymap_from_notice(
-                                dateobs, notice_id, user_id, session, asynchronous=False
+                            localization_id = post_skymap_from_notice(
+                                dateobs,
+                                notice_id,
+                                user_id,
+                                session,
+                                asynchronous=False,
+                                notify=False,
+                            )
+                            request_body = {
+                                'target_class_name': 'Localization',
+                                'target_id': localization_id,
+                            }
+                            notified_on_skymap = post_notification(
+                                request_body, timeout=30
                             )
                         except Exception as e:
                             log(
@@ -200,6 +215,12 @@ def poll_events():
                         log(
                             f'No skymap available for gcn_event: {dateobs}, notice_id: {notice_id}'
                         )
+                    if not notified_on_skymap:
+                        request_body = {
+                            'target_class_name': 'GcnNotice',
+                            'target_id': notice_id,
+                        }
+                        post_notification(request_body, timeout=30)
 
         except Exception as e:
             log(f'Failed to consume gcn event: {e}')

--- a/services/notification_queue/notification_queue.py
+++ b/services/notification_queue/notification_queue.py
@@ -30,6 +30,7 @@ from skyportal.models import (
     FacilityTransaction,
     FollowupRequest,
     GcnEvent,
+    GcnNotice,
     GcnTag,
     Group,
     GroupAdmissionRequest,
@@ -492,7 +493,8 @@ def api(queue):
             target_content = None
 
             is_facility_transaction = target_class_name == "FacilityTransaction"
-            is_gcnevent = target_class_name == "Localization"
+            is_gcn_notice = target_class_name == "GcnNotice"
+            is_gcn_localization = target_class_name == "Localization"
             is_gcn_tag = target_class_name == "GcnTag"
             is_classification = target_class_name == "Classification"
             is_spectra = target_class_name == "Spectrum"
@@ -505,7 +507,7 @@ def api(queue):
 
             with DBSession() as session:
                 try:
-                    if is_gcnevent or is_gcn_tag:
+                    if is_gcn_notice or is_gcn_localization or is_gcn_tag:
                         stmt = sa.select(User).where(
                             User.preferences["notifications"]["gcn_events"]["active"]
                             .astext.cast(sa.Boolean)
@@ -535,9 +537,9 @@ def api(queue):
                             else:
                                 return
 
-                        target_class = Localization
+                        target_class = Localization if not is_gcn_notice else GcnNotice
                         target = session.scalars(
-                            sa.select(Localization).where(Localization.id == target_id)
+                            sa.select(target_class).where(target_class.id == target_id)
                         ).first()
                         target_data = target.to_dict()
                         target_content = gcn_notification_content(target, session)
@@ -741,7 +743,9 @@ def api(queue):
                                 ).first()
                                 is not None
                             ):
-                                if (is_gcnevent or is_gcn_tag) and (pref is not None):
+                                if (
+                                    is_gcn_notice or is_gcn_localization or is_gcn_tag
+                                ) and (pref is not None):
                                     event = session.scalars(
                                         sa.select(GcnEvent).where(
                                             GcnEvent.dateobs == target_data["dateobs"]
@@ -749,18 +753,30 @@ def api(queue):
                                     ).first()
 
                                     notices = event.gcn_notices
-                                    filtered_notices = [
-                                        notice
-                                        for notice in notices
-                                        if notice.id == target_data["notice_id"]
-                                    ]
+                                    if target_class is not GcnNotice:
+                                        filtered_notices = [
+                                            notice
+                                            for notice in notices
+                                            if notice.id == target_data["notice_id"]
+                                        ]
 
-                                    if len(filtered_notices) > 0:
-                                        # the notice is the one with "localization_ingested" equal to the "id" of target_id
-                                        notice = filtered_notices[0]
+                                        if len(filtered_notices) > 0:
+                                            # the notice is the one with "localization_ingested" equal to the "id" of target_id
+                                            notice = filtered_notices[0]
+                                        else:
+                                            # we trigger the notification on localization, but we notify only if it comes from a notice
+                                            continue
                                     else:
-                                        # we trigger the notification on localization, but we notify only if it comes from a notice
-                                        continue
+                                        # here, the notice is the notice of the target_id
+                                        filtered_notices = [
+                                            notice
+                                            for notice in notices
+                                            if notice.id == target_id
+                                        ]
+                                        if len(filtered_notices) > 0:
+                                            notice = filtered_notices[0]
+                                        else:
+                                            continue
 
                                     gcn_prefs = pref["gcn_events"].get("properties", {})
                                     if len(gcn_prefs.keys()) == 0:
@@ -825,56 +841,64 @@ def api(queue):
                                             if not any(properties_bool):
                                                 continue
 
-                                        localization = session.scalars(
-                                            sa.select(Localization).where(
-                                                Localization.dateobs
-                                                == target_data["dateobs"]
-                                            )
-                                        ).first()
-                                        (
-                                            localization_properties_dict,
-                                            localization_tags_list,
-                                        ) = get_skymap_properties(localization)
-
-                                        if (
-                                            len(gcn_pref.get("localization_tags", []))
-                                            > 0
-                                        ):
-                                            intersection = list(
-                                                set(localization_tags_list)
-                                                & set(gcn_pref["localization_tags"])
-                                            )
-                                            if len(intersection) == 0:
-                                                continue
-
-                                        for prop_filt in gcn_pref.get(
-                                            "localization_properties", []
-                                        ):
-                                            prop_split = prop_filt.split(":")
-                                            if not len(prop_split) == 3:
-                                                raise ValueError(
-                                                    "Invalid propertiesFilter value -- property filter must have 3 values"
+                                        if not is_gcn_notice:
+                                            localization = session.scalars(
+                                                sa.select(Localization).where(
+                                                    Localization.id == target_id
                                                 )
-                                            name = prop_split[0].strip()
-                                            if name in localization_properties_dict:
-                                                value = prop_split[1].strip()
-                                                try:
-                                                    value = float(value)
-                                                except ValueError as e:
-                                                    raise ValueError(
-                                                        f"Invalid propertiesFilter value: {e}"
+                                            ).first()
+                                            (
+                                                localization_properties_dict,
+                                                localization_tags_list,
+                                            ) = get_skymap_properties(localization)
+
+                                            if (
+                                                len(
+                                                    gcn_pref.get(
+                                                        "localization_tags", []
                                                     )
-                                                op = prop_split[2].strip()
-                                                if op not in op_options:
-                                                    raise ValueError(
-                                                        f"Invalid operator: {op}"
-                                                    )
-                                                comp_function = getattr(operator, op)
-                                                if not comp_function(
-                                                    localization_properties_dict[name],
-                                                    value,
-                                                ):
+                                                )
+                                                > 0
+                                            ):
+                                                intersection = list(
+                                                    set(localization_tags_list)
+                                                    & set(gcn_pref["localization_tags"])
+                                                )
+                                                if len(intersection) == 0:
                                                     continue
+
+                                            for prop_filt in gcn_pref.get(
+                                                "localization_properties", []
+                                            ):
+                                                prop_split = prop_filt.split(":")
+                                                if not len(prop_split) == 3:
+                                                    raise ValueError(
+                                                        "Invalid propertiesFilter value -- property filter must have 3 values"
+                                                    )
+                                                name = prop_split[0].strip()
+                                                if name in localization_properties_dict:
+                                                    value = prop_split[1].strip()
+                                                    try:
+                                                        value = float(value)
+                                                    except ValueError as e:
+                                                        raise ValueError(
+                                                            f"Invalid propertiesFilter value: {e}"
+                                                        )
+                                                    op = prop_split[2].strip()
+                                                    if op not in op_options:
+                                                        raise ValueError(
+                                                            f"Invalid operator: {op}"
+                                                        )
+                                                    comp_function = getattr(
+                                                        operator, op
+                                                    )
+                                                    if not comp_function(
+                                                        localization_properties_dict[
+                                                            name
+                                                        ],
+                                                        value,
+                                                    ):
+                                                        continue
 
                                         if is_gcn_tag:
                                             text = (

--- a/skyportal/models/user_notification.py
+++ b/skyportal/models/user_notification.py
@@ -12,7 +12,6 @@ from baselayer.app.models import Base, AccessibleIfUserMatches
 from ..utils.notifications import post_notification
 from .analysis import ObjAnalysis
 from .classification import Classification
-from .localization import Localization
 from .spectrum import Spectrum
 from .comment import Comment
 from .facility_transaction import FacilityTransaction
@@ -69,7 +68,6 @@ class UserNotification(Base):
 @event.listens_for(ObjAnalysis, 'after_update')
 @event.listens_for(EventObservationPlan, 'after_insert')
 @event.listens_for(FollowupRequest, 'after_update')
-@event.listens_for(Localization, 'after_insert')
 def add_user_notifications(mapper, connection, target):
 
     # Add front-end user notifications

--- a/skyportal/utils/notifications.py
+++ b/skyportal/utils/notifications.py
@@ -27,7 +27,13 @@ def gcn_notification_content(target, session):
     stmt = sa.select(GcnEvent).where(GcnEvent.dateobs == dateobs)
     gcn_event = session.execute(stmt).scalars().first()
 
-    tags = [tag.text for tag in target.tags]
+    localizations = gcn_event.localizations
+    tags = []
+    # get the latest localization
+    localization = None
+    if localizations is not None and len(localizations) > 0:
+        localization = localizations[-1]
+        tags = [tag.text for tag in localization.tags]
 
     time_since_dateobs = datetime.datetime.utcnow() - gcn_event.dateobs
     # remove the microseconds from the timedelta
@@ -104,7 +110,7 @@ def gcn_notification_content(target, session):
         'tags': tags,
         'links': links,
         'app_url': app_url,
-        'localization_name': target.localization_name,
+        'localization_name': localization.localization_name if localization else None,
     }
 
 
@@ -131,9 +137,13 @@ def gcn_slack_notification(target, data=None, new_tag=False):
         if data['error'] < SOURCE_RADIUS_THRESHOLD:
             localization_text += f"\n *-* Source Page Link: <{app_url}/source/{data['source_name']}|*{data['source_name']}*>"
 
-    else:
+    elif data['localization_name'] is not None:
         # the event has an associated skymap
         localization_text = f"*Localization*:\n *-* Localization Type: Skymap\n *-* Name: {data['localization_name']}"
+    else:
+        localization_text = (
+            "*Localization*:\n *-* No localization available for this event (yet)"
+        )
 
     external_links_text = None
     if len(data['links']):
@@ -142,7 +152,7 @@ def gcn_slack_notification(target, data=None, new_tag=False):
             external_links_text += f"\n *-* <{value}|*{key}*>"
 
     tags_text = None
-    if len(data['tags']):
+    if len(data['tags']) > 0:
         tags_text = f"*Event tags*: {','.join(data['tags'])}"
 
     blocks = [
@@ -190,9 +200,11 @@ def gcn_email_notification(target, data=None, new_tag=False):
         localization_text = f"<h4>Localization:</h4><ul><li>Localization Type: Point</li><li>Coordinates: ra={data['ra']}, dec={data['dec']}, error radius={data['error']} deg</li>"
         if data['error'] < SOURCE_RADIUS_THRESHOLD:
             localization_text += f"<li>Associated source Link: <a href='{app_url}/source/{data['source_name']}'>{data['source_name']}</a></li>"
-    else:
+    elif data['localization_name'] is not None:
         # the event has an associated skymap
         localization_text = f"<h4>Localization:</h4><ul><li>Localization Type: Skymap</li><li>Name: {data['localization_name']}</li>"
+    else:
+        localization_text = "<h4>Localization:</h4><ul><li>No localization available for this event (yet)</li>"
 
     localization_text = f"<div>{localization_text}</ul></div>"
 
@@ -204,7 +216,7 @@ def gcn_email_notification(target, data=None, new_tag=False):
         external_links_text += "</ul>"
 
     tags_text = None
-    if len(data['tags']):
+    if len(data['tags']) > 0:
         tags_text = f"<h4>Event tags: {','.join(data['tags'])}</h4><ul>"
 
     return subject, "".join(
@@ -356,3 +368,6 @@ def post_notification(request_body, timeout=2):
         log(
             f'Notification request failed for {request_body["target_class_name"]} with ID {request_body["target_id"]}: {resp.content}'
         )
+        return False
+    else:
+        return True


### PR DESCRIPTION
This PR tries to change how we trigger notifications on events. Instead of relying on new Localization being added and triggering a db trigger, we simply push to the queue in the method to ingest events. That way, we can handle missing localizations as well as wait for tags (of both events and localizations) to be added.