### PR TITLE
TNS Monitoring

### DIFF
--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -76,7 +76,7 @@ app:
     bot_id:
     bot_name:
     api_key:
-    look_back_days: 2
+    look_back_days: 1
 
   gracedb_endpoint: https://gracedb.ligo.org/api/
   # See https://computing.docs.ligo.org/guide/auth/x509/ for example

--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -71,7 +71,12 @@ app:
 
   treasuremap_endpoint: https://treasuremap.space
 
-  tns_endpoint: https://sandbox.wis-tns.org
+  tns:
+    endpoint: https://sandbox.wis-tns.org
+    bot_id:
+    bot_name:
+    api_key:
+    look_back_days: 2
 
   gracedb_endpoint: https://gracedb.ligo.org/api/
   # See https://computing.docs.ligo.org/guide/auth/x509/ for example

--- a/services/tns_queue/tns_queue.py
+++ b/services/tns_queue/tns_queue.py
@@ -15,6 +15,7 @@ import conesearch_alchemy as ca
 
 from baselayer.app.env import load_env
 from baselayer.app.models import init_db
+from baselayer.app.flow import Flow
 from baselayer.log import make_log
 from skyportal.handlers.api.photometry import serialize
 from skyportal.models import DBSession, Instrument, Obj, Photometry, TNSRobot, User
@@ -370,6 +371,9 @@ def tns_watcher():
     tns_headers = {
         "User-Agent": f'tns_marker{{"tns_id": {bot_id},"type": "bot", "name": "{bot_name}"}}',
     }
+
+    flow = Flow()
+
     while True:
         try:
             tns_objects = get_tns_objects(
@@ -408,6 +412,11 @@ def tns_watcher():
                                 session.commit()
                                 log(
                                     f"Updated object {obj.id} with TNS name {tns_obj['name']}"
+                                )
+                                flow.push(
+                                    '*',
+                                    'skyportal/REFRESH_SOURCE',
+                                    payload={'obj_key': obj.internal_key},
                                 )
                     except Exception as e:
                         log(f"Error adding TNS name to object: {str(e)}")

--- a/services/tns_queue/tns_queue.py
+++ b/services/tns_queue/tns_queue.py
@@ -40,7 +40,7 @@ search_frontend_url = urllib.parse.urljoin(TNS_URL, 'search')
 bot_id = cfg.get('app.tns.bot_id', None)
 bot_name = cfg.get('app.tns.bot_name', None)
 api_key = cfg.get('app.tns.api_key', None)
-look_back_days = cfg.get('app.tns.look_back_days', 5)
+look_back_days = cfg.get('app.tns.look_back_days', 2)
 
 queue = []
 

--- a/services/tns_queue/tns_queue.py
+++ b/services/tns_queue/tns_queue.py
@@ -40,7 +40,7 @@ search_frontend_url = urllib.parse.urljoin(TNS_URL, 'search')
 bot_id = cfg.get('app.tns.bot_id', None)
 bot_name = cfg.get('app.tns.bot_name', None)
 api_key = cfg.get('app.tns.api_key', None)
-look_back_days = cfg.get('app.tns.look_back_days', 2)
+look_back_days = cfg.get('app.tns.look_back_days', 1)
 
 queue = []
 

--- a/services/tns_queue/tns_queue.py
+++ b/services/tns_queue/tns_queue.py
@@ -1,32 +1,30 @@
-import astropy
-from threading import Thread
+import asyncio
+import json
 import time
+import urllib
+from threading import Thread
 
+import astropy
+import requests
+import sqlalchemy as sa
+import tornado.escape
 import tornado.ioloop
 import tornado.web
-import asyncio
-import tornado.escape
-import json
-import requests
-import urllib
+from sqlalchemy.orm import scoped_session, sessionmaker
+import conesearch_alchemy as ca
 
-import sqlalchemy as sa
-from sqlalchemy.orm import sessionmaker, scoped_session
-
-from baselayer.app.models import init_db
 from baselayer.app.env import load_env
+from baselayer.app.models import init_db
 from baselayer.log import make_log
-
 from skyportal.handlers.api.photometry import serialize
-from skyportal.utils.tns import get_IAUname, TNS_INSTRUMENT_IDS, SNCOSMO_TO_TNSFILTER
-from skyportal.models import (
-    DBSession,
-    Instrument,
-    Obj,
-    Photometry,
-    TNSRobot,
-    User,
+from skyportal.models import DBSession, Instrument, Obj, Photometry, TNSRobot, User
+from skyportal.utils.tns import (
+    SNCOSMO_TO_TNSFILTER,
+    TNS_INSTRUMENT_IDS,
+    get_IAUname,
+    get_tns_objects,
 )
+from skyportal.utils.calculations import great_circle_distance, radec_str2deg
 
 env, cfg = load_env()
 log = make_log('tns_queue')
@@ -35,8 +33,14 @@ init_db(**cfg['database'])
 
 Session = scoped_session(sessionmaker())
 
-TNS_URL = cfg['app.tns_endpoint']
+TNS_URL = cfg['app.tns.endpoint']
 report_url = urllib.parse.urljoin(TNS_URL, 'api/bulk-report')
+search_frontend_url = urllib.parse.urljoin(TNS_URL, 'search')
+
+bot_id = cfg.get('app.tns.bot_id', None)
+bot_name = cfg.get('app.tns.bot_name', None)
+api_key = cfg.get('app.tns.api_key', None)
+look_back_days = cfg.get('app.tns.look_back_days', 5)
 
 queue = []
 
@@ -353,12 +357,76 @@ def api(queue):
     loop.run_forever()
 
 
+def tns_watcher():
+    if (
+        TNS_URL is None
+        or bot_id is None
+        or bot_name is None
+        or api_key is None
+        or look_back_days is None
+    ):
+        log("TNS watcher not configured, skipping")
+        return
+    tns_headers = {
+        "User-Agent": f'tns_marker{{"tns_id": {bot_id},"type": "bot", "name": "{bot_name}"}}',
+    }
+    while True:
+        try:
+            tns_objects = get_tns_objects(
+                tns_headers,
+                discovered_period_value=look_back_days,
+                discovered_period_units='days',
+            )
+            if len(tns_objects) > 0:
+                for tns_obj in tns_objects:
+                    tns_ra, tns_dec = radec_str2deg(tns_obj["ra"], tns_obj["dec"])
+                    if Session.registry.has():
+                        session = Session()
+                    else:
+                        session = Session(bind=DBSession.session_factory.kw["bind"])
+                    try:
+                        other = ca.Point(ra=tns_ra, dec=tns_dec)
+                        obj_query = session.scalars(
+                            sa.select(Obj).where(
+                                Obj.within(other, 0.000555556)  # 2 arcseconds
+                            )
+                        ).all()
+                        if len(obj_query) > 0:
+                            closest_obj = obj_query[0]
+                            closest_obj_dist = great_circle_distance(
+                                tns_ra, tns_dec, closest_obj.ra, closest_obj.dec
+                            )
+                            for obj in obj_query:
+                                dist = great_circle_distance(
+                                    tns_ra, tns_dec, obj.ra, obj.dec
+                                )
+                                if dist < closest_obj_dist:
+                                    closest_obj = obj
+                                    closest_obj_dist = dist
+                            if obj.tns_name is None or obj.tns_name == "":
+                                obj.tns_name = str(tns_obj["name"]).strip()
+                                session.commit()
+                                log(
+                                    f"Updated object {obj.id} with TNS name {tns_obj['name']}"
+                                )
+                    except Exception as e:
+                        log(f"Error adding TNS name to object: {str(e)}")
+                        session.rollback()
+                    finally:
+                        session.close()
+        except Exception as e:
+            log(f"Error getting TNS objects: {str(e)}")
+        time.sleep(60 * 4)
+
+
 if __name__ == "__main__":
     try:
         t = Thread(target=service, args=(queue,))
         t2 = Thread(target=api, args=(queue,))
+        t3 = Thread(target=tns_watcher)
         t.start()
         t2.start()
+        t3.start()
 
         while True:
             log(f"Current TNS queue length: {len(queue)}")

--- a/skyportal/handlers/api/tns.py
+++ b/skyportal/handlers/api/tns.py
@@ -566,7 +566,6 @@ def tns_retrieval(
             log(f'Failed to retrieve {obj_id} from TNS: {r.content}')
         session.commit()
 
-        flow = Flow()
         flow.push(
             '*',
             'skyportal/REFRESH_SOURCE',

--- a/skyportal/handlers/api/tns.py
+++ b/skyportal/handlers/api/tns.py
@@ -45,7 +45,7 @@ _, cfg = load_env()
 
 Session = scoped_session(sessionmaker())
 
-TNS_URL = cfg['app.tns_endpoint']
+TNS_URL = cfg['app.tns.endpoint']
 upload_url = urllib.parse.urljoin(TNS_URL, 'api/file-upload')
 report_url = urllib.parse.urljoin(TNS_URL, 'api/bulk-report')
 search_url = urllib.parse.urljoin(TNS_URL, 'api/get/search')

--- a/skyportal/utils/calculations.py
+++ b/skyportal/utils/calculations.py
@@ -1,32 +1,11 @@
-from math import pi
-
+from astropy.coordinates import SkyCoord
+from astropy import units as u
 import numpy as np
 
 
-def radec_str2rad(_ra_str, _dec_str):
-    """
-    :param _ra_str: 'H:M:S'
-    :param _dec_str: 'D:M:S'
-    :return: ra, dec in rad
-    """
-    # convert to rad:
-    _ra = list(map(float, _ra_str.split(":")))
-    _ra = (_ra[0] + _ra[1] / 60.0 + _ra[2] / 3600.0) * pi / 12.0
-    _dec = list(map(float, _dec_str.split(":")))
-    _sign = -1 if _dec_str.strip()[0] == "-" else 1
-    _dec = (
-        _sign
-        * (abs(_dec[0]) + abs(_dec[1]) / 60.0 + abs(_dec[2]) / 3600.0)
-        * pi
-        / 180.0
-    )
-
-    return _ra, _dec
-
-
 def radec_str2deg(_ra_str, _dec_str):
-    ra, dec = radec_str2rad(_ra_str, _dec_str)
-    return ra * 180.0 / pi, dec * 180.0 / pi
+    c = SkyCoord(_ra_str, _dec_str, unit=(u.hourangle, u.deg))
+    return c.ra.deg, c.dec.deg
 
 
 def great_circle_distance(ra1_deg, dec1_deg, ra2_deg, dec2_deg):

--- a/skyportal/utils/calculations.py
+++ b/skyportal/utils/calculations.py
@@ -1,0 +1,50 @@
+import numpy as np
+
+
+def radec_str2deg(_ra_str, _dec_str):
+    """
+    :param _ra_str: 'H:M:S'
+    :param _dec_str: 'D:M:S'
+    :return: ra, dec in deg
+    """
+    # convert to rad:
+    _ra = list(map(float, _ra_str.split(":")))
+    _ra = _ra[0] + _ra[1] / 60.0 + _ra[2] / 3600.0
+    _dec = list(map(float, _dec_str.split(":")))
+    _sign = -1 if _dec_str.strip()[0] == "-" else 1
+    _dec = _sign * (abs(_dec[0]) + abs(_dec[1]) / 60.0 + abs(_dec[2]) / 3600.0)
+
+    return _ra, _dec
+
+
+def great_circle_distance(ra1_deg, dec1_deg, ra2_deg, dec2_deg):
+    """
+        Distance between two points on the sphere
+    :param ra1_deg:
+    :param dec1_deg:
+    :param ra2_deg:
+    :param dec2_deg:
+    :return: distance in degrees
+    """
+    # this is orders of magnitude faster than astropy.coordinates.Skycoord.separation
+    DEGRA = np.pi / 180.0
+    ra1, dec1, ra2, dec2 = (
+        ra1_deg * DEGRA,
+        dec1_deg * DEGRA,
+        ra2_deg * DEGRA,
+        dec2_deg * DEGRA,
+    )
+    delta_ra = np.abs(ra2 - ra1)
+    distance = np.arctan2(
+        np.sqrt(
+            (np.cos(dec2) * np.sin(delta_ra)) ** 2
+            + (
+                np.cos(dec1) * np.sin(dec2)
+                - np.sin(dec1) * np.cos(dec2) * np.cos(delta_ra)
+            )
+            ** 2
+        ),
+        np.sin(dec1) * np.sin(dec2) + np.cos(dec1) * np.cos(dec2) * np.cos(delta_ra),
+    )
+
+    return distance * 180.0 / np.pi

--- a/skyportal/utils/calculations.py
+++ b/skyportal/utils/calculations.py
@@ -1,20 +1,32 @@
+from math import pi
+
 import numpy as np
 
 
-def radec_str2deg(_ra_str, _dec_str):
+def radec_str2rad(_ra_str, _dec_str):
     """
     :param _ra_str: 'H:M:S'
     :param _dec_str: 'D:M:S'
-    :return: ra, dec in deg
+    :return: ra, dec in rad
     """
     # convert to rad:
     _ra = list(map(float, _ra_str.split(":")))
-    _ra = _ra[0] + _ra[1] / 60.0 + _ra[2] / 3600.0
+    _ra = (_ra[0] + _ra[1] / 60.0 + _ra[2] / 3600.0) * pi / 12.0
     _dec = list(map(float, _dec_str.split(":")))
     _sign = -1 if _dec_str.strip()[0] == "-" else 1
-    _dec = _sign * (abs(_dec[0]) + abs(_dec[1]) / 60.0 + abs(_dec[2]) / 3600.0)
+    _dec = (
+        _sign
+        * (abs(_dec[0]) + abs(_dec[1]) / 60.0 + abs(_dec[2]) / 3600.0)
+        * pi
+        / 180.0
+    )
 
     return _ra, _dec
+
+
+def radec_str2deg(_ra_str, _dec_str):
+    ra, dec = radec_str2rad(_ra_str, _dec_str)
+    return ra * 180.0 / pi, dec * 180.0 / pi
 
 
 def great_circle_distance(ra1_deg, dec1_deg, ra2_deg, dec2_deg):

--- a/static/js/units.js
+++ b/static/js/units.js
@@ -9,12 +9,17 @@ dayjs.extend(relativeTime);
 
 const hours_to_ra = (hours) => {
   const hoursSplit = hours.split(/[^\d\w]+/);
-  return (
-    (360 / 24) *
-    (parseInt(hoursSplit[0], 10) +
-      parseInt(hoursSplit[1], 10) / 60 +
-      parseInt(hoursSplit[2], 10) / (60 * 60))
-  );
+  const hh = parseInt(hoursSplit[0], 10);
+  const mm = parseInt(hoursSplit[1], 10) / 60;
+
+  let ss;
+  if (hoursSplit.length === 3) {
+    ss = parseInt(hoursSplit[2], 10) / (60 * 60);
+  } else {
+    ss = parseFloat(`${hoursSplit[2]}.${hoursSplit[3]}`) / (60 * 60);
+  }
+
+  return (360 / 24) * (hh + mm + ss);
 };
 
 const dms_to_dec = (dms) => {
@@ -23,12 +28,18 @@ const dms_to_dec = (dms) => {
   if (dms[0] === "-") {
     mult = -1;
   }
-  return (
-    mult *
-    (parseInt(dmsSplit[0], 10) +
-      parseInt(dmsSplit[1], 10) / 60 +
-      parseInt(dmsSplit[2], 10) / (60 * 60))
-  );
+
+  const dd = parseInt(dmsSplit[0], 10);
+  const mm = parseInt(dmsSplit[1], 10) / 60;
+
+  let ss;
+  if (dmsSplit.length === 3) {
+    ss = parseInt(dmsSplit[2], 10) / (60 * 60);
+  } else {
+    ss = parseFloat(`${dmsSplit[2]}.${dmsSplit[3]}`) / (60 * 60);
+  }
+
+  return mult * (dd + mm + ss);
 };
 
 const ra_to_hours = (ra, sep = null) => {


### PR DESCRIPTION
In this PR, we add a TNS name retrieval queue that runs in the same place as the submission queue, only in a different thread.
This system will query for the TNS names from the last `X` days, and run 2 arcseconds cone searches to determine whether or not an object in the database might be associated with it. If that is the case, it will add a TNS name to it.

In a following PR, we want to extend that system to add as much `tns_info` as we can to the objects in the DB. Here we used bs4 to get the TNS data instead of the API, simply because the API does not return the coordinates of objects when fetching multiple objects at once, while the frontend does. Given that we get 50 objects per page, even with just 50 objects added in a day or 2, that brings us to 1 GET request instead of 1+50x1=51 requests, gaining speed while actually letting TNS take a breath (especially considering its very restrictive rate limits). This however does not get the full tns_info. We can imagine calling TNS' API object endpoint ONLY if there is a TNS crossmatch (found with bs4), and not for each object.


🚨 CONFIG CHANGE 🚨: there is now a `tns` key under which one can specify the TNS endpoint, bot_name, bot_id and api_key that can be used by the backend, instead of just **one** key called `tns_endpoint`