### PR TITLE
Observations in GCN: Min obs per field

### DIFF
--- a/static/js/components/GcnSelectionForm.jsx
+++ b/static/js/components/GcnSelectionForm.jsx
@@ -741,6 +741,7 @@ const GcnSelectionForm = ({
           instrumentName: instLookUp[selectedInstrumentId]?.name,
           telescopeName:
             telLookUp[instLookUp[selectedInstrumentId]?.telescope_id]?.name,
+          numberObservations: formData?.numberDetections || 1,
         })
       );
       setHasFetchedObservations(true);
@@ -786,7 +787,7 @@ const GcnSelectionForm = ({
       },
       numberDetections: {
         type: "number",
-        title: "Minimum Number of Detections",
+        title: "Min Number of Detections/Observations",
         default: 2,
       },
       localizationCumprob: {

--- a/static/js/components/GcnSummary.jsx
+++ b/static/js/components/GcnSummary.jsx
@@ -155,6 +155,7 @@ const GcnSummary = ({ dateobs }) => {
   const [localizationName, setLocalizationName] = useState(null);
   const [localizationCumprob, setLocalizationCumprob] = useState("0.95");
   const [numberDetections, setNumberDetections] = useState("2");
+  const [numberObservations, setNumberObservations] = useState("1");
   const [showSources, setShowSources] = useState(false);
   const [showGalaxies, setShowGalaxies] = useState(false);
   const [showObservations, setShowObservations] = useState(false);
@@ -351,6 +352,7 @@ const GcnSummary = ({ dateobs }) => {
         localizationName,
         localizationCumprob,
         numberDetections,
+        numberObservations,
         showSources,
         showGalaxies,
         showObservations,
@@ -503,6 +505,12 @@ const GcnSummary = ({ dateobs }) => {
                     label="Minimum Number of Detections"
                     value={numberDetections}
                     onChange={(e) => setNumberDetections(e.target.value)}
+                  />
+                  <TextField
+                    id="numberObservations"
+                    label="Minimum Number of Observations (per field)"
+                    value={numberObservations}
+                    onChange={(e) => setNumberObservations(e.target.value)}
                   />
                   <div className={classes.checkboxes}>
                     <FormControlLabel


### PR DESCRIPTION
This PR adds an (optional) parameter to specify a minimum of observations per field required when fetching observations overlapping with a localization at the Nth credible region. 
This is useful as some folks only care about reporting observations of fields that have been observed at least N times (especially when generating summaries, which has been added here too).

When None or set to 1, this will simply be ignored and the query will be unchanged.