### PR TITLE
Photometry upload bugfix: avoid issue with obj_ids converted to int64

### DIFF
--- a/skyportal/handlers/api/photometry.py
+++ b/skyportal/handlers/api/photometry.py
@@ -499,6 +499,9 @@ def standardize_photometry_data(data):
             raise ValidationError(f'Invalid instrument ID: {iid}')
         instrument_cache[iid] = instrument
 
+    # convert the object IDs to str datatype
+    df['obj_id'] = df['obj_id'].astype(str)
+
     for oid in df['obj_id'].unique():
         obj = Obj.query.get(oid)
         if not obj:


### PR DESCRIPTION
Pandas converts obj_ids that are just made of numbers to int64, which breaks the query that checks if the object exists as the datatype doesn't match the one of the column. This is a quick bugfix.