### PR TITLE
TNS submission queue port: Change to something an api instance wouldn't use

### DIFF
--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -654,7 +654,7 @@ ports:
   observation_plan_queue: 64710
   tns_retrieval_queue: 64810
   thumbnail_queue: 64910
-  tns_submission_queue: 65010
+  tns_submission_queue: 64812
 
 gcn:
   server: gcn.nasa.gov


### PR DESCRIPTION
After deploying an app kept dying caus it used the port I specified (app 10), as the app ports are in that range.
I added a hotfix, but good to know.