### PR TITLE
Expanded Annotation table: Fit screen

### DIFF
--- a/static/js/components/AnnotationsTable.jsx
+++ b/static/js/components/AnnotationsTable.jsx
@@ -2,7 +2,6 @@ import React, { useState } from "react";
 import { useDispatch } from "react-redux";
 import PropTypes from "prop-types";
 import CircularProgress from "@mui/material/CircularProgress";
-import Typography from "@mui/material/Typography";
 
 import {
   createTheme,
@@ -10,15 +9,12 @@ import {
   StyledEngineProvider,
   useTheme,
 } from "@mui/material/styles";
-import { withStyles, makeStyles } from "@mui/styles";
+import { makeStyles } from "@mui/styles";
 import MUIDataTable from "mui-datatables";
 import IconButton from "@mui/material/IconButton";
 import ExpandIcon from "@mui/icons-material/Expand";
 import Dialog from "@mui/material/Dialog";
 import DialogContent from "@mui/material/DialogContent";
-import MuiDialogTitle from "@mui/material/DialogTitle";
-import Close from "@mui/icons-material/Close";
-import grey from "@mui/material/colors/grey";
 
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
@@ -37,6 +33,7 @@ const useStyles = makeStyles(() => ({
   container: {
     width: "100%",
     margin: "auto",
+    height: "100%",
   },
 }));
 
@@ -83,42 +80,12 @@ const getMuiTheme = (theme) =>
     },
   });
 
-const dialogTitleStyles = (theme) => ({
-  root: {
-    margin: 0,
-    padding: theme.spacing(2),
-  },
-  title: {
-    marginRight: theme.spacing(2),
-    fontSize: "1.5rem",
-  },
-  closeButton: {
-    position: "absolute",
-    right: theme.spacing(1),
-    top: theme.spacing(1),
-    color: grey[500],
-  },
-});
-
-const DialogTitle = withStyles(dialogTitleStyles)(
-  ({ children, classes, onClose }) => (
-    <MuiDialogTitle className={classes.root}>
-      <Typography className={classes.title}>{children}</Typography>
-      {onClose ? (
-        <IconButton
-          aria-label="close"
-          className={classes.closeButton}
-          onClick={onClose}
-        >
-          <Close />
-        </IconButton>
-      ) : null}
-    </MuiDialogTitle>
-  )
-);
-
 // Table for displaying annotations
-const AnnotationsTable = ({ annotations, spectrumAnnotations = [] }) => {
+const AnnotationsTable = ({
+  annotations,
+  spectrumAnnotations = [],
+  canExpand = true,
+}) => {
   const classes = useStyles();
   const theme = useTheme();
   const dispatch = useDispatch();
@@ -270,21 +237,26 @@ const AnnotationsTable = ({ annotations, spectrumAnnotations = [] }) => {
     rowsPerPageOptions: [10, 15, 50],
     jumpToPage: false,
     pagination: true,
-    tableBodyMaxHeight: "20rem",
-    customToolbar: () => (
-      <IconButton
-        name="expand_annotations"
-        onClick={() => {
-          setOpenAnnotations(true);
-        }}
-      >
-        <ExpandIcon />
-      </IconButton>
-    ),
+    tableBodyMaxHeight: canExpand ? "20rem" : "75vh",
+    customToolbar: () => {
+      if (canExpand) {
+        return (
+          <IconButton
+            name="expand_annotations"
+            onClick={() => {
+              setOpenAnnotations(true);
+            }}
+          >
+            <ExpandIcon />
+          </IconButton>
+        );
+      }
+      return null;
+    },
   };
 
   return (
-    <div>
+    <div style={{ height: "100%", width: "100%" }}>
       <div className={classes.container}>
         <StyledEngineProvider injectFirst>
           <ThemeProvider theme={getMuiTheme(theme)}>
@@ -301,14 +273,14 @@ const AnnotationsTable = ({ annotations, spectrumAnnotations = [] }) => {
           <Dialog
             open={openAnnotations}
             onClose={handleClose}
-            style={{ position: "fixed" }}
-            maxWidth="md"
+            style={{ position: "fixed", height: "100vh" }}
+            maxWidth={canExpand ? "md" : "lg"}
           >
-            <DialogTitle onClose={handleClose}>Annotations Table</DialogTitle>
             <DialogContent dividers>
               <AnnotationsTable
                 annotations={annotations}
                 spectrumAnnotations={spectrumAnnotations}
+                canExpand={false}
               />
             </DialogContent>
           </Dialog>
@@ -340,9 +312,11 @@ AnnotationsTable.propTypes = {
       spectrum_observed_at: PropTypes.string.isRequired,
     })
   ),
+  canExpand: PropTypes.bool,
 };
 AnnotationsTable.defaultProps = {
   spectrumAnnotations: [],
+  canExpand: true,
 };
 
 export default AnnotationsTable;


### PR DESCRIPTION
We already had the possibility to open a dialog with the annotation table (on the source page) so that it could be easier to read. However, this didn't work, as its height was still constrained and basically showed the same table. Also, the button to expand the table showed even in the table in the dialog, resulting in an annotations-ception if used incorrectly 🕳️ .

This PR solves both of these problems.