### PR TITLE
Catalog queries: Use kowalski's new skymap endpoint + better frontend

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -73,7 +73,7 @@ black==23.3.0
 click==8.1.3
 arviz==0.15.1
 corner==2.2.1
-penquins==2.3.1
+penquins==2.3.2
 selenium==4.8.3
 selenium-requests==2.0.3
 afterglowpy==0.7.3

--- a/skyportal/handlers/api/catalog_services.py
+++ b/skyportal/handlers/api/catalog_services.py
@@ -190,14 +190,23 @@ def fetch_transients(allocation_id, user_id, group_ids, payload):
 
             log("Querying kowalski for sources")
             # Query kowalski
+            log(str(payload))
             sources = query_kowalski(
-                altdata['access_token'],
-                jd_trigger,
-                ra_center,
-                dec_center,
+                token=altdata['access_token'],
+                dateobs=localization.dateobs,
+                localization_name=localization.localization_name,
+                contour=payload['localizationCumprob'] * 100,
+                localization_file=localization.get_localization_path(),
                 max_days=dt,
                 within_days=dt,
             )
+            if sources is None:
+                catalog_query.status = 'failed'
+                session.commit()
+                return
+
+            catalog_query.status = f'found {len(sources)} sources, posting...'
+            session.commit()
             obj_ids = []
             log("Looping over sources")
             for source in sources:

--- a/skyportal/handlers/api/catalog_services.py
+++ b/skyportal/handlers/api/catalog_services.py
@@ -163,11 +163,6 @@ def fetch_transients(allocation_id, user_id, group_ids, payload):
             )
         ).first()
 
-        healpix = localization.flat_2d
-        ra_center, dec_center = get_conesearch_centers(
-            healpix, level=payload['localizationCumprob']
-        )
-
         start_date = Time(arrow.get(payload['startDate'].strip()).datetime)
         end_date = Time(arrow.get(payload['endDate'].strip()).datetime)
 
@@ -190,7 +185,6 @@ def fetch_transients(allocation_id, user_id, group_ids, payload):
 
             log("Querying kowalski for sources")
             # Query kowalski
-            log(str(payload))
             sources = query_kowalski(
                 token=altdata['access_token'],
                 dateobs=localization.dateobs,
@@ -208,7 +202,7 @@ def fetch_transients(allocation_id, user_id, group_ids, payload):
             catalog_query.status = f'found {len(sources)} sources, posting...'
             session.commit()
             obj_ids = []
-            log("Looping over sources")
+            log(f"Found {len(sources)} sources, posting...")
             for source in sources:
                 log(f"Retrieving {source['id']}")
                 s = session.scalars(
@@ -238,6 +232,11 @@ def fetch_transients(allocation_id, user_id, group_ids, payload):
             ).first()
             if instrument is None:
                 raise ValueError('Expected an Instrument named ZTF')
+
+            healpix = localization.flat_2d
+            ra_center, dec_center = get_conesearch_centers(
+                healpix, level=payload['localizationCumprob']
+            )
 
             log("Querying Fink for sources")
             sources = query_fink(

--- a/skyportal/utils/catalog.py
+++ b/skyportal/utils/catalog.py
@@ -1,12 +1,12 @@
-import numpy as np
-from astropy import units as u
-from astropy.coordinates import SkyCoord
-from astropy.time import Time
-import healpy as hp
-import pandas as pd
-from penquins import Kowalski
-import requests
+import base64
 import urllib
+
+import healpy as hp
+import numpy as np
+import pandas as pd
+import requests
+from astropy.time import Time
+from penquins import Kowalski
 
 from baselayer.app.env import load_env
 from skyportal.facility_apis.ztf import inv_bands
@@ -91,13 +91,12 @@ def select_sources_in_level(sources, skymap, level=0.95):
 
 def query_kowalski(
     token,
-    jd_trigger,
-    ra_center,
-    dec_center,
-    radius=60.0,
+    dateobs,
+    localization_name,
+    localization_file,
+    contour,
     min_days=0.0,
     max_days=7.0,
-    slices=10,
     ndethist_min=2,
     within_days=7.0,
     after_trigger=True,
@@ -118,8 +117,6 @@ def query_kowalski(
         Time in days after trigger for first detection. Defaults to 0.
     max_days : float
         Time in days after trigger for final detection. Defaults to 7.
-    slices : int
-        Number of slices for parallelizing the cone search. Defaults to 10.
     ndethist_min : int
         Minimum number of detections for an object. Defaults to 2.
     within_days : float
@@ -141,199 +138,186 @@ def query_kowalski(
     )
     # Initialize a set for the results
     set_objectId_all = set()
-    slices = slices + 1
 
-    for slice_lim, i in zip(
-        np.linspace(0, len(ra_center), slices)[:-1],
-        np.arange(len(np.linspace(0, len(ra_center), slices)[:-1])),
-    ):
-        try:
-            ra_center_slice = ra_center[
-                int(slice_lim) : int(np.linspace(0, len(ra_center), slices)[:-1][i + 1])
-            ]
-            dec_center_slice = dec_center[
-                int(slice_lim) : int(
-                    np.linspace(0, len(dec_center), slices)[:-1][i + 1]
-                )
-            ]
-        except IndexError:
-            ra_center_slice = ra_center[int(slice_lim) :]
-            dec_center_slice = dec_center[int(slice_lim) :]
-        coords_arr = []
-        for ra, dec in zip(ra_center_slice, dec_center_slice):
-            try:
-                # Remove points too far south for ZTF.
-                # Say, keep only Dec>-40 deg to be conservative
-                if dec < -40.0:
-                    continue
-                coords = SkyCoord(ra=float(ra) * u.deg, dec=float(dec) * u.deg)
-                coords_arr.append((coords.ra.deg, coords.dec.deg))
-            except ValueError:
-                print("Problems with the galaxy coordinates?")
-                continue
+    # Correct the minimum number of detections
+    ndethist_min_corrected = int(ndethist_min - 1)
 
-        # Correct the minimum number of detections
-        ndethist_min_corrected = int(ndethist_min - 1)
-
-        # Correct the jd_trigger if the user specifies to query
-        # also before the trigger
-        if after_trigger is False:
-            jd_trigger = 0
-        q = {
-            "query_type": "cone_search",
-            "query": {
-                "object_coordinates": {
-                    "radec": f"{coords_arr}",
-                    "cone_search_radius": f"{radius}",
-                    "cone_search_unit": "arcmin",
+    dateobs_str = dateobs.strftime('%Y%m%dT%H%M%S')
+    exists = k.api(
+        'head',
+        'api/skymap',
+        data={
+            'dateobs': dateobs_str,
+            'localization_name': localization_name,
+            contour: contour,
+        },
+    )
+    print(exists)
+    if exists['status'] != 'success':
+        # post the skymap
+        with open(localization_file, 'rb') as f:
+            skymap = f.read()
+            skymap_data = {
+                'localization_name': localization_name,
+                'content': base64.b64encode(skymap).decode('utf-8'),
+            }
+            posted = k.api(
+                'put',
+                'api/skymap',
+                data={
+                    'dateobs': dateobs_str,
+                    'skymap': skymap_data,
+                    'contours': [contour],
                 },
-                "catalogs": {
-                    "ZTF_alerts": {
-                        "filter": {
-                            "candidate.jd": {'$gt': jd_trigger},
-                            "candidate.drb": {'$gt': 0.8},
-                            "candidate.ndethist": {'$gt': ndethist_min_corrected},
-                            "candidate.jdstarthist": {
-                                '$gt': jd_trigger,
-                                '$lt': jd_trigger + within_days,
-                            },
-                        },
-                        "projection": {
-                            "objectId": 1,
-                            "candidate.rcid": 1,
-                            "candidate.ra": 1,
-                            "candidate.dec": 1,
-                            "candidate.jd": 1,
-                            "candidate.ndethist": 1,
-                            "candidate.jdstarthist": 1,
-                            "candidate.jdendhist": 1,
-                            "candidate.jdendhist": 1,
-                            "candidate.magpsf": 1,
-                            "candidate.sigmapsf": 1,
-                            "candidate.fid": 1,
-                            "candidate.programid": 1,
-                            "candidate.isdiffpos": 1,
-                            "candidate.ndethist": 1,
-                            "candidate.ssdistnr": 1,
-                            "candidate.rb": 1,
-                            "candidate.drb": 1,
-                            "candidate.distpsnr1": 1,
-                            "candidate.sgscore1": 1,
-                            "candidate.srmag1": 1,
-                            "candidate.distpsnr2": 1,
-                            "candidate.sgscore2": 1,
-                            "candidate.srmag2": 1,
-                            "candidate.distpsnr3": 1,
-                            "candidate.sgscore3": 1,
-                            "candidate.srmag3": 1,
-                        },
-                    }
-                },
-                "kwargs": {"hint": "gw01"},
+            )
+            print(posted)
+            if posted['status'] != 'success':
+                print('Failed to post skymap')
+                return
+
+    # Correct the jd_trigger if the user specifies to query
+    # also before the trigger
+    if after_trigger is False:
+        jd_trigger = 0
+    else:
+        jd_trigger = dateobs
+
+    q = {
+        "query_type": "skymap",
+        "query": {
+            "skymap": {
+                "localization_name": localization_name,
+                "dateobs": dateobs_str,
+                "contour": contour,
             },
-        }
+            "catalog": "ZTF_alerts",
+            "filter": {
+                "candidate.jd": {'$gt': jd_trigger},
+                "candidate.drb": {'$gt': 0.8},
+                "candidate.ndethist": {'$gt': ndethist_min_corrected},
+                "candidate.jdstarthist": {
+                    '$gt': jd_trigger,
+                    '$lt': jd_trigger + within_days,
+                },
+            },
+            "projection": {
+                "objectId": 1,
+                "candidate.rcid": 1,
+                "candidate.ra": 1,
+                "candidate.dec": 1,
+                "candidate.jd": 1,
+                "candidate.ndethist": 1,
+                "candidate.jdstarthist": 1,
+                "candidate.jdendhist": 1,
+                "candidate.jdendhist": 1,
+                "candidate.magpsf": 1,
+                "candidate.sigmapsf": 1,
+                "candidate.fid": 1,
+                "candidate.programid": 1,
+                "candidate.isdiffpos": 1,
+                "candidate.ndethist": 1,
+                "candidate.ssdistnr": 1,
+                "candidate.rb": 1,
+                "candidate.drb": 1,
+                "candidate.distpsnr1": 1,
+                "candidate.sgscore1": 1,
+                "candidate.srmag1": 1,
+                "candidate.distpsnr2": 1,
+                "candidate.sgscore2": 1,
+                "candidate.srmag2": 1,
+                "candidate.distpsnr3": 1,
+                "candidate.sgscore3": 1,
+                "candidate.srmag3": 1,
+            },
+            "kwargs": {"hint": "gw01"},
+        },
+    }
 
-        # Perform the query
-        r = k.query(query=q)
-        if not r.get("default").get("status", "error") == "success":
-            raise ValueError("Query failed")
+    # Perform the query
+    r = k.query(query=q)
+    if not r.get("default").get("status", "error") == "success":
+        raise ValueError("Query failed")
 
-        objectId_list = []
-        with_neg_sub = []
-        old = []
-        out_of_time_window = []
-        stellar_list = []
+    print(r.get("default").get("data"))
 
-        # Try to query kowalski up to 5 times
-        i = 1
-        no_candidates = False
-        while i <= 5:
-            try:
-                if r.get("default").get("data") == []:
-                    no_candidates = True
-                keys_list = list(r['data']['ZTF_alerts'].keys())
-                break
-            except (AttributeError, KeyError, TypeError, ConnectionError):
-                i += 1
-        if i > 5:
+    objectId_list = []
+    with_neg_sub = []
+    old = []
+    out_of_time_window = []
+    stellar_list = []
+
+    candidates = r.get("default", {}).get("data", {}).get('ZTF_alerts', [])
+    for info in candidates:
+        if info['objectId'] in old:
             continue
-        if no_candidates is True:
+        if info['objectId'] in stellar_list:
             continue
-        for key in keys_list:
-            all_info = r['data']['ZTF_alerts'][key]
+        if np.abs(info['candidate']['ssdistnr']) < 10:
+            continue
+        if info['candidate']['isdiffpos'] in ['f', 0]:
+            with_neg_sub.append(info['objectId'])
+        if (
+            info['candidate']['jdendhist'] - info['candidate']['jdstarthist']
+        ) < min_days:
+            continue
+        if (
+            info['candidate']['jdendhist'] - info['candidate']['jdstarthist']
+        ) > max_days:
+            old.append(info['objectId'])
+        if (info['candidate']['jdstarthist'] - jd_trigger) > within_days:
+            old.append(info['objectId'])
+        # REMOVE!  Only for O3a paper
+        # if (info['candidate']['jdendhist'] -
+        # info['candidate']['jdstarthist']) >= 72./24. and info['candidate']['ndethist'] <= 2.:
+        #    out_of_time_window.append(info['objectId'])
+        if after_trigger is True:
+            if (info['candidate']['jdendhist'] - jd_trigger) > max_days:
+                out_of_time_window.append(info['objectId'])
+        else:
+            if (
+                info['candidate']['jdendhist'] - info['candidate']['jdstarthist']
+            ) > max_days:
+                out_of_time_window.append(info['objectId'])
+        try:
+            if (
+                np.abs(info['candidate']['distpsnr1']) < 1.5
+                and info['candidate']['sgscore1'] > 0.50
+            ):
+                stellar_list.append(info['objectId'])
+        except (KeyError, ValueError):
+            pass
+        try:
+            if (
+                np.abs(info['candidate']['distpsnr1']) < 15.0
+                and info['candidate']['srmag1'] < 15.0
+                and info['candidate']['srmag1'] > 0.0
+                and info['candidate']['sgscore1'] >= 0.5
+            ):
+                continue
+        except (KeyError, ValueError):
+            pass
+        try:
+            if (
+                np.abs(info['candidate']['distpsnr2']) < 15.0
+                and info['candidate']['srmag2'] < 15.0
+                and info['candidate']['srmag2'] > 0.0
+                and info['candidate']['sgscore2'] >= 0.5
+            ):
+                continue
+        except (KeyError, ValueError):
+            pass
+        try:
+            if (
+                np.abs(info['candidate']['distpsnr3']) < 15.0
+                and info['candidate']['srmag3'] < 15.0
+                and info['candidate']['srmag3'] > 0.0
+                and info['candidate']['sgscore3'] >= 0.5
+            ):
+                continue
+        except (KeyError, ValueError):
+            pass
 
-            for info in all_info:
-                if info['objectId'] in old:
-                    continue
-                if info['objectId'] in stellar_list:
-                    continue
-                if np.abs(info['candidate']['ssdistnr']) < 10:
-                    continue
-                if info['candidate']['isdiffpos'] in ['f', 0]:
-                    with_neg_sub.append(info['objectId'])
-                if (
-                    info['candidate']['jdendhist'] - info['candidate']['jdstarthist']
-                ) < min_days:
-                    continue
-                if (
-                    info['candidate']['jdendhist'] - info['candidate']['jdstarthist']
-                ) > max_days:
-                    old.append(info['objectId'])
-                if (info['candidate']['jdstarthist'] - jd_trigger) > within_days:
-                    old.append(info['objectId'])
-                # REMOVE!  Only for O3a paper
-                # if (info['candidate']['jdendhist'] -
-                # info['candidate']['jdstarthist']) >= 72./24. and info['candidate']['ndethist'] <= 2.:
-                #    out_of_time_window.append(info['objectId'])
-                if after_trigger is True:
-                    if (info['candidate']['jdendhist'] - jd_trigger) > max_days:
-                        out_of_time_window.append(info['objectId'])
-                else:
-                    if (
-                        info['candidate']['jdendhist']
-                        - info['candidate']['jdstarthist']
-                    ) > max_days:
-                        out_of_time_window.append(info['objectId'])
-                try:
-                    if (
-                        np.abs(info['candidate']['distpsnr1']) < 1.5
-                        and info['candidate']['sgscore1'] > 0.50
-                    ):
-                        stellar_list.append(info['objectId'])
-                except (KeyError, ValueError):
-                    pass
-                try:
-                    if (
-                        np.abs(info['candidate']['distpsnr1']) < 15.0
-                        and info['candidate']['srmag1'] < 15.0
-                        and info['candidate']['srmag1'] > 0.0
-                        and info['candidate']['sgscore1'] >= 0.5
-                    ):
-                        continue
-                except (KeyError, ValueError):
-                    pass
-                try:
-                    if (
-                        np.abs(info['candidate']['distpsnr2']) < 15.0
-                        and info['candidate']['srmag2'] < 15.0
-                        and info['candidate']['srmag2'] > 0.0
-                        and info['candidate']['sgscore2'] >= 0.5
-                    ):
-                        continue
-                except (KeyError, ValueError):
-                    pass
-                try:
-                    if (
-                        np.abs(info['candidate']['distpsnr3']) < 15.0
-                        and info['candidate']['srmag3'] < 15.0
-                        and info['candidate']['srmag3'] > 0.0
-                        and info['candidate']['sgscore3'] >= 0.5
-                    ):
-                        continue
-                except (KeyError, ValueError):
-                    pass
-
-                objectId_list.append(info['objectId'])
+        objectId_list.append(info['objectId'])
 
         set_objectId = (
             set(objectId_list)
@@ -345,33 +329,15 @@ def query_kowalski(
 
         set_objectId_all = set_objectId_all | set_objectId
 
-    q = {
-        "query_type": "find",
-        "query": {
-            "catalog": "ZTF_alerts",
-            "filter": {"objectId": {"$in": list(set_objectId_all)}},
-            "projection": {
-                "_id": 0,
-                "candid": 1,
-                "objectId": 1,
-                "candidate.ra": 1,
-                "candidate.dec": 1,
-            },
-        },
-    }
-    results_all = k.query(query=q)
-    if not results_all.get("default").get("status", "error") == "success":
-        raise ValueError("Query failed")
-    results = results_all.get("default").get("data")
     sources = []
     for n in set_objectId_all:
         source = {}
         source["id"] = n
         source["ra"] = list(
-            r["candidate"]["ra"] for r in results if r["objectId"] == n
+            r["candidate"]["ra"] for r in candidates if r["objectId"] == n
         )[0]
         source["dec"] = list(
-            r["candidate"]["dec"] for r in results if r["objectId"] == n
+            r["candidate"]["dec"] for r in candidates if r["objectId"] == n
         )[0]
         sources.append(source)
 

--- a/static/js/components/AddCatalogQueryPage.jsx
+++ b/static/js/components/AddCatalogQueryPage.jsx
@@ -3,6 +3,7 @@ import { useDispatch, useSelector } from "react-redux";
 import Dialog from "@mui/material/Dialog";
 import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
+import Grid from "@mui/material/Grid";
 
 import Button from "./Button";
 import CatalogQueryForm from "./CatalogQueryForm";
@@ -46,15 +47,18 @@ const AddCatalogQueryPage = () => {
         open={dialogOpen}
         onClose={closeDialog}
         style={{ position: "fixed" }}
+        maxWidth="xlg"
       >
         <DialogTitle>Catalog Query</DialogTitle>
         <DialogContent>
-          <div>
-            <CatalogQueryForm gcnevent={gcnEvent} />
-            {catalogQueryList?.length > 0 && (
-              <CatalogQueryLists catalog_queries={catalogQueryList} />
-            )}
-          </div>
+          <Grid container spacing={2}>
+            <Grid item xs={12} md={4}>
+              <CatalogQueryForm gcnevent={gcnEvent} />
+            </Grid>
+            <Grid item xs={12} md={8}>
+              <CatalogQueryLists catalog_queries={catalogQueryList || []} />
+            </Grid>
+          </Grid>
         </DialogContent>
       </Dialog>
     </>

--- a/static/js/ducks/gcnEvent.js
+++ b/static/js/ducks/gcnEvent.js
@@ -83,6 +83,8 @@ const FETCH_GCNEVENT_CATALOG_QUERIES =
   "skyportal/FETCH_GCNEVENT_CATALOG_QUERIES";
 const FETCH_GCNEVENT_CATALOG_QUERIES_OK =
   "skyportal/FETCH_GCNEVENT_CATALOG_QUERIES_OK";
+const REFRESH_GCNEVENT_CATALOG_QUERIES =
+  "skyportal/REFRESH_GCNEVENT_CATALOG_QUERIES";
 
 const FETCH_GCNEVENT_OBSERVATION_PLAN_REQUESTS =
   "skyportal/FETCH_GCNEVENT_OBSERVATION_PLAN_REQUESTS";
@@ -377,6 +379,12 @@ messageHandler.add((actionType, payload, dispatch, getState) => {
     const loaded_gcnevent_key = gcnEvent?.dateobs;
     if (loaded_gcnevent_key === payload.gcnEvent_dateobs) {
       dispatch(fetchObservationPlanRequests(gcnEvent?.id));
+    }
+  }
+  if (actionType === REFRESH_GCNEVENT_CATALOG_QUERIES) {
+    const loaded_gcnevent_key = gcnEvent?.dateobs;
+    if (loaded_gcnevent_key === payload.gcnEvent_dateobs) {
+      dispatch(fetchGcnEventCatalogQueries({ gcnID: gcnEvent?.id }));
     }
   }
 });


### PR DESCRIPTION
Best way to try this is to take the Kowalski config from prod, add a token to a P48 allocation of the demo data, and run it on some events. the GW event in the test demo data (from 2019) wont work because the fits file is too large for Kowalski currently. I suggest grabbing a voevent from prod and ingesting that to run it on a gw event from O4. Like:
[S230627c.txt](https://github.com/skyportal/skyportal/files/11962708/S230627c.txt)
or
[S230615az.txt](https://github.com/skyportal/skyportal/files/11962709/S230615az.txt)