### PR TITLE
Frontend - Candidate scanning and sources in GCN: exclude forced photometry

### DIFF
--- a/static/js/components/FilterCandidateList.jsx
+++ b/static/js/components/FilterCandidateList.jsx
@@ -381,6 +381,9 @@ const FilterCandidateList = ({
       if (formData.numberDetections) {
         data.numberDetections = formData.numberDetections;
       }
+      if (formData.excludeForcedPhotometry) {
+        data.excludeForcedPhotometry = formData.excludeForcedPhotometry;
+      }
     }
     if (formData.sortingOrigin) {
       data.sortByAnnotationOrigin = formData.sortingOrigin;
@@ -867,6 +870,26 @@ const FilterCandidateList = ({
                       )}
                       name="numberDetections"
                       control={control}
+                    />
+                  </div>
+                  <div className={classes.gcnFormRow}>
+                    <FormControlLabel
+                      control={
+                        <Controller
+                          render={({ field: { onChange, value } }) => (
+                            <Checkbox
+                              onChange={(event) => {
+                                onChange(event.target.checked);
+                              }}
+                              checked={value}
+                            />
+                          )}
+                          name="excludeForcedPhotometry"
+                          control={control}
+                          defaultValue
+                        />
+                      }
+                      label="Exclude Forced Photometry"
                     />
                   </div>
                 </>

--- a/static/js/components/GcnSelectionForm.jsx
+++ b/static/js/components/GcnSelectionForm.jsx
@@ -805,6 +805,11 @@ const GcnSelectionForm = ({
         type: "boolean",
         title: "Do not display rejected sources",
       },
+      excludeForcedPhotometry: {
+        type: "boolean",
+        title: "Exclude forced photometry",
+        default: true,
+      },
       queryList: {
         type: "array",
         items: {
@@ -842,7 +847,8 @@ const GcnSelectionForm = ({
         maxDistance: 4,
       },
       {
-        localizationRejectSources: 12,
+        localizationRejectSources: 6,
+        excludeForcedPhotometry: 6,
       },
       {
         queryList: 6,


### PR DESCRIPTION
This PR is the frontend counterpart of #4404, added separately to not expose the frontend in prod before all the photstats are updated.