### PR TITLE
Dockerfile: add screen

### DIFF
--- a/.github/workflows/test_docker_build.yaml
+++ b/.github/workflows/test_docker_build.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   test:
-    if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'docker')
+    if: github.event_name == 'push' || ${{ github.event.label.name == 'docker' }}
     name: Test Docker build
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,8 @@ RUN apt-get update && \
     apt-get -y upgrade && \
     apt-get install -y python3 python3-venv python3-dev \
     libpq-dev supervisor \
-    git nginx nodejs postgresql-client vim nano htop \
+    git nginx nodejs postgresql-client vim nano screen htop \
     libcurl4-gnutls-dev libgnutls28-dev && \
-    screen && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
     useradd --create-home --shell /bin/bash skyportal

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && \
     libpq-dev supervisor \
     git nginx nodejs postgresql-client vim nano htop \
     libcurl4-gnutls-dev libgnutls28-dev && \
+    screen && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
     useradd --create-home --shell /bin/bash skyportal


### PR DESCRIPTION
add screen to the docker image, which is very useful when we need to run long running scripts to update entries of the db in bulk for example, which has proven challenging and suboptimal which dedicated endpoints (both for development and when running the code).

With screen, we can create screens in which to run the scripts, detach (when leaving the container) and re-attach to verify the progress of a script.