### PR TITLE
Obsplan queue: time limit

### DIFF
--- a/services/observation_plan_queue/observation_plan_queue.py
+++ b/services/observation_plan_queue/observation_plan_queue.py
@@ -161,7 +161,8 @@ class ObservationPlanQueue:
                 try:
                     stmt = sa.select(ObservationPlanRequest).where(
                         ObservationPlanRequest.status == "pending submission",
-                        # ObservationPlanRequest.created_at > arrow.now().shift(days=-1).datetime,
+                        ObservationPlanRequest.created_at
+                        > arrow.utcnow().shift(days=-1).datetime,
                         # we only want to process plans that have been created in the last 24 hours
                     )
                     single_requests = session.execute(stmt).scalars().all()


### PR DESCRIPTION
Limit how far back in time we look when fetching plans to process