### PR TITLE
Frontend caching fix: routes lazy loading

### DIFF
--- a/skyportal/tests/frontend/test_user.py
+++ b/skyportal/tests/frontend/test_user.py
@@ -3,6 +3,6 @@ def test_user_info(driver, super_admin_user):
     driver.get(f'/become_user/{user.id}')
     driver.get(f'/user/{user.id}')
     driver.wait_for_xpath(f'//div[contains(.,"{user.username}")]')
-    pg_src = driver.page_source
     for acl in user.permissions:
-        assert acl in pg_src
+        permission = f'//ul/li[contains(.,"{acl}")]'
+        driver.wait_for_xpath(permission)

--- a/static/js/components/CommentEntry.jsx
+++ b/static/js/components/CommentEntry.jsx
@@ -30,7 +30,9 @@ const useStyles = makeStyles(() => ({
 
 const CommentEntry = ({ addComment, editComment }) => {
   const styles = useStyles();
+  const users = useSelector((state) => state.users);
   const { userAccessible: groups } = useSelector((state) => state.groups);
+  const { instrumentList } = useSelector((state) => state.instruments);
   const [textValue, setTextValue] = useState("");
   const [textInputCursorIndex, setTextInputCursorIndex] = useState(0);
   const [autosuggestVisible, setAutosuggestVisible] = useState(false);
@@ -39,12 +41,10 @@ const CommentEntry = ({ addComment, editComment }) => {
   const [instrumentPrefixMatches, setInstrumentPrefixMatches] = useState({});
   const textAreaRef = useRef(null);
   const autoSuggestRootItem = useRef(null);
-  const { users } = useSelector((state) => state.users);
-  const { instrumentList } = useSelector((state) => state.instruments);
 
   const usernameTrie = useMemo(() => {
     const trie = UsernameTrie();
-    users.forEach((user) => {
+    (users?.users || []).forEach((user) => {
       trie.insertUser({
         username: user.username,
         firstName: user.first_name || "",

--- a/static/js/components/CommentListMobile.jsx
+++ b/static/js/components/CommentListMobile.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { Suspense, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import PropTypes from "prop-types";
 import { useSelector, useDispatch } from "react-redux";
@@ -599,7 +599,9 @@ const CommentListMobile = ({
       >
         <DialogTitle onClose={handleClose}>Comments</DialogTitle>
         <DialogContent dividers>
-          <CommentList isCandidate={isCandidate} />
+          <Suspense fallback={<div>Loading comments...</div>}>
+            <CommentList isCandidate={isCandidate} />
+          </Suspense>
         </DialogContent>
       </Dialog>
     </div>

--- a/static/js/components/EarthquakePage.jsx
+++ b/static/js/components/EarthquakePage.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef } from "react";
+import React, { useEffect, useState, useRef, Suspense } from "react";
 import PropTypes from "prop-types";
 import { useSelector, useDispatch } from "react-redux";
 import { Link } from "react-router-dom";
@@ -225,10 +225,12 @@ const EarthquakePage = ({ route }) => {
                   </Typography>
                 </AccordionSummary>
                 <AccordionDetails>
-                  <CommentList
-                    associatedResourceType="earthquake"
-                    earthquakeID={earthquake.id.toString()}
-                  />
+                  <Suspense fallback={<div>Loading comments...</div>}>
+                    <CommentList
+                      associatedResourceType="earthquake"
+                      earthquakeID={earthquake.id.toString()}
+                    />
+                  </Suspense>
                 </AccordionDetails>
               </Accordion>
             </div>

--- a/static/js/components/GcnEventPage.jsx
+++ b/static/js/components/GcnEventPage.jsx
@@ -1,11 +1,11 @@
 import PropTypes from "prop-types";
-import React, { useEffect, useRef, useState } from "react";
+import React, { Suspense, useEffect, useRef, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import Cancel from "@mui/icons-material/Cancel";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import GetAppIcon from "@mui/icons-material/GetApp";
-import { useMediaQuery } from "@mui/material";
+import { CircularProgress, useMediaQuery } from "@mui/material";
 import Accordion from "@mui/material/Accordion";
 import AccordionDetails from "@mui/material/AccordionDetails";
 import AccordionSummary from "@mui/material/AccordionSummary";
@@ -454,11 +454,13 @@ const GcnEventPage = ({ route }) => {
                 </AccordionSummary>
                 <AccordionDetails>
                   {route?.dateobs === gcnEvent?.dateobs && route?.dateobs ? (
-                    <CommentList
-                      associatedResourceType="gcn_event"
-                      gcnEventID={gcnEvent.id}
-                      maxHeightList="60vh"
-                    />
+                    <Suspense fallback={<CircularProgress />}>
+                      <CommentList
+                        associatedResourceType="gcn_event"
+                        gcnEventID={gcnEvent.id}
+                        maxHeightList="60vh"
+                      />
+                    </Suspense>
                   ) : (
                     <p> Fetching event... </p>
                   )}

--- a/static/js/components/GcnSelectionForm.jsx
+++ b/static/js/components/GcnSelectionForm.jsx
@@ -1,5 +1,5 @@
 import { PropTypes } from "prop-types";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, Suspense } from "react";
 import { useDispatch, useSelector } from "react-redux";
 // eslint-disable-next-line import/no-unresolved
 import { useMediaQuery } from "@mui/material";
@@ -38,13 +38,14 @@ import AddCatalogQueryPage from "./AddCatalogQueryPage";
 import AddSurveyEfficiencyObservationsPage from "./AddSurveyEfficiencyObservationsPage";
 import ExecutedObservationsTable from "./ExecutedObservationsTable";
 import GalaxyTable from "./GalaxyTable";
-import GcnReport from "./GcnReport";
-import GcnSummary from "./GcnSummary";
 import LocalizationPlot from "./LocalizationPlot";
 import SourceTable from "./SourceTable";
 import ProgressIndicator from "./ProgressIndicators";
 
 import * as localizationActions from "../ducks/localization";
+
+const GcnReport = React.lazy(() => import("./GcnReport"));
+const GcnSummary = React.lazy(() => import("./GcnSummary"));
 
 dayjs.extend(relativeTime);
 dayjs.extend(utc);
@@ -1104,8 +1105,12 @@ const GcnSelectionForm = ({
               {gcnEvent && selectedLocalizationId ? (
                 <Grid item xs={11} sm={12}>
                   <div className={classes.buttons}>
-                    <GcnSummary dateobs={dateobs} />
-                    <GcnReport dateobs={dateobs} />
+                    <Suspense fallback={<CircularProgress />}>
+                      <GcnSummary dateobs={dateobs} />
+                    </Suspense>
+                    <Suspense fallback={<CircularProgress />}>
+                      <GcnReport dateobs={dateobs} />
+                    </Suspense>
                     <AddSurveyEfficiencyObservationsPage />
                     <AddCatalogQueryPage />
                     {isSubmittingTreasureMap === selectedInstrumentId ? (

--- a/static/js/components/Main.jsx.template
+++ b/static/js/components/Main.jsx.template
@@ -2,7 +2,7 @@
 import { Notifications } from "baselayer/components/Notifications";
 
 // React and Redux
-import React, { useEffect } from "react";
+import React, { useEffect, Suspense } from "react";
 import PropTypes from "prop-types";
 import { Provider, useSelector } from "react-redux";
 import ReactDOM from "react-dom";
@@ -19,6 +19,7 @@ import {
 } from "@mui/material/styles";
 import makeStyles from "@mui/styles/makeStyles";
 import { isMobile } from "react-device-detect";
+import Spinner from "./Spinner";
 
 import DayJSUtils from "@date-io/dayjs";
 import clsx from "clsx";
@@ -35,10 +36,9 @@ import hydrate from "../actions";
 import * as rotateLogoActions from "../ducks/logo";
 
 import NoMatchingRoute from "./NoMatchingRoute";
-import Responsive from "./Responsive";
 
 {% for route in app.routes -%}
-import {{ route.component }} from "./{{ route.component }}";
+const {{ route.component }} = React.lazy(() => import("./{{ route.component }}"));
 {% endfor %}
 
 import Theme from "./Theme";
@@ -132,7 +132,7 @@ const MainContentInternal = ({ root }) => {
           <Routes>
 
             {%- for route in app.routes %}
-            <Route path="{{ route.path }}" element={{ "{<" }}{{ route.component }}{{ "/>}" }} />
+            <Route path="{{ route.path }}" element={{ "{<Suspense fallback={<Spinner />}><" }}{{ route.component }}{{ "/></Suspense>}" }} />
             {%- endfor %}
 
             <Route path="*" element={<NoMatchingRoute/>} />

--- a/static/js/components/OriginSelect.jsx
+++ b/static/js/components/OriginSelect.jsx
@@ -7,6 +7,7 @@ import SelectWithChips from "./SelectWithChips";
 
 const OriginSelect = ({ onOriginSelectChange, initValue, parent }) => {
   const dispatch = useDispatch();
+  const photometry = useSelector((state) => state.photometry);
 
   useEffect(() => {
     // const fetchOrigins = async () => {
@@ -15,11 +16,9 @@ const OriginSelect = ({ onOriginSelectChange, initValue, parent }) => {
     // fetchOrigins(); //TODO: uncomment this line when the API is fixed. For now this times out.
   }, [dispatch]);
 
-  const originsList = ["Clear selections"].concat(
-    useSelector((state) => state.photometry.origins)?.filter(
-      (origin) => origin !== "None"
-    )
-  );
+  const originsList = ["Clear selections"]
+    .concat(photometry?.origins || [])
+    ?.filter((origin) => origin !== "None");
 
   return (
     <>

--- a/static/js/components/ShareDataForm.jsx
+++ b/static/js/components/ShareDataForm.jsx
@@ -183,11 +183,13 @@ const SpectrumRow = ({ rowData, route, annotations }) => {
             sm={6}
           >
             <Typography variant="h6">Comments</Typography>
-            <CommentList
-              associatedResourceType="spectra"
-              objID={route.id}
-              spectrumID={spectrumID}
-            />
+            <Suspense fallback={<CircularProgress />}>
+              <CommentList
+                associatedResourceType="spectra"
+                objID={route.id}
+                spectrumID={spectrumID}
+              />
+            </Suspense>
           </Grid>
           <Grid item sm={6}>
             <Typography variant="h6">Annotations</Typography>

--- a/static/js/components/ShiftManagement.jsx
+++ b/static/js/components/ShiftManagement.jsx
@@ -22,7 +22,6 @@ import {
   deleteShiftUser,
   updateShiftUser,
 } from "../ducks/shifts";
-import CommentList from "./CommentList";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -165,7 +164,7 @@ const userLabel = (user) => {
   return label;
 };
 
-export function CurrentShiftMenu({ currentShift }) {
+const ShiftManagement = ({ currentShift }) => {
   const classes = useStyles();
   const currentUser = useSelector((state) => state.profile);
   const dispatch = useDispatch();
@@ -829,9 +828,9 @@ export function CurrentShiftMenu({ currentShift }) {
       </div>
     )
   );
-}
+};
 
-CurrentShiftMenu.propTypes = {
+ShiftManagement.propTypes = {
   currentShift: PropTypes.shape({
     id: PropTypes.number,
     name: PropTypes.string,
@@ -870,20 +869,4 @@ CurrentShiftMenu.propTypes = {
   }).isRequired,
 };
 
-export function CommentOnShift() {
-  const classes = useStyles();
-  const { currentShift } = useSelector((state) => state.shift);
-
-  return (
-    currentShift?.id && (
-      <div id="current_shift_comment" className={classes.root}>
-        <div className={classes.content}>
-          <CommentList
-            associatedResourceType="shift"
-            shiftID={currentShift?.id}
-          />
-        </div>
-      </div>
-    )
-  );
-}
+export default ShiftManagement;

--- a/static/js/components/ShiftPage.jsx
+++ b/static/js/components/ShiftPage.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, Suspense } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import PropTypes from "prop-types";
 import makeStyles from "@mui/styles/makeStyles";
@@ -9,12 +9,14 @@ import { showNotification } from "baselayer/components/Notifications";
 import Button from "./Button";
 import NewShift from "./NewShift";
 import MyCalendar from "./ShiftCalendar";
-import { CurrentShiftMenu, CommentOnShift } from "./ShiftManagement";
+import ShiftManagement from "./ShiftManagement";
 import ShiftSummary from "./ShiftSummary";
 import Reminders from "./Reminders";
 
 import { getShiftsSummary, fetchShift } from "../ducks/shift";
 import * as shiftsActions from "../ducks/shifts";
+
+const CommentList = React.lazy(() => import("./CommentList"));
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -25,6 +27,13 @@ const useStyles = makeStyles((theme) => ({
   paperContent: {
     marginBottom: theme.spacing(2),
     padding: "1rem",
+  },
+  comments: {
+    paddingTop: "0.5rem",
+    paddingBottom: "1rem",
+    marginBottom: "1rem",
+    marginLeft: "1rem",
+    marginRight: "1rem",
   },
 }));
 
@@ -113,11 +122,20 @@ const ShiftPage = ({ route }) => {
         </Paper>
         <Paper elevation={1}>
           {shiftList && !show && currentShift?.id ? (
-            <CurrentShiftMenu currentShift={currentShift} />
+            <ShiftManagement currentShift={currentShift} />
           ) : null}
         </Paper>
         <Paper elevation={1}>
-          {shiftList && !show && currentShift?.id ? <CommentOnShift /> : null}
+          {shiftList && !show && currentShift?.id ? (
+            <div id="current_shift_comment" className={classes.comments}>
+              <Suspense fallback={<CircularProgress />}>
+                <CommentList
+                  associatedResourceType="shift"
+                  shiftID={currentShift?.id}
+                />
+              </Suspense>
+            </div>
+          ) : null}
         </Paper>
         <Paper elevation={1}>
           {shiftList && !show && currentShift?.id ? (

--- a/static/js/components/SourceDesktop.jsx
+++ b/static/js/components/SourceDesktop.jsx
@@ -21,7 +21,6 @@ import RemoveIcon from "@mui/icons-material/Remove";
 import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
 import Button from "./Button";
 
-import CommentList from "./CommentList";
 import CopyPhotometryDialog from "./CopyPhotometryDialog";
 import ClassificationList from "./ClassificationList";
 import ClassificationForm from "./ClassificationForm";
@@ -65,6 +64,8 @@ import SourcePlugins from "./SourcePlugins";
 
 import * as spectraActions from "../ducks/spectra";
 import * as sourceActions from "../ducks/source";
+
+const CommentList = React.lazy(() => import("./CommentList"));
 
 const VegaHR = React.lazy(() => import("./VegaHR"));
 
@@ -881,7 +882,9 @@ const SourceDesktop = ({ source }) => {
                 </Typography>
               </AccordionSummary>
               <AccordionDetails>
-                <CommentList />
+                <Suspense fallback={<CircularProgress />}>
+                  <CommentList />
+                </Suspense>
               </AccordionDetails>
             </Accordion>
           </div>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -90,7 +90,7 @@ const config = {
   },
   plugins: [
     // Uncomment the following line to enable bundle size analysis
-    //    new BundleAnalyzerPlugin()
+    // new BundleAnalyzerPlugin(),
     // Needed for non-polyfilled node modules; we aim to remove this when possible
     new webpack.ProvidePlugin({
       process: path.resolve(__dirname, "node_modules/process/browser.js"),


### PR DESCRIPTION
This PR is an attempt to fix the issues with chrome and firefox not caching our monolithic webpack that's over 50MB, by splitting it in a smaller main bundle, along with individual assets for each route. 

This seems to fix all caching issues on chrome and firefox, and here's why:

Currently, our webpack is over 50MB. This seems to prevent browsers like chrome and firefox from caching it once it has been loaded. For firefox, this is imply because there is a hard limit to how big one file can be to be cached. For chrome it is still unclear, as they claim there is no limit, even though it behaves like there is one.
Most websites don't send the client all of the assets as soon as they access any page, but rather split their website in smaller chunks, that will be lazy loaded in the background, or only when the client goes to a page where they're needed.

In SkyPortal, there is a `Main.template.jsx` file which generates `Main.jsx`, using values from the config file. This `Main.jsx` file is what will contain references to all of the valid routes (webpages) of our website, and it is the entry point when a client accesses any page.

So far, Main.jsx was importing all of the pages of SkyPortal without any lazy loading, meaning that as soon as you access any page, it will download the whole website. Because of that, webpack was also generating one big file for our whole website, meaning it couldn't be split in several smaller assets.

In this PR, the main change we make is to use `React.lazy` in `Main.template.jsx` in the for loop that generates all of the import based on the routes found in the config. That way, webpack will split the assets in multiple ones:
- one or more asset(s) with shared ressources/components, used accross several pages/routes.
- assets for each route of the website.

On the client side this means:
- only the assets you need for the page you are trying to access will be loaded, which speeds up initial loading of the website.
- As you navigate to more and more pages, the full webpack will effectively be downloaded.
- As each asset is now smaller, they are cached as expected!

Also, since each assets are named with a hash generated based on their content, even after deploy, if some pages haven't changed, it is likely that the asset will be the same, and won't need to be redownloaded!


**BUT**, this did create some issues with the existing code. Mainly, this has to do with redux. As the order in which things are loaded changed, it might be that a page is now looking for a ressource in a redux state before it has been loaded. Here is an example:

let's say you had code like `const origins = useSelector((state) => state.photometry.origins)` but before it is hydrated, the photometry state might be undefined, or an empty dict without any `origins` key. Now that things are lazy loaded and split by routes, it might throw an error like `state.photometry is undefined`. Luckily, there are plenty of ways to fix this. For instance, you can replace your line with `const photometry = useSelector((state) => state.photometry)`, and later when you need the origins do something like `const origins = photometry?.origins || []` which will just give you an empty list while what you need is being fetched, and will rerender once it's done fetching.