### PR TITLE
WIP - ZTF cutouts for all objects

### DIFF
--- a/skyportal/enum_types.py
+++ b/skyportal/enum_types.py
@@ -57,7 +57,8 @@ THUMBNAIL_TYPES = (
     'dr8',
     'ls',
     'ps1',
-    "new_gz",
+    'ztf',
+    'new_gz',
     'ref_gz',
     'sub_gz',
 )

--- a/static/js/components/ThumbnailList.jsx
+++ b/static/js/components/ThumbnailList.jsx
@@ -75,6 +75,9 @@ const Thumbnail = ({ ra, dec, name, url, size, grayscale, header }) => {
     case "sub":
       alt = `subtracted image`;
       break;
+    case "ztf":
+      alt = "ZTF public science image";
+      break;
     case "sdss":
       alt = "Link to SDSS Navigate tool";
       link = `https://skyserver.sdss.org/dr16/en/tools/chart/navi.aspx?opt=G&ra=${ra}&dec=${dec}&scale=0.25`;
@@ -165,7 +168,7 @@ const ThumbnailList = ({
   thumbnails,
   useGrid = true,
   size = "13rem",
-  displayTypes = ["new", "ref", "sub", "sdss", "ls", "ps1"],
+  displayTypes = ["new", "ref", "sub", "ztf", "sdss", "ls", "ps1"],
 }) => {
   thumbnails
     ?.filter((thumbnail) => displayTypes.includes(thumbnail.type))
@@ -175,7 +178,7 @@ const ThumbnailList = ({
     ?.map((type) => thumbnails.find((thumbnail) => thumbnail.type === type))
     ?.filter((thumbnail) => thumbnail !== undefined);
 
-  const thumbnail_order = ["new", "ref", "sub", "sdss", "ls", "ps1"];
+  const thumbnail_order = ["new", "ref", "sub", "ztf", "sdss", "ls", "ps1"];
   // Sort thumbnails by order of appearance in `thumbnail_order`
   latestThumbnails?.sort((a, b) =>
     thumbnail_order.indexOf(a.type) < thumbnail_order.indexOf(b.type) ? -1 : 1
@@ -249,7 +252,7 @@ ThumbnailList.propTypes = {
 
 ThumbnailList.defaultProps = {
   size: "13rem",
-  displayTypes: ["new", "ref", "sub", "sdss", "ls", "ps1"],
+  displayTypes: ["new", "ref", "sub", "ztf", "sdss", "ls", "ps1"],
   useGrid: true,
 };
 


### PR DESCRIPTION
This adds a super basic version to grab ZTF thumbnails for all objects that aren't coming from ZTF alerts, by grabbing images from IPAC.

TODO:
- [ ] Grab the right image(s), to decide for which filters, and which type.
- [x] Find more recent images? So far, what I got from IPAC looks a little old. Maybe there is a better source for the images.
- [ ] Migrations, as usual. **SOLVED: grab all images that cover a 63x63 arcsec area centered on the object, sort by date, and grab the most recent.**
- [ ] Frontend improvement? If we get cutouts for different bands/filters, we might want to make it so you see only one by default, but can switch between bands with a slider/menu element.


Tagging you @AshishMahabal here so you can give you help figure out what's needed.

So far, it simply grabs the science image that is closest to the object's position, and requests a cutout of size 63x63 from that image, and uploads it. However it can be of any band (as it just grabs the closest img), and the date at which the image  was taken isn't saved anywhere. We might want to add that. 

It simply looks like this, following the current standard we have for cutouts:
<img width="709" alt="image" src="https://github.com/skyportal/skyportal/assets/49785117/41e8b476-7eab-452a-82fa-8ee86780a4dd">
