### PR TITLE
Spectrum upload: Pre-fill form using URL arguments

### DIFF
--- a/static/js/components/UploadSpectrum.jsx
+++ b/static/js/components/UploadSpectrum.jsx
@@ -177,15 +177,21 @@ const UploadSpectrumForm = ({ route }) => {
         mjd: searchParams.get("mjd")
           ? parseFloat(searchParams.get("mjd"))
           : undefined,
-        wave_column: 0,
-        flux_column: 1,
-        has_fluxerr: "No",
+        wave_column: searchParams.get("wave_column")
+          ? parseInt(searchParams.get("wave_column"), 10)
+          : 0,
+        flux_column: searchParams.get("flux_column")
+          ? parseInt(searchParams.get("flux_column"), 10)
+          : 1,
+        has_fluxerr: searchParams.get("has_fluxerr") || "No",
         instrument_id: searchParams.get("instrument_id")
           ? parseInt(searchParams.get("instrument_id"), 10)
           : undefined,
         spectrum_type: searchParams.get("spectrum_type") || "source",
         user_label: searchParams.get("user_label") || undefined,
-        fluxerr_column: undefined,
+        fluxerr_column: searchParams.get("fluxerr_column")
+          ? parseInt(searchParams.get("fluxerr_column"), 10)
+          : undefined,
         observed_by: searchParams.get("observed_by")
           ? searchParams
               .get("observed_by")


### PR DESCRIPTION
This PR allows us to pre-fill the upload spectrum page's form by passing arguments directly in the URL.
When it comes to uploading the file itself, the file can be passed as a URL from where it can be downloaded.

These are the arguments that can be passed:
-observed_by (list of ints of user ids)
- reduced_by (list of ints of user ids)
- spectrum_type (source, host, or host_center)
- instrument_id (int)
- mjd (float)
- group_ids (list of ints of group ids)
- has_fluxerr (Yes or No)
- fluxerr_column (int, nb of the column in the ascii file. To pass only if has_fluxerr is Yes)
- flux_column (int, nb of the column in the ascii file)
- wave_column (int, nb of the column in the ascii file)
- file_name (string)
- file_url (string)

String values should NOT be in quotes, though we do recommend it for the file_url as it might confuse the router otherwise.