### PR TITLE
Phot plot height fix when legend is too long

### DIFF
--- a/skyportal/plot.py
+++ b/skyportal/plot.py
@@ -1866,6 +1866,7 @@ def make_photometry_panel(
         legend_row_height,
         legend_items_per_row,
     ) = get_dimensions_by_device(device, width)
+
     height = (
         500
         if device == "browser"
@@ -1873,6 +1874,8 @@ def make_photometry_panel(
         + legend_row_height * int(len(grouped_data) / legend_items_per_row)
         + 30  # 30 is the height of the toolbar
     )
+    if device == "browser" and len(grouped_data) > 16:
+        height += legend_row_height * int(len(grouped_data) - 16 - 1)
     active_drag = None if "mobile" in device or "tablet" in device else "box_zoom"
     tools = (
         'box_zoom,pan,reset'


### PR DESCRIPTION
If there are too many items in the legend, those are cropped and it makes it impossible to hide/show items on the photometry plot. This is a quick fix as this is impacting user experience, but we might want to handle this better in the future.

Basically, here, we just add more height as needed, which already the case on other deviced, but didn't work on desktop as we forced the height to 500.