### PR TITLE
WIP: Add script to run analysis on candidates

### DIFF
--- a/jobs/candidate_analysis_cronjob.py
+++ b/jobs/candidate_analysis_cronjob.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+import os
+import urllib
+import requests
+import time
+from typing import Optional, Mapping
+from requests.exceptions import InvalidJSONError, JSONDecodeError
+from urllib3.exceptions import ProtocolError
+import argparse
+
+token = os.getenv('TOKEN')
+protocol = os.getenv('PROTOCOL')
+host = os.getenv('HOST')
+base_url = f"{protocol}://{host}/"
+
+MAX_ATTEMPTS = 10
+SLEEP_TIME = 5
+
+
+def api(
+    method: str,
+    endpoint: str,
+    data: Optional[Mapping] = None,
+    token: str = token,
+    base_url: str = base_url,
+    max_attempts: int = MAX_ATTEMPTS,
+    sleep_time: int = SLEEP_TIME,
+):
+    method = method.upper()
+    headers = {"Authorization": f"token {token}"}
+    kwargs = {
+        "method": method,
+        "url": urllib.parse.urljoin(base_url, endpoint),
+        "headers": headers,
+    }
+    if method not in ("GET", "HEAD"):
+        kwargs["json"] = data
+    elif method == "GET":
+        kwargs["params"] = data
+
+    for attempt in range(max_attempts):
+        try:
+            response = requests.request(**kwargs)
+            break
+        except (
+            InvalidJSONError,
+            ConnectionError,
+            ProtocolError,
+            OSError,
+            JSONDecodeError,
+        ):
+            print(f'Error - Retrying (attempt {attempt+1}).')
+            time.sleep(sleep_time)
+            continue
+
+    return response
+    
+
+def run_analysis(service, model):
+    services_response = api('GET', 'api/analysis_service')
+    try:
+        services_data = services_response.json().get('data')
+    except Exception as e:
+        print(f"Error querying available services: {e}")
+        return
+    
+    service_id = None
+    if services_data is not None:
+        for srv in services_data:
+            name = srv['name']
+            if name == service:
+                service_id = srv['id']
+    else:
+        print("No available analysis services.")
+        return
+    
+    if service_id is not None:
+        print(f"Found service under ID {service_id}. Running {service} using {model} model...")
+        api('POST', f'api/obj/ZTF21aaqjmps/analysis/{service_id}', {'analysis_parameters': {'source':model}}).json()
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--service",
+        type=str,
+        default=None,
+        help="Name of analysis service to run",
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        default=None,
+        help="Name of model to use for analysis run",
+    )
+
+    args = parser.parse_args()
+    
+    run_analysis(service=args.service, model=args.model)

--- a/jobs/candidate_analysis_cronjob.py
+++ b/jobs/candidate_analysis_cronjob.py
@@ -83,7 +83,7 @@ def run_analysis(service, model):
             f'api/obj/ZTF21aaqjmps/analysis/{service_id}',
             {'analysis_parameters': {'source': model}},
         )
-        return analysis_response
+        print(analysis_response)
     else:
         print(f"Service {service} not found.")
 

--- a/jobs/candidate_analysis_cronjob.py
+++ b/jobs/candidate_analysis_cronjob.py
@@ -78,11 +78,14 @@ def run_analysis(service, model):
         print(
             f"Found service under ID {service_id}. Running {service} using {model} model..."
         )
-        api(
+        analysis_response = api(
             'POST',
             f'api/obj/ZTF21aaqjmps/analysis/{service_id}',
             {'analysis_parameters': {'source': model}},
-        ).json()
+        )
+        return analysis_response
+    else:
+        print(f"Service {service} not found.")
 
 
 if __name__ == '__main__':

--- a/jobs/candidate_analysis_cronjob.py
+++ b/jobs/candidate_analysis_cronjob.py
@@ -54,7 +54,7 @@ def api(
             continue
 
     return response
-    
+
 
 def run_analysis(service, model):
     services_response = api('GET', 'api/analysis_service')
@@ -63,7 +63,7 @@ def run_analysis(service, model):
     except Exception as e:
         print(f"Error querying available services: {e}")
         return
-    
+
     service_id = None
     if services_data is not None:
         for srv in services_data:
@@ -73,10 +73,16 @@ def run_analysis(service, model):
     else:
         print("No available analysis services.")
         return
-    
+
     if service_id is not None:
-        print(f"Found service under ID {service_id}. Running {service} using {model} model...")
-        api('POST', f'api/obj/ZTF21aaqjmps/analysis/{service_id}', {'analysis_parameters': {'source':model}}).json()
+        print(
+            f"Found service under ID {service_id}. Running {service} using {model} model..."
+        )
+        api(
+            'POST',
+            f'api/obj/ZTF21aaqjmps/analysis/{service_id}',
+            {'analysis_parameters': {'source': model}},
+        ).json()
 
 
 if __name__ == '__main__':
@@ -95,5 +101,5 @@ if __name__ == '__main__':
     )
 
     args = parser.parse_args()
-    
+
     run_analysis(service=args.service, model=args.model)


### PR DESCRIPTION
This WIP PR adds a script to `jobs` that runs an analysis service on transient candidates. The intent is for this script to be run as a cron job to facilitate regular automated analyses of the latest data.

Currently the analysis service and model can be specified in this script's arguments. It may be useful to add a configuration file that contains more specific parameters for a given service (e.g. `tmin`, `tmax` and `dt` for NMMA_Analysis).

The script still needs code to identify the candidates on which to run the analysis. One way of doing this could be to keep a running list of recent candidates along with number of detections, and any time a new candidate is saved or an existing one gets more photometry, that candidate is queued for a new analysis. [This script](https://github.com/ZwickyTransientFacility/scope/blob/4112cb426e536b62936707d2d8816d69d58c0fda/gcn_cronjob.py#L4) offers an example of a running list of candidates that is checked each run (for a different workflow).