### PR TITLE
FollowupRequestForm - frontend crashes fix

### DIFF
--- a/static/js/components/FollowupRequestForm.jsx
+++ b/static/js/components/FollowupRequestForm.jsx
@@ -218,8 +218,9 @@ const FollowupRequestForm = ({
         groupIDs={selectedGroupIds}
       />
       <div data-testid="followup-request-form">
-        {allocationLookUp[selectedAllocationId].instrument_id in
-        instrumentFormParams ? (
+        {allocationLookUp[selectedAllocationId] !== undefined &&
+        allocationLookUp[selectedAllocationId]?.instrument_id in
+          instrumentFormParams ? (
           <Form
             schema={
               instrumentFormParams[


### PR DESCRIPTION
This is an attempt to prevent an issue a user (yes, just one) encounters when going to the source page.