### PR TITLE
Observation planning - Use references, better frontend.

### DIFF
--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -685,21 +685,6 @@ gcn:
   reject_tags: # reject notices with these tags (optional)
     - MDC
 
-  observation_plans:
-    - allocation-proposal_id: ZTF-001
-      payload:
-        filter_strategy: block
-        schedule_type: greedy_slew
-        schedule_strategy: tiling
-        galaxy_catalog: CLU_mini
-        exposure_time: 300
-        filters: ztfg,ztfr,ztfg
-        maximum_airmass: 2
-        integrated_probability: 90
-        minimum_time_difference: 30
-        program_id: Partnership
-        subprogram_name: GRB
-
 health_monitor:
   seconds_between_checks: 30.5
   allowed_downtime_seconds: 120

--- a/skyportal/facility_apis/observation_plan.py
+++ b/skyportal/facility_apis/observation_plan.py
@@ -575,7 +575,9 @@ def generate_plan(
 
             if request.payload.get("use_references", False):
                 config[request.instrument.name]["reference_images"] = {
-                    field.field_id: field.reference_filters if field.reference_filters is not None else []
+                    field.field_id: field.reference_filters
+                    if field.reference_filters is not None
+                    else []
                     for field in fields
                 }
 
@@ -977,9 +979,14 @@ class MMAAPI(FollowUpAPI):
 
                 if not required_parameters.issubset(set(request.payload.keys())):
                     raise ValueError('Missing required planning parameter')
-                
-                if request.payload["filter_strategy"] is "integrated" and "minimum_time_difference" not in request.payload:
-                    raise ValueError('minimum_time_difference must be defined for integrated scheduling')
+
+                if (
+                    request.payload["filter_strategy"] == "integrated"
+                    and "minimum_time_difference" not in request.payload
+                ):
+                    raise ValueError(
+                        'minimum_time_difference must be defined for integrated scheduling'
+                    )
 
                 if request.payload["schedule_type"] not in [
                     "greedy",
@@ -1109,9 +1116,14 @@ class MMAAPI(FollowUpAPI):
 
                 if not required_parameters.issubset(set(request.payload.keys())):
                     raise ValueError('Missing required planning parameter')
-                
-                if request.payload["filter_strategy"] is "integrated" and "minimum_time_difference" not in request.payload:
-                    raise ValueError('minimum_time_difference must be defined for integrated scheduling')
+
+                if (
+                    request.payload["filter_strategy"] == "integrated"
+                    and "minimum_time_difference" not in request.payload
+                ):
+                    raise ValueError(
+                        'minimum_time_difference must be defined for integrated scheduling'
+                    )
 
                 if request.payload["schedule_type"] not in [
                     "greedy",
@@ -1247,10 +1259,16 @@ class MMAAPI(FollowUpAPI):
             end_date = Time(end_date, format='jd').iso
 
         # we add a use_references boolean to the schema if any of the instrument's fields has reference filters
-        has_references = DBSession().query(InstrumentField).filter(
-            InstrumentField.instrument_id == instrument.id,
-            InstrumentField.reference_filters != '{}'
-        ).count() > 0
+        has_references = (
+            DBSession()
+            .query(InstrumentField)
+            .filter(
+                InstrumentField.instrument_id == instrument.id,
+                InstrumentField.reference_filters != '{}',
+            )
+            .count()
+            > 0
+        )
 
         form_json_schema = {
             "type": "object",
@@ -1341,109 +1359,115 @@ class MMAAPI(FollowUpAPI):
             "dependencies": {
                 "galactic_plane": {
                     "oneOf": [
-                    {
-                        "properties": {
-                            "galactic_plane": {
-                                "enum": [True],
+                        {
+                            "properties": {
+                                "galactic_plane": {
+                                    "enum": [True],
+                                },
+                                "galactic_latitude": {
+                                    "title": "Galactic latitude to exclude",
+                                    "type": "number",
+                                    "default": 10.0,
+                                    "minimum": 0,
+                                    "maximum": 90,
+                                },
                             },
-                            "galactic_latitude": {
-                                "title": "Galactic latitude to exclude",
-                                "type": "number",
-                                "default": 10.0,
-                                "minimum": 0,
-                                "maximum": 90,
-                            },
-                            },
-                        "required": ["galactic_latitude"],
-                    },
+                            "required": ["galactic_latitude"],
+                        },
                     ],
                 },
                 "max_tiles": {
                     "oneOf": [
-                    {
-                        "properties": {
-                            "max_tiles": {
-                                "enum": [True],
+                        {
+                            "properties": {
+                                "max_tiles": {
+                                    "enum": [True],
+                                },
+                                "max_nb_tiles": {
+                                    "title": "Maximum number of fields",
+                                    "type": "number",
+                                    "default": 100.0,
+                                    "minimum": 0,
+                                    "maximum": 1000,
+                                },
                             },
-                            "max_nb_tiles": {
-                                "title": "Maximum number of fields",
-                                "type": "number",
-                                "default": 100.0,
-                                "minimum": 0,
-                                "maximum": 1000,
-                            },
+                            "required": ["max_nb_tiles"],
                         },
-                        "required": ["max_nb_tiles"],
-                    },
                     ],
                 },
                 "ra_slice": {
                     "oneOf": [
-                    {
-                        "properties": {
-                            "ra_slice": {
-                                "enum": [True],
+                        {
+                            "properties": {
+                                "ra_slice": {
+                                    "enum": [True],
+                                },
+                                "ra_slice_min": {
+                                    "title": "Minimum RA",
+                                    "type": "number",
+                                    "default": 0.0,
+                                    "minimum": 0,
+                                    "maximum": 360,
+                                },
+                                "ra_slice_max": {
+                                    "title": "Maximum RA",
+                                    "type": "number",
+                                    "default": 360.0,
+                                    "minimum": 0.0,
+                                    "maximum": 360,
+                                },
                             },
-                            "ra_slice_min": {
-                                "title": "Minimum RA",
-                                "type": "number",
-                                "default": 0.0,
-                                "minimum": 0,
-                                "maximum": 360,
-                            },
-                            "ra_slice_max": {
-                                "title": "Maximum RA",
-                                "type": "number",
-                                "default": 360.0,
-                                "minimum": 0.0,
-                                "maximum": 360,
-                            },
+                            "required": ["ra_slice_min", "ra_slice_max"],
                         },
-                        "required": ["ra_slice_min", "ra_slice_max"],
-                    },
                     ],
                 },
                 "filter_strategy": {
                     # we want to show min_time_difference only if filter_strategy is integrated
                     "oneOf": [
-                    {
-                        "properties": {
-                            "filter_strategy": {
-                                "enum": ["integrated"],
+                        {
+                            "properties": {
+                                "filter_strategy": {
+                                    "enum": ["integrated"],
+                                },
+                                "minimum_time_difference": {
+                                    "title": "Minimum time difference [min] (0-180)",
+                                    "type": "number",
+                                    "default": 30.0,
+                                    "minimum": 0,
+                                    "maximum": 180,
+                                },
                             },
-                            "minimum_time_difference": {
-                                "title": "Minimum time difference [min] (0-180)",
-                                "type": "number",
-                                "default": 30.0,
-                                "minimum": 0,
-                                "maximum": 180,
-                            },
+                            "required": ["minimum_time_difference"],
                         },
-                        "required": ["minimum_time_difference"],
-                    },
                     ],
                 },
                 # we want to show galaxy_catalog and galaxy_sorting only if schedule_strategy is galaxy
                 "schedule_strategy": {
                     "oneOf": [
-                    {
-                        "properties": {
-                            "schedule_strategy": {
-                                "enum": ["galaxy"],
+                        {
+                            "properties": {
+                                "schedule_strategy": {
+                                    "enum": ["galaxy"],
+                                },
+                                "galaxy_catalog": {
+                                    "type": "string",
+                                    "enum": galaxies,
+                                    "default": galaxies[0] if len(galaxies) > 0 else "",
+                                },
+                                "galaxy_sorting": {
+                                    "type": "string",
+                                    "enum": [
+                                        "equal",
+                                        "sfr_fuv",
+                                        "mstar",
+                                        "magb",
+                                        "magk",
+                                    ],
+                                    "default": "equal",
+                                },
                             },
-                            "galaxy_catalog": {
-                                "type": "string",
-                                "enum": galaxies,
-                                "default": galaxies[0] if len(galaxies) > 0 else "",
-                            },
-                            "galaxy_sorting": {
-                                "type": "string",
-                                "enum": ["equal", "sfr_fuv", "mstar", "magb", "magk"],
-                                "default": "equal",
-                            },
+                            "required": ["galaxy_catalog", "galaxy_sorting"],
                         },
-                        "required": ["galaxy_catalog", "galaxy_sorting"],
-                    },
                     ],
                 },
             },

--- a/skyportal/facility_apis/observation_plan.py
+++ b/skyportal/facility_apis/observation_plan.py
@@ -444,9 +444,9 @@ def generate_plan(
             'telescopes': [request.instrument.name for request in requests],
             # minimum difference between observations of the same field
             'doMindifFilt': True
-            if request.payload["minimum_time_difference"] > 0
+            if request.payload.get("minimum_time_difference", 0) > 0
             else False,
-            'mindiff': request.payload["minimum_time_difference"] * 60,
+            'mindiff': request.payload.get("minimum_time_difference", 0) * 60,
             # maximum airmass with which to observae
             'airmass': request.payload["maximum_airmass"],
             # array of exposure times (same length as filter array)
@@ -485,8 +485,8 @@ def generate_plan(
             'maximumOverlap': 1.0,
             # time allocation strategy
             'timeallocationType': 'powerlaw',
-            # check for references
-            'doReferences': False,
+            # check for references, works in gwemopt only for ZTF and DECAM
+            'doReferences': request.payload.get("use_references", False),
             # treasuremap interactions
             'treasuremap_token': None,
             # number of scheduling blocks to attempt
@@ -506,7 +506,6 @@ def generate_plan(
             'doChipGaps': False,
         }
 
-        # TODO: understand why this is required for combined plans
         if len(requests) > 1:
             params['doOrderByObservability'] = True
 
@@ -573,6 +572,13 @@ def generate_plan(
                 # limiting magnitude given telescope time
                 'magnitude': 0.0,
             }
+
+            if request.payload.get("use_references", False):
+                config[request.instrument.name]["reference_images"] = {
+                    field.field_id: field.reference_filters if field.reference_filters is not None else []
+                    for field in fields
+                }
+
         params['config'] = config
 
         if request.payload["schedule_strategy"] == "galaxy":
@@ -966,12 +972,14 @@ class MMAAPI(FollowUpAPI):
                     'filters',
                     'maximum_airmass',
                     'integrated_probability',
-                    'minimum_time_difference',
                     'galactic_latitude',
                 }
 
                 if not required_parameters.issubset(set(request.payload.keys())):
                     raise ValueError('Missing required planning parameter')
+                
+                if request.payload["filter_strategy"] is "integrated" and "minimum_time_difference" not in request.payload:
+                    raise ValueError('minimum_time_difference must be defined for integrated scheduling')
 
                 if request.payload["schedule_type"] not in [
                     "greedy",
@@ -1097,11 +1105,13 @@ class MMAAPI(FollowUpAPI):
                     'filters',
                     'maximum_airmass',
                     'integrated_probability',
-                    'minimum_time_difference',
                 }
 
                 if not required_parameters.issubset(set(request.payload.keys())):
                     raise ValueError('Missing required planning parameter')
+                
+                if request.payload["filter_strategy"] is "integrated" and "minimum_time_difference" not in request.payload:
+                    raise ValueError('minimum_time_difference must be defined for integrated scheduling')
 
                 if request.payload["schedule_type"] not in [
                     "greedy",
@@ -1227,7 +1237,7 @@ class MMAAPI(FollowUpAPI):
 
     def custom_json_schema(instrument, user):
 
-        from ..models import DBSession, Galaxy
+        from ..models import DBSession, Galaxy, InstrumentField
 
         galaxies = [g for g, in DBSession().query(Galaxy.catalog_name).distinct().all()]
         end_date = instrument.telescope.next_sunrise()
@@ -1236,9 +1246,19 @@ class MMAAPI(FollowUpAPI):
         else:
             end_date = Time(end_date, format='jd').iso
 
+        # we add a use_references boolean to the schema if any of the instrument's fields has reference filters
+        has_references = DBSession().query(InstrumentField).filter(
+            InstrumentField.instrument_id == instrument.id,
+            InstrumentField.reference_filters != '{}'
+        ).count() > 0
+
         form_json_schema = {
             "type": "object",
             "properties": {
+                "queue_name": {
+                    "type": "string",
+                    "default": f"ToO_{str(datetime.utcnow()).replace(' ', 'T')}",
+                },
                 "start_date": {
                     "type": "string",
                     "default": str(datetime.utcnow()),
@@ -1257,22 +1277,12 @@ class MMAAPI(FollowUpAPI):
                 "schedule_type": {
                     "type": "string",
                     "enum": ["greedy", "greedy_slew", "sear", "airmass_weighted"],
-                    "default": "greedy_slew",
+                    "default": "greedy",
                 },
                 "schedule_strategy": {
                     "type": "string",
                     "enum": ["tiling", "galaxy"],
                     "default": "tiling",
-                },
-                "galaxy_catalog": {
-                    "type": "string",
-                    "enum": galaxies,
-                    "default": galaxies[0] if len(galaxies) > 0 else "",
-                },
-                "galaxy_sorting": {
-                    "type": "string",
-                    "enum": ["equal", "sfr_fuv", "mstar", "magb", "magk"],
-                    "default": "equal",
                 },
                 "exposure_time": {
                     "title": "Exposure Time [s]",
@@ -1295,34 +1305,15 @@ class MMAAPI(FollowUpAPI):
                     "minimum": 0,
                     "maximum": 100,
                 },
-                "minimum_time_difference": {
-                    "title": "Minimum time difference [min] (0-180)",
-                    "type": "number",
-                    "default": 30.0,
-                    "minimum": 0,
-                    "maximum": 180,
-                },
                 "galactic_plane": {
                     "title": "Avoid the Galactic Plane?",
                     "type": "boolean",
-                },
-                "galactic_latitude": {
-                    "title": "Galactic latitude to exclude",
-                    "type": "number",
-                    "default": 10.0,
-                    "minimum": 0,
-                    "maximum": 90,
+                    "default": False,
                 },
                 "max_tiles": {
                     "title": "Threshold on number of fields?",
                     "type": "boolean",
-                },
-                "max_nb_tiles": {
-                    "title": "Maximum number of fields",
-                    "type": "number",
-                    "default": 100.0,
-                    "minimum": 0,
-                    "maximum": 1000,
+                    "default": False,
                 },
                 "balance_exposure": {
                     "title": "Balance exposures across fields",
@@ -1332,24 +1323,7 @@ class MMAAPI(FollowUpAPI):
                 "ra_slice": {
                     "title": "RA Slicing",
                     "type": "boolean",
-                },
-                "ra_slice_min": {
-                    "title": "Minimum RA",
-                    "type": "number",
-                    "default": 0.0,
-                    "minimum": 0,
-                    "maximum": 360,
-                },
-                "ra_slice_max": {
-                    "title": "Maximum RA",
-                    "type": "number",
-                    "default": 360.0,
-                    "minimum": 0.0,
-                    "maximum": 360,
-                },
-                "queue_name": {
-                    "type": "string",
-                    "default": f"ToO_{str(datetime.utcnow()).replace(' ', 'T')}",
+                    "default": False,
                 },
             },
             "required": [
@@ -1363,10 +1337,124 @@ class MMAAPI(FollowUpAPI):
                 "exposure_time",
                 "maximum_airmass",
                 "integrated_probability",
-                "minimum_time_difference",
             ],
+            "dependencies": {
+                "galactic_plane": {
+                    "oneOf": [
+                    {
+                        "properties": {
+                            "galactic_plane": {
+                                "enum": [True],
+                            },
+                            "galactic_latitude": {
+                                "title": "Galactic latitude to exclude",
+                                "type": "number",
+                                "default": 10.0,
+                                "minimum": 0,
+                                "maximum": 90,
+                            },
+                            },
+                        "required": ["galactic_latitude"],
+                    },
+                    ],
+                },
+                "max_tiles": {
+                    "oneOf": [
+                    {
+                        "properties": {
+                            "max_tiles": {
+                                "enum": [True],
+                            },
+                            "max_nb_tiles": {
+                                "title": "Maximum number of fields",
+                                "type": "number",
+                                "default": 100.0,
+                                "minimum": 0,
+                                "maximum": 1000,
+                            },
+                        },
+                        "required": ["max_nb_tiles"],
+                    },
+                    ],
+                },
+                "ra_slice": {
+                    "oneOf": [
+                    {
+                        "properties": {
+                            "ra_slice": {
+                                "enum": [True],
+                            },
+                            "ra_slice_min": {
+                                "title": "Minimum RA",
+                                "type": "number",
+                                "default": 0.0,
+                                "minimum": 0,
+                                "maximum": 360,
+                            },
+                            "ra_slice_max": {
+                                "title": "Maximum RA",
+                                "type": "number",
+                                "default": 360.0,
+                                "minimum": 0.0,
+                                "maximum": 360,
+                            },
+                        },
+                        "required": ["ra_slice_min", "ra_slice_max"],
+                    },
+                    ],
+                },
+                "filter_strategy": {
+                    # we want to show min_time_difference only if filter_strategy is integrated
+                    "oneOf": [
+                    {
+                        "properties": {
+                            "filter_strategy": {
+                                "enum": ["integrated"],
+                            },
+                            "minimum_time_difference": {
+                                "title": "Minimum time difference [min] (0-180)",
+                                "type": "number",
+                                "default": 30.0,
+                                "minimum": 0,
+                                "maximum": 180,
+                            },
+                        },
+                        "required": ["minimum_time_difference"],
+                    },
+                    ],
+                },
+                # we want to show galaxy_catalog and galaxy_sorting only if schedule_strategy is galaxy
+                "schedule_strategy": {
+                    "oneOf": [
+                    {
+                        "properties": {
+                            "schedule_strategy": {
+                                "enum": ["galaxy"],
+                            },
+                            "galaxy_catalog": {
+                                "type": "string",
+                                "enum": galaxies,
+                                "default": galaxies[0] if len(galaxies) > 0 else "",
+                            },
+                            "galaxy_sorting": {
+                                "type": "string",
+                                "enum": ["equal", "sfr_fuv", "mstar", "magb", "magk"],
+                                "default": "equal",
+                            },
+                        },
+                        "required": ["galaxy_catalog", "galaxy_sorting"],
+                    },
+                    ],
+                },
+            },
         }
 
+        if has_references:
+            form_json_schema["properties"]["use_references"] = {
+                "title": "Use fields with references only?",
+                "type": "boolean",
+                "default": True,
+            }
         return form_json_schema
 
     @staticmethod

--- a/skyportal/facility_apis/ztf.py
+++ b/skyportal/facility_apis/ztf.py
@@ -923,8 +923,16 @@ class ZTFMMAAPI(MMAAPI):
         form_json_schema = MMAAPI.custom_json_schema(instrument, user)
 
         # we make sure that all the boolean properties come last, which helps with the display
-        non_boolean_properties = {k: v for k, v in form_json_schema["properties"].items() if v["type"] != "boolean"}
-        boolean_properties = {k: v for k, v in form_json_schema["properties"].items() if v["type"] == "boolean"}
+        non_boolean_properties = {
+            k: v
+            for k, v in form_json_schema["properties"].items()
+            if v["type"] != "boolean"
+        }
+        boolean_properties = {
+            k: v
+            for k, v in form_json_schema["properties"].items()
+            if v["type"] == "boolean"
+        }
 
         form_json_schema["properties"] = {
             **non_boolean_properties,

--- a/skyportal/facility_apis/ztf.py
+++ b/skyportal/facility_apis/ztf.py
@@ -922,8 +922,12 @@ class ZTFMMAAPI(MMAAPI):
     def custom_json_schema(instrument, user):
         form_json_schema = MMAAPI.custom_json_schema(instrument, user)
 
+        # we make sure that all the boolean properties come last, which helps with the display
+        non_boolean_properties = {k: v for k, v in form_json_schema["properties"].items() if v["type"] != "boolean"}
+        boolean_properties = {k: v for k, v in form_json_schema["properties"].items() if v["type"] == "boolean"}
+
         form_json_schema["properties"] = {
-            **form_json_schema["properties"],
+            **non_boolean_properties,
             "program_id": {
                 "type": "string",
                 "enum": ["Partnership", "Caltech"],
@@ -938,12 +942,16 @@ class ZTFMMAAPI(MMAAPI):
             "use_primary": {
                 "title": "Use primary grid only?",
                 "type": "boolean",
+                "default": True,
             },
             "use_secondary": {
                 "title": "Use secondary grid only?",
                 "type": "boolean",
+                "default": False,
             },
+            **boolean_properties,
         }
+
         form_json_schema["required"] = form_json_schema["required"] + [
             "subprogram_name",
             "program_id",

--- a/skyportal/handlers/api/gcn.py
+++ b/skyportal/handlers/api/gcn.py
@@ -1856,24 +1856,6 @@ def add_observation_plans(localization_id, user_id, parent_session=None):
         user = session.scalar(sa.select(User).where(User.id == user_id))
         localization = session.query(Localization).get(localization_id)
         dateobs = localization.dateobs
-        config_gcn_observation_plans_all = [
-            observation_plan for observation_plan in cfg["gcn.observation_plans"]
-        ]
-        config_gcn_observation_plans = []
-        for config_gcn_observation_plan in config_gcn_observation_plans_all:
-            allocation = session.scalars(
-                Allocation.select(user).where(
-                    Allocation.proposal_id
-                    == config_gcn_observation_plan["allocation-proposal_id"]
-                )
-            ).first()
-            if allocation is not None:
-                allocation_id = allocation.id
-                config_gcn_observation_plan["allocation_id"] = allocation_id
-                config_gcn_observation_plan["survey_efficiencies"] = []
-                config_gcn_observation_plans.append(config_gcn_observation_plan)
-            else:
-                allocation_id = None
 
         default_observation_plans = (
             session.scalars(DefaultObservationPlanRequest.select(user)).unique().all()
@@ -1887,7 +1869,6 @@ def add_observation_plans(localization_id, user_id, parent_session=None):
                 'default': plan.id,
             }
             gcn_observation_plans.append(gcn_observation_plan)
-        gcn_observation_plans = gcn_observation_plans + config_gcn_observation_plans
 
         event = session.scalars(
             GcnEvent.select(user).where(GcnEvent.dateobs == dateobs)

--- a/skyportal/handlers/api/observation_plan.py
+++ b/skyportal/handlers/api/observation_plan.py
@@ -3,6 +3,7 @@ import functools
 import io
 import json
 import random
+import re
 import tempfile
 import time
 import urllib
@@ -28,12 +29,8 @@ import requests
 import simsurvey
 import sncosmo
 import sqlalchemy as sa
-from astroplan import (
-    AirmassConstraint,
-    AtNightConstraint,
-    Observer,
-    is_event_observable,
-)
+from astroplan import (AirmassConstraint, AtNightConstraint, Observer,
+                       is_event_observable)
 from astropy import units as u
 from astropy.coordinates import EarthLocation, SkyCoord
 from astropy.time import Time
@@ -56,33 +53,21 @@ from baselayer.app.env import load_env
 from baselayer.app.flow import Flow
 from baselayer.log import make_log
 from skyportal.enum_types import ALLOWED_BANDPASSES
-from skyportal.facility_apis.observation_plan import (
-    generate_observation_plan_statistics,
-)
+from skyportal.facility_apis.observation_plan import \
+    generate_observation_plan_statistics
 from skyportal.handlers.api.followup_request import post_assignment
 from skyportal.handlers.api.observingrun import post_observing_run
 from skyportal.handlers.api.source import post_source
 
-from ...models import (
-    Allocation,
-    DBSession,
-    DefaultObservationPlanRequest,
-    EventObservationPlan,
-    GcnEvent,
-    GcnTrigger,
-    Group,
-    Instrument,
-    InstrumentField,
-    Localization,
-    ObservationPlanRequest,
-    PlannedObservation,
-    SurveyEfficiencyForObservationPlan,
-    SurveyEfficiencyForObservations,
-    Telescope,
-    User,
-)
+from ...models import (Allocation, DBSession, DefaultObservationPlanRequest,
+                       EventObservationPlan, GcnEvent, GcnTrigger, Group,
+                       Instrument, InstrumentField, Localization,
+                       ObservationPlanRequest, PlannedObservation,
+                       SurveyEfficiencyForObservationPlan,
+                       SurveyEfficiencyForObservations, Telescope, User)
 from ...models.schema import ObservationPlanPost
-from ...utils.simsurvey import get_simsurvey_parameters, random_parameters_notheta
+from ...utils.simsurvey import (get_simsurvey_parameters,
+                                random_parameters_notheta)
 from ..base import BaseHandler
 
 env, cfg = load_env()
@@ -2307,8 +2292,10 @@ class ObservationPlanAirmassChartHandler(BaseHandler):
                     content = g.read()
 
             data = io.BytesIO(content)
+            # we remove special characters and extensions other than .pdf
+            # otherwise, some browsers won't save the file as a PDF
             filename = (
-                f"{localization.localization_name}-{telescope.nickname}.{output_format}"
+                f"{re.sub(r'[^a-zA-Z0-9]', '_', localization.localization_name).replace('.fits', '').replace('.fit', '')}-{telescope.nickname}.{output_format}"
             )
 
             await self.send_file(data, filename, output_type=output_format)

--- a/skyportal/handlers/api/observation_plan.py
+++ b/skyportal/handlers/api/observation_plan.py
@@ -29,8 +29,12 @@ import requests
 import simsurvey
 import sncosmo
 import sqlalchemy as sa
-from astroplan import (AirmassConstraint, AtNightConstraint, Observer,
-                       is_event_observable)
+from astroplan import (
+    AirmassConstraint,
+    AtNightConstraint,
+    Observer,
+    is_event_observable,
+)
 from astropy import units as u
 from astropy.coordinates import EarthLocation, SkyCoord
 from astropy.time import Time
@@ -53,21 +57,33 @@ from baselayer.app.env import load_env
 from baselayer.app.flow import Flow
 from baselayer.log import make_log
 from skyportal.enum_types import ALLOWED_BANDPASSES
-from skyportal.facility_apis.observation_plan import \
-    generate_observation_plan_statistics
+from skyportal.facility_apis.observation_plan import (
+    generate_observation_plan_statistics,
+)
 from skyportal.handlers.api.followup_request import post_assignment
 from skyportal.handlers.api.observingrun import post_observing_run
 from skyportal.handlers.api.source import post_source
 
-from ...models import (Allocation, DBSession, DefaultObservationPlanRequest,
-                       EventObservationPlan, GcnEvent, GcnTrigger, Group,
-                       Instrument, InstrumentField, Localization,
-                       ObservationPlanRequest, PlannedObservation,
-                       SurveyEfficiencyForObservationPlan,
-                       SurveyEfficiencyForObservations, Telescope, User)
+from ...models import (
+    Allocation,
+    DBSession,
+    DefaultObservationPlanRequest,
+    EventObservationPlan,
+    GcnEvent,
+    GcnTrigger,
+    Group,
+    Instrument,
+    InstrumentField,
+    Localization,
+    ObservationPlanRequest,
+    PlannedObservation,
+    SurveyEfficiencyForObservationPlan,
+    SurveyEfficiencyForObservations,
+    Telescope,
+    User,
+)
 from ...models.schema import ObservationPlanPost
-from ...utils.simsurvey import (get_simsurvey_parameters,
-                                random_parameters_notheta)
+from ...utils.simsurvey import get_simsurvey_parameters, random_parameters_notheta
 from ..base import BaseHandler
 
 env, cfg = load_env()
@@ -2294,9 +2310,7 @@ class ObservationPlanAirmassChartHandler(BaseHandler):
             data = io.BytesIO(content)
             # we remove special characters and extensions other than .pdf
             # otherwise, some browsers won't save the file as a PDF
-            filename = (
-                f"{re.sub(r'[^a-zA-Z0-9]', '_', localization.localization_name).replace('.fits', '').replace('.fit', '')}-{telescope.nickname}.{output_format}"
-            )
+            filename = f"{re.sub(r'[^a-zA-Z0-9]', '_', localization.localization_name).replace('.fits', '').replace('.fit', '')}-{telescope.nickname}.{output_format}"
 
             await self.send_file(data, filename, output_type=output_format)
 

--- a/skyportal/tests/api/candidates_sources_events/test_observation_plan.py
+++ b/skyportal/tests/api/candidates_sources_events/test_observation_plan.py
@@ -171,7 +171,7 @@ def test_observation_plan_tiling(super_admin_token, public_group):
                 'galactic_latitude': 10,
             },
         }
-        for _ in range(5)
+        for _ in range(3)
     ]
 
     for request_data in requests_data:
@@ -209,7 +209,13 @@ def test_observation_plan_tiling(super_admin_token, public_group):
             ]
             assert len(data) == len(requests_data)
             for i, d in enumerate(data):
-                assert d["payload"] == requests_data[i]["payload"]
+
+                assert any(
+                    [
+                        d['payload'] == request_data["payload"]
+                        for request_data in requests_data
+                    ]
+                )
                 observation_plans = d['observation_plans']
                 assert len(observation_plans) == 1
                 observation_plan = observation_plans[0]
@@ -231,8 +237,8 @@ def test_observation_plan_tiling(super_admin_token, public_group):
                 # same with the validity window start
                 assert any(
                     [
-                        observation_plan['validity_window_end']
-                        == request_data["payload"]['end_date'].replace(" ", "T")
+                        observation_plan['validity_window_start']
+                        == request_data["payload"]['start_date'].replace(" ", "T")
                         for request_data in requests_data
                     ]
                 )
@@ -465,7 +471,7 @@ def test_observation_plan_galaxy(super_admin_token, view_only_token, public_grou
                 'galactic_latitude': 10,
             },
         }
-        for _ in range(5)
+        for _ in range(3)
     ]
 
     for request_data in requests_data:
@@ -500,26 +506,34 @@ def test_observation_plan_galaxy(super_admin_token, view_only_token, public_grou
             assert len(data) == len(requests_data)
 
             for i, d in enumerate(data):
-                assert d["payload"] == requests_data[i]["payload"]
+                assert any(
+                    [
+                        d['payload']['queue_name']
+                        == request_data["payload"]['queue_name']
+                        for request_data in requests_data
+                    ]
+                )
                 observation_plans = d['observation_plans']
                 assert len(observation_plans) == 1
                 observation_plan = observation_plans[0]
 
-                assert (
-                    observation_plan['plan_name']
-                    == requests_data[i]["payload"]['queue_name']
+                assert any(
+                    [
+                        observation_plan['plan_name']
+                        == request_data["payload"]['queue_name']
+                        for request_data in requests_data
+                    ]
                 )
-                assert observation_plan['validity_window_start'] == requests_data[i][
+                assert observation_plan['validity_window_start'] == requests_data[0][
                     "payload"
                 ]['start_date'].replace(" ", "T")
-                assert observation_plan['validity_window_end'] == requests_data[i][
+                assert observation_plan['validity_window_end'] == requests_data[0][
                     "payload"
                 ]['end_date'].replace(" ", "T")
 
                 planned_observations = observation_plan['planned_observations']
-                assert len(planned_observations) > 0
+                assert len(planned_observations) >= 11
 
-                assert len(planned_observations) == 11
                 assert all(
                     [
                         obs['filt'] == requests_data[i]["payload"]['filters']

--- a/static/js/components/FollowupRequestLists.jsx
+++ b/static/js/components/FollowupRequestLists.jsx
@@ -126,7 +126,6 @@ const FollowupRequestLists = ({
   const handleGet = async (id) => {
     setIsGetting(id);
     dispatch(Actions.getPhotometryRequest(id)).then((response) => {
-      console.log(response);
       if (response.status === "success") {
         dispatch(
           showNotification(

--- a/static/js/components/LocalizationPlot.jsx
+++ b/static/js/components/LocalizationPlot.jsx
@@ -24,6 +24,7 @@ const LocalizationPlot = ({
   galaxies,
   instrument,
   observations,
+  airmass_threshold=2.5,
   options,
   height,
   width,
@@ -76,6 +77,7 @@ const LocalizationPlot = ({
       selectedFields={selectedFields}
       setSelectedFields={setSelectedFields}
       projectionType={projection}
+      airmass_threshold={airmass_threshold}
     />
   );
 };
@@ -189,6 +191,7 @@ LocalizationPlot.propTypes = {
       })
     ),
   }),
+  airmass_threshold: PropTypes.number,
   options: PropTypes.shape({
     skymap: PropTypes.bool,
     sources: PropTypes.bool,
@@ -212,6 +215,7 @@ LocalizationPlot.defaultProps = {
   galaxies: null,
   instrument: null,
   observations: null,
+  airmass_threshold: 2.5,
   options: {
     skymap: false,
     sources: false,
@@ -505,11 +509,17 @@ const GeoJSONGlobePlot = ({
           return 0;
         });
 
+        const has_ref = data.instrument.fields.some(
+          (f) => (f.reference_filters || []).length > 0
+        );
+
         data.instrument.fields.forEach((f) => {
           const { field_id } = f;
           const { features } = f.contour_summary;
           const selected = selectedFields.includes(Number(f.id));
           const { airmass } = f;
+          const references = f.reference_filters || [];
+
           svg
             .data(features)
             .append("path")
@@ -523,7 +533,8 @@ const GeoJSONGlobePlot = ({
                 : airmass && airmass < airmass_threshold
                 ? "white"
                 : "gray"
-            )
+            ) // we make the field semi-transparent if it doesn't have references
+            .style("opacity", has_ref && references.length === 0 ? 0.3 : 0.95)
             .attr("d", geoGenerator)
             .on("click", () => {
               if (!selected) {
@@ -538,9 +549,8 @@ const GeoJSONGlobePlot = ({
             })
             .append("title")
             .text(
-              `field ID: ${field_id} \nra: ${f.ra} \ndec: ${
-                f.dec
-              } \nfilters: ${data.instrument.filters.join(", ")}`
+              `field ID: ${field_id} \nra: ${f.ra} \ndec: ${f.dec} \nfilters: ${data.instrument.filters.join(", ")}${airmass ? ` \nairmass: ${airmass}` : ""}${has_ref ? ` \nreferences: ${(references).join(", ")}` : ""}
+              `
             );
         });
       }

--- a/static/js/components/LocalizationPlot.jsx
+++ b/static/js/components/LocalizationPlot.jsx
@@ -24,7 +24,7 @@ const LocalizationPlot = ({
   galaxies,
   instrument,
   observations,
-  airmass_threshold=2.5,
+  airmass_threshold = 2.5,
   options,
   height,
   width,
@@ -549,7 +549,11 @@ const GeoJSONGlobePlot = ({
             })
             .append("title")
             .text(
-              `field ID: ${field_id} \nra: ${f.ra} \ndec: ${f.dec} \nfilters: ${data.instrument.filters.join(", ")}${airmass ? ` \nairmass: ${airmass}` : ""}${has_ref ? ` \nreferences: ${(references).join(", ")}` : ""}
+              `field ID: ${field_id} \nra: ${f.ra} \ndec: ${
+                f.dec
+              } \nfilters: ${data.instrument.filters.join(", ")}${
+                airmass ? ` \nairmass: ${airmass}` : ""
+              }${has_ref ? ` \nreferences: ${references.join(", ")}` : ""}
               `
             );
         });

--- a/static/js/components/NewShift.jsx
+++ b/static/js/components/NewShift.jsx
@@ -132,7 +132,6 @@ const NewShift = () => {
             .add(i * 7, "day")
             .format("YYYY-MM-DDTHH:mm:ssZ")
             .replace(/[-+]\d\d:\d\d$/, "");
-          console.log(newFormData.start_date);
           if (i === weeks - 1) {
             newFormData.end_date = endDate
               .format("YYYY-MM-DDTHH:mm:ssZ")

--- a/static/js/components/ObservationPlanRequestForm.jsx
+++ b/static/js/components/ObservationPlanRequestForm.jsx
@@ -615,9 +615,21 @@ const ObservationPlanRequestForm = ({ dateobs }) => {
                   </MenuItem>
                 ))}
               </Select>
-              <InputLabel id="airmassTimeSelectLabel" style={{marginBottom: "0.5rem"}}>Airmass Time</InputLabel>
+              <InputLabel
+                id="airmassTimeSelectLabel"
+                style={{ marginBottom: "0.5rem" }}
+              >
+                Airmass Time
+              </InputLabel>
               <Grid container spacing={1} alignItems="center">
-                <Grid item style={{ display: "grid", gridTemplateColumns: "3fr 1fr", gap: "0.2rem" }}>
+                <Grid
+                  item
+                  style={{
+                    display: "grid",
+                    gridTemplateColumns: "3fr 1fr",
+                    gap: "0.2rem",
+                  }}
+                >
                   <LocalizationProvider dateAdapter={AdapterDateFns}>
                     <DateTimePicker
                       value={temporaryAirmassTime}
@@ -819,7 +831,8 @@ const ObservationPlanRequestForm = ({ dateobs }) => {
               onDelete={() => {
                 setPlanQueues(
                   planQueues.filter(
-                    (queue) => queue.payload.queue_name !== plan.payload.queue_name
+                    (queue) =>
+                      queue.payload.queue_name !== plan.payload.queue_name
                   )
                 );
               }}

--- a/static/js/components/ObservationPlanRequestForm.jsx
+++ b/static/js/components/ObservationPlanRequestForm.jsx
@@ -186,6 +186,7 @@ const ObservationPlanGlobe = ({
   selectedFields,
   setSelectedFields,
   selectedProjection,
+  airmassValue = 2.5,
 }) => {
   const displayOptions = [
     "localization",
@@ -209,6 +210,7 @@ const ObservationPlanGlobe = ({
       selectedFields={selectedFields}
       setSelectedFields={setSelectedFields}
       projection={selectedProjection}
+      airmass_threshold={airmassValue}
     />
   );
 };
@@ -249,11 +251,13 @@ ObservationPlanGlobe.propTypes = {
   selectedFields: PropTypes.arrayOf(PropTypes.number).isRequired,
   setSelectedFields: PropTypes.func.isRequired,
   selectedProjection: PropTypes.string,
+  airmassValue: PropTypes.number,
 };
 
 ObservationPlanGlobe.defaultProps = {
   skymapInstrument: null,
   selectedProjection: "orthographic",
+  airmassValue: 2.5,
 };
 
 const MyObjectFieldTemplate = (props) => {
@@ -311,6 +315,7 @@ const ObservationPlanRequestForm = ({ dateobs }) => {
     dayjs(gcnEvent?.dateobs).format("YYYY-MM-DDTHH:mm:ssZ")
   );
   const [airmassTime, setAirmassTime] = useState(defaultAirmassTime);
+  const [airmassValue, setAirmassValue] = useState(2.5);
   const [temporaryAirmassTime, setTemporaryAirmassTime] =
     useState(defaultAirmassTime);
 
@@ -580,6 +585,7 @@ const ObservationPlanRequestForm = ({ dateobs }) => {
               selectedFields={selectedFields}
               setSelectedFields={setSelectedFields}
               selectedProjection={selectedProjection}
+              airmassValue={airmassValue}
             />
           </Grid>
           <Grid item xs={12} sm={5} md={12}>
@@ -609,9 +615,9 @@ const ObservationPlanRequestForm = ({ dateobs }) => {
                   </MenuItem>
                 ))}
               </Select>
-              <InputLabel id="airmassTimeSelectLabel">Airmass Time</InputLabel>
+              <InputLabel id="airmassTimeSelectLabel" style={{marginBottom: "0.5rem"}}>Airmass Time</InputLabel>
               <Grid container spacing={1} alignItems="center">
-                <Grid item>
+                <Grid item style={{ display: "grid", gridTemplateColumns: "3fr 1fr", gap: "0.2rem" }}>
                   <LocalizationProvider dateAdapter={AdapterDateFns}>
                     <DateTimePicker
                       value={temporaryAirmassTime}
@@ -626,6 +632,22 @@ const ObservationPlanRequestForm = ({ dateobs }) => {
                       style={{ minWidth: "100%" }}
                     />
                   </LocalizationProvider>
+                  <TextField
+                    id="airmassThreshold"
+                    label="Threshold"
+                    type="number"
+                    value={airmassValue}
+                    onChange={(e) => setAirmassValue(e.target.value)}
+                    InputLabelProps={{
+                      shrink: true,
+                    }}
+                    inputProps={{
+                      step: 0.1,
+                      min: 1.0,
+                      max: 3.0,
+                    }}
+                    style={{ width: "100%" }}
+                  />
                 </Grid>
                 <Grid item>
                   <Button id="setAirmassSelect" onClick={() => setAirmass()}>
@@ -794,6 +816,13 @@ const ObservationPlanRequestForm = ({ dateobs }) => {
                   ?.name
               }: ${plan.payload.queue_name}`}
               data-testid={`queueName_${plan.payload.queue_name}`}
+              onDelete={() => {
+                setPlanQueues(
+                  planQueues.filter(
+                    (queue) => queue.payload.queue_name !== plan.payload.queue_name
+                  )
+                );
+              }}
             />
           ))}
         </div>

--- a/static/js/components/RunSummary.jsx
+++ b/static/js/components/RunSummary.jsx
@@ -265,7 +265,6 @@ const RunSummary = ({ route }) => {
 
   const renderRise = (dataIndex) => {
     const assignment = assignments[dataIndex];
-    console.log("assignment", assignment);
     return (
       <div key={`${assignment.id}_rise`}>
         {assignment.rise_time_utc === ""


### PR DESCRIPTION
This PR allows us to pass reference filters to gwemopt, but also improves on a few things:
- only show sub-parameters when the parameter they depend on it set on the right value, which helps make the frontend form WAY more usable.
- allows to change the airmass threshold used when plotting fields, from the frontend directly.
- fixes a bug where downloading an airmass chart on browsers other than firefox wouldn't save it as PDF.