### PR TITLE
Faster airmass, rise and set time calculations

### DIFF
--- a/skyportal/handlers/api/observation_plan.py
+++ b/skyportal/handlers/api/observation_plan.py
@@ -22,7 +22,6 @@ import matplotlib.animation as animation
 import matplotlib.patches as mpatches
 import matplotlib.pyplot as plt
 import numpy as np
-import numpy.ma as ma
 import pandas as pd
 import requests
 import simsurvey
@@ -62,6 +61,7 @@ from skyportal.facility_apis.observation_plan import (
 from skyportal.handlers.api.followup_request import post_assignment
 from skyportal.handlers.api.observingrun import post_observing_run
 from skyportal.handlers.api.source import post_source
+from skyportal.utils.calculations import get_rise_set_time
 
 from ...models import (
     Allocation,
@@ -787,42 +787,47 @@ class ObservationPlanRequestHandler(BaseHandler):
                     observation_plans = []
                     for observation_plan in observation_plan_request.observation_plans:
                         planned_observations = []
-                        for (
-                            planned_observation
-                        ) in observation_plan.planned_observations:
-                            set_time = planned_observation.set_time()
-                            if set_time is not None:
-                                set_time = set_time.isot
-                            rise_time = planned_observation.rise_time()
-                            if rise_time is not None:
-                                rise_time = rise_time.isot
-                            planned_observation_data = planned_observation.to_dict()
-                            del planned_observation_data["instrument"]
+                        fields = [
+                            planned_observation.field.to_dict()
+                            for planned_observation in observation_plan.planned_observations
+                        ]
+                        rise_times, set_times = get_rise_set_time(
+                            fields=fields,
+                            observer=observation_plan.instrument.telescope.observer,
+                        )
+                        for (planned_observation, rise_time, set_time) in zip(
+                            observation_plan.planned_observations, rise_times, set_times
+                        ):
+                            planned_observation_data = {
+                                **planned_observation.to_dict(),
+                                'field': planned_observation.field.to_dict(),
+                            }
                             # rename the field_id key to field_db_id to avoid confusion
                             planned_observation_data[
                                 "field_db_id"
                             ] = planned_observation_data.pop("field_id")
                             planned_observation_data[
                                 "field_id"
-                            ] = planned_observation_data['field'].field_id
+                            ] = planned_observation_data['field']['field_id']
 
                             planned_observations.append(
                                 {
                                     **planned_observation_data,
-                                    'rise_time': rise_time
-                                    if not type(rise_time) is ma.masked_array
+                                    'rise_time': rise_time.isot
+                                    if isinstance(rise_time, Time)
                                     else None,
-                                    'set_time': set_time
-                                    if not type(set_time) is ma.masked_array
+                                    'set_time': set_time.isot
+                                    if isinstance(set_time, Time)
                                     else None,
                                 }
                             )
-                            # sort the planned observations by obstime
-                            planned_observations = sorted(
-                                planned_observations,
-                                key=lambda k: k['obstime'],
-                                reverse=False,
-                            )
+                        # sort the planned observations by obstime
+                        planned_observations = sorted(
+                            planned_observations,
+                            key=lambda k: k['obstime'],
+                            reverse=False,
+                        )
+
                         observation_plans.append(
                             {
                                 **observation_plan.to_dict(),

--- a/skyportal/utils/calculations.py
+++ b/skyportal/utils/calculations.py
@@ -1,6 +1,8 @@
-from astropy.coordinates import SkyCoord
-from astropy import units as u
+import astroplan
 import numpy as np
+from astropy import units as u
+from astropy.coordinates import SkyCoord
+from astropy.time import Time
 
 
 def radec_str2deg(_ra_str, _dec_str):
@@ -39,3 +41,139 @@ def great_circle_distance(ra1_deg, dec1_deg, ra2_deg, dec2_deg):
     )
 
     return distance * 180.0 / np.pi
+
+
+def get_observer(telescope: dict):
+    """Return an `astroplan.Observer` representing an observer at this
+    facility, accounting for the latitude, longitude, and elevation."""
+
+    return astroplan.Observer(
+        longitude=telescope['lon'] * u.deg,
+        latitude=telescope['lat'] * u.deg,
+        elevation=telescope['elevation'] * u.m,
+    )
+
+
+def get_target(fields: list[dict]):
+    """Return an `astroplan.FixedTarget` representing the target of this
+    observation."""
+    ra = np.array([field['ra'] for field in fields])
+    dec = np.array([field['dec'] for field in fields])
+    field_ids = np.array([field['field_id'] for field in fields])
+    return astroplan.FixedTarget(
+        SkyCoord(ra=ra * u.deg, dec=dec * u.deg), name=field_ids
+    )
+
+
+def get_altitude(
+    time: np.ndarray, target: astroplan.FixedTarget, observer: astroplan.Observer
+):
+    """Return the altitude of the object at a given time.
+
+    Parameters
+    ----------
+    time : `astropy.time.Time`
+        The time or times at which to calculate the altitude
+
+    Returns
+    -------
+    alt : `astropy.coordinates.AltAz`
+        The altitude of the Obj at the requested times
+    """
+    time = np.atleast_1d(time)
+    return observer.altaz(time, target, grid_times_targets=True).alt
+
+
+def get_airmass(fields: list, time: np.ndarray, below_horizon=np.inf, **kwargs):
+    """Return the airmass of the field at a given time. Uses the Pickering
+    (2002) interpolation of the Rayleigh (molecular atmosphere) airmass.
+
+    The Pickering interpolation tends toward 38.7494 as the altitude
+    approaches zero.
+
+    Parameters
+    ----------
+    fields : list of dict
+        The fields to calculate the airmass for. Each field is a dict
+        with keys 'ra','dec' and 'field_id'.
+    time : `astropy.time.Time` or list of astropy.time.Time`
+        The time or times at which to calculate the airmass
+    below_horizon : scalar, Numeric
+        Airmass value to assign when an object is below the horizon.
+        An object is "below the horizon" when its altitude is less than
+        zero degrees.
+    observer : `astroplan.Observer`
+        The observer for which to calculate the airmass. If not
+        provided, provide a telescope instead.
+    telescope: dict
+        The telescope for which to calculate the airmass. If not
+        provided, provide an observer instead.
+
+    Returns
+    -------
+    airmass : ndarray
+        The airmass of the Obj at the requested times
+    """
+
+    if 'observer' in kwargs:
+        observer = kwargs['observer']
+    elif 'telescope' in kwargs:
+        observer = observer(kwargs['telescope'])
+
+    # the output shape should be targets x times
+    output_shape = (len(fields), len(time))
+    time = np.atleast_1d(time)
+    target = get_target(fields)
+    altitude = get_altitude(time, target, observer).to('degree').value
+    above = altitude > 0
+
+    # use Pickering (2002) interpolation to calculate the airmass
+    # The Pickering interpolation tends toward 38.7494 as the altitude
+    # approaches zero.
+    sinarg = np.zeros_like(altitude)
+    airmass = np.ones_like(altitude) * np.inf
+    sinarg[above] = altitude[above] + 244 / (165 + 47 * altitude[above] ** 1.1)
+    airmass[above] = 1.0 / np.sin(np.deg2rad(sinarg[above]))
+
+    # set objects below the horizon to an airmass of infinity
+    airmass[~above] = below_horizon
+    airmass = airmass.reshape(output_shape)
+
+    return airmass
+
+
+def get_rise_set_time(fields, altitude=30 * u.degree, **kwargs):
+    """The set time of the field as an astropy.time.Time."""
+    if 'observer' in kwargs:
+        observer = kwargs['observer']
+    elif 'telescope' in kwargs:
+        observer = get_observer(kwargs['telescope'])
+
+    if 'time' in kwargs:
+        time = kwargs['time']
+    else:
+        time = Time.now()
+
+    sunrise = observer.sun_rise_time(time, which='next')
+    sunset = observer.sun_set_time(time, which='next')
+
+    targets = get_target(fields)
+
+    rise_time = observer.target_rise_time(
+        sunset, targets, which='next', horizon=altitude
+    )
+    set_time = observer.target_set_time(sunset, targets, which='next', horizon=altitude)
+
+    # if next rise time is after next sunrise, the target rises before
+    # sunset. show the previous rise so that the target is shown to be
+    # "already up" when the run begins (a beginning of night target).
+
+    recalc = rise_time > sunrise
+
+    if np.any(recalc):
+        # recalculate the rise time only for those targets that need it
+        rise_time[recalc] = observer.target_rise_time(
+            sunset, targets, which='previous', horizon=altitude
+        )[recalc]
+
+    return rise_time, set_time


### PR DESCRIPTION
This PR duplicates some of the methods found in telescopes, instruments, and observation_plans models, and refactors them to process multiple fields add once. That way, fetching the instrument fields that overlap with a skymap (where we calculate airmass), and fetching a single observation plan (where we calculate rise and set times) is **much** faster.

The speed up is more than x100 times, and even better than that for large maps and for plans with a lot of observations. It takes us from a few seconds to virtually nothing, removing some of the delay experienced when going to an event's page.

Latency aside, the goal here is to reduce the load put on the machine running the app.