### PR TITLE
TNS Watcher service: keep TNS prefix

### DIFF
--- a/services/tns_retrieval_queue/tns_retrieval_queue.py
+++ b/services/tns_retrieval_queue/tns_retrieval_queue.py
@@ -500,17 +500,25 @@ def tns_watcher():
                         if len(obj_query) > 0:
                             for obj in obj_query:
                                 try:
-                                    if obj.tns_name is None or obj.tns_name == "":
+                                    if obj.tns_name == str(tns_obj["name"]).strip():
+                                        continue
+                                    elif obj.tns_name is None or obj.tns_name == "":
                                         obj.tns_name = str(tns_obj["name"]).strip()
-                                        session.commit()
-                                        log(
-                                            f"Updated object {obj.id} with TNS name {tns_obj['name']}"
-                                        )
-                                        flow.push(
-                                            '*',
-                                            'skyportal/REFRESH_SOURCE',
-                                            payload={'obj_key': obj.internal_key},
-                                        )
+                                    # if the current name contains AT but the new name does not, update
+                                    elif "AT" in obj.tns_name and "AT" not in str(
+                                        tns_obj["name"]
+                                    ):
+                                        obj.tns_name = str(tns_obj["name"]).strip()
+
+                                    session.commit()
+                                    log(
+                                        f"Updated object {obj.id} with TNS name {tns_obj['name']}"
+                                    )
+                                    flow.push(
+                                        '*',
+                                        'skyportal/REFRESH_SOURCE',
+                                        payload={'obj_key': obj.internal_key},
+                                    )
                                 except Exception as e:
                                     log(f"Error updating object: {str(e)}")
                                     session.rollback()

--- a/skyportal/utils/tns.py
+++ b/skyportal/utils/tns.py
@@ -413,8 +413,8 @@ def get_objects_from_soup(soup):
             if not {"public", "odd"}.issubset(set(row.attrs.get('class', []))):
                 continue
             name = str(
-                row.find('td', attrs={'class': 'cell-name'}).find('a').get("href")
-            ).split('/')[-1]
+                row.find('td', attrs={'class': 'cell-name'}).find('a').contents[0]
+            )
             ra = row.find('td', attrs={'class': 'cell-ra'}).text
             dec = row.find('td', attrs={'class': 'cell-decl'}).text
             if name is None or ra is None or dec is None:

--- a/static/js/components/SourceDesktop.jsx
+++ b/static/js/components/SourceDesktop.jsx
@@ -548,7 +548,11 @@ const SourceDesktop = ({ source }) => {
                 <div key="tns_name">
                   <a
                     key={source.tns_name}
-                    href={`https://www.wis-tns.org/object/${source.tns_name}`}
+                    href={`https://www.wis-tns.org/object/${
+                      source.tns_name.trim().includes(" ")
+                        ? source.tns_name.split(" ")[1]
+                        : source.tns_name
+                    }`}
                     target="_blank"
                     rel="noopener noreferrer"
                   >

--- a/static/js/components/SourceMobile.jsx
+++ b/static/js/components/SourceMobile.jsx
@@ -534,7 +534,11 @@ const SourceMobile = WidthProvider(
                         <div key="tns_name">
                           <a
                             key={source.tns_name}
-                            href={`https://www.wis-tns.org/object/${source.tns_name}`}
+                            href={`https://www.wis-tns.org/object/${
+                              source.tns_name.trim().includes(" ")
+                                ? source.tns_name.split(" ")[1]
+                                : source.tns_name
+                            }`}
                             target="_blank"
                             rel="noopener noreferrer"
                           >


### PR DESCRIPTION
I was wondering why we had the TNS prefix on the TNS objects we create but not the existing objects. This is because the watcher service that takes care of that didn't get updated like the other service. 