### PR TITLE
TNSRobotHandler: change permission

### DIFF
--- a/skyportal/handlers/api/tns.py
+++ b/skyportal/handlers/api/tns.py
@@ -119,7 +119,7 @@ class TNSRobotHandler(BaseHandler):
             except Exception as e:
                 return self.error(f'Failed to retrieve TNS robots: {e}')
 
-    @permissions(['Manage tnsrobots'])
+    @permissions(['Manage groups'])
     def post(self):
         """
         ---
@@ -224,7 +224,7 @@ class TNSRobotHandler(BaseHandler):
             )
             return self.success(data={"id": tnsrobot.id})
 
-    @permissions(['Manage tnsrobots'])
+    @permissions(['Manage groups'])
     def put(self, tnsrobot_id):
         """
         ---
@@ -390,7 +390,7 @@ class TNSRobotHandler(BaseHandler):
                 raise e
                 return self.error(f'Failed to update TNS robot: {e}')
 
-    @permissions(['Manage tnsrobots'])
+    @permissions(['Manage groups'])
     def delete(self, tnsrobot_id):
         """
         ---


### PR DESCRIPTION
Set the required permission to `Manage groups`, given that robots are attached to groups it should be the same permission.