### PR TITLE
Centroid plot: add filter in tooltip

### DIFF
--- a/static/js/components/CentroidPlot.jsx
+++ b/static/js/components/CentroidPlot.jsx
@@ -198,6 +198,7 @@ const spec = (inputData, textColor, titleFontSize, labelFontSize) => ({
         },
         tooltip: [
           { field: "id", type: "quantitative" },
+          { field: "filter", type: "nominal" },
           { field: "delRA", type: "quantitative" },
           { field: "delDec", type: "quantitative" },
           { field: "ra", type: "quantitative", title: "RA" },


### PR DESCRIPTION
One problem with the centroid plot is the current color scheme, which makes it hard to figure out which points are in which filter and instrument. Fixing the color scheme is a problem of it's own (to fix here, and in Fritz with the addition of the Kowalski crossmatches), but I found that at least adding the filter in the tooltip allows one to know what they're looking at.