### PR TITLE
GCN Event page: avoid some repetitive API calls

### DIFF
--- a/static/js/components/AddCatalogQueryPage.jsx
+++ b/static/js/components/AddCatalogQueryPage.jsx
@@ -12,8 +12,9 @@ import CatalogQueryLists from "./CatalogQueryLists";
 import { fetchGcnEventCatalogQueries } from "../ducks/gcnEvent";
 
 const AddCatalogQueryPage = () => {
-  const [dialogOpen, setDialogOpen] = useState(false);
   const dispatch = useDispatch();
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [fetchingCatalogQueries, setFetchingCatalogQueries] = useState(false);
 
   const gcnEvent = useSelector((state) => state.gcnEvent);
 
@@ -26,8 +27,13 @@ const AddCatalogQueryPage = () => {
   };
 
   useEffect(() => {
-    if (gcnEvent?.id && !gcnEvent?.survey_efficiency) {
-      dispatch(fetchGcnEventCatalogQueries({ gcnID: gcnEvent?.id }));
+    if (gcnEvent?.id && !gcnEvent?.catalog_queries && !fetchingCatalogQueries) {
+      setFetchingCatalogQueries(true);
+      dispatch(fetchGcnEventCatalogQueries({ gcnID: gcnEvent?.id })).then(
+        () => {
+          setFetchingCatalogQueries(false);
+        }
+      );
     }
   }, [dispatch, gcnEvent]);
 

--- a/static/js/components/AddSurveyEfficiencyObservationsPage.jsx
+++ b/static/js/components/AddSurveyEfficiencyObservationsPage.jsx
@@ -11,8 +11,10 @@ import SurveyEfficiencyObservationsLists from "./SurveyEfficiencyObservationsLis
 import { fetchGcnEventSurveyEfficiency } from "../ducks/gcnEvent";
 
 const AddSurveyEfficiencyObservationsPage = () => {
-  const [dialogOpen, setDialogOpen] = useState(false);
   const dispatch = useDispatch();
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [fetchingSurveyEfficiency, setFetchingSurveyEfficiency] =
+    useState(false);
 
   const gcnEvent = useSelector((state) => state.gcnEvent);
 
@@ -25,8 +27,17 @@ const AddSurveyEfficiencyObservationsPage = () => {
   };
 
   useEffect(() => {
-    if (gcnEvent?.id && !gcnEvent?.survey_efficiency) {
-      dispatch(fetchGcnEventSurveyEfficiency({ gcnID: gcnEvent?.id }));
+    if (
+      gcnEvent?.id &&
+      !gcnEvent?.survey_efficiency &&
+      !fetchingSurveyEfficiency
+    ) {
+      setFetchingSurveyEfficiency(true);
+      dispatch(fetchGcnEventSurveyEfficiency({ gcnID: gcnEvent?.id })).then(
+        () => {
+          setFetchingSurveyEfficiency(false);
+        }
+      );
     }
   }, [dispatch, gcnEvent]);
 

--- a/static/js/components/NewDefaultObservationPlan.jsx
+++ b/static/js/components/NewDefaultObservationPlan.jsx
@@ -61,8 +61,8 @@ const NewDefaultObservationPlan = () => {
   const [selectedAllocationId, setSelectedAllocationId] = useState(null);
   const [selectedGroupIds, setSelectedGroupIds] = useState([]);
   const [
-    instrumentObsplanFormParamsFetched,
-    setInstrumentObsplanFormParamsFetched,
+    fetchingInstrumentObsplanFormParams,
+    setFetchingInstrumentObsplanFormParams,
   ] = useState(false);
 
   const { instrumentList, instrumentObsplanFormParams } = useSelector(
@@ -88,15 +88,12 @@ const NewDefaultObservationPlan = () => {
 
     if (
       Object.keys(instrumentObsplanFormParams).length === 0 &&
-      !instrumentObsplanFormParamsFetched
+      !fetchingInstrumentObsplanFormParams
     ) {
-      dispatch(instrumentsActions.fetchInstrumentObsplanForms()).then(
-        (response) => {
-          if (response.status === "success") {
-            setInstrumentObsplanFormParamsFetched(true);
-          }
-        }
-      );
+      setFetchingInstrumentObsplanFormParams(true);
+      dispatch(instrumentsActions.fetchInstrumentObsplanForms()).then(() => {
+        setFetchingInstrumentObsplanFormParams(false);
+      });
     }
 
     // Don't want to reset everytime the component rerenders and

--- a/static/js/components/ObservationPlanRequestForm.jsx
+++ b/static/js/components/ObservationPlanRequestForm.jsx
@@ -316,10 +316,6 @@ const ObservationPlanRequestForm = ({ dateobs }) => {
   const [skymapInstrument, setSkymapInstrument] = useState(null);
   const [selectedFields, setSelectedFields] = useState([]);
   const [multiPlansChecked, setMultiPlansChecked] = useState(false);
-  const [
-    instrumentObsplanFormParamsFetched,
-    setInstrumentObsplanFormParamsFetched,
-  ] = useState(false);
 
   const defaultAirmassTime = new Date(
     dayjs(gcnEvent?.dateobs).format("YYYY-MM-DDTHH:mm:ssZ")
@@ -330,6 +326,14 @@ const ObservationPlanRequestForm = ({ dateobs }) => {
     useState(defaultAirmassTime);
 
   const [fetchingLocalization, setFetchingLocalization] = useState(false);
+  const [
+    fetchingInstrumentObsplanFormParams,
+    setFetchingInstrumentObsplanFormParams,
+  ] = useState(false);
+  const [
+    fetchingAllocationListApiObsplan,
+    setFetchingAllocationListApiObsplan,
+  ] = useState(false);
 
   const { instrumentList, instrumentObsplanFormParams } = useSelector(
     (state) => state.instruments
@@ -423,7 +427,12 @@ const ObservationPlanRequestForm = ({ dateobs }) => {
       // the new default form fields, so that the allocations list can
       // update
 
-      if (!allocationListApiObsplan || allocationListApiObsplan?.length === 0) {
+      if (
+        !allocationListApiObsplan ||
+        (allocationListApiObsplan?.length === 0 &&
+          !fetchingAllocationListApiObsplan)
+      ) {
+        setFetchingAllocationListApiObsplan(true);
         dispatch(allocationActions.fetchAllocationsApiObsplan()).then(
           (response) => {
             if (response.status !== "success") {
@@ -438,6 +447,7 @@ const ObservationPlanRequestForm = ({ dateobs }) => {
             setSelectedAllocationId(data[0]?.id);
             setSelectedGroupIds([data[0]?.group_id]);
             setSelectedLocalizationId(gcnEvent.localizations[0]?.id);
+            setFetchingAllocationListApiObsplan(false);
           }
         );
       } else if (
@@ -458,15 +468,12 @@ const ObservationPlanRequestForm = ({ dateobs }) => {
 
     if (
       Object.keys(instrumentObsplanFormParams).length === 0 &&
-      !instrumentObsplanFormParamsFetched
+      !fetchingInstrumentObsplanFormParams
     ) {
-      dispatch(instrumentsActions.fetchInstrumentObsplanForms()).then(
-        (response) => {
-          if (response.status === "success") {
-            setInstrumentObsplanFormParamsFetched(true);
-          }
-        }
-      );
+      setFetchingInstrumentObsplanFormParams(true);
+      dispatch(instrumentsActions.fetchInstrumentObsplanForms()).then(() => {
+        setFetchingInstrumentObsplanFormParams(false);
+      });
     }
 
     // Don't want to reset everytime the component rerenders and


### PR DESCRIPTION
Avoid repeating some API calls. The tricky thing is that the useEffect is triggered on changes on the event (for good reason), but the fetch methods called in the useEffect modify the event, retriggering it.

To prevent that, we just add some `fetching...` state variables, to prevent starting an API call while one is already running. 