### PR TITLE
Github actions: pin postgres version

### DIFF
--- a/.github/workflows/build-and-deploy-docs.yaml
+++ b/.github/workflows/build-and-deploy-docs.yaml
@@ -15,7 +15,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres
+        image: postgres:14.9
         env:
           POSTGRES_USER: skyportal
           POSTGRES_PASSWORD: anything

--- a/.github/workflows/test_api_and_frontend.yaml
+++ b/.github/workflows/test_api_and_frontend.yaml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 120
     services:
       postgres:
-        image: postgres
+        image: postgres:14.9
         env:
           POSTGRES_USER: skyportal
           POSTGRES_PASSWORD: anything

--- a/.github/workflows/test_migrations.yaml
+++ b/.github/workflows/test_migrations.yaml
@@ -33,7 +33,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres
+        image: postgres:14.9
         env:
           POSTGRES_USER: skyportal
           POSTGRES_PASSWORD: anything

--- a/.github/workflows/test_models.yaml
+++ b/.github/workflows/test_models.yaml
@@ -13,7 +13,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres
+        image: postgres:14.9
         env:
           POSTGRES_USER: skyportal
           POSTGRES_PASSWORD: anything


### PR DESCRIPTION
We haven't pinned a specific dockerhub image for postgres. It looks like the latest one (version 16.0) creates some issues.

This is an attempt to pin the latest available image for version 14 (the one we support), to see if that helps.

Of course we can consider fixing it for version 16, but we need to get the Github actions to work again first.