### PR TITLE
Gcn summary: bugfix attempt

### DIFF
--- a/skyportal/handlers/api/gcn.py
+++ b/skyportal/handlers/api/gcn.py
@@ -2277,7 +2277,7 @@ def add_gcn_summary(
             if len(user_ids) > 0:
                 users = []
                 for mentioned_user_id in user_ids:
-                    mentioned_user = User.query.get(mentioned_user_id)
+                    mentioned_user = session.query(User).get(mentioned_user_id)
                     if mentioned_user is not None:
                         users.append(mentioned_user)
 


### PR DESCRIPTION
Some summaries fail in prod, and I believe it might be because of that line. The error has to do with 'SSL connection closed', so maybe using the session we just created rather than the old sqlalchemy syntax might fix it.