### PR TITLE
Legacy get_sources method: fix default sort order

### DIFF
--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -2766,6 +2766,9 @@ class SourceHandler(BaseHandler):
             get_sources_experimental if use_experimental else get_sources
         )
 
+        if not use_experimental and sort_by is None:
+            sort_order = "asc"
+
         if obj_id is not None:
             with self.Session() as session:
                 try:


### PR DESCRIPTION
fix the default sort order when no sort by is specified.