### PR TITLE
Sources: don't save if already saved to group_ids, avoid duplicate comments

### DIFF
--- a/skyportal/handlers/api/catalog_services.py
+++ b/skyportal/handlers/api/catalog_services.py
@@ -230,7 +230,7 @@ def fetch_transients(allocation_id, user_id, group_ids, payload):
                 if s is None:
                     log(f"Posting {source['id']} as source")
                     source['group_ids'] = group_ids
-                    obj_id = post_source(source, user_id, session)
+                    (obj_id,) = post_source(source, user_id, session)
                     obj_ids.append(obj_id)
 
                 if alert_available:
@@ -280,7 +280,7 @@ def fetch_transients(allocation_id, user_id, group_ids, payload):
                 ).first()
                 if s is None:
                     source['group_ids'] = group_ids
-                    obj_id = post_source(source, user_id, session)
+                    (obj_id,) = post_source(source, user_id, session)
                     obj_ids.append(obj_id)
 
                 if len(df.index) > 0:
@@ -491,7 +491,7 @@ def fetch_swift_transients(instrument_id, user_id, group_ids):
                 s = session.scalars(Obj.select(user).where(Obj.id == obj_name)).first()
                 if s is None:
                     data['group_ids'] = group_ids
-                    obj_id = post_source(data, user_id, session)
+                    (obj_id,) = post_source(data, user_id, session)
                     obj_ids.append(obj_id)
                 else:
                     obj_id = s.id
@@ -740,7 +740,7 @@ def fetch_gaia_transients(instrument_id, user_id, group_ids, payload):
             s = session.scalars(Obj.select(user).where(Obj.id == name)).first()
             if s is None:
                 data['group_ids'] = group_ids
-                obj_id = post_source(data, user_id, session)
+                (obj_id,) = post_source(data, user_id, session)
                 obj_ids.append(obj_id)
             else:
                 obj_id = s.id
@@ -960,7 +960,7 @@ def fetch_tess_transients(instrument_id, user_id, group_ids, payload):
             s = session.scalars(Obj.select(user).where(Obj.id == name)).first()
             if s is None:
                 data['group_ids'] = group_ids
-                obj_id = post_source(data, user_id, session)
+                (obj_id,) = post_source(data, user_id, session)
                 obj_ids.append(obj_id)
             else:
                 obj_id = s.id

--- a/skyportal/handlers/api/comment.py
+++ b/skyportal/handlers/api/comment.py
@@ -438,17 +438,32 @@ class CommentHandler(BaseHandler):
                         f'Cannot find one or more groups with IDs: {group_ids}.'
                     )
 
+                existing = None
                 if associated_resource_type.lower() == "sources":
                     obj_id = resource_id
-                    comment = Comment(
-                        text=comment_text,
-                        obj_id=obj_id,
-                        attachment_bytes=attachment_bytes,
-                        attachment_name=attachment_name,
-                        author=author,
-                        groups=groups,
-                        bot=is_bot_request,
-                    )
+                    existing = session.scalars(
+                        Comment.select(self.current_user).where(
+                            Comment.text == comment_text,
+                            Comment.obj_id == obj_id,
+                            Comment.attachment_bytes == attachment_bytes,
+                            Comment.attachment_name == attachment_name,
+                            Comment.author_id == author.id,
+                            Comment.bot == is_bot_request,
+                        )
+                    ).first()
+                    if existing is not None:
+                        if {g.id for g in existing.groups} != set(group_ids):
+                            existing = None
+                    if existing is None:
+                        comment = Comment(
+                            text=comment_text,
+                            obj_id=obj_id,
+                            attachment_bytes=attachment_bytes,
+                            attachment_name=attachment_name,
+                            author=author,
+                            groups=groups,
+                            bot=is_bot_request,
+                        )
                 elif associated_resource_type.lower() == "spectra":
                     spectrum_id = resource_id
                     spectrum = session.scalars(
@@ -460,16 +475,30 @@ class CommentHandler(BaseHandler):
                         return self.error(
                             f'Could not find any accessible spectra with ID {spectrum_id}.'
                         )
-                    comment = CommentOnSpectrum(
-                        text=comment_text,
-                        spectrum_id=spectrum_id,
-                        attachment_bytes=attachment_bytes,
-                        attachment_name=attachment_name,
-                        author=author,
-                        groups=groups,
-                        bot=is_bot_request,
-                        obj_id=spectrum.obj_id,
-                    )
+                    existing = session.scalars(
+                        CommentOnSpectrum.select(self.current_user).where(
+                            CommentOnSpectrum.text == comment_text,
+                            CommentOnSpectrum.spectrum_id == spectrum_id,
+                            CommentOnSpectrum.attachment_bytes == attachment_bytes,
+                            CommentOnSpectrum.attachment_name == attachment_name,
+                            CommentOnSpectrum.author_id == author.id,
+                            CommentOnSpectrum.bot == is_bot_request,
+                        )
+                    ).first()
+                    if existing is not None:
+                        if {g.id for g in existing.groups} != set(group_ids):
+                            existing = None
+                    if existing is None:
+                        comment = CommentOnSpectrum(
+                            text=comment_text,
+                            spectrum_id=spectrum_id,
+                            attachment_bytes=attachment_bytes,
+                            attachment_name=attachment_name,
+                            author=author,
+                            groups=groups,
+                            bot=is_bot_request,
+                            obj_id=spectrum.obj_id,
+                        )
 
                 elif associated_resource_type.lower() == "gcn_event":
                     gcnevent_id = resource_id
@@ -482,15 +511,29 @@ class CommentHandler(BaseHandler):
                         return self.error(
                             f'Could not find any accessible gcn events with ID {gcnevent_id}.'
                         )
-                    comment = CommentOnGCN(
-                        text=comment_text,
-                        gcn_id=gcn_event.id,
-                        attachment_bytes=attachment_bytes,
-                        attachment_name=attachment_name,
-                        author=author,
-                        groups=groups,
-                        bot=is_bot_request,
-                    )
+                    existing = session.scalars(
+                        CommentOnGCN.select(self.current_user).where(
+                            CommentOnGCN.text == comment_text,
+                            CommentOnGCN.gcn_id == gcnevent_id,
+                            CommentOnGCN.attachment_bytes == attachment_bytes,
+                            CommentOnGCN.attachment_name == attachment_name,
+                            CommentOnGCN.author_id == author.id,
+                            CommentOnGCN.bot == is_bot_request,
+                        )
+                    ).first()
+                    if existing is not None:
+                        if {g.id for g in existing.groups} != set(group_ids):
+                            existing = None
+                    if existing is None:
+                        comment = CommentOnGCN(
+                            text=comment_text,
+                            gcn_id=gcn_event.id,
+                            attachment_bytes=attachment_bytes,
+                            attachment_name=attachment_name,
+                            author=author,
+                            groups=groups,
+                            bot=is_bot_request,
+                        )
                 elif associated_resource_type.lower() == "earthquake":
                     earthquake_id = resource_id
                     earthquake = session.scalars(
@@ -502,15 +545,29 @@ class CommentHandler(BaseHandler):
                         return self.error(
                             f'Could not find any accessible earthquakes with ID {earthquake_id}.'
                         )
-                    comment = CommentOnEarthquake(
-                        text=comment_text,
-                        earthquake_id=earthquake.id,
-                        attachment_bytes=attachment_bytes,
-                        attachment_name=attachment_name,
-                        author=author,
-                        groups=groups,
-                        bot=is_bot_request,
-                    )
+                    existing = session.scalars(
+                        CommentOnEarthquake.select(self.current_user).where(
+                            CommentOnEarthquake.text == comment_text,
+                            CommentOnEarthquake.earthquake_id == earthquake_id,
+                            CommentOnEarthquake.attachment_bytes == attachment_bytes,
+                            CommentOnEarthquake.attachment_name == attachment_name,
+                            CommentOnEarthquake.author_id == author.id,
+                            CommentOnEarthquake.bot == is_bot_request,
+                        )
+                    ).first()
+                    if existing is not None:
+                        if {g.id for g in existing.groups} != set(group_ids):
+                            existing = None
+                    if existing is None:
+                        comment = CommentOnEarthquake(
+                            text=comment_text,
+                            earthquake_id=earthquake.id,
+                            attachment_bytes=attachment_bytes,
+                            attachment_name=attachment_name,
+                            author=author,
+                            groups=groups,
+                            bot=is_bot_request,
+                        )
                 elif associated_resource_type.lower() == "shift":
                     shift_id = resource_id
                     shift = session.scalars(
@@ -520,18 +577,40 @@ class CommentHandler(BaseHandler):
                         return self.error(
                             f'Could not access Shift {shift.id}.', status=403
                         )
-                    comment = CommentOnShift(
-                        text=comment_text,
-                        shift_id=shift.id,
-                        attachment_bytes=attachment_bytes,
-                        attachment_name=attachment_name,
-                        author=author,
-                        groups=groups,
-                        bot=is_bot_request,
-                    )
+                    existing = session.scalars(
+                        CommentOnShift.select(self.current_user).where(
+                            CommentOnShift.text == comment_text,
+                            CommentOnShift.shift_id == shift_id,
+                            CommentOnShift.attachment_bytes == attachment_bytes,
+                            CommentOnShift.attachment_name == attachment_name,
+                            CommentOnShift.author_id == author.id,
+                            CommentOnShift.bot == is_bot_request,
+                        )
+                    ).first()
+                    if existing is not None:
+                        if {g.id for g in existing.groups} != set(group_ids):
+                            existing = None
+                    if existing is None:
+                        comment = CommentOnShift(
+                            text=comment_text,
+                            shift_id=shift.id,
+                            attachment_bytes=attachment_bytes,
+                            attachment_name=attachment_name,
+                            author=author,
+                            groups=groups,
+                            bot=is_bot_request,
+                        )
                 else:
                     return self.error(
                         f'Unknown resource type "{associated_resource_type}".'
+                    )
+
+                if existing is not None:
+                    return self.success(
+                        data={
+                            'comment_id': existing.id,
+                            "message": "Same comment already exists.",
+                        }
                     )
 
                 users_mentioned_in_comment = users_mentioned(comment_text, session)

--- a/skyportal/handlers/api/followup_request.py
+++ b/skyportal/handlers/api/followup_request.py
@@ -381,7 +381,6 @@ def post_followup_request(data, constraints, session, refresh_source=True):
     """
 
     if isinstance(constraints, dict):
-        print(f"constraints: {constraints}")
         if len(constraints.get('source_group_ids', [])) > 0:
             # verify that there is a source for each of the group IDs
             existing_sources = session.scalars(
@@ -391,7 +390,6 @@ def post_followup_request(data, constraints, session, refresh_source=True):
                     Source.active.is_(True),
                 )
             ).all()
-            print(f"existing_sources: {existing_sources}")
             if len(existing_sources) != len(constraints['source_group_ids']):
                 raise ValueError(
                     'There is no source for one or more of the source_group_ids specified as a constraint, not submitting request.'

--- a/skyportal/handlers/api/observation_plan.py
+++ b/skyportal/handlers/api/observation_plan.py
@@ -2416,7 +2416,7 @@ class ObservationPlanCreateObservingRunHandler(BaseHandler):
                 else:
                     source['group_ids'] = [allocation.group_id]
 
-                obj_id = post_source(source, self.associated_user_object.id, session)
+                (obj_id,) = post_source(source, self.associated_user_object.id, session)
                 if np.max(priorities) - np.min(priorities) == 0.0:
                     # assign equal weights if all the same
                     normalized_priority = 0.5

--- a/skyportal/models/followup_request.py
+++ b/skyportal/models/followup_request.py
@@ -348,6 +348,6 @@ def add_followup(mapper, connection, target):
                     'allocation_id': allocation_id,
                     'obj_id': obj_id,
                 }
-                post_followup_request(data, session, refresh_source=False)
+                post_followup_request(data, {}, session, refresh_source=False)
             except Exception as e:
                 log(f"Error posting followup request: {e}")

--- a/skyportal/models/schema.py
+++ b/skyportal/models/schema.py
@@ -1217,7 +1217,17 @@ class FollowupRequestPost(_Schema):
         required=False,
         metadata={
             'description': (
-                'IDs of groups to share the results of the f' 'ollowup request with.'
+                'IDs of groups to share the results of the followup request with.'
+            )
+        },
+    )
+
+    source_group_ids = fields.List(
+        fields.Integer,
+        required=False,
+        metadata={
+            'description': (
+                'IDs of groups to which there must be a source for the object associated with the followup request.'
             )
         },
     )


### PR DESCRIPTION
This PR adds 3 features:
- (1) When using the POST endpoint to save a source to group(s), cancel saving to some group(s) if they've already been saved as sources to some defined groups. Here's an example: you want to save an obj as a source to group A, but only if it's not already saved to group B. So you pass an extra argument called `ignore_if_in_group_ids` equal to `{group_A_id: [group_B_id]}`.
- (2) When triggering a follow-up request on an object, pass a list of group IDs to which the object needs to be saved as a source already. Example: you want to trigger a follow-up with allocation A, but only if the obj is saved as a source to group A, so you pass `source-group_ids` as an argument, which value will be `[group_A_id]`.
- (3) When posting a comment with the same author, text, attachments, and groups as an existing comment, return 200 with the existing comment id and a message like "comments already exists", without creating a new - duplicated - comment. 

The idea being that kowalski's autosave feature can use (1) to not autosave to group X if a source has for example been saved in Group X junk. And for (2), this will be useful once we have the auto_followup feature running in Kowalski, to prevent triggering followup requests if the candidate hasn't been saved as a source to the group associated to the filter, maybe because of (1). For both autosave and auto followup, we also want to (optionally) post associated comments on the source.