### PR TITLE
More follow-up constraints 

### DIFF
--- a/skyportal/handlers/api/followup_request.py
+++ b/skyportal/handlers/api/followup_request.py
@@ -743,6 +743,13 @@ class FollowupRequestHandler(BaseHandler):
 
                 return self.success(data={"id": followup_request_id})
             except Exception as e:
+                if (
+                    'not submitting request' in str(e)
+                    and len(list(constraints.keys())) > 0
+                ):
+                    return self.success(
+                        data={"id": None, "ignored": True, "message": str(e)}
+                    )
                 return self.error(
                     f'Error submitting follow-up request: {e.normalized_messages() if hasattr(e, "normalized_messages") else str(e)}'
                 )

--- a/skyportal/models/schema.py
+++ b/skyportal/models/schema.py
@@ -1232,6 +1232,24 @@ class FollowupRequestPost(_Schema):
         },
     )
 
+    not_if_classified = fields.Boolean(
+        required=False,
+        metadata={
+            'description': (
+                'If true, the followup request will not be executed if the object is already classified.'
+            )
+        },
+    )
+
+    not_if_spectra_exist = fields.Boolean(
+        required=False,
+        metadata={
+            'description': (
+                'If true, the followup request will not be executed if the object already has spectra.'
+            )
+        },
+    )
+
 
 class ObservationPlanPost(_Schema):
 


### PR DESCRIPTION
add more followup constraints (which if met, cancel triggering):
- not_if_classified
- not_if_spectra_exists
This will be used by the auto-followup feature of Kowalski, to avoid triggering if a source is already classified or already has spectra data.

Also, if constraints are met and we don't trigger, still send a 200 instead of an error (as this cancelation has been requested by the user), along with an ignored flag set to true, and a message containing the reason why it wasn't triggered (which constraint was met).