### PR TITLE
GroupUser without stream access: better error message

### DIFF
--- a/skyportal/handlers/api/group.py
+++ b/skyportal/handlers/api/group.py
@@ -494,7 +494,7 @@ class GroupUserHandler(BaseHandler):
             for stream in group.streams:
                 if stream.id not in user_streams:
                     return self.error(
-                        f'User with ID {user_id} does not have stream access with ID {stream.id}',
+                        f'User with ID {user_id} ({user.username}) does not have stream access with ID {stream.id} ({stream.name}). Please contact a super-admin to grant access.',
                         status=403,
                     )
 


### PR DESCRIPTION
Igor wasn't able to add another user to his group, because the user did not have access to one of your group's stream(s).

Stream access control is limited to super admin (for a good reason), so this is something that a user needs to contact a super admin to take care of it. 
The current error message isn't that clear and isn't very helpful in understanding what to do.

This should help.