### PR TITLE
FollowupRequestHandler: return target groups

### DIFF
--- a/skyportal/handlers/api/followup_request.py
+++ b/skyportal/handlers/api/followup_request.py
@@ -624,6 +624,7 @@ class FollowupRequestHandler(BaseHandler):
                     joinedload(FollowupRequest.watchers),
                     joinedload(FollowupRequest.transaction_requests),
                     joinedload(FollowupRequest.transactions),
+                    joinedload(FollowupRequest.target_groups),
                 )
                 followup_request = session.scalars(followup_requests).first()
                 if followup_request is None:
@@ -673,6 +674,7 @@ class FollowupRequestHandler(BaseHandler):
                 joinedload(FollowupRequest.obj),
                 joinedload(FollowupRequest.requester),
                 joinedload(FollowupRequest.watchers),
+                joinedload(FollowupRequest.target_groups),
             )
 
             count_stmt = sa.select(func.count()).select_from(followup_requests)


### PR DESCRIPTION
add missing target group ids in the response when fetching follow-up request(s), which is useful information in general, but especially when you want to update the request, so you have the list and you do not risk to change it without knowing when using the PUT handler.