### PR TITLE
Follow-up requests GET: more filtering options

### DIFF
--- a/static/js/components/FollowupRequestLists.jsx
+++ b/static/js/components/FollowupRequestLists.jsx
@@ -152,9 +152,10 @@ const FollowupRequestLists = ({
   };
 
   if (
-    instrumentList.length === 0 ||
-    followupRequests.length === 0 ||
-    Object.keys(instrumentFormParams).length === 0
+    (instrumentList.length === 0 ||
+      followupRequests.length === 0 ||
+      Object.keys(instrumentFormParams).length === 0) &&
+    !serverSide
   ) {
     return <p>No robotic followup requests found...</p>;
   }
@@ -175,10 +176,6 @@ const FollowupRequestLists = ({
     ];
     return r;
   }, {});
-
-  Object.values(requestsGroupedByInstId).forEach((value) => {
-    value.sort((a, b) => (a.created_at > b.created_at ? 1 : -1));
-  });
 
   const getDataTableColumns = (keys, instrument_id) => {
     const columns = [
@@ -366,6 +363,10 @@ const FollowupRequestLists = ({
         customBodyRenderLite: renderWatcher,
       },
     });
+
+    if (serverSide) {
+      columns.push({ name: "created_at", label: "Created at" });
+    }
 
     return columns;
   };

--- a/static/js/components/FollowupRequestPage.jsx
+++ b/static/js/components/FollowupRequestPage.jsx
@@ -206,7 +206,10 @@ const FollowupRequestPage = () => {
     currentUser.permissions?.includes("System admin") ||
     currentUser.permissions?.includes("Manage allocations");
 
-  const defaultStartDate = dayjs().utc().format("YYYY-MM-DDTHH:mm:ssZ");
+  const defaultStartDate = dayjs()
+    .subtract(1, "day")
+    .utc()
+    .format("YYYY-MM-DDTHH:mm:ssZ");
   const defaultEndDate = dayjs()
     .add(1, "day")
     .utc()
@@ -215,8 +218,10 @@ const FollowupRequestPage = () => {
   const [fetchParams, setFetchParams] = useState({
     pageNumber: 1,
     numPerPage: defaultNumPerPage,
-    observationStartDate: defaultStartDate,
-    observationEndDate: defaultEndDate,
+    startDate: defaultStartDate,
+    endDate: defaultEndDate,
+    sortBy: "created_at",
+    sortOrder: "desc",
   });
 
   useEffect(() => {
@@ -272,7 +277,7 @@ const FollowupRequestPage = () => {
 
   return (
     <Grid container spacing={3}>
-      <Grid item md={6} sm={12}>
+      <Grid item md={8} sm={12}>
         <Paper elevation={1}>
           <div className={classes.paperContent}>
             <Typography variant="h6">List of Followup Requests</Typography>
@@ -311,7 +316,7 @@ const FollowupRequestPage = () => {
       </Grid>
       <br />
       <br />
-      <Grid item md={6} sm={12}>
+      <Grid item md={4} sm={12}>
         <Paper>
           <div className={classes.paperContent}>
             <Typography variant="h6">Filter Followup Requests</Typography>


### PR DESCRIPTION
This PR:
- fixes the filtering by start_date and end_date of the requests, and makes it optional by default
- adds filtering by allocation
- adds filtering by requester
- display the created_at date of each request on the followup requests page
- adds sorting on created_at, modified, and obj_id
- sort by created_at desc (newer first) by default on the followup requests page