### PR TITLE
Hydration from existing tabs - allow partial hydration

### DIFF
--- a/static/js/actions.js
+++ b/static/js/actions.js
@@ -55,47 +55,166 @@ import * as groupActions from "./ducks/group";
 import * as instrumentActions from "./ducks/instrument";
 /* eslint-enable no-unused-vars */
 
-export default function hydrate(dashboardOnly = false) {
+// this is used to keep track of what has been hydrated yet or not
+import * as hydrationActions from "./ducks/hydration";
+
+export default function hydrate(
+  dashboardOnly = false,
+  ducks_to_hydrate = hydrationActions.DUCKS_TO_HYDRATE
+) {
   return (dispatch) => {
     if (!dashboardOnly) {
       // initial data
-      dispatch(sysInfoActions.fetchSystemInfo());
-      dispatch(dbInfoActions.fetchDBInfo());
-      dispatch(configActions.fetchConfig());
-      dispatch(profileActions.fetchUserProfile());
-      dispatch(groupsActions.fetchGroups(true));
-      dispatch(usersActions.fetchUsers());
+      if (ducks_to_hydrate.includes("sysInfo")) {
+        dispatch(sysInfoActions.fetchSystemInfo()).then(() => {
+          dispatch(hydrationActions.finishedHydrating("sysInfo"));
+        });
+      }
+      if (ducks_to_hydrate.includes("dbInfo")) {
+        dispatch(dbInfoActions.fetchDBInfo()).then(() => {
+          dispatch(hydrationActions.finishedHydrating("dbInfo"));
+        });
+      }
+      if (ducks_to_hydrate.includes("config")) {
+        dispatch(configActions.fetchConfig()).then(() => {
+          dispatch(hydrationActions.finishedHydrating("config"));
+        });
+      }
+      if (ducks_to_hydrate.includes("profile")) {
+        dispatch(profileActions.fetchUserProfile()).then(() => {
+          dispatch(hydrationActions.finishedHydrating("profile"));
+        });
+      }
+      if (ducks_to_hydrate.includes("groups")) {
+        dispatch(groupsActions.fetchGroups(true)).then(() => {
+          dispatch(hydrationActions.finishedHydrating("groups"));
+        });
+      }
+      if (ducks_to_hydrate.includes("users")) {
+        dispatch(usersActions.fetchUsers()).then(() => {
+          dispatch(hydrationActions.finishedHydrating("users"));
+        });
+      }
     }
-    // dashboard data
+    // dashboard data, always refreshed
     dispatch(newsFeedActions.fetchNewsFeed());
     dispatch(topSourcesActions.fetchTopSources());
     dispatch(recentSourcesActions.fetchRecentSources());
     dispatch(sourceCountsActions.fetchSourceCounts());
     dispatch(recentGcnEventsActions.fetchRecentGcnEvents());
-
     if (!dashboardOnly) {
       // other data
-      dispatch(streamsActions.fetchStreams());
-      dispatch(enumTypesActions.fetchEnumTypes());
-      dispatch(instrumentsActions.fetchInstruments());
-      dispatch(allocationsActions.fetchAllocations());
-      dispatch(telescopesActions.fetchTelescopes());
-      dispatch(taxonomyActions.fetchTaxonomies());
-      dispatch(instrumentsActions.fetchInstrumentForms());
-      dispatch(favoritesActions.fetchFavorites());
-      dispatch(tnsrobotsActions.fetchTNSRobots());
-      dispatch(rejectedActions.fetchRejected());
-      dispatch(observingRunsActions.fetchObservingRuns());
-      dispatch(allocationsActions.fetchAllocationsApiClassname());
-      dispatch(observationPlansActions.fetchObservationPlanNames());
-      dispatch(analysisServicesActions.fetchAnalysisServices());
-      dispatch(defaultFollowupRequestsActions.fetchDefaultFollowupRequests());
-      dispatch(defaultObservationPlansActions.fetchDefaultObservationPlans());
-      dispatch(
-        defaultSurveyEfficienciesActions.fetchDefaultSurveyEfficiencies()
-      );
-      dispatch(earthquakeActions.fetchEarthquakes());
-      dispatch(mmadetectorActions.fetchMMADetectors());
+      if (ducks_to_hydrate.includes("streams")) {
+        dispatch(streamsActions.fetchStreams()).then(() => {
+          dispatch(hydrationActions.finishedHydrating("streams"));
+        });
+      }
+      if (ducks_to_hydrate.includes("enumTypes")) {
+        dispatch(enumTypesActions.fetchEnumTypes()).then(() => {
+          dispatch(hydrationActions.finishedHydrating("enumTypes"));
+        });
+      }
+      if (ducks_to_hydrate.includes("instruments")) {
+        dispatch(instrumentsActions.fetchInstruments()).then(() => {
+          dispatch(hydrationActions.finishedHydrating("instruments"));
+        });
+      }
+      if (ducks_to_hydrate.includes("allocations")) {
+        dispatch(allocationsActions.fetchAllocations()).then(() => {
+          dispatch(hydrationActions.finishedHydrating("allocations"));
+        });
+      }
+      if (ducks_to_hydrate.includes("telescopes")) {
+        dispatch(telescopesActions.fetchTelescopes()).then(() => {
+          dispatch(hydrationActions.finishedHydrating("telescopes"));
+        });
+      }
+      if (ducks_to_hydrate.includes("taxonomy")) {
+        dispatch(taxonomyActions.fetchTaxonomies()).then(() => {
+          dispatch(hydrationActions.finishedHydrating("taxonomy"));
+        });
+      }
+      if (ducks_to_hydrate.includes("instrumentForms")) {
+        dispatch(instrumentsActions.fetchInstrumentForms()).then(() => {
+          dispatch(hydrationActions.finishedHydrating("instrumentForms"));
+        });
+      }
+      if (ducks_to_hydrate.includes("favorites")) {
+        dispatch(favoritesActions.fetchFavorites()).then(() => {
+          dispatch(hydrationActions.finishedHydrating("favorites"));
+        });
+      }
+      if (ducks_to_hydrate.includes("tnsrobots")) {
+        dispatch(tnsrobotsActions.fetchTNSRobots()).then(() => {
+          dispatch(hydrationActions.finishedHydrating("tnsrobots"));
+        });
+      }
+      if (ducks_to_hydrate.includes("rejected")) {
+        dispatch(rejectedActions.fetchRejected()).then(() => {
+          dispatch(hydrationActions.finishedHydrating("rejected"));
+        });
+      }
+      if (ducks_to_hydrate.includes("observingRuns")) {
+        dispatch(observingRunsActions.fetchObservingRuns()).then(() => {
+          dispatch(hydrationActions.finishedHydrating("observingRuns"));
+        });
+      }
+      if (ducks_to_hydrate.includes("allocationsApiClassname")) {
+        dispatch(allocationsActions.fetchAllocationsApiClassname()).then(() => {
+          dispatch(
+            hydrationActions.finishedHydrating("allocationsApiClassname")
+          );
+        });
+      }
+      if (ducks_to_hydrate.includes("observationPlans")) {
+        dispatch(observationPlansActions.fetchObservationPlanNames()).then(
+          () => {
+            dispatch(hydrationActions.finishedHydrating("observationPlans"));
+          }
+        );
+      }
+      if (ducks_to_hydrate.includes("analysisServices")) {
+        dispatch(analysisServicesActions.fetchAnalysisServices()).then(() => {
+          dispatch(hydrationActions.finishedHydrating("analysisServices"));
+        });
+      }
+      if (ducks_to_hydrate.includes("defaultFollowupRequests")) {
+        dispatch(
+          defaultFollowupRequestsActions.fetchDefaultFollowupRequests()
+        ).then(() => {
+          dispatch(
+            hydrationActions.finishedHydrating("defaultFollowupRequests")
+          );
+        });
+      }
+      if (ducks_to_hydrate.includes("defaultObservationPlans")) {
+        dispatch(
+          defaultObservationPlansActions.fetchDefaultObservationPlans()
+        ).then(() => {
+          dispatch(
+            hydrationActions.finishedHydrating("defaultObservationPlans")
+          );
+        });
+      }
+      if (ducks_to_hydrate.includes("defaultSurveyEfficiencies")) {
+        dispatch(
+          defaultSurveyEfficienciesActions.fetchDefaultSurveyEfficiencies()
+        ).then(() => {
+          dispatch(
+            hydrationActions.finishedHydrating("defaultSurveyEfficiencies")
+          );
+        });
+      }
+      if (ducks_to_hydrate.includes("earthquake")) {
+        dispatch(earthquakeActions.fetchEarthquakes()).then(() => {
+          dispatch(hydrationActions.finishedHydrating("earthquake"));
+        });
+      }
+      if (ducks_to_hydrate.includes("mmadetector")) {
+        dispatch(mmadetectorActions.fetchMMADetectors()).then(() => {
+          dispatch(hydrationActions.finishedHydrating("mmadetector"));
+        });
+      }
     }
   };
 }

--- a/static/js/components/Main.jsx.template
+++ b/static/js/components/Main.jsx.template
@@ -34,6 +34,7 @@ import store from "../store";
 // Actions
 import hydrate from "../actions";
 import * as rotateLogoActions from "../ducks/logo";
+import * as hydrationActions from "../ducks/hydration";
 
 import NoMatchingRoute from "./NoMatchingRoute";
 
@@ -95,13 +96,22 @@ const MainContentInternal = ({ root }) => {
   useEffect(() => {
     store.dispatch(rotateLogoActions.rotateLogo());
     setTimeout(() => {
-      const sysInfo = store.getState().sysInfo;
-      if (!sysInfo.version) {
-        store.dispatch(hydrate());
-        store.dispatch(rotateLogoActions.rotateLogo());
-      } else {
+      store.dispatch(hydrationActions.verifyHydration());
+    }, 1400);
+    setTimeout(() => {
+      const {hydratedList, hydrated} = store.getState().hydration;
+      if (hydrated === true) {
+        // fully hydrated, do nothing except dashboard refresh
         store.dispatch(hydrate(true));
+      } else if (hydratedList?.length > 0) {
+        // not fully hydrated, hydrate only missing
+        const missing = Array.from([...hydrationActions.DUCKS_TO_HYDRATE].filter(x => !hydratedList.includes(x)));
+        store.dispatch(hydrate(false, missing));
+      } else {
+        // not hydrated at all, hydrate everything
+        store.dispatch(hydrate());
       }
+      store.dispatch(rotateLogoActions.rotateLogo());
     }, 1500);
   }, []);
 

--- a/static/js/ducks/hydration.js
+++ b/static/js/ducks/hydration.js
@@ -1,0 +1,70 @@
+import store from "../store";
+
+const FINISHED_HYDRATING = "skyportal/FINISHED_HYDRATING";
+const VERIFY_HYDRATION = "skyportal/VERIFY_HYDRATION";
+
+export const DUCKS_TO_HYDRATE = [
+  "groups",
+  "profile",
+  "dbInfo",
+  "sysInfo",
+  "config",
+  "users",
+  "taxonomy",
+  "enumTypes",
+  "streams",
+  "allocations",
+  "tnsrobots",
+  "instrumentForms",
+  "observingRuns",
+  "analysisServices",
+  "instruments",
+  "earthquake",
+  "allocationsApiClassname",
+  "defaultFollowupRequests",
+  "defaultObservationPlans",
+  "mmadetector",
+  "defaultSurveyEfficiencies",
+  "telescopes",
+  "favorites",
+  "rejected",
+  "observationPlans",
+];
+
+export const NUMBER_OF_DUCKS_TO_HYDRATE = DUCKS_TO_HYDRATE.length;
+
+// eslint-disable-next-line import/prefer-default-export
+export function finishedHydrating(ducks) {
+  return {
+    data: ducks,
+    type: FINISHED_HYDRATING,
+  };
+}
+
+export function verifyHydration() {
+  return {
+    type: VERIFY_HYDRATION,
+  };
+}
+
+const reducer = (state = { hydratedList: [], hydrated: false }, action) => {
+  switch (action.type) {
+    case FINISHED_HYDRATING: {
+      return {
+        ...state,
+        hydratedList: [...new Set([...state.hydratedList, action.data])],
+        hydrated: state.hydratedList.length === NUMBER_OF_DUCKS_TO_HYDRATE,
+      };
+    }
+    case VERIFY_HYDRATION: {
+      return {
+        ...state,
+        hydrated: state?.hydratedList?.length === NUMBER_OF_DUCKS_TO_HYDRATE,
+      };
+    }
+    default:
+      return state;
+  }
+};
+
+store.injectReducer("hydration", reducer);


### PR DESCRIPTION
If users open multiple tabs one after the other, with the current code, new tabs might think they are fully hydrated when really the previous tab was only partially hydrated.

This should help with that, by better tracking how complete hydration is, and partially hydrating if needed.