### PR TITLE
Source: Quick save

### DIFF
--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -1740,7 +1740,6 @@ def post_source(data, user_id, session, refresh_source=True):
             "Invalid group_ids field. Please specify at least "
             "one valid group ID that you belong to."
         )
-    log(f"group_ids: {group_ids}")
     # we use the ignore_if_in_group_ids field, to cancel saving to the specified group_ids if there is already a source
     # saved to one of the ignore_if_in_group_ids
     # ignore_if_in_group_ids is a dict, where each keys are the group_ids for which we want to specify groups to avoid

--- a/static/js/components/QuickSaveSource.jsx
+++ b/static/js/components/QuickSaveSource.jsx
@@ -1,0 +1,112 @@
+import React, { useState } from "react";
+import PropTypes from "prop-types";
+import { useDispatch, useSelector } from "react-redux";
+
+import SaveIcon from "@mui/icons-material/Save";
+import { showNotification } from "baselayer/components/Notifications";
+import CircularProgress from "@mui/material/CircularProgress";
+
+import { Tooltip } from "@mui/material";
+import * as sourceActions from "../ducks/source";
+import Button from "./Button";
+
+const QuickSaveButton = ({ sourceId, alreadySavedGroups }) => {
+  const dispatch = useDispatch();
+  const profile = useSelector((state) => state.profile);
+  const userAccessibleGroups = useSelector(
+    (state) => state.groups.userAccessible
+  );
+  const { hydratedList } = useSelector((state) => state.hydration);
+
+  const [isSaving, setIsSaving] = useState(false);
+
+  const alreadySavedGroupsSet = new Set(alreadySavedGroups);
+  const quickSaveGroupsSet = new Set(
+    profile?.preferences?.quicksave_group_ids || []
+  );
+
+  const quickSaveSource = () => {
+    setIsSaving(true);
+    const data = {
+      id: sourceId,
+      group_ids: [...alreadySavedGroupsSet, ...quickSaveGroupsSet],
+    };
+    dispatch(sourceActions.saveSource(data)).then((response) => {
+      if (response.status === "success") {
+        dispatch(
+          showNotification(
+            `Source quick saved to ${quickSaveGroupsSet.size} group(s)`
+          )
+        );
+        setIsSaving(false);
+      } else {
+        setIsSaving(false);
+        dispatch(showNotification("Error saving source", "error"));
+      }
+    });
+  };
+
+  if (!(profile?.preferences?.quicksave_group_ids?.length > 0)) {
+    return null;
+  }
+
+  // if quickSaveGroupsSet alreadySavedGroupsSet contains all elements of quickSaveGroupsSet, return null
+  if (
+    alreadySavedGroupsSet.size > 0 &&
+    [...quickSaveGroupsSet].every((group) => alreadySavedGroupsSet.has(group))
+  ) {
+    return null;
+  }
+
+  const groupsLoaded =
+    typeof hydratedList === "object" &&
+    Array.isArray(hydratedList) &&
+    hydratedList.includes("groups");
+
+  if (userAccessibleGroups?.length === 0) {
+    return null;
+  }
+
+  const tooltipText = !groupsLoaded
+    ? "Loading..."
+    : `Quick Save Source to: ${[...quickSaveGroupsSet]
+        .map((groupId) => {
+          const group = userAccessibleGroups.find((g) => g.id === groupId);
+          return group.nickname || group.name;
+        })
+        .join(", ")}`;
+
+  return (
+    <Tooltip title={tooltipText}>
+      <span>
+        <Button
+          variant="contained"
+          color="primary"
+          size="small"
+          onClick={quickSaveSource}
+          disabled={isSaving || !groupsLoaded}
+          endIcon={
+            isSaving || !groupsLoaded ? (
+              <CircularProgress size="1rem" />
+            ) : (
+              <SaveIcon />
+            )
+          }
+        >
+          {groupsLoaded ? "Quick Save" : "Loading..."}
+        </Button>
+      </span>
+    </Tooltip>
+  );
+};
+
+QuickSaveButton.propTypes = {
+  sourceId: PropTypes.string.isRequired,
+  alreadySavedGroups: PropTypes.arrayOf(PropTypes.number),
+};
+
+QuickSaveButton.defaultProps = {
+  alreadySavedGroups: [],
+};
+
+export default QuickSaveButton;

--- a/static/js/components/QuickSaveSourcePreferences.jsx
+++ b/static/js/components/QuickSaveSourcePreferences.jsx
@@ -1,0 +1,83 @@
+import React, { useState, useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { makeStyles } from "@mui/styles";
+
+import Select from "@mui/material/Select";
+import MenuItem from "@mui/material/MenuItem";
+import UserPreferencesHeader from "./UserPreferencesHeader";
+
+import * as profileActions from "../ducks/profile";
+
+const useStyles = makeStyles(() => ({
+  allocationSelect: {
+    width: "100%",
+  },
+  SelectItem: {
+    display: "flex",
+    justifyContent: "space-between",
+  },
+}));
+
+const QuickSaveSourcePreferences = () => {
+  const dispatch = useDispatch();
+  const classes = useStyles();
+
+  const userAccessibleGroups = useSelector(
+    (state) => state.groups.userAccessible
+  );
+  const profile = useSelector((state) => state.profile);
+
+  const [selectedGroupIds, setSelectedGroupIds] = useState([]);
+
+  useEffect(() => {
+    setSelectedGroupIds(profile?.preferences?.quicksave_group_ids || []);
+  }, [profile, userAccessibleGroups]);
+
+  const onSubmitGroupIds = (event) => {
+    const groupIds = event.target.value;
+    setSelectedGroupIds(groupIds);
+    const prefs = {
+      quicksave_group_ids: groupIds,
+    };
+    dispatch(profileActions.updateUserPreferences(prefs));
+  };
+
+  return (
+    <div className="quick-save-source-preferences">
+      <UserPreferencesHeader
+        title="Quick Save Source Preferences"
+        popupText="Select the groups you would like to be able to quick save sources to. If any groups are selected, a quick save button will appear on the source page."
+      />
+      {!userAccessibleGroups && <div>Loading...</div>}
+      {userAccessibleGroups && userAccessibleGroups?.length === 0 && (
+        <div>
+          You do not seem to have access to any groups. Please contact an
+          administrator or group admin to be added to a group.
+        </div>
+      )}
+      {userAccessibleGroups && userAccessibleGroups?.length > 0 && (
+        <Select
+          inputProps={{ MenuProps: { disableScrollLock: true } }}
+          labelId="quicksaveGroupsSelectLabel"
+          value={selectedGroupIds}
+          onChange={onSubmitGroupIds}
+          name="quicksaveGroupsSelect"
+          className={classes.allocationSelect}
+          multiple
+        >
+          {(userAccessibleGroups || []).map((ignore_group) => (
+            <MenuItem
+              value={ignore_group.id}
+              key={ignore_group.id}
+              className={classes.SelectItem}
+            >
+              {ignore_group.name}
+            </MenuItem>
+          ))}
+        </Select>
+      )}
+    </div>
+  );
+};
+
+export default QuickSaveSourcePreferences;

--- a/static/js/components/SourceDesktop.jsx
+++ b/static/js/components/SourceDesktop.jsx
@@ -59,6 +59,7 @@ import FavoritesButton from "./FavoritesButton";
 import SourceAnnotationButtons from "./SourceAnnotationButtons";
 import TNSATForm from "./TNSATForm";
 import Reminders from "./Reminders";
+import QuickSaveButton from "./QuickSaveSource";
 
 import SourcePlugins from "./SourcePlugins";
 
@@ -657,6 +658,10 @@ const SourceDesktop = ({ source }) => {
           icon
         />
         <SourceSaveHistory groups={source.groups} />
+        <QuickSaveButton
+          sourceId={source.id}
+          alreadySavedGroups={source.groups?.map((g) => g.id)}
+        />
         <div className={classes.columnItem}>
           <ThumbnailList
             ra={source.ra}

--- a/static/js/components/SourceMobile.jsx
+++ b/static/js/components/SourceMobile.jsx
@@ -29,6 +29,7 @@ import {
 import { WidthProvider } from "react-grid-layout";
 import { log10, abs, ceil } from "mathjs";
 import RemoveIcon from "@mui/icons-material/Remove";
+import QuickSaveButton from "./QuickSaveSource";
 import Button from "./Button";
 
 import CommentListMobile from "./CommentListMobile";
@@ -644,6 +645,10 @@ const SourceMobile = WidthProvider(
                   icon
                 />
                 <SourceSaveHistory groups={source.groups} />
+                <QuickSaveButton
+                  sourceId={source.id}
+                  alreadySavedGroups={source.groups?.map((g) => g.id)}
+                />
               </div>
               <div className={classes.thumbnails}>
                 <ThumbnailList

--- a/static/js/components/UpdateProfileForm.jsx
+++ b/static/js/components/UpdateProfileForm.jsx
@@ -31,6 +31,7 @@ import FollowupRequestPreferences from "./FollowupRequestPreferences";
 import PhotometryPlottingPreferences from "./PhotometryPlottingPreferences";
 import SpectroscopyPlottingPreferences from "./SpectroscopyPlottingPreferences";
 import ClassificationsShortcutForm from "./ClassificationsShortcutForm";
+import QuickSaveSourcePreferences from "./QuickSaveSourcePreferences";
 
 const useStyles = makeStyles(() => ({
   spacing: {
@@ -317,6 +318,9 @@ const UpdateProfileForm = () => {
         </CardContent>
         <CardContent>
           <SpectroscopyPlottingPreferences />
+        </CardContent>
+        <CardContent>
+          <QuickSaveSourcePreferences />
         </CardContent>
       </Card>
       <Dialog

--- a/static/js/store.js
+++ b/static/js/store.js
@@ -12,10 +12,10 @@ import {
 
 const syncConfig = {
   whitelist: [
-    "baselayer/SHOW_NOTIFICATION",
+    // "baselayer/SHOW_NOTIFICATION",
     "baselayer/HIDE_NOTIFICATION",
     "baselayer/HIDE_NOTIFICATION_BY_TAG",
-    "skyportal/FETCH_INSTRUMENTS_OK",
+    // "skyportal/FETCH_INSTRUMENTS_OK",
     // TODO: add more _OK actions here, as long as
     // they don't trigger any fetching of data
   ],


### PR DESCRIPTION
This PR adds a quick save button on the source page. Most scanners save sources to the same groups, and complain that saving a source to the same groups every time is not practical, as they need to go click save -> which opens a dialog window -> they need to go through their list of groups and select them -> confirm. When really, they could just set which groups they want to always save to, and click a "quick save" button instead.

This PR adds that, by adding a section in the user preferences to select the groups to "quick save" to, and the button to do so on the source page.