### PR TITLE
Health monitor: DB migration check patience

### DIFF
--- a/services/health_monitor/health_monitor.py
+++ b/services/health_monitor/health_monitor.py
@@ -30,7 +30,7 @@ class DownStatus:
 def migrated():
     try:
         r = requests.get(
-            f'http://localhost:{cfg["ports.migration_manager"]}', timeout=10
+            f'http://localhost:{cfg["ports.migration_manager"]}', timeout=30
         )
         data = r.json()
         return data["migrated"]


### PR DESCRIPTION
I noticed in prod that the health monitor wasn't running as expected. Before it starts monitoring the apps, it wants to check if the DB is migrated. For that, it queries the DB migration server, which runs some alembic code. Aside from using quite a bit of CPU resources when running this alembic code, the timeout set in the health monitor is too short (10sec) so this query timeouts, and runs again 30 seconds after, also timing out.

Changing that 10-second timeout to 30 seems to be enough to not timeout anymore.