### PR TITLE
Telescopes: next day/night time caching

### DIFF
--- a/skyportal/handlers/api/telescope.py
+++ b/skyportal/handlers/api/telescope.py
@@ -199,7 +199,7 @@ class TelescopeHandler(BaseHandler):
                 if telescope is None:
                     continue
                 temp = telescope.to_dict()
-                temp = {**temp, **telescope.current_time}
+                temp = {**temp, **telescope.current_time()}
                 temp["morning"] = (
                     temp["morning"].iso if isinstance(temp["morning"], Time) else False
                 )
@@ -289,6 +289,9 @@ class TelescopeHandler(BaseHandler):
                 t.weather_link = data['weather_link']
 
             session.commit()
+
+            if any([k in data for k in ['lat', 'lon', 'elevation']]):
+                t.current_time(refresh=True)
 
             self.push_all(action="skyportal/REFRESH_TELESCOPES")
             return self.success()

--- a/skyportal/models/telescope.py
+++ b/skyportal/models/telescope.py
@@ -334,8 +334,7 @@ class Telescope(Base):
             'twilight_evening_nautical_unix_ms': twilight_evening_nautical_unix_ms,
         }
 
-    @property
-    def current_time(self):
+    def current_time(self, refresh=False):
         if (
             not self.fixed_location
             or self.lon is None
@@ -350,7 +349,7 @@ class Telescope(Base):
             }
 
         cached = cache[f"{self.id}"]
-        if cached is not None:
+        if cached is not None and not refresh:
             try:
                 time_info = np.load(cached, allow_pickle=True).item()
                 # if morning or evening is before now, then we need to update the cache


### PR DESCRIPTION
Cache telescope current time info (next day time, next night time, is it day or night right now), and only refresh the cache when any of these dates are past the current UTC date. This ensures that we don't trigger astroplan's slow calculations every time we hit the telescopes endpoint from the frontend, which currently takes ~7 seconds to return in production. This should get that back to ~100 ms, except of course when one or more telescopes' current time info needs to be updated.