### PR TITLE
Analysis Frontend: update list after adding,deleting, and updating

### DIFF
--- a/skyportal/handlers/api/analysis.py
+++ b/skyportal/handlers/api/analysis.py
@@ -469,7 +469,6 @@ def post_analysis(
             session.commit()
             if analysis_resource_type.lower() == 'obj':
                 try:
-                    logger(f"Refreshing analyses for {analysis.obj.internal_key}")
                     flow = Flow()
                     flow.push(
                         '*',
@@ -1386,11 +1385,17 @@ class AnalysisHandler(BaseHandler):
                 session.commit()
 
                 try:
+                    flow = Flow()
                     if analysis.analysis_service.is_summary:
-                        flow = Flow()
                         flow.push(
                             '*',
                             'skyportal/REFRESH_SOURCE',
+                            payload={'obj_key': analysis.obj.internal_key},
+                        )
+                    elif analysis_resource_type == 'obj':
+                        flow.push(
+                            '*',
+                            'skyportal/REFRESH_OBJ_ANALYSES',
                             payload={'obj_key': analysis.obj.internal_key},
                         )
                 except Exception as e:

--- a/skyportal/handlers/api/analysis.py
+++ b/skyportal/handlers/api/analysis.py
@@ -467,6 +467,18 @@ def post_analysis(
                 f"[id={analysis_id} service={analysis_service_id}] status='{analysis.status}' message='{analysis.status_message}'"
             )
             session.commit()
+            if analysis_resource_type.lower() == 'obj':
+                try:
+                    logger(f"Refreshing analyses for {analysis.obj.internal_key}")
+                    flow = Flow()
+                    flow.push(
+                        '*',
+                        'skyportal/REFRESH_OBJ_ANALYSES',
+                        payload={'obj_key': analysis.obj.internal_key},
+                    )
+                except Exception as e:
+                    logger(f"Could not refresh analyses: {e}")
+                    pass
 
     # Start the analysis service in a separate thread and log any exceptions
     x = IOLoop.current().run_in_executor(None, external_analysis_service)

--- a/skyportal/handlers/api/webhook.py
+++ b/skyportal/handlers/api/webhook.py
@@ -142,6 +142,7 @@ class AnalysisWebhookHandler(BaseHandler):
         # check the analysis type and push to the source
         # if the analysis type is a summary
         try:
+            flow = Flow()
             if analysis.analysis_service.is_summary:
                 summary = {"summary": analysis.serialize_results_data()['summary']}
                 summary["created_at"] = analysis.created_at
@@ -152,12 +153,18 @@ class AnalysisWebhookHandler(BaseHandler):
                 )
                 session.commit()
                 log("analysis is a summary. Pushing to source.")
-                flow = Flow()
                 flow.push(
                     '*',
                     'skyportal/REFRESH_SOURCE',
                     payload={'obj_key': analysis.obj.internal_key},
                 )
+            else:
+                if analysis_resource_type.lower() == 'obj':
+                    flow.push(
+                        '*',
+                        'skyportal/REFRESH_OBJ_ANALYSES',
+                        payload={'obj_key': analysis.obj.internal_key},
+                    )
         except Exception as e:
             log(f"Error pushing update to source: {e}")
 

--- a/static/js/components/AnalysisList.jsx
+++ b/static/js/components/AnalysisList.jsx
@@ -1,5 +1,5 @@
-import React, { useState, useEffect } from "react";
-import { useDispatch } from "react-redux";
+import React, { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 
 import PropTypes from "prop-types";
@@ -114,16 +114,20 @@ const AnalysisList = ({ obj_id }) => {
   const theme = useTheme();
   const dispatch = useDispatch();
 
-  const [analysesList, setAnalysesList] = useState(null);
+  const fetchAnalysesList = async (objID) => {
+    dispatch(sourceActions.fetchAnalyses("obj", { objID }));
+  };
+
+  const analyses = useSelector((state) => state.source.analyses);
   useEffect(() => {
-    const fetchAnalysesList = async (objID) => {
-      const response = await dispatch(
-        sourceActions.fetchAnalyses("obj", { objID })
-      );
-      setAnalysesList(response.data);
-    };
     fetchAnalysesList(obj_id);
-  }, [dispatch, setAnalysesList, obj_id]);
+  }, [dispatch, obj_id]);
+
+  // filter out the results, to only show the analyses for this object
+  let analysesList = [];
+  if (analyses !== undefined && analyses !== null) {
+    analysesList = analyses.filter((analysis) => analysis.obj_id === obj_id);
+  }
 
   if (!analysesList || analysesList.length === 0) {
     return <p>No analyses for this source...</p>;
@@ -131,14 +135,9 @@ const AnalysisList = ({ obj_id }) => {
 
   const deleteAnalysis = async (analysisID) => {
     dispatch(showNotification(`Deleting Analysis (${analysisID}).`));
-    dispatch(sourceActions.deleteAnalysis(analysisID));
-    const fetchAnalysesList = async (objID) => {
-      const response = await dispatch(
-        sourceActions.fetchAnalyses("obj", { objID })
-      );
-      setAnalysesList(response.data);
-    };
-    fetchAnalysesList(obj_id);
+    dispatch(sourceActions.deleteAnalysis(analysisID)).then(() => {
+      fetchAnalysesList(obj_id);
+    });
   };
 
   const getDataTableColumns = () => {
@@ -412,7 +411,7 @@ const AnalysisList = ({ obj_id }) => {
           <StyledEngineProvider injectFirst>
             <ThemeProvider theme={getMuiTheme(theme)}>
               <MUIDataTable
-                data={analysesList}
+                data={analysesList || []}
                 options={options}
                 columns={getDataTableColumns()}
               />

--- a/static/js/components/AnalysisList.jsx
+++ b/static/js/components/AnalysisList.jsx
@@ -114,12 +114,11 @@ const AnalysisList = ({ obj_id }) => {
   const theme = useTheme();
   const dispatch = useDispatch();
 
-  const fetchAnalysesList = async (objID) => {
-    dispatch(sourceActions.fetchAnalyses("obj", { objID }));
-  };
-
   const analyses = useSelector((state) => state.source.analyses);
   useEffect(() => {
+    const fetchAnalysesList = async (objID) => {
+      dispatch(sourceActions.fetchAnalyses("obj", { objID }));
+    };
     fetchAnalysesList(obj_id);
   }, [dispatch, obj_id]);
 
@@ -135,9 +134,7 @@ const AnalysisList = ({ obj_id }) => {
 
   const deleteAnalysis = async (analysisID) => {
     dispatch(showNotification(`Deleting Analysis (${analysisID}).`));
-    dispatch(sourceActions.deleteAnalysis(analysisID)).then(() => {
-      fetchAnalysesList(obj_id);
-    });
+    dispatch(sourceActions.deleteAnalysis(analysisID));
   };
 
   const getDataTableColumns = () => {

--- a/static/js/ducks/source.js
+++ b/static/js/ducks/source.js
@@ -99,6 +99,7 @@ const START_ANALYSIS_FOR_OBJ = "skyportal/START_SERVICE_FOR_OBJ";
 const DELETE_ANALYSIS = "skyportal/DELETE_ANALYSIS";
 
 const FETCH_ANALYSES_FOR_OBJ = "skyportal/FETCH_ANALYSES_FOR_OBJ";
+const FETCH_ANALYSES_FOR_OBJ_OK = "skyportal/FETCH_ANALYSES_FOR_OBJ_OK";
 const FETCH_ANALYSIS_FOR_OBJ = "skyportal/FETCH_ANALYSIS_FOR_OBJ";
 const FETCH_ANALYSIS_RESULTS_FOR_OBJ = "skyportal/FETCH_ANALYSIS_FOR_OBJ";
 
@@ -502,18 +503,27 @@ export const fetchAssociatedGCNs = (sourceID) =>
 // Websocket message handler
 messageHandler.add((actionType, payload, dispatch, getState) => {
   const { source } = getState();
-
   if (actionType === REFRESH_SOURCE) {
     const loaded_obj_key = source?.internal_key;
     if (loaded_obj_key === payload.obj_key) {
       dispatch(fetchSource(source.id));
+    }
+  } else if (actionType === REFRESH_OBJ_ANALYSES) {
+    const loaded_obj_key = source?.internal_key;
+    if (loaded_obj_key === payload.obj_key) {
+      dispatch(fetchAnalyses("obj", { obj_id: source.id }));
     }
   }
 });
 
 // Reducer for currently displayed source
 const reducer = (
-  state = { source: null, loadError: false, associatedGCNs: null },
+  state = {
+    source: null,
+    loadError: false,
+    associatedGCNs: null,
+    analyses: null,
+  },
   action
 ) => {
   switch (action.type) {
@@ -591,6 +601,13 @@ const reducer = (
       return {
         ...state,
         associatedGCNs: gcns,
+      };
+    }
+    case FETCH_ANALYSES_FOR_OBJ_OK: {
+      const { data } = action;
+      return {
+        ...state,
+        analyses: data,
       };
     }
     default:


### PR DESCRIPTION
Currently, the list of analyses isn't responsive at all to any changes. This PR ensures that:
- we refresh the list to show a new analysis when a user submits one
- we refresh the list correctly after deleting an analysis
- we refresh the list when an analysis gets updated (as completed or failed) through the associated webhook

This should help prevent users from refreshing the whole page every time they perform any actions there, or when the results are uploaded back to SkyPortal.