### PR TITLE
Download/Preview attachments: bugfix

### DIFF
--- a/skyportal/handlers/api/comment.py
+++ b/skyportal/handlers/api/comment.py
@@ -1301,6 +1301,12 @@ class CommentAttachmentHandler(BaseHandler):
                     except Exception as e:
                         log(f'Cannot render {attachment_name} as image: {str(e)}')
 
+                # we remove all non-ascii characters from the attachment name, which tornado does not like
+                # as they can't be encoded in latin-1
+                attachment_name = ''.join(
+                    [i if ord(i) < 128 else ' ' for i in attachment_name]
+                )
+
                 self.set_header(
                     "Content-Disposition",
                     "attachment; " f"filename={attachment_name}",


### PR DESCRIPTION
Recently folks have been uploading attachments that are png screenshots. However, looks like their system includes some non standard space chars, which can't be encoded with the default latin-1 that tornado uses.

To get around that, and prevent any other weird names from breaking the download process, we make sure that non-ascii characters are all replaced by simple spaces. We can imagine something a little smarter, but having a first bugfix is important.

Right now that failure leads to the "system provisioning" error for the client for some reason, preventing any other API call from running for a few seconds.