### PR TITLE
Follow-up requests lists on source page: fix table count

### DIFF
--- a/static/js/components/FollowupRequestLists.jsx
+++ b/static/js/components/FollowupRequestLists.jsx
@@ -445,10 +445,10 @@ const FollowupRequestLists = ({
     jumpToPage: true,
     serverSide,
     pagination: true,
-    count: totalMatches,
   };
   if (typeof handleTableChange === "function") {
     options.onTableChange = handleTableChange;
+    options.count = totalMatches;
   }
   if (typeof onDownload === "function") {
     options.onDownload = () => {


### PR DESCRIPTION
It looks like the count parameter passed to the mui datatable options used the totalMatches value. However, since the requests are split in lists by instruments, we want the count to be the one for that instrument.

For that, and since the pagination here isn't server-side, we can simply not pass that count parameter and only pass it when navigating the follow-up requests page (where we only query one instrument at a time/allocation at the time anyway, so that number is always accurate).