### PR TITLE
'Create New Group' form css changed

### DIFF
--- a/static/js/components/NewGroupForm.jsx
+++ b/static/js/components/NewGroupForm.jsx
@@ -73,7 +73,11 @@ const NewGroupForm = () => {
   const useStyles = makeStyles((theme) => ({
     formControl: {
       margin: `${theme.spacing(1)} 0`,
-      minWidth: 130,
+      minWidth: "50%",
+    },
+    customTextField: {
+      width: "50%", // Set the desired width
+      marginBottom: theme.spacing(2), // Example spacing
     },
     chips: {
       display: "flex",
@@ -112,6 +116,7 @@ const NewGroupForm = () => {
             name="name"
             value={formState.name}
             onChange={handleChange}
+            className={classes.customTextField}
           />
         </Box>
         <Box>
@@ -120,6 +125,7 @@ const NewGroupForm = () => {
             name="nickname"
             value={formState.nickname}
             onChange={handleChange}
+            className={classes.customTextField}
           />
         </Box>
         <Box>
@@ -128,6 +134,7 @@ const NewGroupForm = () => {
             name="description"
             value={formState.description}
             onChange={handleChange}
+            className={classes.customTextField}
           />
         </Box>
         <Box>


### PR DESCRIPTION

The form elements were not sized correctly. The text boxes were small and the Group admin placeholder overlapped with the dropdown icon. Though this did not affect functionality, it made the UI look incomplete.
I changed the css in NewGroupForm.jsx to fix this.


Add screenshots and/or movies showing the changes, if relevant
 
<img width="1435" alt="Screenshot 2023-11-17 at 1 23 29 PM" src="https://github.com/skyportal/skyportal/assets/91302532/852c34f9-64ed-4864-b403-e19f70443121">

changed to:
<img width="1440" alt="Screenshot 2023-11-17 at 1 54 05 PM" src="https://github.com/skyportal/skyportal/assets/91302532/768e578b-e9b1-4be2-8e36-648c2030ea89">
