### PR TITLE
external_photometry method - different behaviors regarding duplicates

### DIFF
--- a/skyportal/facility_apis/atlas.py
+++ b/skyportal/facility_apis/atlas.py
@@ -99,7 +99,6 @@ def commit_photometry(
         DBSession,
         FollowupRequest,
         Instrument,
-        User,
     )
 
     if parent_session is None:
@@ -114,7 +113,9 @@ def commit_photometry(
     try:
         request = session.query(FollowupRequest).get(request_id)
         instrument = session.query(Instrument).get(instrument_id)
-        user = session.query(User).get(user_id)
+        allocation = request.allocation
+        if not allocation:
+            raise ValueError("Missing request's allocation information.")
 
         result_url = json_response['result_url']
         request.status = f"Task is complete with results available at {result_url}"
@@ -192,10 +193,18 @@ def commit_photometry(
         df['magsys'] = 'ab'
         df['origin'] = 'fp'
 
+        # data is visible to the group attached to the allocation
+        # as well as to any of the allocation's default share groups
         data_out = {
             'obj_id': request.obj_id,
             'instrument_id': instrument.id,
-            'group_ids': [g.id for g in user.accessible_groups],
+            'group_ids': list(
+                set(
+                    [allocation.group_id] + allocation.default_share_group_ids
+                    if allocation.default_share_group_ids
+                    else []
+                )
+            ),
             **df.to_dict(orient='list'),
         }
 

--- a/skyportal/facility_apis/atlas.py
+++ b/skyportal/facility_apis/atlas.py
@@ -68,7 +68,13 @@ class ATLASRequest:
 
 
 def commit_photometry(
-    json_response, altdata, request_id, instrument_id, user_id, parent_session=None
+    json_response,
+    altdata,
+    request_id,
+    instrument_id,
+    user_id,
+    parent_session=None,
+    duplicates="error",
 ):
     """
     Commits ATLAS photometry to the database
@@ -196,7 +202,11 @@ def commit_photometry(
         from skyportal.handlers.api.photometry import add_external_photometry
 
         if len(df.index) > 0:
-            add_external_photometry(data_out, request.requester)
+            ids, _ = add_external_photometry(
+                data_out, request.requester, duplicates=duplicates
+            )
+            if ids is None:
+                raise ValueError('Failed to commit photometry')
             request.status = "Photometry committed to database"
         else:
             request.status = "No photometry to commit to database"

--- a/skyportal/facility_apis/ps1.py
+++ b/skyportal/facility_apis/ps1.py
@@ -90,7 +90,11 @@ def commit_photometry(text_response, request_id, instrument_id, user_id):
         from skyportal.handlers.api.photometry import add_external_photometry
 
         if len(df.index) > 0:
-            add_external_photometry(data_out, request.requester)
+            ids, _ = add_external_photometry(
+                data_out, request.requester, duplicates="update"
+            )
+            if ids is None:
+                raise ValueError('Failed to commit photometry')
             request.status = "Photometry committed to database"
         else:
             request.status = "No photometry to commit to database"

--- a/skyportal/facility_apis/ztf.py
+++ b/skyportal/facility_apis/ztf.py
@@ -208,7 +208,13 @@ class ZTFRequest:
 
 
 def commit_photometry(
-    url, altdata, request_id, instrument_id, user_id, parent_session=None
+    url,
+    altdata,
+    request_id,
+    instrument_id,
+    user_id,
+    parent_session=None,
+    duplicates="error",
 ):
     """
     Commits ZTF forced photometry to the database
@@ -320,7 +326,11 @@ def commit_photometry(
         from skyportal.handlers.api.photometry import add_external_photometry
 
         if len(df.index) > 0:
-            add_external_photometry(data_out, request.requester)
+            ids, _ = add_external_photometry(
+                data_out, request.requester, duplicates=duplicates
+            )
+            if ids is None:
+                raise ValueError('Failed to commit photometry')
             request.status = "Photometry committed to database"
         else:
             request.status = "No photometry to commit to database"

--- a/skyportal/handlers/api/photometry.py
+++ b/skyportal/handlers/api/photometry.py
@@ -949,7 +949,6 @@ def add_external_photometry(json, user, parent_session=None, duplicates="update"
                     id_map_no_update_needed[df_index] = duplicate.id
 
             if duplicates in ["update"] and len(id_map_no_update_needed) > 0:
-                # log that we didn't update these photometry points
                 log(
                     f'A total of (len{id_map_no_update_needed}) duplicate photometry points did not need to be updated: {id_map_no_update_needed.values()}'
                 )

--- a/skyportal/handlers/api/photometry.py
+++ b/skyportal/handlers/api/photometry.py
@@ -826,7 +826,7 @@ def get_stream_ids(data, user, parent_session=None):
     return stream_ids
 
 
-def add_external_photometry(json, user, parent_session=None):
+def add_external_photometry(json, user, parent_session=None, duplicates="update"):
     """
     Posts external photometry to the database (as from
     another API)
@@ -841,6 +841,11 @@ def add_external_photometry(json, user, parent_session=None):
     parent_session : sqlalchemy.orm.session.Session
         Session to use for the database transaction (optional)
     """
+
+    if duplicates not in ["error", "ignore", "update"]:
+        raise ValueError(
+            "duplicates argument can only be one of: error, ignore, update"
+        )
 
     if parent_session is None:
         session = DBSession()
@@ -872,12 +877,112 @@ def add_external_photometry(json, user, parent_session=None):
                 f'LOCK TABLE {Photometry.__tablename__} IN SHARE ROW EXCLUSIVE MODE'
             )
         )
-        ids, upload_id = insert_new_photometry_data(
-            df, instrument_cache, group_ids, stream_ids, user, session
-        )
-        log(
-            f'Request from {username} with {len(df.index)} rows complete with upload_id {upload_id}'
-        )
+        if duplicates in ["ignore", "update"]:
+            values_table, condition = get_values_table_and_condition(df)
+
+            new_photometry_query = session.execute(
+                sa.select(values_table.c.pdidx)
+                .outerjoin(Photometry, condition)
+                .filter(Photometry.id.is_(None))
+            )
+
+            new_photometry_df_idxs = [g[0] for g in new_photometry_query]
+
+            duplicated_photometry = (
+                session.execute(
+                    sa.select(values_table.c.pdidx, Photometry)
+                    .join(Photometry, condition)
+                    .options(joinedload(Photometry.groups))
+                    .options(joinedload(Photometry.streams))
+                )
+                .unique()
+                .all()
+            )
+
+            id_map = {}
+
+            for df_index, duplicate in duplicated_photometry:
+                id_map[df_index] = duplicate.id
+
+                if duplicates in ["ignore"]:
+                    continue
+
+                duplicate_group_ids = {g.id for g in duplicate.groups}
+                duplicate_stream_ids = {s.id for s in duplicate.streams}
+
+                # posting to new groups?
+                if len(set(group_ids) - duplicate_group_ids) > 0:
+                    # select old + new groups
+                    group_ids_update = set(group_ids).union(duplicate_group_ids)
+                    groups = (
+                        session.execute(
+                            sa.select(Group).filter(Group.id.in_(group_ids_update))
+                        )
+                        .scalars()
+                        .all()
+                    )
+                    # update the corresponding photometry entry in the db
+                    duplicate.groups = groups
+                    log(
+                        f'Adding groups {group_ids_update} to photometry {duplicate.id}'
+                    )
+
+                # posting to new streams?
+                if stream_ids:
+                    # Add new stream_photometry rows if not already present
+                    stream_ids_update = set(stream_ids) - duplicate_stream_ids
+                    if len(stream_ids_update) > 0:
+                        for id in stream_ids_update:
+                            session.add(
+                                StreamPhotometry(
+                                    photometr_id=duplicate.id, stream_id=id
+                                )
+                            )
+                        log(
+                            f'Adding streams {stream_ids_update} to photometry {duplicate.id}'
+                        )
+
+            # now safely drop the duplicates:
+            new_photometry = df.loc[new_photometry_df_idxs]
+            log(
+                f'Inserting {len(new_photometry.index)} '
+                f'(out of {len(df.index)}) new photometry points'
+            )
+        else:
+            new_photometry = df.copy()
+
+        if len(new_photometry) > 0:
+            ids, upload_id = insert_new_photometry_data(
+                new_photometry,
+                instrument_cache,
+                group_ids,
+                stream_ids,
+                user,
+                session,
+                validate=True if duplicates in ["error"] else False,
+            )
+
+            if duplicates in ["ignore", "update"]:
+                for (df_index, _), id in zip(new_photometry.iterrows(), ids):
+                    id_map[df_index] = id
+
+        # release the lock
+        session.commit()
+
+        if duplicates in ["ignore", "update"]:
+            # get ids in the correct order
+            ids = [id_map[pdidx] for pdidx, _ in df.iterrows()]
+
+        if len(new_photometry) > 0:
+            log(
+                f'Request from {username} with '
+                f'{len(new_photometry.index)} rows complete with upload_id {upload_id}.'
+            )
+        else:
+            log(
+                f'Request from {username} with '
+                f'{len(new_photometry.index)} rows complete with no new photometry.'
+            )
         return ids, upload_id
     except Exception as e:
         session.rollback()

--- a/static/js/components/AirmassPlot.jsx
+++ b/static/js/components/AirmassPlot.jsx
@@ -44,7 +44,7 @@ const airmassSpec = (url, ephemeris, titleFontSize, labelFontSize) => ({
   },
   transform: [
     {
-      calculate: "toDate(utcFormat(datum.time, '%Y-%m-%dT%H:%M:%S.%L'))",
+      calculate: "datetime(datum.time)",
       as: "formattedDate",
     },
   ],

--- a/static/js/components/PhotometryTable.jsx
+++ b/static/js/components/PhotometryTable.jsx
@@ -169,7 +169,7 @@ const PhotometryTable = ({ obj_id, open, onClose }) => {
       };
       columns.push({
         name: "owner",
-        label: "Owner",
+        label: "owner",
         options: {
           customBodyRenderLite: renderOwner,
         },

--- a/static/js/components/PhotometryTable.jsx
+++ b/static/js/components/PhotometryTable.jsx
@@ -8,6 +8,12 @@ import CloseIcon from "@mui/icons-material/Close";
 import IconButton from "@mui/material/IconButton";
 import Tooltip from "@mui/material/Tooltip";
 import makeStyles from "@mui/styles/makeStyles";
+import {
+  createTheme,
+  ThemeProvider,
+  StyledEngineProvider,
+  useTheme,
+} from "@mui/material/styles";
 import CircularProgress from "@mui/material/CircularProgress";
 import MUIDataTable from "mui-datatables";
 
@@ -23,6 +29,50 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
+const getMuiTheme = (theme) =>
+  createTheme({
+    palette: theme.palette,
+    components: {
+      MUITableCell: {
+        styleOverrides: {
+          paddingCheckbox: {
+            padding: 0,
+            margin: 0,
+          },
+        },
+      },
+      MUIDataTableBodyCell: {
+        styleOverrides: {
+          root: {
+            padding: "0.25rem",
+            paddingRight: 0,
+            margin: 0,
+          },
+        },
+      },
+      MUIDataTableHeadCell: {
+        styleOverrides: {
+          root: {
+            padding: "0.5rem",
+            paddingRight: 0,
+            margin: 0,
+          },
+          sortLabelRoot: {
+            height: "1.4rem",
+          },
+        },
+      },
+    },
+  });
+
+const defaultHiddenColumns = [
+  "instrument_id",
+  "snr",
+  "magsys",
+  "annotations",
+  "created_at",
+];
+
 // eslint-disable-next-line
 const Transition = React.forwardRef(function Transition(props, ref) {
   // eslint-disable-next-line
@@ -37,6 +87,7 @@ const PhotometryTable = ({ obj_id, open, onClose }) => {
   let bodyContent = null;
 
   const classes = useStyles();
+  const theme = useTheme();
   const dispatch = useDispatch();
 
   const [isDeleting, setIsDeleting] = useState(null);
@@ -57,7 +108,34 @@ const PhotometryTable = ({ obj_id, open, onClose }) => {
     if (data.length === 0) {
       bodyContent = <p>Source has no photometry.</p>;
     } else {
-      const keys = Object.keys(data[0]).filter((key) => key !== "groups");
+      const keys = [
+        "id",
+        "mjd",
+        "mag",
+        "magerr",
+        "limiting_mag",
+        "filter",
+        "instrument_name",
+        "instrument_id",
+        "snr",
+        "magsys",
+        "origin",
+        "altdata",
+        "ra",
+        "dec",
+        "ra_unc",
+        "dec_unc",
+        "created_at",
+      ];
+      Object.keys(data[0]).forEach((key) => {
+        if (
+          !keys.includes(key) &&
+          !["groups", "owner", "obj_id", "id"].includes(key)
+        ) {
+          keys.push(key);
+        }
+      });
+
       const columns = keys.map((key) => ({
         name: key,
         options: {
@@ -75,8 +153,27 @@ const PhotometryTable = ({ obj_id, open, onClose }) => {
             }
             return value;
           },
+          display: !defaultHiddenColumns.includes(key),
         },
       }));
+
+      const renderOwner = (dataIndex) => {
+        const phot = data[dataIndex];
+        return (
+          <div>
+            <div className={classes.actionButtons}>
+              <div>{phot.owner.username}</div>
+            </div>
+          </div>
+        );
+      };
+      columns.push({
+        name: "owner",
+        label: "Owner",
+        options: {
+          customBodyRenderLite: renderOwner,
+        },
+      });
 
       const renderEdit = (dataIndex) => {
         const phot = data[dataIndex];
@@ -158,12 +255,16 @@ const PhotometryTable = ({ obj_id, open, onClose }) => {
 
       bodyContent = (
         <div>
-          <MUIDataTable
-            title={`Photometry of ${obj_id}`}
-            columns={columns}
-            data={data}
-            options={options}
-          />
+          <StyledEngineProvider injectFirst>
+            <ThemeProvider theme={getMuiTheme(theme)}>
+              <MUIDataTable
+                title={`Photometry of ${obj_id}`}
+                columns={columns}
+                data={data}
+                options={options}
+              />
+            </ThemeProvider>
+          </StyledEngineProvider>
         </div>
       );
     }

--- a/static/js/components/UpdatePhotometry.jsx
+++ b/static/js/components/UpdatePhotometry.jsx
@@ -18,10 +18,6 @@ const useStyles = makeStyles(() => ({
     textAlign: "center",
     margin: "1rem",
   },
-  editIcon: {
-    height: "0.75rem",
-    cursor: "pointer",
-  },
 }));
 
 const UpdatePhotometry = ({ phot }) => {
@@ -99,7 +95,6 @@ const UpdatePhotometry = ({ phot }) => {
         data-testid="updatePhotometryIconButton"
         size="small"
         type="submit"
-        className={classes.editIcon}
         onClick={() => {
           setDialogOpen(true);
         }}

--- a/static/js/ducks/photometry.js
+++ b/static/js/ducks/photometry.js
@@ -17,7 +17,9 @@ const UPDATE_PHOTOMETRY = "skyportal/UPDATE_PHOTOMETRY";
 
 // eslint-disable-next-line import/prefer-default-export
 export function fetchSourcePhotometry(id) {
-  return API.GET(`/api/sources/${id}/photometry`, FETCH_SOURCE_PHOTOMETRY);
+  return API.GET(`/api/sources/${id}/photometry`, FETCH_SOURCE_PHOTOMETRY, {
+    includeOwnerInfo: true,
+  });
 }
 
 export function fetchFilterWavelengths(filterParams = {}) {


### PR DESCRIPTION
This PR extends on the current add_external_photomety method to make sure that we can either:
- as we do currently, error when any new rows already exist, and not even add the non-duplicates
- ignore duplicates, and only add new ones
- update duplicates if needed, and then add new ones

I made it so that the update is the default behavior, as I believe most places in the code that do call that method want to be doing that, but we could keep it to "error" by default, and specify that we allow an "update" where needed.