### PR TITLE
Issue #4627 Fixed - "Fixing the Resizing of the 'Add a Source' Drag Down on the Dashboard"

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@rjsf/validator-ajv8": "5.5.0",
     "autosuggest-highlight": "3.3.4",
     "buffer": "6.0.3",
-    "check-dependencies": "1.1.0",
+    "check-dependencies": "^1.1.0",
     "choices.js": "10.2.0",
     "clsx": "1.2.1",
     "convert-css-length": "2.0.1",

--- a/static/js/components/NewSource.jsx
+++ b/static/js/components/NewSource.jsx
@@ -20,6 +20,10 @@ import { hours_to_ra, dms_to_dec } from "../units";
 
 dayjs.extend(utc);
 
+const newSource = {
+  overflowY: 'scroll'
+};
+
 const NewSource = ({ classes }) => {
   const navigate = useNavigate();
   const dispatch = useDispatch();
@@ -118,7 +122,7 @@ const NewSource = ({ classes }) => {
   return (
     <Paper elevation={1} className={classes.widgetPaperFillSpace}>
       <div className={classes.widgetPaperDiv}>
-        <div>
+        <div style={newSource}>
           <Typography variant="h6" display="inline">
             Add a Source
           </Typography>


### PR DESCRIPTION
The 'Add a Source' menu now properly resizes with a scrollbar when the box is shrunk. Here is an image depicting the change:
![image](https://github.com/skyportal/skyportal/assets/45305455/8ed35b75-435c-4007-b5f2-d9e1dfad3b7f)


ORIGINAL BUG REPORT: https://github.com/skyportal/skyportal/issues/4627
Name: Bug report
About: Create a report to help us improve
Title: Fixing the Resizing of the 'Add a Source' Drag Down on the Dashboard
Labels: bug
Assignees: 'Pranav Karthik'

Describe the bug
On the dashboard of the Skyportal interface, attempting to resize the 'Add a Source' menu does not properly work; no sidebar pops up when it is shrunk and it retains its original size, squeezing out of its box

To Reproduce
Steps to reproduce the behavior:

Go to the Skyportal interface using local host.
Click on the dashboard
Scroll down to the 'Add a Source' box.
Clicking on the corner to resize, and shrinking the box does not affect the text, which now squeezes out of the box. Moving it around does work as intended, meaning other boxes can overlap with the text that juts out.
Expected behavior
Shrinking the box should cause a sidebar to appear that allows you to scroll up and down within the box.

Screenshots
image
image

Platform information:

SkyPortal version:
Interface:
[✓] I am using the API