### PR TITLE
GA bugfix: pycurl system dependencies

### DIFF
--- a/.github/workflows/build-and-deploy-docs.yaml
+++ b/.github/workflows/build-and-deploy-docs.yaml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Install system dependencies
         run: |
-
+          sudo apt update -y
           sudo apt install -y libcurl4-gnutls-dev libgnutls28-dev
 
           python -m pip install pip==23.1.2

--- a/.github/workflows/test_api_and_frontend.yaml
+++ b/.github/workflows/test_api_and_frontend.yaml
@@ -93,6 +93,7 @@ jobs:
 
       - name: Install system dependencies
         run: |
+          sudo apt update -y
           sudo apt install -y wget unzip firefox nginx libcurl4-gnutls-dev libgnutls28-dev
 
           pip install pip==23.1.2

--- a/.github/workflows/test_migrations.yaml
+++ b/.github/workflows/test_migrations.yaml
@@ -19,7 +19,7 @@ on:
 jobs:
   test:
     name: Test SkyPortal migrations
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
       # We only check migrations from this point onward, since we know

--- a/.github/workflows/test_migrations.yaml
+++ b/.github/workflows/test_migrations.yaml
@@ -19,7 +19,7 @@ on:
 jobs:
   test:
     name: Test SkyPortal migrations
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 90
     env:
       # We only check migrations from this point onward, since we know

--- a/.github/workflows/test_migrations.yaml
+++ b/.github/workflows/test_migrations.yaml
@@ -77,6 +77,7 @@ jobs:
 
       - name: Install system dependencies
         run: |
+          sudo apt update -y
           sudo apt install -y wget unzip firefox nginx libcurl4-gnutls-dev libgnutls28-dev
 
           pip install pip==23.1.2

--- a/.github/workflows/test_models.yaml
+++ b/.github/workflows/test_models.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 120
 
     services:
@@ -81,6 +81,7 @@ jobs:
 
       - name: Install system dependencies
         run: |
+          sudo apt update -y
           sudo apt install -y wget unzip firefox nginx libcurl4-gnutls-dev libgnutls28-dev
 
           pip install pip==23.1.2

--- a/.github/workflows/test_models.yaml
+++ b/.github/workflows/test_models.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 120
 
     services:
@@ -81,6 +81,7 @@ jobs:
 
       - name: Install system dependencies
         run: |
+          sudo apt update -y
           sudo apt install -y wget unzip firefox nginx libcurl4-gnutls-dev libgnutls28-dev
 
           pip install pip==23.1.2

--- a/.github/workflows/test_models.yaml
+++ b/.github/workflows/test_models.yaml
@@ -81,7 +81,6 @@ jobs:
 
       - name: Install system dependencies
         run: |
-          sudo apt update -y
           sudo apt install -y wget unzip firefox nginx libcurl4-gnutls-dev libgnutls28-dev
 
           pip install pip==23.1.2


### PR DESCRIPTION
Looks like the GAs are not running because we're not managing to install a few system dependencies we need for pycurl.

Opening a PR just so I can run said actions and try a few potential bugfixes.