### PR TITLE
WIP - Revert new sqlalchemy syntax when creating sessions

### DIFF
--- a/services/facility_queue/facility_queue.py
+++ b/services/facility_queue/facility_queue.py
@@ -151,7 +151,6 @@ def service(queue):
                                         altdata,
                                         followup_request.id,
                                         instrument.id,
-                                        followup_request.requester.id,
                                         parent_session=session,
                                         duplicates="update",
                                     )
@@ -304,7 +303,6 @@ def service(queue):
                                         altdata,
                                         followup_request.id,
                                         instrument.id,
-                                        followup_request.requester.id,
                                         parent_session=session,
                                         duplicates="update",
                                     )

--- a/skyportal/facility_apis/atlas.py
+++ b/skyportal/facility_apis/atlas.py
@@ -72,7 +72,6 @@ def commit_photometry(
     altdata,
     request_id,
     instrument_id,
-    user_id,
     parent_session=None,
     duplicates="error",
 ):
@@ -89,10 +88,10 @@ def commit_photometry(
         FollowupRequest SkyPortal ID
     instrument_id : int
         Instrument SkyPortal ID
-    user_id : int
-        User SkyPortal ID
     parent_session : sqlalchemy.orm.session.Session
         Session to use for database transactions. If None, a new session will be created.
+    duplicates : str
+        How to handle duplicate photometry. Must be one of "error", "update", "ignore".
     """
 
     from ..models import (

--- a/skyportal/facility_apis/tess.py
+++ b/skyportal/facility_apis/tess.py
@@ -271,5 +271,5 @@ class TESSAPI(FollowUpAPI):
                 'skyportal/REFRESH_FOLLOWUP_REQUESTS',
             )
 
-    form_json_schema = {}
+    form_json_schema_forced_photometry = {}
     ui_json_schema = {}

--- a/skyportal/facility_apis/tess.py
+++ b/skyportal/facility_apis/tess.py
@@ -2,7 +2,6 @@ from astropy.time import Time, TimeDelta
 from astropy.table import Table
 import numpy as np
 import sqlalchemy as sa
-from sqlalchemy.orm import sessionmaker, scoped_session
 from tornado.ioloop import IOLoop
 
 from . import FollowUpAPI
@@ -19,7 +18,7 @@ lightcurve_url = f"{TESS_URL}/light_curves/"
 log = make_log('facility_apis/tess')
 
 
-def commit_photometry(lc, request_id, instrument_id, user_id):
+def commit_photometry(lc, request_id, instrument_id):
     """
     Commits TESS photometry to the database
 
@@ -31,8 +30,6 @@ def commit_photometry(lc, request_id, instrument_id, user_id):
         FollowupRequest SkyPortal ID
     instrument_id : int
         Instrument SkyPortal ID
-    user_id : int
-        User SkyPortal ID
     """
 
     from ..models import (
@@ -41,129 +38,125 @@ def commit_photometry(lc, request_id, instrument_id, user_id):
         PhotometricSeries,
     )
 
-    Session = scoped_session(sessionmaker())
-    if Session.registry.has():
-        session = Session()
-    else:
-        session = Session(bind=DBSession.session_factory.kw["bind"])
+    with DBSession() as session:
+        try:
+            request = session.query(FollowupRequest).get(request_id)
+            allocation = request.allocation
+            if not allocation:
+                raise ValueError("Missing request's allocation information.")
 
-    try:
-        request = session.query(FollowupRequest).get(request_id)
-        allocation = request.allocation
-        if not allocation:
-            raise ValueError("Missing request's allocation information.")
+            lc['mjd'] = (
+                Time(2457000, format='jd') + TimeDelta(lc['BTJD'], format='jd')
+            ).mjd
+            lc['ra'] = request.obj.ra
+            lc['dec'] = request.obj.dec
+            lc['limiting_mag'] = 18.4
+            lc['zp'] = 20.5
+            lc['filter'] = 'tess'
+            lc['magsys'] = 'ab'
 
-        lc['mjd'] = (
-            Time(2457000, format='jd') + TimeDelta(lc['BTJD'], format='jd')
-        ).mjd
-        lc['ra'] = request.obj.ra
-        lc['dec'] = request.obj.dec
-        lc['limiting_mag'] = 18.4
-        lc['zp'] = 20.5
-        lc['filter'] = 'tess'
-        lc['magsys'] = 'ab'
+            df = lc.to_pandas()
+            df.rename(
+                columns={
+                    'e_mag': 'magerr',
+                    'cts_per_s': 'flux',
+                    'e_cts_per_s': 'fluxerr',
+                },
+                inplace=True,
+            )
 
-        df = lc.to_pandas()
-        df.rename(
-            columns={
-                'e_mag': 'magerr',
-                'cts_per_s': 'flux',
-                'e_cts_per_s': 'fluxerr',
-            },
-            inplace=True,
-        )
+            magerr_none = df['magerr'] == None  # noqa: E711
+            df.loc[magerr_none, 'mag'] = None
 
-        magerr_none = df['magerr'] == None  # noqa: E711
-        df.loc[magerr_none, 'mag'] = None
+            isnan = np.isnan(df['magerr'])
+            df.loc[isnan, 'mag'] = None
+            df.loc[isnan, 'magerr'] = None
 
-        isnan = np.isnan(df['magerr'])
-        df.loc[isnan, 'mag'] = None
-        df.loc[isnan, 'magerr'] = None
+            is99 = np.isclose(df['magerr'], 99.9)
+            df.loc[is99, 'mag'] = None
+            df.loc[is99, 'magerr'] = None
 
-        is99 = np.isclose(df['magerr'], 99.9)
-        df.loc[is99, 'mag'] = None
-        df.loc[is99, 'magerr'] = None
+            drop_columns = list(
+                set(df.columns.values)
+                - {
+                    'mjd',
+                    'ra',
+                    'dec',
+                    'mag',
+                    'magerr',
+                    'flux',
+                    'fluxerr',
+                    'zp',
+                    'limiting_mag',
+                    'filter',
+                    'magsys',
+                }
+            )
+            df.drop(
+                columns=drop_columns,
+                inplace=True,
+            )
 
-        drop_columns = list(
-            set(df.columns.values)
-            - {
-                'mjd',
-                'ra',
-                'dec',
-                'mag',
-                'magerr',
-                'flux',
-                'fluxerr',
-                'zp',
-                'limiting_mag',
-                'filter',
-                'magsys',
+            # data is visible to the group attached to the allocation
+            # as well as to any of the allocation's default share groups
+            data_out = {
+                'obj_id': request.obj.id,
+                'series_name': 'tesstransients',
+                'series_obj_id': request.obj.id,
+                'exp_time': 2.0,
+                'instrument_id': instrument_id,
+                'group_ids': list(
+                    set(
+                        [allocation.group_id] + allocation.default_share_group_ids
+                        if allocation.default_share_group_ids
+                        else []
+                    )
+                ),
             }
-        )
-        df.drop(
-            columns=drop_columns,
-            inplace=True,
-        )
 
-        # data is visible to the group attached to the allocation
-        # as well as to any of the allocation's default share groups
-        data_out = {
-            'obj_id': request.obj.id,
-            'series_name': 'tesstransients',
-            'series_obj_id': request.obj.id,
-            'exp_time': 2.0,
-            'instrument_id': instrument_id,
-            'group_ids': list(
-                set(
-                    [allocation.group_id] + allocation.default_share_group_ids
-                    if allocation.default_share_group_ids
-                    else []
-                )
-            ),
-        }
+            from skyportal.handlers.api.photometric_series import (
+                post_photometric_series,
+                update_photometric_series,
+            )
 
-        from skyportal.handlers.api.photometric_series import (
-            post_photometric_series,
-            update_photometric_series,
-        )
+            if len(df.index) > 0:
+                try:
+                    post_photometric_series(
+                        data_out, df, {}, request.requester, session
+                    )
+                    request.status = "Photometry committed to database"
+                except Exception:
+                    ps = session.scalars(
+                        sa.select(PhotometricSeries).where(
+                            PhotometricSeries.series_obj_id == request.obj.id,
+                            PhotometricSeries.obj_id == request.obj.id,
+                        )
+                    ).first()
+                    if ps is not None:
+                        update_photometric_series(
+                            ps, data_out, df, {}, request.requester, session
+                        )
+                        request.status = "Photometry updated in database"
+                    else:
+                        request.status = "No photometry to commit to database"
+            else:
+                request.status = "No photometry to commit to database"
 
-        if len(df.index) > 0:
+            session.add(request)
+            session.commit()
+
+            flow = Flow()
+            flow.push(
+                '*',
+                "skyportal/REFRESH_SOURCE",
+                payload={"obj_key": request.obj.internal_key},
+            )
+        except Exception as e:
+            log(f"Unable to commit photometry for {request_id}: {e}")
             try:
-                post_photometric_series(data_out, df, {}, request.requester, session)
-                request.status = "Photometry committed to database"
+                session.rollback()
             except Exception:
-                ps = session.scalars(
-                    sa.select(PhotometricSeries).where(
-                        PhotometricSeries.series_obj_id == request.obj.id,
-                        PhotometricSeries.obj_id == request.obj.id,
-                    )
-                ).first()
-                if ps is not None:
-                    update_photometric_series(
-                        ps, data_out, df, {}, request.requester, session
-                    )
-                    request.status = "Photometry updated in database"
-                else:
-                    request.status = "No photometry to commit to database"
-        else:
-            request.status = "No photometry to commit to database"
-
-        session.add(request)
-        session.commit()
-
-        flow = Flow()
-        flow.push(
-            '*',
-            "skyportal/REFRESH_SOURCE",
-            payload={"obj_key": request.obj.internal_key},
-        )
-
-    except Exception as e:
-        session.rollback()
-        log(f"Unable to commit photometry for {request_id}: {e}")
-    finally:
-        session.close()
-        Session.remove()
+                pass
 
 
 class TESSAPI(FollowUpAPI):
@@ -215,9 +208,7 @@ class TESSAPI(FollowUpAPI):
                 else:
                     IOLoop.current().run_in_executor(
                         None,
-                        lambda: commit_photometry(
-                            lc, request.id, instrument.id, request.requester.id
-                        ),
+                        lambda: commit_photometry(lc, request.id, instrument.id),
                     )
 
             except FileNotFoundError:

--- a/skyportal/facility_apis/ztf.py
+++ b/skyportal/facility_apis/ztf.py
@@ -212,7 +212,6 @@ def commit_photometry(
     altdata,
     request_id,
     instrument_id,
-    user_id,
     parent_session=None,
     duplicates="error",
 ):
@@ -229,10 +228,10 @@ def commit_photometry(
         FollowupRequest SkyPortal ID
     instrument_id : int
         Instrument SkyPortal ID
-    user_id : int
-        User SkyPortal ID
     parent_session : sqlalchemy.orm.session.Session
         SQLAlchemy session object. If None, a new session is created.
+    duplicates : str
+        How to handle duplicate photometry. One of "error", "update", "ignore".
     """
 
     from ..models import (


### PR DESCRIPTION
Looks like this new syntax is causing us trouble again.

Unfortunately, the PS1 API is down right now, so I can't test these changes properly. I will have to wait until it's back up to verify everything. The way we create the sessions recently (with the bindings to DBSession instead of directly using DBSession after import) is the only different between places where it works and places where it doesn't work, so I'd like to try to revert that and test it on preview. 