### PR TITLE
Pin gcn-kafka to 0.3.3 and confluent-kafka to 2.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -77,8 +77,8 @@ penquins==2.3.2
 selenium==4.8.3
 selenium-requests==2.0.3
 afterglowpy==0.7.3
-gcn-kafka==0.3.0
-confluent_kafka==1.9.2 # dependency of gcn-kafka: pinning to understand memory effects on GCNEvents
+gcn-kafka==0.3.3
+confluent_kafka==2.2.0 # dependency of gcn-kafka: pinning to understand memory effects on GCNEvents
 iminuit==2.24.0
 watchdog==3.0.0
 PyAstronomy==0.19.0


### PR DESCRIPTION
An attempt to fix a failed dependabot PR