### PR TITLE
GA: labeler v5 update

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,54 +2,65 @@
 
 # Add 'config-change' label to any change to default config files
 config-change:
-  - "config.yaml.defaults"
-  - "test_config.yaml"
+  - changed-files:
+      - any-glob-to-any-file: ["config.yaml.defaults", "test_config.yaml"]
 
 # Add 'demo-data' label to any change to provided demo data
 demo-data:
-  - data/**/*
+  - changed-files:
+      - any-glob-to-any-file: "data/**/*"
 
 # Add 'dependencies' label to any change to dependencies
 dependencies:
-  - "requirements.txt"
-  - "requirements.docs.txt"
-  - "package.json"
+  - changed-files:
+      - any-glob-to-any-file:
+          ["requirements.txt", "requirements.docs.txt", "package.json"]
 
 # Add 'docker' label to any change to files related to Docker deployment
 docker:
-  - "Dockerfile"
-  - "docker.yaml"
-  - "docker-compose.yaml"
-  - ".dockerignore"
+  - changed-files:
+      - any-glob-to-any-file:
+          ["Dockerfile", "docker.yaml", "docker-compose.yaml", ".dockerignore"]
 
 # Add 'documentation' label to any change to the doc directory
 documentation:
-  - doc/**/*
+  - changed-files:
+      - any-glob-to-any-file: "doc/**/*"
 
 # Add 'formatting-and-linting' label to any changes to the formatting and
 # linting checks, and the pre-commit hooks that run them
 formatting-and-linting:
-  - ".eslintignore"
-  - ".eslintrc.yaml"
-  - ".flake8"
-  - ".git-pre-commit"
-  - ".pep8speaks.yml"
-  - ".pre-commit-config.yaml"
+  - changed-files:
+      - any-glob-to-any-file:
+          [
+            ".eslintignore",
+            ".eslintrc.yaml",
+            ".flake8",
+            ".git-pre-commit",
+            ".pep8speaks.yml",
+            ".pre-commit-config.yaml",
+          ]
 
 # Add 'migration' label to any change within the 'alembic' directory
 migration:
-  - alembic/versions/*
+  - changed-files:
+      - any-glob-to-any-file: "alembic/versions/*"
 
 # Add 'needs-migration?' label to any change to models.py without changes to
 # the Alembic versions
 needs-migration?:
-  - any: ["skyportal/models.py", "skyportal/models/*"]
-    all: ["!alembic/versions/*"]
-  - any: ["baselayer/app/models.py", "baselayer/app/models/*"]
-    all: ["!alembic/versions/*"]
-  - any: ["requirements.txt"]
-    all: ["!alembic/versions/*"]
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["skyportal/models.py", "skyportal/models/*"]
+          - all-globs-to-all-files: "!alembic/versions/*"
+      - changed-files:
+          - any-glob-to-any-file:
+              ["baselayer/app/models.py", "baselayer/app/models/*"]
+          - all-globs-to-all-files: "!alembic/versions/*"
+      - changed-files:
+          - any-glob-to-any-file: ["requirements.txt"]
+          - all-globs-to-all-files: "!alembic/versions/*"
 
 # Add 'workflows' label to any changes to GA workflows (.github folder)
 workflows:
-  - .github/**/*
+  - any-glob-to-any-file: ".github/**/*"

--- a/.github/workflows/add_labels.yaml
+++ b/.github/workflows/add_labels.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     # Add labels based on contents of .github/labeler.yml
     steps:
-      - uses: actions/labeler@main
+      - uses: actions/labeler@5.0.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           sync-labels: true


### PR DESCRIPTION
In our GitHub actions, we're not specifying a version of the labeler to use. They recently released a new version which seems to break ours.

This is an attempt to update to that newer syntax, which honestly isn't as clear as the previous version in my opinion.