### PR TITLE
Multi-threaded microservices: thread health check

### DIFF
--- a/services/facility_queue/facility_queue.py
+++ b/services/facility_queue/facility_queue.py
@@ -415,6 +415,14 @@ if __name__ == "__main__":
         while True:
             log(f"Current facility queue length: {len(queue)}")
             time.sleep(120)
+            if not t.is_alive():
+                log("Facility queue service thread died, restarting")
+                t = Thread(target=service, args=(queue,))
+                t.start()
+            if not t2.is_alive():
+                log("Facility queue API thread died, restarting")
+                t2 = Thread(target=api, args=(queue,))
+                t2.start()
     except Exception as e:
         log(f"Error starting facility queue: {str(e)}")
         raise e

--- a/services/notification_queue/notification_queue.py
+++ b/services/notification_queue/notification_queue.py
@@ -1556,6 +1556,14 @@ if __name__ == "__main__":
         while True:
             log(f"Current notification queue length: {len(queue)}")
             time.sleep(120)
+            if not t.is_alive():
+                log("Notification queue service thread died, restarting")
+                t = Thread(target=service, args=(queue,))
+                t.start()
+            if not t2.is_alive():
+                log("Notification queue API thread died, restarting")
+                t2 = Thread(target=api, args=(queue,))
+                t2.start()
     except Exception as e:
         log(f"Error starting notification queue: {str(e)}")
         raise e


### PR DESCRIPTION
We had an issue in production where the thumbnails queue kept filling up and didn't seem to get processed at all, as if the API running on one thread was doing just fine, but the queue processing running on the other wasn't there anymore. Nothing in said queue processing service seems to be able to just get stuck like that, so it's likely that the thread was just not alive anymore for some reason. The app had been up for more than a week which rarely happens, so that might be the reason.

This should check if the threads are still up and restart them if necessary.