### PR TITLE
Labeler action: fix version number

### DIFF
--- a/.github/workflows/add_labels.yaml
+++ b/.github/workflows/add_labels.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     # Add labels based on contents of .github/labeler.yml
     steps:
-      - uses: actions/labeler@v5.0.0
+      - uses: actions/labeler@v5
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           sync-labels: true

--- a/.github/workflows/add_labels.yaml
+++ b/.github/workflows/add_labels.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     # Add labels based on contents of .github/labeler.yml
     steps:
-      - uses: actions/labeler@main
+      - uses: actions/labeler@v4
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           sync-labels: true

--- a/.github/workflows/add_labels.yaml
+++ b/.github/workflows/add_labels.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     # Add labels based on contents of .github/labeler.yml
     steps:
-      - uses: actions/labeler@v4.3.0
+      - uses: actions/labeler@v5.0.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           sync-labels: true


### PR DESCRIPTION
Numerous issues with the version of the action that's on its main branch. Following the new documentation to fix breaking changes still leaves us with an issue that prevents anything from running. This is an attempt to just pin the previous (working) version while we figure out the v5 or while it gets fixed.

EDIT: The version number I pinned is incorrect. Let's try to fix that first to see if the v5 actually works now