### PR TITLE
Forced Photometry Form - dynamic date range

### DIFF
--- a/static/js/components/FollowupRequestForm.jsx
+++ b/static/js/components/FollowupRequestForm.jsx
@@ -270,6 +270,28 @@ const FollowupRequestForm = ({
           allocationLookUp[selectedAllocationId].instrument_id
         ].formSchema;
 
+  if (
+    schema &&
+    requestType === "forced_photometry" &&
+    schema.properties?.start_date &&
+    schema.properties?.end_date
+  ) {
+    // edit the start and end date to be 30 days ending right now (in UTC)
+    const endDate = new Date();
+    const startDate = new Date(endDate - 30 * 24 * 60 * 60 * 1000);
+    // eslint-disable-next-line no-param-reassign
+    schema.properties.start_date.default = startDate // eslint-disable-line prefer-destructuring
+      .toISOString()
+      .replace("Z", "")
+      .replace("T", " ")
+      .split(".")[0];
+    schema.properties.end_date.default = endDate // eslint-disable-line prefer-destructuring
+      .toISOString()
+      .replace("Z", "")
+      .replace("T", " ")
+      .split(".")[0];
+  }
+
   const { uiSchema } =
     instrumentFormParams[allocationLookUp[selectedAllocationId].instrument_id];
 

--- a/static/js/components/FollowupRequestForm.jsx
+++ b/static/js/components/FollowupRequestForm.jsx
@@ -270,26 +270,39 @@ const FollowupRequestForm = ({
           allocationLookUp[selectedAllocationId].instrument_id
         ].formSchema;
 
-  if (
-    schema &&
-    requestType === "forced_photometry" &&
-    schema.properties?.start_date &&
-    schema.properties?.end_date
-  ) {
-    // edit the start and end date to be 30 days ending right now (in UTC)
-    const endDate = new Date();
-    const startDate = new Date(endDate - 30 * 24 * 60 * 60 * 1000);
-    // eslint-disable-next-line no-param-reassign
-    schema.properties.start_date.default = startDate // eslint-disable-line prefer-destructuring
-      .toISOString()
-      .replace("Z", "")
-      .replace("T", " ")
-      .split(".")[0];
-    schema.properties.end_date.default = endDate // eslint-disable-line prefer-destructuring
-      .toISOString()
-      .replace("Z", "")
-      .replace("T", " ")
-      .split(".")[0];
+  if (schema && schema.properties?.start_date && schema.properties?.end_date) {
+    if (requestType === "forced_photometry") {
+      // edit the start and end date to be 30 days ending right now (in UTC)
+      const endDate = new Date();
+      const startDate = new Date(endDate - 30 * 24 * 60 * 60 * 1000);
+      schema.properties.start_date.default = startDate // eslint-disable-line prefer-destructuring
+        .toISOString()
+        .replace("Z", "")
+        .replace("T", " ")
+        .split(".")[0];
+      schema.properties.end_date.default = endDate // eslint-disable-line prefer-destructuring
+        .toISOString()
+        .replace("Z", "")
+        .replace("T", " ")
+        .split(".")[0];
+    } else {
+      // here, the range isn't necessarily 30 days, so we look at the values provided
+      // calculate the range, and then update the default to be:
+      // - start_date: now
+      // - end_date: now + range
+      const { start_date, end_date } = schema.properties;
+      const startDate = new Date(start_date.default);
+      const endDate = new Date(end_date.default);
+      const range = endDate - startDate;
+      const newStartDate = new Date();
+      const newEndDate = new Date(newStartDate.getTime() + range);
+      schema.properties.start_date.default = newStartDate // eslint-disable-line prefer-destructuring
+        .toISOString()
+        .split("T")[0];
+      schema.properties.end_date.default = newEndDate // eslint-disable-line prefer-destructuring
+        .toISOString()
+        .split("T")[0];
+    }
   }
 
   const { uiSchema } =


### PR DESCRIPTION
Right now, the start and end date values of our instrument forms are calculated in the backend when they are fetched. However, this means that the values aren't updated in real time. So for example, if you have a Fritz tab left open, the date will never update.

This PR addresses that problem for both forced photometry and follow-up requests:
- for the forced photometry, we simply use 30 days with now as the end date.
- for follow-up requests, we calculate the time range used from the default values, and recalculate new values using now as the start date and now + calculated range as the end date.