### PR TITLE
GitHub actions: PostgreSQL 15

### DIFF
--- a/.github/workflows/build-and-deploy-docs.yaml
+++ b/.github/workflows/build-and-deploy-docs.yaml
@@ -15,7 +15,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:14.9
+        image: postgres:15
         env:
           POSTGRES_USER: skyportal
           POSTGRES_PASSWORD: anything

--- a/.github/workflows/test_api_and_frontend.yaml
+++ b/.github/workflows/test_api_and_frontend.yaml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 120
     services:
       postgres:
-        image: postgres:14.9
+        image: postgres:15
         env:
           POSTGRES_USER: skyportal
           POSTGRES_PASSWORD: anything

--- a/.github/workflows/test_migrations.yaml
+++ b/.github/workflows/test_migrations.yaml
@@ -33,7 +33,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:14.9
+        image: postgres:15
         env:
           POSTGRES_USER: skyportal
           POSTGRES_PASSWORD: anything

--- a/.github/workflows/test_models.yaml
+++ b/.github/workflows/test_models.yaml
@@ -13,7 +13,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:14.9
+        image: postgres:15
         env:
           POSTGRES_USER: skyportal
           POSTGRES_PASSWORD: anything


### PR DESCRIPTION
Migrate to PostgreSQL 15 for the GitHub actions.

If possible, we'll also want to open a PR where we document how to upgrade the DB in our docs.