### PR TITLE
Insert photometry bugfix - no error when no rows are uploaded

### DIFF
--- a/skyportal/handlers/api/photometry.py
+++ b/skyportal/handlers/api/photometry.py
@@ -965,6 +965,7 @@ def add_external_photometry(json, user, parent_session=None, duplicates="update"
         else:
             new_photometry = df.copy()
 
+        ids, upload_id = [], None
         if len(new_photometry) > 0:
             ids, upload_id = insert_new_photometry_data(
                 new_photometry,


### PR DESCRIPTION
A variable (upload_id) ended up being undefined if there is no new photometry to upload. This should fix it.