### PR TITLE
Thumbnails ingestion - Simpler & (hopefully) better

### DIFF
--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -656,7 +656,6 @@ ports:
   notification_queue: 64610
   observation_plan_queue: 64710
   tns_retrieval_queue: 64810
-  thumbnail_queue: 64910
   tns_submission_queue: 64812
 
 gcn:

--- a/services/gcn_service/gcn_service.py
+++ b/services/gcn_service/gcn_service.py
@@ -1,10 +1,8 @@
 import os
-import time
 import uuid
 
 import gcn
 import lxml
-import requests
 import sqlalchemy as sa
 import xmlschema
 from gcn_kafka import Consumer
@@ -20,6 +18,7 @@ from skyportal.handlers.api.gcn import (
 from skyportal.models import DBSession, GcnEvent
 from skyportal.utils.gcn import get_dateobs, get_skymap_metadata, get_trigger
 from skyportal.utils.notifications import post_notification
+from skyportal.utils.services import check_loaded
 
 env, cfg = load_env()
 
@@ -37,38 +36,6 @@ reject_tags = cfg.get('gcn.reject_tags', [])
 log = make_log('gcnserver')
 
 user_id = 1
-
-REQUEST_TIMEOUT_SECONDS = cfg['health_monitor.request_timeout_seconds']
-
-host = f'{cfg["server.protocol"]}://{cfg["server.host"]}' + (
-    f':{cfg["server.port"]}' if cfg['server.port'] not in [80, 443] else ''
-)
-
-
-def is_loaded():
-    try:
-        r = requests.get(f'{host}/api/sysinfo', timeout=REQUEST_TIMEOUT_SECONDS)
-    except:  # noqa: E722
-        status_code = 0
-    else:
-        status_code = r.status_code
-
-    if status_code == 200:
-        return True
-    else:
-        return False
-
-
-def service():
-    if not is_configured():
-        return
-    while True:
-        if is_loaded():
-            try:
-                poll_events()
-            except Exception as e:
-                log(e)
-        time.sleep(15)
 
 
 def get_root_from_payload(payload):
@@ -101,7 +68,8 @@ def is_configured():
     return True
 
 
-def poll_events():
+@check_loaded(logger=log)
+def poll_events(*args, **kwargs):
     client_group_id = cfg.get('gcn.client_group_id')
     if client_group_id is None or client_group_id == '':
         client_group_id = str(uuid.uuid4())
@@ -224,6 +192,16 @@ def poll_events():
 
         except Exception as e:
             log(f'Failed to consume gcn event: {e}')
+
+
+def service():
+    if not is_configured():
+        return
+    while True:
+        try:
+            poll_events()
+        except Exception as e:
+            log(e)
 
 
 if __name__ == "__main__":

--- a/services/observation_plan_queue/observation_plan_queue.py
+++ b/services/observation_plan_queue/observation_plan_queue.py
@@ -1,10 +1,8 @@
 import itertools
-import requests
 import time
 
 import arrow
 import sqlalchemy as sa
-from sqlalchemy.orm import scoped_session, sessionmaker
 
 from baselayer.app.env import load_env
 from baselayer.app.models import init_db
@@ -16,295 +14,259 @@ from skyportal.models import (
     EventObservationPlan,
     ObservationPlanRequest,
 )
+from skyportal.utils.services import check_loaded
 
 env, cfg = load_env()
 log = make_log('observation_plan_queue')
 
 init_db(**cfg['database'])
 
-Session = scoped_session(sessionmaker())
 
-REQUEST_TIMEOUT_SECONDS = cfg['health_monitor.request_timeout_seconds']
-
-host = f'{cfg["server.protocol"]}://{cfg["server.host"]}' + (
-    f':{cfg["server.port"]}' if cfg['server.port'] not in [80, 443] else ''
-)
-
-
-def is_loaded():
+def prioritize_requests(requests):
     try:
-        r = requests.get(f'{host}/api/sysinfo', timeout=REQUEST_TIMEOUT_SECONDS)
-    except:  # noqa: E722
-        status_code = 0
-    else:
-        status_code = r.status_code
-
-    if status_code == 200:
-        return True
-    else:
-        return False
-
-
-class ObservationPlanQueue:
-    def __init__(self):
-        self.scoped_session = scoped_session(sessionmaker())
-
-    def Session(self):
-        if self.scoped_session.registry.has():
-            return self.scoped_session()
-        else:
-            return self.scoped_session(bind=DBSession.session_factory.kw["bind"])
-
-    def prioritize_requests(self, requests):
-        try:
-            if (
-                len(requests) == 1
-            ):  # if there is only one plan in the queue, no need to prioritize
-                return 0
-
-            telescopeAllocationLookup = {}
-            allocationByPlanLookup = {}
-
-            # we create 2 lookups to avoid repeating some operations like getting the morning and evening for a telescope
-            for ii, plan_requests in enumerate(requests):
-                for plan in plan_requests:
-                    allocation_id = plan.allocation_id
-                    if ii not in allocationByPlanLookup.keys():
-                        allocationByPlanLookup[ii] = [
-                            {
-                                "allocation_id": allocation_id,
-                                "start_date": plan.payload.get("start_date", None),
-                            }
-                        ]
-                    else:
-                        allocationByPlanLookup[ii].append(
-                            {
-                                "allocation_id": allocation_id,
-                                "start_date": plan.payload.get("start_date", None),
-                            }
-                        )
-                    if allocation_id not in telescopeAllocationLookup:
-                        telescopeAllocationLookup[
-                            allocation_id
-                        ] = plan.allocation.instrument.telescope.current_time
-
-            # now we loop over the plans. For plans with multiple plans we pick the allocation with the earliest start date and morning time
-            # at the same time, we pick the plan to prioritize
-            plan_with_priority = None
-            for plan_id, allocationsAndStartDate in allocationByPlanLookup.items():
-                if plan_with_priority is None:
-                    plan_with_priority = {
-                        "plan_id": plan_id,
-                        "morning": telescopeAllocationLookup[
-                            allocationsAndStartDate[0]["allocation_id"]
-                        ]["morning"],
-                        "start_date": allocationsAndStartDate[0]["start_date"],
-                    }
-                earliest = None
-                for allocationAndStartDate in allocationsAndStartDate:
-                    # find the plan
-                    if earliest is None:
-                        earliest = allocationAndStartDate
-                        continue
-                    if (
-                        telescopeAllocationLookup[
-                            allocationAndStartDate["allocation_id"]
-                        ]["morning"]
-                        is False
-                    ):
-                        continue
-                    start_date = allocationAndStartDate["start_date"]
-                    if start_date is None:
-                        continue
-                    start_date = arrow.get(start_date).datetime
-                    if (
-                        start_date
-                        > telescopeAllocationLookup[
-                            allocationAndStartDate["allocation_id"]
-                        ]["morning"].datetime
-                    ):
-                        continue
-                    if (
-                        telescopeAllocationLookup[earliest["allocation_id"]]["morning"]
-                        is False
-                    ):
-                        earliest = allocationAndStartDate
-                        continue
-                    if (
-                        telescopeAllocationLookup[
-                            allocationAndStartDate["allocation_id"]
-                        ]["morning"].datetime
-                        < telescopeAllocationLookup[earliest["allocation_id"]][
-                            "morning"
-                        ].datetime
-                    ):
-                        earliest = plan.allocation
-                        continue
-                allocationByPlanLookup[plan_id] = [earliest]
-
-                # check if that plan is more urgent than the current plan_with_priority
-                if (
-                    telescopeAllocationLookup[earliest["allocation_id"]]["morning"]
-                    is None
-                ):
-                    continue
-                if plan_with_priority["morning"] is None:
-                    plan_with_priority = {
-                        "plan_id": plan_id,
-                        "morning": telescopeAllocationLookup[earliest["allocation_id"]][
-                            "morning"
-                        ],
-                        "start_date": earliest["start_date"],
-                    }
-                    continue
-                if (
-                    telescopeAllocationLookup[earliest["allocation_id"]]["morning"]
-                    <= plan_with_priority["morning"]
-                    and earliest["start_date"] < plan_with_priority["start_date"]
-                ):
-                    plan_with_priority = {
-                        "plan_id": plan_id,
-                        "morning": telescopeAllocationLookup[earliest["allocation_id"]][
-                            "morning"
-                        ],
-                        "start_date": earliest["start_date"],
-                    }
-                    continue
-
-            return plan_with_priority["plan_id"]
-        except Exception as e:
-            log(f"Error occured prioritizing the observation plan queue: {e}")
+        if (
+            len(requests) == 1
+        ):  # if there is only one plan in the queue, no need to prioritize
             return 0
 
-    def service(self):
-        log("Starting observation plan queue.")
-        while True:
-            with self.Session() as session:
-                try:
-                    stmt = sa.select(ObservationPlanRequest).where(
-                        ObservationPlanRequest.status == "pending submission",
-                        ObservationPlanRequest.created_at
-                        > arrow.utcnow().shift(days=-1).datetime,
-                        # we only want to process plans that have been created in the last 24 hours
+        telescopeAllocationLookup = {}
+        allocationByPlanLookup = {}
+
+        # we create 2 lookups to avoid repeating some operations like getting the morning and evening for a telescope
+        for ii, plan_requests in enumerate(requests):
+            for plan in plan_requests:
+                allocation_id = plan.allocation_id
+                if ii not in allocationByPlanLookup.keys():
+                    allocationByPlanLookup[ii] = [
+                        {
+                            "allocation_id": allocation_id,
+                            "start_date": plan.payload.get("start_date", None),
+                        }
+                    ]
+                else:
+                    allocationByPlanLookup[ii].append(
+                        {
+                            "allocation_id": allocation_id,
+                            "start_date": plan.payload.get("start_date", None),
+                        }
                     )
-                    single_requests = session.execute(stmt).scalars().unique().all()
+                if allocation_id not in telescopeAllocationLookup:
+                    telescopeAllocationLookup[
+                        allocation_id
+                    ] = plan.allocation.instrument.telescope.current_time
 
-                    # requests is a list. We want to group that list of plans to be a list of list,
-                    # we group based on the plans 'combined_id' which is a unique uuid for a group of plans
-                    # plans that are not grouped simply don't have one
-                    combined_requests = [
-                        request
-                        for request in single_requests
-                        if request.combined_id is not None
+        # now we loop over the plans. For plans with multiple plans we pick the allocation with the earliest start date and morning time
+        # at the same time, we pick the plan to prioritize
+        plan_with_priority = None
+        for plan_id, allocationsAndStartDate in allocationByPlanLookup.items():
+            if plan_with_priority is None:
+                plan_with_priority = {
+                    "plan_id": plan_id,
+                    "morning": telescopeAllocationLookup[
+                        allocationsAndStartDate[0]["allocation_id"]
+                    ]["morning"],
+                    "start_date": allocationsAndStartDate[0]["start_date"],
+                }
+            earliest = None
+            for allocationAndStartDate in allocationsAndStartDate:
+                # find the plan
+                if earliest is None:
+                    earliest = allocationAndStartDate
+                    continue
+                if (
+                    telescopeAllocationLookup[allocationAndStartDate["allocation_id"]][
+                        "morning"
                     ]
-                    requests = [
-                        list(group)
-                        for _, group in itertools.groupby(
-                            combined_requests, lambda x: x.combined_id
+                    is False
+                ):
+                    continue
+                start_date = allocationAndStartDate["start_date"]
+                if start_date is None:
+                    continue
+                start_date = arrow.get(start_date).datetime
+                if (
+                    start_date
+                    > telescopeAllocationLookup[
+                        allocationAndStartDate["allocation_id"]
+                    ]["morning"].datetime
+                ):
+                    continue
+                if (
+                    telescopeAllocationLookup[earliest["allocation_id"]]["morning"]
+                    is False
+                ):
+                    earliest = allocationAndStartDate
+                    continue
+                if (
+                    telescopeAllocationLookup[allocationAndStartDate["allocation_id"]][
+                        "morning"
+                    ].datetime
+                    < telescopeAllocationLookup[earliest["allocation_id"]][
+                        "morning"
+                    ].datetime
+                ):
+                    earliest = plan.allocation
+                    continue
+            allocationByPlanLookup[plan_id] = [earliest]
+
+            # check if that plan is more urgent than the current plan_with_priority
+            if telescopeAllocationLookup[earliest["allocation_id"]]["morning"] is None:
+                continue
+            if plan_with_priority["morning"] is None:
+                plan_with_priority = {
+                    "plan_id": plan_id,
+                    "morning": telescopeAllocationLookup[earliest["allocation_id"]][
+                        "morning"
+                    ],
+                    "start_date": earliest["start_date"],
+                }
+                continue
+            if (
+                telescopeAllocationLookup[earliest["allocation_id"]]["morning"]
+                <= plan_with_priority["morning"]
+                and earliest["start_date"] < plan_with_priority["start_date"]
+            ):
+                plan_with_priority = {
+                    "plan_id": plan_id,
+                    "morning": telescopeAllocationLookup[earliest["allocation_id"]][
+                        "morning"
+                    ],
+                    "start_date": earliest["start_date"],
+                }
+                continue
+
+        return plan_with_priority["plan_id"]
+    except Exception as e:
+        log(f"Error occured prioritizing the observation plan queue: {e}")
+        return 0
+
+
+@check_loaded(logger=log)
+def service(*args, **kwargs):
+    log("Starting observation plan queue.")
+    while True:
+        with DBSession() as session:
+            try:
+                stmt = sa.select(ObservationPlanRequest).where(
+                    ObservationPlanRequest.status == "pending submission",
+                    ObservationPlanRequest.created_at
+                    > arrow.utcnow().shift(days=-1).datetime,
+                    # we only want to process plans that have been created in the last 24 hours
+                )
+                single_requests = session.execute(stmt).scalars().unique().all()
+
+                # requests is a list. We want to group that list of plans to be a list of list,
+                # we group based on the plans 'combined_id' which is a unique uuid for a group of plans
+                # plans that are not grouped simply don't have one
+                combined_requests = [
+                    request
+                    for request in single_requests
+                    if request.combined_id is not None
+                ]
+                requests = [
+                    list(group)
+                    for _, group in itertools.groupby(
+                        combined_requests, lambda x: x.combined_id
+                    )
+                ] + [
+                    [request]
+                    for request in single_requests
+                    if request.combined_id is None
+                ]
+
+                if len(requests) == 0:
+                    time.sleep(2)
+                    continue
+
+                log(f"Prioritizing {len(requests)} observation plan requests...")
+
+                index = prioritize_requests(requests)
+
+                plan_requests = requests[index]
+                plan_ids = []
+                if len(plan_requests) == 1:
+                    plan_request = plan_requests[0]
+                    try:
+                        plan_id = (
+                            plan_request.allocation.instrument.api_class_obsplan.submit(
+                                plan_request.id, asynchronous=False
+                            )
                         )
-                    ] + [
-                        [request]
-                        for request in single_requests
-                        if request.combined_id is None
-                    ]
+                        plan_ids.append(plan_id)
+                    except Exception as e:
+                        plan_request.status = 'failed to process'
+                        log(f'Error processing observation plan: {e.args[0]}')
+                        session.commit()
+                        time.sleep(2)
+                        continue
+                    plan_request.status = 'complete'
+                    session.commit()
 
-                    if len(requests) == 0:
+                else:
+                    try:
+                        plan_ids = plan_requests[
+                            0
+                        ].allocation.instrument.api_class_obsplan.submit_multiple(
+                            plan_requests, asynchronous=False
+                        )
+                    except Exception as e:
+                        for plan_request in plan_requests:
+                            plan_request.status = 'failed to process'
+                        log(
+                            f'Error processing combined plans: {[plan_request.id for plan_request in plan_requests]}: {str(e)}'
+                        )
+                        session.commit()
                         time.sleep(2)
                         continue
 
-                    log(f"Prioritizing {len(requests)} observation plan requests...")
-
-                    index = self.prioritize_requests(requests)
-
-                    plan_requests = requests[index]
-                    plan_ids = []
-                    if len(plan_requests) == 1:
-                        plan_request = plan_requests[0]
-                        try:
-                            plan_id = plan_request.allocation.instrument.api_class_obsplan.submit(
-                                plan_request.id, asynchronous=False
-                            )
-                            plan_ids.append(plan_id)
-                        except Exception as e:
-                            plan_request.status = 'failed to process'
-                            log(f'Error processing observation plan: {e.args[0]}')
-                            session.commit()
-                            time.sleep(2)
-                            continue
+                    for plan_request in plan_requests:
                         plan_request.status = 'complete'
-                        session.commit()
+                    session.commit()
 
-                    else:
-                        try:
-                            plan_ids = plan_requests[
-                                0
-                            ].allocation.instrument.api_class_obsplan.submit_multiple(
-                                plan_requests, asynchronous=False
+                log(f"Generated plans: {plan_ids}")
+                for id in plan_ids:
+                    try:
+                        plan = session.scalars(
+                            sa.select(EventObservationPlan).where(
+                                EventObservationPlan.id == int(id)
                             )
-                        except Exception as e:
-                            for plan_request in plan_requests:
-                                plan_request.status = 'failed to process'
-                            log(
-                                f'Error processing combined plans: {[plan_request.id for plan_request in plan_requests]}: {str(e)}'
-                            )
-                            session.commit()
-                            time.sleep(2)
-                            continue
-
-                        for plan_request in plan_requests:
-                            plan_request.status = 'complete'
-                        session.commit()
-
-                    log(f"Generated plans: {plan_ids}")
-                    for id in plan_ids:
-                        try:
-                            plan = session.scalars(
-                                sa.select(EventObservationPlan).where(
-                                    EventObservationPlan.id == int(id)
+                        ).first()
+                        default = plan.observation_plan_request.payload.get(
+                            'default', None
+                        )
+                        if default is not None:
+                            defaultobsplanrequest = session.scalars(
+                                sa.select(DefaultObservationPlanRequest).where(
+                                    DefaultObservationPlanRequest.id == int(default)
                                 )
                             ).first()
-                            default = plan.observation_plan_request.payload.get(
-                                'default', None
-                            )
-                            if default is not None:
-                                defaultobsplanrequest = session.scalars(
-                                    sa.select(DefaultObservationPlanRequest).where(
-                                        DefaultObservationPlanRequest.id == int(default)
+                            if defaultobsplanrequest is not None:
+                                for (
+                                    default_survey_efficiency
+                                ) in defaultobsplanrequest.default_survey_efficiencies:
+                                    post_survey_efficiency_analysis(
+                                        default_survey_efficiency.to_dict(),
+                                        plan.id,
+                                        1,
+                                        session,
+                                        asynchronous=False,
                                     )
-                                ).first()
-                                if defaultobsplanrequest is not None:
-                                    for (
-                                        default_survey_efficiency
-                                    ) in (
-                                        defaultobsplanrequest.default_survey_efficiencies
-                                    ):
-                                        post_survey_efficiency_analysis(
-                                            default_survey_efficiency.to_dict(),
-                                            plan.id,
-                                            1,
-                                            session,
-                                            asynchronous=False,
-                                        )
-                        except Exception as e:
-                            log(
-                                f"Error occured processing default survey efficiency for plan {id}: {e}"
-                            )
-                            session.rollback()
-                            time.sleep(2)
+                    except Exception as e:
+                        log(
+                            f"Error occured processing default survey efficiency for plan {id}: {e}"
+                        )
+                        session.rollback()
+                        time.sleep(2)
 
-                except Exception as e:
-                    log(f"Error occured processing the observation plan queue: {e}")
-                    session.rollback()
-                    time.sleep(2)
+            except Exception as e:
+                log(f"Error occured processing the observation plan queue: {e}")
+                session.rollback()
+                time.sleep(2)
 
 
 if __name__ == "__main__":
     try:
-        while not is_loaded():
-            log("Waiting for the app to start...")
-            time.sleep(15)
-        queue = ObservationPlanQueue()
-        queue.service()
+        service()
     except Exception as e:
         log(f"Error starting observation plan queue: {str(e)}")
         raise e

--- a/services/thumbnail_queue/thumbnail_queue.py
+++ b/services/thumbnail_queue/thumbnail_queue.py
@@ -1,3 +1,5 @@
+import time
+
 import sqlalchemy as sa
 
 from baselayer.app.models import init_db
@@ -52,6 +54,9 @@ def service():
     while True:
         try:
             obj_ids = fetch_obj_ids()
+            if len(obj_ids) == 0:
+                time.sleep(5)
+                continue
             for obj_id in obj_ids:
                 internal_key = None
                 with DBSession() as session:

--- a/services/thumbnail_queue/thumbnail_queue.py
+++ b/services/thumbnail_queue/thumbnail_queue.py
@@ -19,8 +19,6 @@ log = make_log('thumbnail_queue')
 
 init_db(**cfg['database'])
 
-queue = []
-
 THUMBNAIL_TYPES = ["sdss", "ls", "ps1"]
 
 REQUEST_TIMEOUT_SECONDS = cfg['health_monitor.request_timeout_seconds']

--- a/services/thumbnail_queue/thumbnail_queue.py
+++ b/services/thumbnail_queue/thumbnail_queue.py
@@ -67,6 +67,8 @@ def service(*args, **kwargs):
                     time.sleep(5)
                     continue
 
+                log(f"Processing thumbnail request for object {obj.id}.")
+
                 try:
                     existing_thumbnail_types = [thumb.type for thumb in obj.thumbnails]
                     thumbnails = list(

--- a/services/watch_list/watch_list.py
+++ b/services/watch_list/watch_list.py
@@ -13,34 +13,13 @@ from skyportal.handlers.api.alert import (
     post_alert,
 )
 from skyportal.models import DBSession, Listing, Telescope, User
+from skyportal.utils.services import check_loaded
 
 env, cfg = load_env()
 
 init_db(**cfg['database'])
 
 log = make_log('watchlist')
-
-REQUEST_TIMEOUT_SECONDS = cfg['health_monitor.request_timeout_seconds']
-MAX_RETRIES = 10
-
-
-host = f'{cfg["server.protocol"]}://{cfg["server.host"]}' + (
-    f':{cfg["server.port"]}' if cfg['server.port'] not in [80, 443] else ''
-)
-
-
-def is_loaded():
-    try:
-        r = requests.get(f'{host}/api/sysinfo', timeout=REQUEST_TIMEOUT_SECONDS)
-    except:  # noqa: E722
-        status_code = 0
-    else:
-        status_code = r.status_code
-
-    if status_code == 200:
-        return True
-    else:
-        return False
 
 
 def ztf_observing_times():
@@ -54,26 +33,6 @@ def ztf_observing_times():
             raise Exception('Could not find ZTF')
         time_info = telescope.current_time
         return time_info
-
-
-def service():
-    while True:
-        loaded = is_loaded()
-        time_info = None
-        if loaded and alert_available:
-            try:
-                time_info = ztf_observing_times()
-            except Exception as e:
-                log(e)
-                time.sleep(5)
-                continue
-            try:
-                check_watch_list(time_info)
-            except Exception as e:
-                log(e)
-                time.sleep(5)
-        else:
-            time.sleep(60)
 
 
 def check_watch_list(time_info):
@@ -251,6 +210,26 @@ def check_watch_list(time_info):
     # if we took less than the shortest interval, sleep for the difference. Otherwise, don't sleep
     if end - start < shortest_interval:
         time.sleep(shortest_interval - (end - start))
+
+
+@check_loaded(logger=log)
+def service(*args, **kwargs):
+    while True:
+        time_info = None
+        if alert_available:
+            try:
+                time_info = ztf_observing_times()
+            except Exception as e:
+                log(e)
+                time.sleep(5)
+                continue
+            try:
+                check_watch_list(time_info)
+            except Exception as e:
+                log(e)
+                time.sleep(5)
+        else:
+            time.sleep(60)
 
 
 if __name__ == "__main__":

--- a/skyportal/handlers/api/candidate.py
+++ b/skyportal/handlers/api/candidate.py
@@ -48,7 +48,6 @@ from ...models import (
 
 from ...utils.cache import Cache, array_to_bytes
 from ...utils.sizeof import sizeof, SIZE_WARNING_THRESHOLD
-from ...utils.thumbnail import post_thumbnails
 
 MAX_NUM_DAYS_USING_LOCALIZATION = 31
 
@@ -1598,10 +1597,11 @@ class CandidateHandler(BaseHandler):
                 return self.error(
                     f"Failed to post candidate for object {obj.id}: {e.args[0]}"
                 )
-
-            obj_id = obj.id
-            if not obj_already_exists:
-                post_thumbnails([obj_id])
+            try:
+                obj.add_linked_thumbnails(['sdss', 'ls'], session)
+            except Exception:
+                session.rollback()
+                pass
 
             return self.success(data={"ids": [c.id for c in candidates]})
 

--- a/skyportal/handlers/api/candidate.py
+++ b/skyportal/handlers/api/candidate.py
@@ -1598,12 +1598,10 @@ class CandidateHandler(BaseHandler):
                     f"Failed to post candidate for object {obj.id}: {e.args[0]}"
                 )
             try:
-                # for new objects, the thumbnails queue will anyway take care of generating thumbnails
-                if obj_already_exists:
-                    existing_thumbnail_types = [thumb.type for thumb in obj.thumbnails]
-                    thumbnails = list({"sdss", "ls"} - set(existing_thumbnail_types))
-                    if len(thumbnails) > 0:
-                        obj.add_linked_thumbnails(thumbnails, session)
+                existing_thumbnail_types = [thumb.type for thumb in obj.thumbnails]
+                thumbnails = list({"sdss", "ls"} - set(existing_thumbnail_types))
+                if len(thumbnails) > 0:
+                    obj.add_linked_thumbnails(thumbnails, session)
             except Exception:
                 session.rollback()
                 pass

--- a/skyportal/handlers/api/candidate.py
+++ b/skyportal/handlers/api/candidate.py
@@ -1598,7 +1598,12 @@ class CandidateHandler(BaseHandler):
                     f"Failed to post candidate for object {obj.id}: {e.args[0]}"
                 )
             try:
-                obj.add_linked_thumbnails(['sdss', 'ls'], session)
+                # for new objects, the thumbnails queue will anyway take care of generating thumbnails
+                if obj_already_exists:
+                    existing_thumbnail_types = [thumb.type for thumb in obj.thumbnails]
+                    thumbnails = list({"sdss", "ls"} - set(existing_thumbnail_types))
+                    if len(thumbnails) > 0:
+                        obj.add_linked_thumbnails(thumbnails, session)
             except Exception:
                 session.rollback()
                 pass

--- a/skyportal/models/obj.py
+++ b/skyportal/models/obj.py
@@ -473,9 +473,9 @@ class Obj(Base, conesearch_alchemy.Point):
             session.add(
                 Thumbnail(obj=self, public_url=self.legacysurvey_dr9_url, type='ls')
             )
-
         if "ps1" in thumbnails:
             session.add(Thumbnail(obj=self, public_url=self.panstarrs_url, type="ps1"))
+
         session.commit()
 
     @property

--- a/skyportal/models/obj.py
+++ b/skyportal/models/obj.py
@@ -42,7 +42,7 @@ log = make_log('models.obj')
 # The minimum signal-to-noise ratio to consider a photometry point as a detection
 PHOT_DETECTION_THRESHOLD = cfg["misc.photometry_detection_threshold_nsigma"]
 
-PS1_CUTOUT_TIMEOUT = 10
+PS1_CUTOUT_TIMEOUT = 15  # seconds
 
 # download dustmap if required
 config['data_dir'] = cfg['misc.dustmap_folder']

--- a/skyportal/models/obj.py
+++ b/skyportal/models/obj.py
@@ -529,6 +529,10 @@ class Obj(Base, conesearch_alchemy.Point):
             log(f"HTTPError getting thumbnail for {self.id}: {http_err}")
         except requests.exceptions.Timeout as timeout_err:
             log(f"Timeout in getting thumbnail for {self.id}: {timeout_err}")
+        except requests.exceptions.ChunkedEncodingError as chunk_err:
+            log(
+                f"Chunked encoding error in getting thumbnail for {self.id}: {chunk_err}"
+            )
         except requests.exceptions.RequestException as other_err:
             log(f"Unexpected error in getting thumbnail for {self.id}: {other_err}")
         finally:

--- a/skyportal/utils/offset.py
+++ b/skyportal/utils/offset.py
@@ -43,7 +43,7 @@ log = make_log('finder-chart')
 
 _, cfg = load_env()
 
-PS1_CUTOUT_TIMEOUT = 10
+PS1_CUTOUT_TIMEOUT = 15  # seconds
 
 
 class GaiaQuery:

--- a/skyportal/utils/services.py
+++ b/skyportal/utils/services.py
@@ -1,0 +1,43 @@
+import time
+
+import requests
+
+from baselayer.app.env import load_env
+
+env, cfg = load_env()
+
+REQUEST_TIMEOUT_SECONDS = cfg['health_monitor.request_timeout_seconds']
+
+HOST = f'{cfg["server.protocol"]}://{cfg["server.host"]}' + (
+    f':{cfg["server.port"]}' if cfg['server.port'] not in [80, 443] else ''
+)
+
+
+def is_loaded():
+    try:
+        r = requests.get(f'{HOST}/api/sysinfo', timeout=REQUEST_TIMEOUT_SECONDS)
+    except Exception:
+        status_code = 0
+    else:
+        status_code = r.status_code
+
+    if status_code == 200:
+        return True
+    else:
+        return False
+
+
+# provide a decorator to wrap a function with a check for whether the app is loaded
+# if not loaded, keep looping until it is, with a 15 second sleep between attempts
+def check_loaded(*args, **kwargs):
+    def decorator(func):
+        while True:
+            if is_loaded():
+                break
+            elif kwargs.get('logger') is not None and callable(kwargs['logger']):
+                kwargs['logger']("Waiting for the app to start...")
+            time.sleep(10)
+
+        func(*args, **kwargs)
+
+    return decorator

--- a/skyportal/utils/thumbnail.py
+++ b/skyportal/utils/thumbnail.py
@@ -1,5 +1,4 @@
 from PIL import Image, ImageStat, UnidentifiedImageError
-import requests
 
 from baselayer.app.env import load_env
 from baselayer.log import make_log
@@ -12,17 +11,6 @@ MSE_cutoff = cfg["image_grayscale_params.MSE_cutoff"]
 adjust_color_bias = cfg["image_grayscale_params.adjust_color_bias"]
 
 log = make_log('thumbnail')
-
-
-def post_thumbnails(obj_ids, timeout=2):
-
-    request_body = {'obj_ids': obj_ids}
-
-    thumbnail_microservice_url = f'http://127.0.0.1:{cfg["ports.thumbnail_queue"]}'
-
-    resp = requests.post(thumbnail_microservice_url, json=request_body, timeout=timeout)
-    if resp.status_code != 200:
-        log(f'Thumbnail request failed for {request_body["obj_id"]}: {resp.content}')
 
 
 def image_is_grayscale(


### PR DESCRIPTION
Truth is we do not need a queue for all thumbnails types. Only PS1 is challenging, because we can't simply format a string and BOOM we've got the URL to add in the DB. Instead, we have to run an API call which proved to be more and more unstable.

So here, we do a few things:
- Synchronously post thumbnails for sdss and ls as this doesn't require any external requests, wherever we need. This effectively replaces all the bits of code where we pushed the obj_id to the thumbnails queue's internal API endpoint.
- Remove the internal API endpoint from the queue, making it much simpler to maintain.
- Instead of getting the list of objects to process from an internal API queue, the service now runs a simple DB query which does: "give me the most recent object for which we don't have all three thumbnail types: sdss, ls, and ps1. Generate what is missing". We repeat that DB query in a loop to hopefully generate missing sdss and ls thumbnails for all objects, and generate ps1 thumbnails.