### PR TITLE
Follow-up request schema: add missing optional constraint field

### DIFF
--- a/skyportal/models/schema.py
+++ b/skyportal/models/schema.py
@@ -1255,7 +1255,7 @@ class FollowupRequestPost(_Schema):
         required=False,
         metadata={
             'description': (
-                'If the source is saved in any of these groups, the followup request will be executed.'
+                'If the source is saved to any of these groups, the followup request will not be executed.'
             )
         },
     )

--- a/skyportal/models/schema.py
+++ b/skyportal/models/schema.py
@@ -1250,6 +1250,16 @@ class FollowupRequestPost(_Schema):
         },
     )
 
+    ignore_source_group_ids = fields.List(
+        fields.Integer,
+        required=False,
+        metadata={
+            'description': (
+                'If the source is saved in any of these groups, the followup request will be executed.'
+            )
+        },
+    )
+
 
 class ObservationPlanPost(_Schema):
 


### PR DESCRIPTION
This causes BTSBot requests to fail recently, so adding it quickly to prevent future failures.