### PR TITLE
Log rather than raise exception when PS1 does not work

### DIFF
--- a/skyportal/utils/offset.py
+++ b/skyportal/utils/offset.py
@@ -1255,7 +1255,8 @@ def fits_image(
         )
 
     if url in [None, ""]:
-        raise Exception(f"Could not get FITS image for source {image_source}")
+        log(f"Could not get FITS image for source {image_source}")
+        return None
 
     cache = Cache(cache_dir=cache_dir, max_items=cache_max_items)
 


### PR DESCRIPTION
This PR logs exception rather than raises when no PS1 url.