### PR TITLE
PS1 Thumbnails: https -> http

### DIFF
--- a/skyportal/models/obj.py
+++ b/skyportal/models/obj.py
@@ -517,7 +517,7 @@ class Obj(Base, conesearch_alchemy.Point):
         we assume that the image is not available and return None.
         """
         ps_query_url = (
-            f"https://ps1images.stsci.edu/cgi-bin/ps1cutouts"
+            f"http://ps1images.stsci.edu/cgi-bin/ps1cutouts"
             f"?pos={self.ra}+{self.dec}&filter=color&filter=g"
             f"&filter=r&filter=i&filetypes=stack&size=250"
         )

--- a/skyportal/utils/offset.py
+++ b/skyportal/utils/offset.py
@@ -287,7 +287,7 @@ def get_ps1_url(ra, dec, imsize, *args, **kwargs):
     numpix = math.ceil(60 * imsize / 0.25)
 
     ps_query_url = (
-        f"https://ps1images.stsci.edu/cgi-bin/ps1cutouts"
+        f"http://ps1images.stsci.edu/cgi-bin/ps1cutouts"
         f"?pos={ra}+{dec}&"
         f"filter=r&filetypes=stack&size={numpix}"
     )


### PR DESCRIPTION
Recent commits on main handled the SSL error we get when querying PS1 with Python `requests`, but the problem is this keeps adding unavailable PS1 thumbnails in production while slowing down the thumbnails queue as we are waiting for the error to occur every time, meaning we take 10 seconds to add thumbnails to any object.

This prevents this error from occurring, even if moving to http isn't ideal. However, let's remember that this first URL is used to get the final image URL, which does have https in it, so it's not a problem for the end user. The URL saved in the DB for the thumbnails does have https in it.