### PR TITLE
fix dependabot config (schedule.time format)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: monthly
-      time: "6:00"
+      time: "06:00"
     open-pull-requests-limit: 10
     ignore:
       - dependency-name: "@date-io/dayjs"


### PR DESCRIPTION
Looks like dependabot's time formatting is more strict than it used to be :)