### PR TITLE
New source page: thumbnails and user preferences feedback

### DIFF
--- a/static/js/components/HeaderContent.jsx.template
+++ b/static/js/components/HeaderContent.jsx.template
@@ -48,6 +48,8 @@ const useStyles = makeStyles((theme) => ({
   logoContainer: {
     height: "100%",
     borderRight: "1px solid white",
+    paddingLeft: "0.4rem",
+    paddingRight: "0.4rem",
     "&:last-of-type": {
       borderRight: "none",
       paddingRight: "0",

--- a/static/js/components/HeaderContent.jsx.template
+++ b/static/js/components/HeaderContent.jsx.template
@@ -28,7 +28,7 @@ const useStyles = makeStyles((theme) => ({
     alignItems: "center",
   },
   title: {
-    marginLeft: "0.5rem",
+    margin: "0 0 0 0.5rem",
     color: "white",
     fontSize: "160%",
     fontWeight: "bold",

--- a/static/js/components/PhotometryPlot.jsx
+++ b/static/js/components/PhotometryPlot.jsx
@@ -336,11 +336,13 @@ const PhotometryPlot = ({
         point.origin !== "" &&
         point.origin !== null
       ) {
-        key += `/${point.origin}`;
-      }
-      // limit the key to 30 characters
-      if (key.length > 30) {
-        key = `${key.substring(0, 27)}...`;
+        // the origin is less relevant, so we crop it to not have more than 23 characters + 3 x ...
+        const remaining = 23 - key.length;
+        if (remaining < point.origin.length) {
+          key += `/${point.origin.substring(0, Math.max(remaining - 3, 3))}...`;
+        } else {
+          key += `/${point.origin}`;
+        }
       }
       if (!acc[key]) {
         acc[key] = [];
@@ -400,7 +402,7 @@ const PhotometryPlot = ({
             text: upperLimits.map((point) => point.text),
             mode: "markers",
             type: "scatter",
-            name: key,
+            name: `${key} (UL)`,
             legendgroup: `${key}upperLimits`,
             marker: {
               line: {
@@ -612,8 +614,8 @@ const PhotometryPlot = ({
             text: upperLimitsText,
             mode: "markers",
             type: "scatter",
-            name: key,
-            legendgroup: key,
+            name: `${key} (UL)`,
+            legendgroup: `${key}upperLimits`,
             marker: {
               line: {
                 width: 1,
@@ -931,7 +933,7 @@ const PhotometryPlot = ({
         sx={{
           display: {
             maxWidth: "95vw",
-            width: "100&",
+            width: "100%",
             "& > button": { lineHeight: "1.5rem" },
           },
         }}
@@ -944,7 +946,7 @@ const PhotometryPlot = ({
       <div
         style={{
           width: "100%",
-          height: plotStyle?.height || "65vh",
+          height: plotStyle?.height || "70vh",
           overflowX: "scroll",
         }}
       >
@@ -955,14 +957,39 @@ const PhotometryPlot = ({
             legend: {
               orientation: mode === "desktop" ? "v" : "h",
               yanchor: "top",
-              y: mode === "desktop" ? 1 : -0.25,
-              x: mode === "desktop" ? 1.15 : 0,
+              y: mode === "desktop" ? 1 : plotData?.length > 10 ? -0.4 : -0.3, // eslint-disable-line no-nested-ternary
+              x: mode === "desktop" ? (dm ? 1.15 : 1) : 0, // eslint-disable-line no-nested-ternary
+              font: { size: 14 },
+              tracegroupgap: 0,
             },
             showlegend: true,
             autosize: true,
-            automargin: true,
+            margin: {
+              l: 70,
+              r: 30,
+              b: 75,
+              t: 80,
+              pad: 0,
+            },
+            shapes: [
+              {
+                // we use a shape to draw a box around the plot to add borders to it
+                type: "rect",
+                xref: "paper",
+                yref: "paper",
+                x0: 0,
+                y0: 0,
+                x1: 1,
+                y1: 1,
+                line: {
+                  color: "black",
+                  width: 1,
+                },
+              },
+            ],
           }}
           config={{
+            responsive: true,
             displaylogo: false,
             // the native autoScale2d and resetScale2d buttons are not working
             // as they are not resetting to the specified ranges

--- a/static/js/components/PhotometryPlot.jsx
+++ b/static/js/components/PhotometryPlot.jsx
@@ -957,6 +957,7 @@ const PhotometryPlot = ({
             legend: {
               orientation: mode === "desktop" ? "v" : "h",
               yanchor: "top",
+              // on mobile with a lot of legend entries, we need to move the legend down to avoid overlap
               y: mode === "desktop" ? 1 : plotData?.length > 10 ? -0.4 : -0.3, // eslint-disable-line no-nested-ternary
               x: mode === "desktop" ? (dm ? 1.15 : 1) : 0, // eslint-disable-line no-nested-ternary
               font: { size: 14 },

--- a/static/js/components/ShowSummaries.jsx
+++ b/static/js/components/ShowSummaries.jsx
@@ -39,7 +39,7 @@ export const useStyles = makeStyles((theme) => ({
 const ShowSummaries = ({ summaries = [], showAISummaries = true }) => {
   const styles = useStyles();
   const renderCommentText = () => {
-    let filteredSummaries = [...summaries].filter(
+    let filteredSummaries = [...(summaries || [])].filter(
       (summary) =>
         summary?.summary &&
         summary?.summary !== null &&

--- a/static/js/components/ShowSummaries.jsx
+++ b/static/js/components/ShowSummaries.jsx
@@ -36,11 +36,22 @@ export const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const ShowSummaries = ({ summaries = [] }) => {
+const ShowSummaries = ({ summaries = [], showAISummaries = true }) => {
   const styles = useStyles();
   const renderCommentText = () => {
-    if (summaries?.length > 0) {
-      return summaries[0].summary;
+    let filteredSummaries = [...summaries].filter(
+      (summary) =>
+        summary?.summary &&
+        summary?.summary !== null &&
+        summary?.summary.trim() !== "",
+    );
+    if (showAISummaries === false) {
+      filteredSummaries = filteredSummaries.filter(
+        (summary) => summary?.is_bot === false,
+      );
+    }
+    if (filteredSummaries?.length > 0) {
+      return filteredSummaries[0].summary;
     }
     return null;
   };
@@ -68,10 +79,12 @@ const ShowSummaries = ({ summaries = [] }) => {
 
 ShowSummaries.propTypes = {
   summaries: PropTypes.arrayOf(PropTypes.string),
+  showAISummaries: PropTypes.bool,
 };
 
 ShowSummaries.defaultProps = {
   summaries: [],
+  showAISummaries: true,
 };
 
 export default ShowSummaries;

--- a/static/js/components/ShowSummaryHistory.jsx
+++ b/static/js/components/ShowSummaryHistory.jsx
@@ -30,7 +30,7 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-const ShowSummaryHistory = ({ obj_id, summaries = [] }) => {
+const ShowSummaryHistory = ({ obj_id, summaries = [], button = false }) => {
   const classes = useStyles();
   const { users: allUsers } = useSelector((state) => state.users);
   const userIdToUsername = {};
@@ -52,18 +52,32 @@ const ShowSummaryHistory = ({ obj_id, summaries = [] }) => {
 
   return (
     <>
-      <Tooltip title="Show history of object summaries">
-        <span>
-          <HistoryIcon
-            data-testid="summaryHistoryIconButton"
-            fontSize="small"
-            className={classes.historyIcon}
+      {button ? (
+        <Tooltip title="Show history of object summaries">
+          <Button
+            secondary
+            size="small"
             onClick={() => {
               setDialogOpen(true);
             }}
-          />
-        </span>
-      </Tooltip>
+          >
+            Summaries
+          </Button>
+        </Tooltip>
+      ) : (
+        <Tooltip title="Show history of object summaries">
+          <span>
+            <HistoryIcon
+              data-testid="summaryHistoryIconButton"
+              fontSize="small"
+              className={classes.historyIcon}
+              onClick={() => {
+                setDialogOpen(true);
+              }}
+            />
+          </span>
+        </Tooltip>
+      )}
       <Dialog
         open={dialogOpen}
         fullWidth
@@ -124,10 +138,12 @@ const ShowSummaryHistory = ({ obj_id, summaries = [] }) => {
 ShowSummaryHistory.propTypes = {
   obj_id: PropTypes.string,
   summaries: PropTypes.arrayOf(PropTypes.shape({})),
+  button: PropTypes.bool,
 };
 ShowSummaryHistory.defaultProps = {
   obj_id: null,
   summaries: null,
+  button: false,
 };
 
 export default ShowSummaryHistory;

--- a/static/js/components/SidebarAndHeader.jsx.template
+++ b/static/js/components/SidebarAndHeader.jsx.template
@@ -48,7 +48,7 @@ const useStyles = makeStyles((theme) => ({
       easing: theme.transitions.easing.sharp,
       duration: theme.transitions.duration.leavingScreen,
     }),
-    height: "4em",
+    height: "fit-content",
     background: theme.palette.primary.dark,
     padding: 0,
     margin: 0,
@@ -81,10 +81,8 @@ const useStyles = makeStyles((theme) => ({
   },
   toolbar: {
     display: "flex",
-    height: "4em",
     alignItems: "center",
     justifyContent: "space-between",
-    //padding: "0.5rem",
     paddingLeft: "1.5rem",
     paddingRight: 0,
     [theme.breakpoints.up("md")]: {

--- a/static/js/components/SidebarAndHeader.jsx.template
+++ b/static/js/components/SidebarAndHeader.jsx.template
@@ -72,6 +72,13 @@ const useStyles = makeStyles((theme) => ({
     fontSize: "1.2em",
     padding: 0,
   },
+  drawerPaperTemporary: {
+    zIndex: 140,
+    width: 'fit-content',
+    background: theme.palette.primary.light,
+    fontSize: "1.2em",
+    padding: 0,
+  },
   toolbar: {
     display: "flex",
     height: "4em",
@@ -146,7 +153,7 @@ const SidebarAndHeader = () => {
   const [temporaryOpen, setTemporaryOpen] = React.useState(false);
 
   let timer = 0;
-  const TIMEOUT = 500;
+  const TIMEOUT = 700;
 
   function mouseEnter() {
     if (!temporaryOpen && !open && !isSmall) {
@@ -314,7 +321,7 @@ const SidebarAndHeader = () => {
         anchor="left"
         open={open || temporaryOpen}
         onClose={isSmall ? handleToggleSidebarOpen : undefined}
-        classes={{ "{{ paper: classes.drawerPaper }}" }}
+        classes={{ "{{ paper: drawerType === 'temporary' ? classes.drawerPaperTemporary : classes.drawerPaper }}" }}
         PaperProps={{ "{{ onMouseEnter: mouseEnter, onMouseLeave: mouseLeave }}" }}
       >
         {!isSmall && <div className={classes.drawerHeader} />}

--- a/static/js/components/Source.jsx
+++ b/static/js/components/Source.jsx
@@ -380,11 +380,11 @@ const SourceContent = ({ source }) => {
     }
   };
 
-  const rightPanelContent = () => (
+  const rightPanelContent = (downLarge, isRightPanelVisible) => (
     <>
-      <Grid item xs={12} order={{ xs: 5, lg: 1 }}>
+      <Grid item xs={12} lg={6} order={{ md: 4, lg: 3 }}>
         <Accordion
-          defaultExpanded={!downMd}
+          defaultExpanded={!downLarge}
           disableGutters
           className={classes.flexColumn}
         >
@@ -397,7 +397,12 @@ const SourceContent = ({ source }) => {
               Auto-annotations
             </Typography>
           </AccordionSummary>
-          <AccordionDetails style={{ padding: 0, minHeight: "52vh" }}>
+          <AccordionDetails
+            style={{
+              padding: 0,
+              minHeight: !(downLarge || isRightPanelVisible) ? "60vh" : "52vh",
+            }}
+          >
             <AnnotationsTable
               annotations={source.annotations}
               spectrumAnnotations={spectrumAnnotations}
@@ -408,7 +413,7 @@ const SourceContent = ({ source }) => {
           </AccordionDetails>
         </Accordion>
       </Grid>
-      <Grid item xs={12} order={{ xs: 3, lg: 2 }}>
+      <Grid item xs={12} lg={6} order={{ md: 2, lg: 4 }}>
         <Accordion
           defaultExpanded
           className={classes.flexColumn}
@@ -423,14 +428,28 @@ const SourceContent = ({ source }) => {
               Comments
             </Typography>
           </AccordionSummary>
-          <AccordionDetails>
+          <AccordionDetails
+            style={{
+              minHeight: !(downLarge || isRightPanelVisible)
+                ? "63.5vh"
+                : "55.5vh",
+            }}
+          >
             <Suspense fallback={<CircularProgress />}>
-              {downMd ? <CommentListMobile /> : <CommentList />}
+              {downLarge ? (
+                <CommentListMobile />
+              ) : (
+                <CommentList
+                  maxHeightList={
+                    !(downLarge || isRightPanelVisible) ? "28.5vh" : "350px"
+                  }
+                />
+              )}
             </Suspense>
           </AccordionDetails>
         </Accordion>
       </Grid>
-      <Grid item xs={12} order={{ xs: 12, lg: 3 }}>
+      <Grid item xs={12} lg={12} order={{ md: 9, lg: 7 }}>
         <Accordion
           defaultExpanded
           disableGutters
@@ -457,69 +476,7 @@ const SourceContent = ({ source }) => {
           </AccordionDetails>
         </Accordion>
       </Grid>
-      <Grid item xs={12} order={{ xs: 13, lg: 4 }}>
-        <Accordion
-          defaultExpanded
-          disableGutters
-          className={classes.flexColumn}
-        >
-          <AccordionSummary
-            expandIcon={<ExpandMoreIcon />}
-            aria-controls="analysis-content"
-            id="analysis-header"
-          >
-            <Typography className={classes.accordionHeading}>
-              External Analysis
-            </Typography>
-          </AccordionSummary>
-          <AccordionDetails>
-            <AnalysisList obj_id={source.id} />
-          </AccordionDetails>
-          <AccordionDetails>
-            <AnalysisForm obj_id={source.id} />
-          </AccordionDetails>
-        </Accordion>
-      </Grid>
-      <Grid item xs={12} order={{ xs: 14, lg: 5 }}>
-        {source.color_magnitude.length ? (
-          <Accordion
-            defaultExpanded
-            disableGutters
-            className={classes.classifications}
-          >
-            <AccordionSummary
-              expandIcon={<ExpandMoreIcon />}
-              aria-controls="hr-diagram-content"
-              id="hr-diagram-header"
-            >
-              <Typography className={classes.accordionHeading}>
-                HR Diagram
-              </Typography>
-            </AccordionSummary>
-            <AccordionDetails>
-              <div
-                className={classes.hr_diagram}
-                data-testid={`hr_diagram_${source.id}`}
-              >
-                <Suspense
-                  fallback={
-                    <div>
-                      <CircularProgress color="secondary" />
-                    </div>
-                  }
-                >
-                  <VegaHR
-                    data={source.color_magnitude}
-                    width={300}
-                    height={300}
-                  />
-                </Suspense>
-              </div>
-            </AccordionDetails>
-          </Accordion>
-        ) : null}
-      </Grid>
-      <Grid item xs={12} order={{ xs: 8, lg: 6 }}>
+      <Grid item xs={12} lg={6} order={{ md: 7, lg: 11 }}>
         <Accordion
           defaultExpanded
           disableGutters
@@ -551,7 +508,71 @@ const SourceContent = ({ source }) => {
           </AccordionDetails>
         </Accordion>
       </Grid>
-      <Grid item xs={12} order={{ xs: 15, lg: 7 }}>
+      <Grid item xs={12} lg={6} order={{ md: 8, lg: 12 }}>
+        <Accordion
+          defaultExpanded
+          disableGutters
+          className={classes.classifications}
+        >
+          <AccordionSummary
+            expandIcon={<ExpandMoreIcon />}
+            aria-controls="hr-diagram-content"
+            id="hr-diagram-header"
+          >
+            <Typography className={classes.accordionHeading}>
+              HR Diagram
+            </Typography>
+          </AccordionSummary>
+          <AccordionDetails>
+            <div
+              className={classes.hr_diagram}
+              data-testid={`hr_diagram_${source.id}`}
+            >
+              {source.color_magnitude?.length > 0 ? (
+                <Suspense
+                  fallback={
+                    <div>
+                      <CircularProgress color="secondary" />
+                    </div>
+                  }
+                >
+                  <VegaHR
+                    data={source.color_magnitude}
+                    width={300}
+                    height={300}
+                  />
+                </Suspense>
+              ) : (
+                <div>No color magnitude for this source</div>
+              )}
+            </div>
+          </AccordionDetails>
+        </Accordion>
+      </Grid>
+      <Grid item xs={12} lg={12} order={{ md: 13, lg: 13 }}>
+        <Accordion
+          defaultExpanded
+          disableGutters
+          className={classes.flexColumn}
+        >
+          <AccordionSummary
+            expandIcon={<ExpandMoreIcon />}
+            aria-controls="analysis-content"
+            id="analysis-header"
+          >
+            <Typography className={classes.accordionHeading}>
+              External Analysis
+            </Typography>
+          </AccordionSummary>
+          <AccordionDetails>
+            <AnalysisList obj_id={source.id} />
+          </AccordionDetails>
+          <AccordionDetails>
+            <AnalysisForm obj_id={source.id} />
+          </AccordionDetails>
+        </Accordion>
+      </Grid>
+      <Grid item xs={12} lg={12} order={{ md: 14, lg: 14 }}>
         <Accordion
           defaultExpanded
           disableGutters
@@ -585,9 +606,11 @@ const SourceContent = ({ source }) => {
         spacing={1.5}
         xs={12}
         lg={rightPanelVisible && !downLg ? 7 : 12}
-        style={{ display: downLg ? "flex" : "block" }}
+        style={{
+          display: downLg || (!downLg && !rightPanelVisible) ? "flex" : "block",
+        }}
       >
-        <Grid item xs={12} order={{ xs: 1, lg: 1 }}>
+        <Grid item xs={12} order={{ md: 1, lg: 1 }}>
           <Paper style={{ padding: "0.5rem" }}>
             <div className={classes.container}>
               <div className={classes.header}>
@@ -1059,7 +1082,12 @@ const SourceContent = ({ source }) => {
                         marginTop: noSummary ? "0.25rem" : 0,
                       }}
                     >
-                      <UpdateSourceSummary source={source} />
+                      <UpdateSourceSummary
+                        source={source}
+                        showAISummaries={
+                          currentUser?.preferences?.showAISourceSummary || false
+                        }
+                      />
                       {source.comments?.length > 0 ||
                       source.classifications?.length > 0 ? (
                         <StartBotSummary obj_id={source.id} />
@@ -1147,7 +1175,7 @@ const SourceContent = ({ source }) => {
             </div>
           </Paper>
         </Grid>
-        <Grid item xs={12} order={{ xs: 4, lg: 3 }}>
+        <Grid item xs={12} order={{ md: 3, lg: 2 }}>
           <Paper>
             <Typography
               variant="h6"
@@ -1163,7 +1191,7 @@ const SourceContent = ({ source }) => {
             </div>
           </Paper>
         </Grid>
-        <Grid item xs={12} order={{ xs: 6, lg: 4 }}>
+        <Grid item xs={12} order={{ md: 5, lg: 5 }}>
           <Accordion
             defaultExpanded
             disableGutters
@@ -1268,7 +1296,7 @@ const SourceContent = ({ source }) => {
             </AccordionDetails>
           </Accordion>
         </Grid>
-        <Grid item xs={12} order={{ xs: 7, lg: 5 }}>
+        <Grid item xs={12} order={{ md: 6, lg: 6 }}>
           <Accordion
             defaultExpanded
             disableGutters
@@ -1325,7 +1353,7 @@ const SourceContent = ({ source }) => {
             </AccordionDetails>
           </Accordion>
         </Grid>
-        <Grid item xs={12} order={{ xs: 9, lg: 6 }}>
+        <Grid item xs={12} order={{ md: 10, lg: 8 }}>
           <Accordion
             defaultExpanded
             disableGutters
@@ -1361,7 +1389,7 @@ const SourceContent = ({ source }) => {
             </AccordionDetails>
           </Accordion>
         </Grid>
-        <Grid item xs={12} order={{ xs: 10, lg: 7 }}>
+        <Grid item xs={12} order={{ md: 11, lg: 9 }}>
           <Accordion>
             <AccordionSummary
               expandIcon={<ExpandMoreIcon />}
@@ -1395,7 +1423,7 @@ const SourceContent = ({ source }) => {
             </AccordionDetails>
           </Accordion>
         </Grid>
-        <Grid item xs={12} order={{ xs: 11, lg: 8 }}>
+        <Grid item xs={12} order={{ md: 12, lg: 10 }}>
           <Accordion
             defaultExpanded
             disableGutters
@@ -1424,25 +1452,24 @@ const SourceContent = ({ source }) => {
             </AccordionDetails>
           </Accordion>
         </Grid>
-        {downLg ? rightPanelContent() : null}
+        {downLg || !rightPanelVisible
+          ? rightPanelContent(downLg, rightPanelVisible)
+          : null}
       </Grid>
-      <Grid
-        container
-        item
-        spacing={1.5}
-        xs={12}
-        lg={!rightPanelVisible || downLg ? 12 : 5}
-        style={{ display: downLg ? "flex" : "block" }}
-      >
-        {rightPanelVisible && !downLg ? rightPanelContent() : null}
+      <Grid item xs={rightPanelVisible && !downLg ? 5 : 12}>
+        <Grid container spacing={1.5} columns={{ xs: 6 }}>
+          {rightPanelVisible && !downLg
+            ? rightPanelContent(downLg, rightPanelVisible)
+            : null}
+        </Grid>
+        <PhotometryTable
+          obj_id={source.id}
+          open={showPhotometry}
+          onClose={() => {
+            setShowPhotometry(false);
+          }}
+        />
       </Grid>
-      <PhotometryTable
-        obj_id={source.id}
-        open={showPhotometry}
-        onClose={() => {
-          setShowPhotometry(false);
-        }}
-      />
     </Grid>
   );
 };

--- a/static/js/components/Source.jsx
+++ b/static/js/components/Source.jsx
@@ -212,10 +212,10 @@ const SourcePageThumbnails = ({
   dec,
   thumbnails,
   rightPanelVisible,
-  downSm,
-  downLg,
+  downSmall,
+  downLarge,
 }) => {
-  if (!rightPanelVisible && !downLg) {
+  if (!rightPanelVisible && !downLarge) {
     return (
       <div
         style={{
@@ -257,7 +257,7 @@ const SourcePageThumbnails = ({
         minSize="6rem"
         maxSize="13rem"
         titleSize={
-          !downSm || (rightPanelVisible && !downLg) ? "0.8rem" : "0.55em"
+          !downSmall || (rightPanelVisible && !downLarge) ? "0.8rem" : "0.55em"
         }
         useGrid={false}
         noMargin
@@ -271,8 +271,8 @@ SourcePageThumbnails.propTypes = {
   dec: PropTypes.number.isRequired,
   thumbnails: PropTypes.arrayOf(PropTypes.object).isRequired, // eslint-disable-line react/forbid-prop-types
   rightPanelVisible: PropTypes.bool.isRequired,
-  downSm: PropTypes.bool.isRequired,
-  downLg: PropTypes.bool.isRequired,
+  downSmall: PropTypes.bool.isRequired,
+  downLarge: PropTypes.bool.isRequired,
 };
 
 const SourceContent = ({ source }) => {
@@ -299,6 +299,8 @@ const SourceContent = ({ source }) => {
     useState(false);
   const [tnsDialogOpen, setTNSDialogOpen] = useState(false);
 
+  // Needed for buttons that open popover menus, indicates where the popover should be anchored
+  // (where it will appear on the screen)
   const [anchorElFindingChart, setAnchorElFindingChart] = React.useState(null);
   const [anchorElObservability, setAnchorElObservability] =
     React.useState(null);
@@ -1169,8 +1171,8 @@ const SourceContent = ({ source }) => {
                 dec={source.dec}
                 thumbnails={source.thumbnails}
                 rightPanelVisible={rightPanelVisible}
-                downSm={downSm}
-                downLg={downLg}
+                downSmall={downSm}
+                downLarge={downLg}
               />
             </div>
           </Paper>
@@ -1228,7 +1230,10 @@ const SourceContent = ({ source }) => {
                 <div className={classes.plotContainer}>
                   {!source.photometry_exists &&
                     (!photometry || photometry?.length === 0) && (
-                      <div> No photometry exists </div>
+                      <div style={{ marginLeft: "1rem" }}>
+                        {" "}
+                        No photometry exists{" "}
+                      </div>
                     )}
                   {source.photometry_exists &&
                     (!photometry || photometry?.length === 0) && (
@@ -1316,7 +1321,10 @@ const SourceContent = ({ source }) => {
                 <div className={classes.plotContainer}>
                   {!source.spectrum_exists &&
                     (!spectra || spectra?.length === 0) && (
-                      <div> No spectrum exists </div>
+                      <div style={{ marginLeft: "1rem" }}>
+                        {" "}
+                        No spectrum exists{" "}
+                      </div>
                     )}
                   {source.spectrum_exists &&
                     (!spectra || spectra?.length === 0) && (

--- a/static/js/components/SpectraPlot.jsx
+++ b/static/js/components/SpectraPlot.jsx
@@ -252,7 +252,7 @@ const SpectraPlot = ({ spectra, redshift, mode, plotStyle }) => {
         return false;
       });
 
-      const traces = spectraFiltered.map((spectrum, index) => {
+      let traces = spectraFiltered.map((spectrum, index) => {
         const date = spectrum.observed_at.split("T")[0].split("-");
         const name = `${spectrum.instrument_name} (${date[1]}/${date[2].slice(
           -2,
@@ -261,6 +261,7 @@ const SpectraPlot = ({ spectra, redshift, mode, plotStyle }) => {
           mode: "lines",
           type: "scatter",
           dataType: "Spectrum",
+          spectrumId: spectrum.id,
           x: spectrum.wavelengths,
           y:
             smoothingValue === 0
@@ -285,6 +286,38 @@ const SpectraPlot = ({ spectra, redshift, mode, plotStyle }) => {
 
         return trace;
       });
+
+      // when smoothing, keep showing the original trace but in the background, in grey with 20% opacity
+      const tracesOriginal =
+        smoothingValue > 0
+          ? spectraFiltered.map((spectrum) => {
+              const date = spectrum.observed_at.split("T")[0].split("-");
+              const name = `${spectrum.instrument_name} (${
+                date[1]
+              }/${date[2].slice(-2)}/${date[0].slice(-2)})`;
+              const trace = {
+                mode: "lines",
+                type: "scatter",
+                dataType: "SpectrumNoSmooth",
+                spectrumId: spectrum.id,
+                x: spectrum.wavelengths,
+                y: spectrum.fluxes_normed,
+                name,
+                legendgroup: `${spectrum.instrument_name}/${spectrum.observed_at}`,
+                line: {
+                  shape: "hvh",
+                  width: 0.85,
+                  color: `rgba(100, 100, 100, 0.2)`,
+                },
+                hoverinfo: "skip",
+                visible: true,
+                showlegend: false,
+              };
+              return trace;
+            })
+          : [];
+
+      traces = [...tracesOriginal, ...traces];
 
       const secondaryAxisX = {
         x: [
@@ -470,7 +503,7 @@ const SpectraPlot = ({ spectra, redshift, mode, plotStyle }) => {
           sx={{
             display: {
               maxWidth: "95vw",
-              width: "100&",
+              width: "100%",
               "& > button": { lineHeight: "1.5rem" },
             },
           }}
@@ -494,12 +527,35 @@ const SpectraPlot = ({ spectra, redshift, mode, plotStyle }) => {
             legend: {
               orientation: mode === "desktop" ? "v" : "h",
               yanchor: "top",
-              y: mode === "desktop" ? 1 : -0.3,
+              y: mode === "desktop" ? 1 : plotData?.length > 10 ? -0.4 : -0.3, // eslint-disable-line no-nested-ternary
               x: mode === "desktop" ? 1.02 : 0,
+              font: { size: 14 },
             },
             showlegend: true,
             autosize: true,
-            automargin: true,
+            margin: {
+              l: 70,
+              r: 20,
+              b: 75,
+              t: 80,
+              pad: 0,
+            },
+            shapes: [
+              {
+                // we use a shape to draw a box around the plot to add borders to it
+                type: "rect",
+                xref: "paper",
+                yref: "paper",
+                x0: 0,
+                y0: 0,
+                x1: 1,
+                y1: 1,
+                line: {
+                  color: "black",
+                  width: 1,
+                },
+              },
+            ],
           }}
           config={{
             displaylogo: false,
@@ -545,12 +601,15 @@ const SpectraPlot = ({ spectra, redshift, mode, plotStyle }) => {
                 trace.visible = true;
               } else if (
                 (visibleTraces === 1 && e.curveNumber === visibleTraceIndex) ||
-                visibleTraces === 0
+                visibleTraces === 0 ||
+                (trace.dataType === "SpectrumNoSmooth" &&
+                  trace.spectrumId === e.data[e.curveNumber].spectrumId)
               ) {
                 // if we already isolated a single trace and we double click on it, or if there are no traces visible, show all
+                // OR, if its the unsmoothed version of the trace we double clicked on, keep it visible
                 trace.visible = true;
               } else {
-                // otherwise, hide all
+                // otherwise, hide all except if SpectrumNoSmooth trace
                 trace.visible = "legendonly";
               }
             });

--- a/static/js/components/SpectraPlot.jsx
+++ b/static/js/components/SpectraPlot.jsx
@@ -527,6 +527,7 @@ const SpectraPlot = ({ spectra, redshift, mode, plotStyle }) => {
             legend: {
               orientation: mode === "desktop" ? "v" : "h",
               yanchor: "top",
+              // on mobile with a lot of legend entries, we need to move the legend down to avoid overlapping with the plot
               y: mode === "desktop" ? 1 : plotData?.length > 10 ? -0.4 : -0.3, // eslint-disable-line no-nested-ternary
               x: mode === "desktop" ? 1.02 : 0,
               font: { size: 14 },

--- a/static/js/components/SpectroscopyButtonsForm.jsx
+++ b/static/js/components/SpectroscopyButtonsForm.jsx
@@ -51,8 +51,6 @@ const SpectroscopyButtonsForm = () => {
   } = useForm();
   const [selectedColor, setSelectedColor] = useState([]);
 
-  console.log(spectroscopyButtons);
-
   const onColorSelectChange = (event) => {
     setSelectedColor(
       event.target.value.includes("Clear selections") ? [] : event.target.value,

--- a/static/js/components/ThumbnailList.jsx
+++ b/static/js/components/ThumbnailList.jsx
@@ -15,9 +15,12 @@ import Typography from "@mui/material/Typography";
 dayjs.extend(calendar);
 
 const useStyles = makeStyles((theme) => ({
-  root: ({ size }) => ({
+  root: ({ size, minSize, maxSize, noMargin }) => ({
     width: size,
-    margin: "0.5rem auto",
+    minWidth: minSize,
+    maxWidth: maxSize,
+    margin: noMargin ? 0 : "0.5rem auto",
+    height: "100%",
     maxHeight: "31rem",
     flexGrow: 1,
   }),
@@ -26,9 +29,10 @@ const useStyles = makeStyles((theme) => ({
       0.75,
     )} ${theme.spacing(1)}`,
   },
-  title: {
-    fontSize: "0.875rem",
-  },
+  title: ({ titleSize }) => ({
+    fontSize: titleSize,
+    textWrap: "nowrap",
+  }),
   pos: {
     marginBottom: 0,
   },
@@ -53,7 +57,19 @@ const useStyles = makeStyles((theme) => ({
   }),
 }));
 
-const Thumbnail = ({ ra, dec, name, url, size, grayscale, header }) => {
+const Thumbnail = ({
+  ra,
+  dec,
+  name,
+  url,
+  size,
+  minSize,
+  maxSize,
+  titleSize,
+  grayscale,
+  header,
+  noMargin,
+}) => {
   // convert mjd to unix timestamp *in ms*. 40587 is the mjd of the
   // unix timestamp epoch (1970-01-01).
 
@@ -61,7 +77,14 @@ const Thumbnail = ({ ra, dec, name, url, size, grayscale, header }) => {
     (state) => state.profile.preferences.invertThumbnails,
   );
 
-  const classes = useStyles({ size, invertThumbnails });
+  const classes = useStyles({
+    size,
+    minSize,
+    maxSize,
+    titleSize,
+    invertThumbnails,
+    noMargin,
+  });
 
   let alt = null;
   let link = null;
@@ -143,8 +166,16 @@ Thumbnail.propTypes = {
   name: PropTypes.string.isRequired,
   url: PropTypes.string.isRequired,
   size: PropTypes.string.isRequired,
+  minSize: PropTypes.string.isRequired,
+  maxSize: PropTypes.string.isRequired,
+  titleSize: PropTypes.string.isRequired,
   grayscale: PropTypes.bool.isRequired,
   header: PropTypes.string.isRequired,
+  noMargin: PropTypes.bool,
+};
+
+Thumbnail.defaultProps = {
+  noMargin: false,
 };
 
 const sortThumbnailsByDate = (a, b) => {
@@ -165,6 +196,10 @@ const ThumbnailList = ({
   thumbnails,
   useGrid = true,
   size = "13rem",
+  minSize = null,
+  maxSize = null,
+  noMargin = false,
+  titleSize = "0.875rem",
   displayTypes = ["new", "ref", "sub", "sdss", "ls", "ps1"],
 }) => {
   thumbnails
@@ -199,8 +234,11 @@ const ThumbnailList = ({
               name={t.type}
               url={t.public_url}
               size={size}
+              minSize={minSize === null ? size : minSize}
+              maxSize={maxSize === null ? size : maxSize}
               grayscale={t.is_grayscale}
               header={thumbnail_display[t.type]}
+              titleSize={titleSize}
             />
           </Grid>
         ))}
@@ -214,28 +252,58 @@ const ThumbnailList = ({
                 name="PanSTARRS DR2: Loading..."
                 url="#"
                 size={size}
+                minSize={minSize === null ? size : minSize}
+                maxSize={maxSize === null ? size : maxSize}
                 grayscale={false}
                 header="PanSTARRS DR2"
+                titleSize={titleSize}
               />
             </Grid>
           )}
       </Grid>
     );
   }
-  return latestThumbnails?.map((t) => (
-    <Grid item key={t.id}>
-      <Thumbnail
-        key={`thumb_${t.type}`}
-        ra={ra}
-        dec={dec}
-        name={t.type}
-        url={t.public_url}
-        size={size}
-        grayscale={t.is_grayscale}
-        header={thumbnail_display[t.type]}
-      />
-    </Grid>
-  ));
+  return (
+    <>
+      {latestThumbnails?.map((t) => (
+        <Grid item key={t.id}>
+          <Thumbnail
+            key={`thumb_${t.type}`}
+            ra={ra}
+            dec={dec}
+            name={t.type}
+            url={t.public_url}
+            size={size}
+            minSize={minSize === null ? size : minSize}
+            maxSize={maxSize === null ? size : maxSize}
+            noMargin={noMargin}
+            grayscale={t.is_grayscale}
+            header={thumbnail_display[t.type]}
+            titleSize={titleSize}
+          />
+        </Grid>
+      ))}
+      {displayTypes?.includes("ps1") &&
+        !latestThumbnails?.map((t) => t.type)?.includes("ps1") && (
+          <Grid item key="thumb_placeholder">
+            <Thumbnail
+              key="thumbPlaceHolder"
+              ra={ra}
+              dec={dec}
+              name="PanSTARRS DR2: Loading..."
+              url="#"
+              size={size}
+              minSize={minSize === null ? size : minSize}
+              maxSize={maxSize === null ? size : maxSize}
+              noMargin={noMargin}
+              grayscale={false}
+              header="PanSTARRS DR2"
+              titleSize={titleSize}
+            />
+          </Grid>
+        )}
+    </>
+  );
 };
 
 ThumbnailList.propTypes = {
@@ -243,14 +311,22 @@ ThumbnailList.propTypes = {
   dec: PropTypes.number.isRequired,
   thumbnails: PropTypes.arrayOf(PropTypes.object).isRequired, // eslint-disable-line react/forbid-prop-types
   size: PropTypes.string,
+  minSize: PropTypes.string,
+  maxSize: PropTypes.string,
+  titleSize: PropTypes.string,
   displayTypes: PropTypes.arrayOf(PropTypes.string),
   useGrid: PropTypes.bool,
+  noMargin: PropTypes.bool,
 };
 
 ThumbnailList.defaultProps = {
   size: "13rem",
+  minSize: null,
+  maxSize: null,
+  titleSize: "0.875rem",
   displayTypes: ["new", "ref", "sub", "sdss", "ls", "ps1"],
   useGrid: true,
+  noMargin: false,
 };
 
 export default ThumbnailList;

--- a/static/js/components/UIPreferences.jsx
+++ b/static/js/components/UIPreferences.jsx
@@ -17,6 +17,10 @@ const UIPreferences = () => {
   const useRefMag = preferences?.useRefMag || false;
   const showBotComments = preferences?.showBotComments || false;
   const hideMLClassifications = preferences?.hideMLClassifications || false;
+  const showSimilarSources = preferences?.showSimilarSources || false;
+  const hideSourceSummary = preferences?.hideSourceSummary || false;
+  const showAISourceSummary = preferences?.showAISourceSummary || false;
+
   const dispatch = useDispatch();
 
   const themeToggled = (event) => {
@@ -65,6 +69,27 @@ const UIPreferences = () => {
   const hideMLClassificationsToggled = (event) => {
     const prefs = {
       hideMLClassifications: event.target.checked,
+    };
+    dispatch(profileActions.updateUserPreferences(prefs));
+  };
+
+  const showSimilarSourcesToggled = (event) => {
+    const prefs = {
+      showSimilarSources: event.target.checked,
+    };
+    dispatch(profileActions.updateUserPreferences(prefs));
+  };
+
+  const hideSourceSummaryToggled = (event) => {
+    const prefs = {
+      hideSourceSummary: event.target.checked,
+    };
+    dispatch(profileActions.updateUserPreferences(prefs));
+  };
+
+  const showAISourceSummaryToggled = (event) => {
+    const prefs = {
+      showAISourceSummary: event.target.checked,
     };
     dispatch(profileActions.updateUserPreferences(prefs));
   };
@@ -125,12 +150,29 @@ const UIPreferences = () => {
     />
   );
 
-  /* To get hold of the current theme:
+  const showSimilarSourcesSwitch = (
+    <Switch
+      value="Show Similar Sources (based on AI summaries) by default"
+      checked={showSimilarSources}
+      onChange={showSimilarSourcesToggled}
+    />
+  );
 
-  const themeCtx = useTheme();
-  console.log(themeCtx.palette.mode);
+  const hideSourceSummarySwitch = (
+    <Switch
+      value="Hide Source Summaries (by default)"
+      checked={hideSourceSummary}
+      onChange={hideSourceSummaryToggled}
+    />
+  );
 
-  */
+  const showAISourceSummarySwitch = (
+    <Switch
+      value="Show AI Source Summaries (by default)"
+      checked={showAISourceSummary}
+      onChange={showAISourceSummaryToggled}
+    />
+  );
 
   return (
     <div>
@@ -158,6 +200,20 @@ const UIPreferences = () => {
           control={hideMLClassificationsSwitch}
           label="Hide ML-based Classifications"
         />
+        <FormControlLabel
+          control={showSimilarSourcesSwitch}
+          label="Show Similar Sources"
+        />
+        <FormControlLabel
+          control={hideSourceSummarySwitch}
+          label="Hide Source Summaries on Source page"
+        />
+        {hideSourceSummary !== true && (
+          <FormControlLabel
+            control={showAISourceSummarySwitch}
+            label="Show AI Source Summaries on Source page"
+          />
+        )}
       </FormGroup>
     </div>
   );

--- a/static/js/components/UpdateSourceSummary.jsx
+++ b/static/js/components/UpdateSourceSummary.jsx
@@ -27,15 +27,10 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-const UpdateSourceSummary = ({ source }) => {
+const UpdateSourceSummary = ({ source, showAISummaries = true }) => {
   const classes = useStyles();
   const dispatch = useDispatch();
-  const [state, setState] = useState({
-    summary:
-      source?.summary_history && source?.summary_history.length > 0
-        ? source?.summary_history[0].summary // eslint-disable-line react/prop-types
-        : "",
-  });
+  const [state, setState] = useState({});
 
   const [dialogOpen, setDialogOpen] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -46,13 +41,17 @@ const UpdateSourceSummary = ({ source }) => {
       // eslint-disable-next-line no-restricted-globals
       false,
     );
+    let summaries = source?.summary_history || [];
+    summaries = [...summaries].filter(
+      (summary) => summary?.summary && summary?.summary !== null,
+    );
+    if (showAISummaries === false) {
+      summaries = [...summaries].filter((summary) => summary?.is_bot === false);
+    }
     setState({
-      summary:
-        source?.summary_history && source?.summary_history.length > 0
-          ? source?.summary_history[0].summary // eslint-disable-line react/prop-types
-          : "",
+      summary: summaries?.length > 0 ? summaries[0].summary : "",
     });
-  }, [source, setInvalid]);
+  }, [source, showAISummaries, setInvalid]);
 
   const handleChange = (e) => {
     const newState = {};
@@ -171,6 +170,11 @@ UpdateSourceSummary.propTypes = {
     summary: PropTypes.string,
     summary_history: PropTypes.arrayOf(PropTypes.shape({})),
   }).isRequired,
+  showAISummaries: PropTypes.bool,
+};
+
+UpdateSourceSummary.defaultProps = {
+  showAISummaries: true,
 };
 
 export default UpdateSourceSummary;


### PR DESCRIPTION
We got a batch of users to try the new source page before deployment to production. Overall they are happy with it, but they do have some suggestions. This PR implements those + some of the suggestions from @profjsb brought up during the weekly SkyPortal meeting.

Now, if there's enough space, we get the thumbnails in a 6x1 layout, and 3x2 thereafter. Users can decide to hide summaries from the source page's header by default, or only hide the AI-generated ones. Also, they can hide the "similar sources" feature (which is based on said AI summaries embeddings) which is now hidden by default as it created some amount of confusion. The edit/pen icons for most editable fields are now hidden except on hover.

Other items addressed here:
- brought back the background greyed-out spectra when smoothing
- minimized a lot of the margins around the plots
- changed the orientation of the hide/show right panel on source page
- rearranged some of the items on the source page
- source plugins, which we use to add ztf-specific buttons in Fritz, are now in the same row/block as the normal buttons, which makes it more compact
- summaries can now be hidden from the source page header, can be turned on from the user preferences. Defaults to showing the summaries.
- AI-based summaries are now hidden from the source page header by default, showing only human summaries. Can be reactivated from the user preferences.
- fixed the margin issue between the additional logos (like the growth logo) and the basic skyportal one.