### PR TITLE
GCN Observations Survey - Bugfixes and frontend improvements

### DIFF
--- a/skyportal/handlers/api/observation.py
+++ b/skyportal/handlers/api/observation.py
@@ -2076,6 +2076,13 @@ def retrieve_observations_and_simsurvey(
         optional_injection_parameters=payload['optional_injection_parameters'],
     )
 
+    flow = Flow()
+    flow.push(
+        '*',
+        "skyportal/REFRESH_GCNEVENT_SURVEY_EFFICIENCY",
+        payload={"gcnEvent_dateobs": localization.dateobs},
+    )
+
 
 class ObservationSimSurveyHandler(BaseHandler):
     @auth_or_token
@@ -2325,6 +2332,11 @@ class ObservationSimSurveyHandler(BaseHandler):
             session.add(survey_efficiency_analysis)
             session.commit()
 
+            self.push_all(
+                'skyportal/REFRESH_GCNEVENT_SURVEY_EFFICIENCY',
+                payload={"gcnEvent_dateobs": localization_dateobs},
+            )
+
             self.push_notification(
                 'Simsurvey analysis in progress. Should be available soon.'
             )
@@ -2374,8 +2386,14 @@ class ObservationSimSurveyHandler(BaseHandler):
                 return self.error(
                     f'Missing survey_efficiency_analysis for id {survey_efficiency_analysis_id}'
                 )
+            dateobs = survey_efficiency_analysis.localization.dateobs
             session.delete(survey_efficiency_analysis)
             session.commit()
+
+            self.push_all(
+                'skyportal/REFRESH_GCNEVENT_SURVEY_EFFICIENCY',
+                payload={"gcnEvent_dateobs": dateobs},
+            )
 
             return self.success()
 

--- a/skyportal/handlers/api/observation_plan.py
+++ b/skyportal/handlers/api/observation_plan.py
@@ -2,6 +2,7 @@ import asyncio
 import functools
 import io
 import json
+import os
 import random
 import re
 import tempfile
@@ -2693,6 +2694,8 @@ def observation_simsurvey(
             mjd_range=(trigger_time.jd, trigger_time.jd),
             transientprop=transientprop,
             skymap=map_struct,
+            sfd98_dir=os.path.join(cfg['misc.dustmap_folder'], "sfd"),
+            apply_mwebv=True,
         )
 
         survey = simsurvey.SimulSurvey(

--- a/static/js/components/AddSurveyEfficiencyObservationsPage.jsx
+++ b/static/js/components/AddSurveyEfficiencyObservationsPage.jsx
@@ -59,7 +59,6 @@ const AddSurveyEfficiencyObservationsPage = () => {
         open={dialogOpen}
         onClose={closeDialog}
         style={{ position: "fixed" }}
-        // we want it to use the whole screen, but not be scrollable
         fullWidth
         maxWidth="xlg"
       >

--- a/static/js/components/AddSurveyEfficiencyObservationsPage.jsx
+++ b/static/js/components/AddSurveyEfficiencyObservationsPage.jsx
@@ -3,6 +3,8 @@ import { useDispatch, useSelector } from "react-redux";
 import Dialog from "@mui/material/Dialog";
 import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
+import Grid from "@mui/material/Grid";
+import Paper from "@mui/material/Paper";
 
 import Button from "./Button";
 import SurveyEfficiencyForm from "./SurveyEfficiencyForm";
@@ -57,17 +59,24 @@ const AddSurveyEfficiencyObservationsPage = () => {
         open={dialogOpen}
         onClose={closeDialog}
         style={{ position: "fixed" }}
+        // we want it to use the whole screen, but not be scrollable
+        fullWidth
+        maxWidth="xlg"
       >
         <DialogTitle>SimSurvey Analysis</DialogTitle>
         <DialogContent>
-          <div>
-            <SurveyEfficiencyForm gcnevent={gcnEvent} />
-            {surveyEfficiencyAnalysisList?.length > 0 && (
+          <Grid container spacing={2} style={{ paddingTop: "0.1em" }}>
+            <Grid item xs={12} lg={8}>
               <SurveyEfficiencyObservationsLists
-                survey_efficiency_analyses={surveyEfficiencyAnalysisList}
+                survey_efficiency_analyses={surveyEfficiencyAnalysisList || []}
               />
-            )}
-          </div>
+            </Grid>
+            <Grid item xs={12} lg={4}>
+              <Paper style={{ padding: "1em" }}>
+                <SurveyEfficiencyForm gcnevent={gcnEvent} />
+              </Paper>
+            </Grid>
+          </Grid>
         </DialogContent>
       </Dialog>
     </>

--- a/static/js/components/CatalogQueryLists.jsx
+++ b/static/js/components/CatalogQueryLists.jsx
@@ -128,7 +128,7 @@ const CatalogQueryLists = ({ catalog_queries }) => {
   const theme = useTheme();
 
   if (!catalog_queries || catalog_queries.length === 0) {
-    return <p>No survey efficiency analyses for this event...</p>;
+    return <p>No catalog queries for this event.</p>;
   }
 
   const getDataTableColumns = () => {

--- a/static/js/components/ProgressIndicators.jsx
+++ b/static/js/components/ProgressIndicators.jsx
@@ -61,4 +61,29 @@ CircularProgressWithLabel.propTypes = {
   percentage: PropTypes.bool,
 };
 
+const TableProgressText = ({ nbItems, status }) => {
+  if (nbItems === 0) {
+    return null;
+  }
+  return (
+    <div>
+      <Typography variant="caption" component="div" color="text.secondary">
+        {`${nbItems} ${status}`}
+      </Typography>
+    </div>
+  );
+};
+
+TableProgressText.defaultProps = {
+  nbItems: 0,
+  status: "pending",
+};
+
+TableProgressText.propTypes = {
+  nbItems: PropTypes.number,
+  status: PropTypes.string,
+};
+
 export default CircularProgressWithLabel;
+
+export { TableProgressText };

--- a/static/js/components/SurveyEfficiencyForm.jsx
+++ b/static/js/components/SurveyEfficiencyForm.jsx
@@ -155,7 +155,6 @@ const SurveyEfficiencyForm = ({ gcnevent, observationplanRequest }) => {
 
   const handleSubmit = async ({ formData }) => {
     setIsSubmitting(true);
-    // if no instrument is selected, show an error
     if (!selectedLocalizationId) {
       dispatch(showNotification("No localization selected", "error"));
       setIsSubmitting(false);

--- a/static/js/components/SurveyEfficiencyObservationPlanLists.jsx
+++ b/static/js/components/SurveyEfficiencyObservationPlanLists.jsx
@@ -42,40 +42,46 @@ const useStyles = makeStyles(() => ({
 const getMuiTheme = (theme) =>
   createTheme({
     palette: theme.palette,
-    overrides: {
+    components: {
       MUIDataTable: {
-        paper: {
-          width: "100%",
+        styleOverrides: {
+          paper: {
+            width: "100%",
+          },
         },
       },
       MUIDataTableBodyCell: {
-        stackedCommon: {
-          overflow: "hidden",
-          "&:last-child": {
-            paddingLeft: "0.25rem",
+        styleOverrides: {
+          stackedCommon: {
+            overflow: "hidden",
+            "&:last-child": {
+              paddingLeft: "0.25rem",
+            },
           },
         },
       },
       MUIDataTablePagination: {
-        toolbar: {
-          flexFlow: "row wrap",
-          justifyContent: "flex-end",
-          padding: "0.5rem 1rem 0",
-          [theme.breakpoints.up("sm")]: {
-            // Cancel out small screen styling and replace
-            padding: "0px",
-            paddingRight: "2px",
-            flexFlow: "row nowrap",
+        styleOverrides: {
+          toolbar: {
+            flexFlow: "row wrap",
+            justifyContent: "flex-end",
+            padding: "0.5rem 1rem 0",
+            [theme.breakpoints.up("sm")]: {
+              // Cancel out small screen styling and replace
+              padding: "0px",
+              paddingRight: "2px",
+              flexFlow: "row nowrap",
+            },
           },
-        },
-        tableCellContainer: {
-          padding: "1rem",
-        },
-        selectRoot: {
-          marginRight: "0.5rem",
-          [theme.breakpoints.up("sm")]: {
-            marginLeft: "0",
-            marginRight: "2rem",
+          tableCellContainer: {
+            padding: "1rem",
+          },
+          selectRoot: {
+            marginRight: "0.5rem",
+            [theme.breakpoints.up("sm")]: {
+              marginLeft: "0",
+              marginRight: "2rem",
+            },
           },
         },
       },
@@ -91,7 +97,7 @@ const SurveyEfficiencyObservationPlanLists = ({
   const [isDeleting, setIsDeleting] = useState(null);
 
   if (!survey_efficiency_analyses || survey_efficiency_analyses.length === 0) {
-    return <p>No survey efficiency analyses for this event...</p>;
+    return <p>No survey efficiency analyses for this observation plan...</p>;
   }
 
   const handleDelete = async (id) => {
@@ -213,14 +219,14 @@ const SurveyEfficiencyObservationPlanLists = ({
             type="submit"
             data-testid={`simsurvey_${analysis.id}`}
           >
-            Download Skymap
+            Download Plot
           </Button>
         </div>
       );
     };
     columns.push({
       name: "plot",
-      label: "Plot",
+      label: " ",
       options: {
         customBodyRenderLite: renderPlot,
       },
@@ -256,7 +262,7 @@ const SurveyEfficiencyObservationPlanLists = ({
     };
     columns.push({
       name: "delete",
-      label: "Delete",
+      label: " ",
       options: {
         customBodyRenderLite: renderDelete,
       },

--- a/static/js/components/SurveyEfficiencyObservationsLists.jsx
+++ b/static/js/components/SurveyEfficiencyObservationsLists.jsx
@@ -19,6 +19,7 @@ import MUIDataTable from "mui-datatables";
 import { showNotification } from "baselayer/components/Notifications";
 import Button from "./Button";
 
+import { TableProgressText } from "./ProgressIndicators";
 import * as surveyEfficiencyObservationsActions from "../ducks/survey_efficiency_observations";
 
 const useStyles = makeStyles(() => ({
@@ -33,49 +34,52 @@ const useStyles = makeStyles(() => ({
   accordion: {
     width: "99%",
   },
-  container: {
-    margin: "1rem 0",
-  },
 }));
 
 // Tweak responsive styling
 const getMuiTheme = (theme) =>
   createTheme({
     palette: theme.palette,
-    overrides: {
+    components: {
       MUIDataTable: {
-        paper: {
-          width: "100%",
+        styleOverrides: {
+          paper: {
+            width: "100%",
+          },
         },
       },
       MUIDataTableBodyCell: {
-        stackedCommon: {
-          overflow: "hidden",
-          "&:last-child": {
-            paddingLeft: "0.25rem",
+        styleOverrides: {
+          stackedCommon: {
+            overflow: "hidden",
+            "&:last-child": {
+              paddingLeft: "0.25rem",
+            },
           },
         },
       },
       MUIDataTablePagination: {
-        toolbar: {
-          flexFlow: "row wrap",
-          justifyContent: "flex-end",
-          padding: "0.5rem 1rem 0",
-          [theme.breakpoints.up("sm")]: {
-            // Cancel out small screen styling and replace
-            padding: "0px",
-            paddingRight: "2px",
-            flexFlow: "row nowrap",
+        styleOverrides: {
+          toolbar: {
+            flexFlow: "row wrap",
+            justifyContent: "flex-end",
+            padding: "0.5rem 1rem 0",
+            [theme.breakpoints.up("sm")]: {
+              // Cancel out small screen styling and replace
+              padding: "0px",
+              paddingRight: "2px",
+              flexFlow: "row nowrap",
+            },
           },
-        },
-        tableCellContainer: {
-          padding: "1rem",
-        },
-        selectRoot: {
-          marginRight: "0.5rem",
-          [theme.breakpoints.up("sm")]: {
-            marginLeft: "0",
-            marginRight: "2rem",
+          tableCellContainer: {
+            padding: "1rem",
+          },
+          selectRoot: {
+            marginRight: "0.5rem",
+            [theme.breakpoints.up("sm")]: {
+              marginLeft: "0",
+              marginRight: "2rem",
+            },
           },
         },
       },
@@ -121,18 +125,36 @@ const SurveyEfficiencyObservationsLists = ({ survey_efficiency_analyses }) => {
     value.sort();
   });
 
+  // for each analysisGroupedByInstId, we sort the analyses by their created_at date, most recent first
+  Object.keys(analysesGroupedByInstId).forEach((key) => {
+    analysesGroupedByInstId[key].sort(
+      (a, b) => new Date(b.created_at) - new Date(a.created_at),
+    );
+  });
+
   const getDataTableColumns = (keys, instrument_id) => {
     const columns = [{ name: "status", label: "Status" }];
 
     const renderPayload = (dataIndex) => {
       const analysis = analysesGroupedByInstId[instrument_id][dataIndex];
-      return <div>{JSON.stringify(analysis.payload)}</div>;
+      return (
+        <p
+          style={{
+            maxHeight: "120px",
+            overflowWrap: "break-word",
+            overflowY: "auto",
+          }}
+        >
+          {JSON.stringify(analysis.payload || {})}
+        </p>
+      );
     };
     columns.push({
       name: "payload",
       label: "Payload",
       options: {
         customBodyRenderLite: renderPayload,
+        setCellProps: () => ({ style: { maxWidth: "40rem" } }),
       },
     });
 
@@ -227,14 +249,14 @@ const SurveyEfficiencyObservationsLists = ({ survey_efficiency_analyses }) => {
             type="submit"
             data-testid={`simsurvey_${analysis.id}`}
           >
-            Download Skymap
+            Plot
           </Button>
         </div>
       );
     };
     columns.push({
       name: "plot",
-      label: "Plot",
+      label: " ",
       options: {
         customBodyRenderLite: renderPlot,
       },
@@ -252,7 +274,7 @@ const SurveyEfficiencyObservationsLists = ({ survey_efficiency_analyses }) => {
             ) : (
               <div>
                 <Button
-                  primary
+                  secondary
                   onClick={() => {
                     handleDelete(analysis.id);
                   }}
@@ -270,7 +292,7 @@ const SurveyEfficiencyObservationsLists = ({ survey_efficiency_analyses }) => {
     };
     columns.push({
       name: "delete",
-      label: "Delete",
+      label: " ",
       options: {
         customBodyRenderLite: renderDelete,
       },
@@ -282,13 +304,96 @@ const SurveyEfficiencyObservationsLists = ({ survey_efficiency_analyses }) => {
   const options = {
     filter: false,
     sort: false,
-    print: true,
+    print: false,
     download: true,
     search: true,
     selectableRows: "none",
     enableNestedDataAccess: ".",
     elevation: 0,
     rowsPerPageOptions: [1, 10, 15],
+    customToolbar: () => (
+      <TableProgressText
+        nbItems={
+          (survey_efficiency_analyses || []).filter(
+            (a) => a.status === "running",
+          ).length
+        }
+      />
+    ),
+    onDownload: (buildHead) => {
+      // iterate over all the payloads and get the full list of keys
+      const allKeys = survey_efficiency_analyses.reduce((r, a) => {
+        Object.keys(a.payload).forEach((key) => {
+          if (!r.includes(key)) {
+            r = [...r, key];
+          }
+        });
+        return r;
+      }, []);
+
+      // we want to have the payload keys, then the status, then the other columns
+      const columnsDownload = allKeys.map((key) => ({
+        name: key,
+        download: true,
+      }));
+      columnsDownload.push({ name: "status", download: true });
+      columnsDownload.push({ name: "ntransients", download: true });
+      columnsDownload.push({ name: "ncovered", download: true });
+      columnsDownload.push({ name: "ndetected", download: true });
+      columnsDownload.push({ name: "efficiency", download: true });
+      columnsDownload.unshift({ name: "id", download: true });
+
+      const data = survey_efficiency_analyses.map((analysis) => {
+        const row = columnsDownload.map((column) => {
+          const key = column.name;
+          if (key === "id") {
+            return analysis.id;
+          }
+          if (key === "status") {
+            return analysis[key];
+          }
+          if (key === "ntransients") {
+            return analysis.number_of_transients || "N/A";
+          }
+          if (key === "ncovered") {
+            return analysis.number_in_covered || "N/A";
+          }
+          if (key === "ndetected") {
+            return analysis.number_detected || "N/A";
+          }
+          if (key === "efficiency") {
+            return analysis.efficiency || "N/A";
+          }
+          if (key === "plot") {
+            return "";
+          }
+          if (key === "delete") {
+            return "";
+          }
+          return typeof analysis.payload[key] === "object"
+            ? JSON.stringify(analysis.payload[key])
+            : analysis.payload[key];
+        });
+        return row;
+      });
+
+      const head = buildHead(columnsDownload);
+      // we build the body ourselves, without the MUIDataTable buildBody function
+      const body = data.map((row) => row.join(","));
+      const result = head + body.join("\n");
+      const blob = new Blob([result], {
+        type: "text/csv;charset=utf-8;",
+      });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.setAttribute("download", "observations.csv");
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+
+      return false;
+    },
   };
 
   const keyOrder = (a, b) => {
@@ -320,7 +425,7 @@ const SurveyEfficiencyObservationsLists = ({ survey_efficiency_analyses }) => {
   };
 
   return (
-    <div className={classes.container}>
+    <div>
       {Object.keys(analysesGroupedByInstId).map((instrument_id) => {
         // get the flat, unique list of all keys across all requests
         const keys = analysesGroupedByInstId[instrument_id].reduce((r, a) => {
@@ -338,6 +443,7 @@ const SurveyEfficiencyObservationsLists = ({ survey_efficiency_analyses }) => {
           <Accordion
             className={classes.accordion}
             key={`instrument_${instrument_id}_table_div`}
+            defaultExpanded
           >
             <AccordionSummary
               expandIcon={<ExpandMoreIcon />}
@@ -350,6 +456,7 @@ const SurveyEfficiencyObservationsLists = ({ survey_efficiency_analyses }) => {
             </AccordionSummary>
             <AccordionDetails
               data-testid={`${instLookUp[instrument_id].name}_observationplanRequestsTable`}
+              style={{ padding: 0 }}
             >
               <StyledEngineProvider injectFirst>
                 <ThemeProvider theme={getMuiTheme(theme)}>

--- a/static/js/components/SurveyEfficiencyObservationsLists.jsx
+++ b/static/js/components/SurveyEfficiencyObservationsLists.jsx
@@ -311,6 +311,37 @@ const SurveyEfficiencyObservationsLists = ({ survey_efficiency_analyses }) => {
     enableNestedDataAccess: ".",
     elevation: 0,
     rowsPerPageOptions: [1, 10, 15],
+    customSearch: (searchText, currentRow, columns) => {
+      try {
+        if (searchText === "" || !searchText) {
+          return true;
+        }
+        const search = searchText.toLowerCase();
+        const payloadColumnIndex = columns.findIndex(
+          (column) => column.name === "payload",
+        );
+        const statusColumnIndex = columns.findIndex(
+          (column) => column.name === "status",
+        );
+
+        const inPayload =
+          payloadColumnIndex !== -1
+            ? (JSON.stringify(currentRow[payloadColumnIndex]) || "")
+                .toLowerCase()
+                .includes(search)
+            : false;
+        const inStatus =
+          statusColumnIndex !== -1
+            ? (currentRow[statusColumnIndex] || "")
+                .toLowerCase()
+                .includes(search)
+            : false;
+
+        return inPayload || inStatus;
+      } catch (e) {
+        return false;
+      }
+    },
     customToolbar: () => (
       <TableProgressText
         nbItems={

--- a/static/js/ducks/gcnEvent.js
+++ b/static/js/ducks/gcnEvent.js
@@ -88,6 +88,8 @@ const FETCH_GCNEVENT_SURVEY_EFFICIENCY =
   "skyportal/FETCH_GCNEVENT_SURVEY_EFFICIENCY";
 const FETCH_GCNEVENT_SURVEY_EFFICIENCY_OK =
   "skyportal/FETCH_GCNEVENT_SURVEY_EFFICIENCY_OK";
+const REFRESH_GCNEVENT_SURVEY_EFFICIENCY =
+  "skyportal/REFRESH_GCNEVENT_SURVEY_EFFICIENCY";
 
 const FETCH_GCNEVENT_CATALOG_QUERIES =
   "skyportal/FETCH_GCNEVENT_CATALOG_QUERIES";
@@ -427,6 +429,11 @@ messageHandler.add((actionType, payload, dispatch, getState) => {
   if (actionType === REFRESH_GCNEVENT_CATALOG_QUERIES) {
     if (loaded_gcnevent_key === payload.gcnEvent_dateobs) {
       dispatch(fetchGcnEventCatalogQueries({ gcnID: gcnEvent?.id }));
+    }
+  }
+  if (actionType === REFRESH_GCNEVENT_SURVEY_EFFICIENCY) {
+    if (loaded_gcnevent_key === payload.gcnEvent_dateobs) {
+      dispatch(fetchGcnEventSurveyEfficiency({ gcnID: gcnEvent?.id }));
     }
   }
   if (actionType === REFRESH_GCNEVENT_REPORT) {


### PR DESCRIPTION
- have the table on the left and form on the right, using the whole width of the page (unless the screen is too small, in which case they are on top of each other).
- use websockets to get the frontend to fetch the updated list of survey analysis when adding and deleting, and when a survey that's running finishes.
- custom search and download logics.
- fix the path to the dustmaps