### PR TITLE
Brotli support in nginx

### DIFF
--- a/.github/workflows/test_api_and_frontend.yaml
+++ b/.github/workflows/test_api_and_frontend.yaml
@@ -100,7 +100,25 @@ jobs:
           sudo add-apt-repository ppa:mozillateam/ppa
           printf 'Package: *\nPin: release o=LP-PPA-mozillateam\nPin-Priority: 1001' | sudo tee /etc/apt/preferences.d/mozilla-firefox
 
-          sudo apt install -y wget unzip firefox nginx libcurl4-gnutls-dev libgnutls28-dev
+          sudo apt install -y wget unzip firefox libcurl4-gnutls-dev libgnutls28-dev
+
+          # if nginx is already installed, remove it
+          sudo apt remove -y nginx nginx-common nginx-core
+
+          # install nginx from source so we can add the brotli module
+          git clone --recursive https://github.com/google/ngx_brotli.git
+          wget https://nginx.org/download/nginx-1.24.0.tar.gz
+          tar zxf nginx-1.24.0.tar.gz
+          cd ngx_brotli/deps/brotli
+          mkdir out && cd out
+          cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DCMAKE_C_FLAGS="-Ofast -m64 -march=native -mtune=native -flto -funroll-loops -ffunction-sections -fdata-sections -Wl,--gc-sections" -DCMAKE_CXX_FLAGS="-Ofast -m64 -march=native -mtune=native -flto -funroll-loops -ffunction-sections -fdata-sections -Wl,--gc-sections" -DCMAKE_INSTALL_PREFIX=./installed ..
+          cmake --build . --config Release --target brotlienc
+          cd ../../../..
+          export CURRENT_DIR=$(pwd)
+          cd nginx-1.24.0
+          ./configure --sbin-path=/usr/bin/nginx --conf-path=/usr/local/nginx/nginx.conf --pid-path=/usr/local/nginx/nginx.pid --with-http_ssl_module --with-stream --with-mail=dynamic --with-http_realip_module --with-compat --add-module=${CURRENT_DIR}/ngx_brotli
+          sudo make && sudo make install
+          sudo nginx
 
           pip install pip==23.1.2
           pip install wheel numpy

--- a/.github/workflows/test_api_and_frontend.yaml
+++ b/.github/workflows/test_api_and_frontend.yaml
@@ -105,20 +105,9 @@ jobs:
           # if nginx is already installed, remove it
           sudo apt remove -y nginx nginx-common nginx-core
 
-          # install nginx from source so we can add the brotli module
-          git clone --recursive https://github.com/google/ngx_brotli.git
-          wget https://nginx.org/download/nginx-1.24.0.tar.gz
-          tar zxf nginx-1.24.0.tar.gz
-          cd ngx_brotli/deps/brotli
-          mkdir out && cd out
-          cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DCMAKE_C_FLAGS="-Ofast -m64 -march=native -mtune=native -flto -funroll-loops -ffunction-sections -fdata-sections -Wl,--gc-sections" -DCMAKE_CXX_FLAGS="-Ofast -m64 -march=native -mtune=native -flto -funroll-loops -ffunction-sections -fdata-sections -Wl,--gc-sections" -DCMAKE_INSTALL_PREFIX=./installed ..
-          cmake --build . --config Release --target brotlienc
-          cd ../../../..
-          export CURRENT_DIR=$(pwd)
-          cd nginx-1.24.0
-          ./configure --sbin-path=/usr/bin/nginx --conf-path=/usr/local/nginx/nginx.conf --pid-path=/usr/local/nginx/nginx.pid --with-http_ssl_module --with-stream --with-mail=dynamic --with-http_realip_module --with-compat --add-module=${CURRENT_DIR}/ngx_brotli
-          sudo make && sudo make install
-          sudo nginx
+          sudo add-apt-repository ppa:ondrej/nginx-mainline -y
+          sudo apt update -y
+          sudo apt install -y nginx libnginx-mod-brotli
 
           pip install pip==23.1.2
           pip install wheel numpy

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,23 +19,10 @@ RUN apt-get update && \
     git nodejs postgresql-client vim nano screen htop \
     libcurl4-gnutls-dev libgnutls28-dev
 
-# we install nginx from source to compile it with brotli support
-RUN git clone --recursive https://github.com/google/ngx_brotli.git && \
-    wget https://nginx.org/download/nginx-1.24.0.tar.gz && \
-    tar zxf nginx-1.24.0.tar.gz && \
-    cd ngx_brotli/deps/brotli && \
-    mkdir out && cd out && \
-    cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DCMAKE_C_FLAGS="-Ofast -m64 -march=native -mtune=native -flto -funroll-loops -ffunction-sections -fdata-sections -Wl,--gc-sections" -DCMAKE_CXX_FLAGS="-Ofast -m64 -march=native -mtune=native -flto -funroll-loops -ffunction-sections -fdata-sections -Wl,--gc-sections" -DCMAKE_INSTALL_PREFIX=./installed .. && \
-    cmake --build . --config Release --target brotlienc && \
-    cd ../../../.. && \
-    export CURRENT_DIR=$(pwd) && \
-    cd nginx-1.24.0 && \
-    ./configure --sbin-path=/usr/sbin/nginx --conf-path=/usr/local/nginx/nginx.conf --pid-path=/usr/local/nginx/nginx.pid --with-http_ssl_module --with-stream --with-mail=dynamic --with-http_realip_module --with-compat --add-module=${CURRENT_DIR}/ngx_brotli && \
-    make && make install
-
-COPY nginx.service /lib/systemd/system/nginx.service
-
-RUN systemctl enable nginx && systemctl start nginx
+# we install nginx with brotli support from ppa:ondrej/nginx-mainline
+RUN add-apt-repository ppa:ondrej/nginx-mainline -y && \
+	apt update -y && \
+	apt install -y nginx libnginx-mod-brotli
 
 RUN apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -56,6 +56,7 @@ These instructions assume that you have [Homebrew](http://brew.sh/) installed.
 	     llvm libomp gsl rust
 	nvm install node
 	```
+	If you want to use [brotli compression](https://en.wikipedia.org/wiki/Brotli) with NGINX (better compression rates for the frontend), you can install NGINX with the `ngx_brotli` module with this command: `brew tap denji/nginx && brew install nginx-full --with-brotli`. *If you already had NGINX installed, you may need to uninstall it first with `brew unlink nginx`.*Otherwise, you can install NGINX normally with `brew install nginx`.
 
 2. Start the PostgreSQL server:
 
@@ -100,10 +101,48 @@ These instructions assume that you have [Homebrew](http://brew.sh/) installed.
 1. Install dependencies
 
 	```
-	sudo apt install nginx supervisor postgresql \
+	sudo apt install supervisor postgresql \
 	      libpq-dev npm python3-pip \
 	      libcurl4-gnutls-dev libgnutls28-dev
 	```
+
+	If you want to run NGINX as is (without brotli), you can simply install it with `sudo apt-get install nginx`.
+	If want to use [brotli compression](https://en.wikipedia.org/wiki/Brotli) with NGINX (to have better compression rates for the frontend), you can install NGINX with the `ngx_brotli` module with these commands:
+	```
+	# install nginx from source so we can add the brotli module
+	git clone --recursive https://github.com/google/ngx_brotli.git
+	wget https://nginx.org/download/nginx-1.24.0.tar.gz
+	tar zxf nginx-1.24.0.tar.gz
+	cd ngx_brotli/deps/brotli
+	mkdir out && cd out
+	cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DCMAKE_C_FLAGS="-Ofast -m64 -march=native -mtune=native -flto -funroll-loops -ffunction-sections -fdata-sections -Wl,--gc-sections" -DCMAKE_CXX_FLAGS="-Ofast -m64 -march=native -mtune=native -flto -funroll-loops -ffunction-sections -fdata-sections -Wl,--gc-sections" -DCMAKE_INSTALL_PREFIX=./installed ..
+	cmake --build . --config Release --target brotlienc
+	cd ../../../..
+	export CURRENT_DIR=$(pwd)
+	cd nginx-1.24.0
+	./configure --sbin-path=/usr/sbin/nginx --conf-path=/usr/local/nginx/nginx.conf --pid-path=/usr/local/nginx/nginx.pid --with-http_ssl_module --with-stream --with-mail=dynamic --with-http_realip_module --with-compat --add-module=${CURRENT_DIR}/ngx_brotli
+	sudo make && sudo make install
+	```
+	To run it as a service, create an Nginx systemd unit file by running `sudo nano /lib/systemd/system/nginx.service` and adding the following content:
+	```
+	[Unit]
+	Description=The NGINX HTTP and reverse proxy server
+	After=syslog.target network-online.target remote-fs.target nss-lookup.target
+	Wants=network-online.target
+
+	[Service]
+	Type=forking
+	PIDFile=/usr/local/nginx/nginx.pid
+	ExecStartPre=/usr/sbin/nginx -t
+	ExecStart=/usr/sbin/nginx
+	ExecReload=/usr/sbin/nginx -s reload
+	ExecStop=/bin/kill -s QUIT $MAINPID
+	PrivateTmp=true
+
+	[Install]
+	WantedBy=multi-user.target
+	```
+	Then run `sudo systemctl start nginx` to start the server. To start it automatically at boot, run `sudo systemctl enable nginx`.
 
 2. Configure your database permissions.
 

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -56,7 +56,7 @@ These instructions assume that you have [Homebrew](http://brew.sh/) installed.
 	     llvm libomp gsl rust
 	nvm install node
 	```
-	If you want to use [brotli compression](https://en.wikipedia.org/wiki/Brotli) with NGINX (better compression rates for the frontend), you can install NGINX with the `ngx_brotli` module with this command: `brew tap denji/nginx && brew install nginx-full --with-brotli`. *If you already had NGINX installed, you may need to uninstall it first with `brew unlink nginx`.*Otherwise, you can install NGINX normally with `brew install nginx`.
+	- If you want to use [brotli compression](https://en.wikipedia.org/wiki/Brotli) with NGINX (better compression rates for the frontend), you can install NGINX with the `ngx_brotli` module with this command: `brew tap denji/nginx && brew install nginx-full --with-brotli`. _If you already had NGINX installed, you may need to uninstall it first with `brew unlink nginx`._ Otherwise, you can install NGINX normally with `brew install nginx`.
 
 2. Start the PostgreSQL server:
 
@@ -106,43 +106,16 @@ These instructions assume that you have [Homebrew](http://brew.sh/) installed.
 	      libcurl4-gnutls-dev libgnutls28-dev
 	```
 
-	If you want to run NGINX as is (without brotli), you can simply install it with `sudo apt-get install nginx`.
-	If want to use [brotli compression](https://en.wikipedia.org/wiki/Brotli) with NGINX (to have better compression rates for the frontend), you can install NGINX with the `ngx_brotli` module with these commands:
-	```
-	# install nginx from source so we can add the brotli module
-	git clone --recursive https://github.com/google/ngx_brotli.git
-	wget https://nginx.org/download/nginx-1.24.0.tar.gz
-	tar zxf nginx-1.24.0.tar.gz
-	cd ngx_brotli/deps/brotli
-	mkdir out && cd out
-	cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DCMAKE_C_FLAGS="-Ofast -m64 -march=native -mtune=native -flto -funroll-loops -ffunction-sections -fdata-sections -Wl,--gc-sections" -DCMAKE_CXX_FLAGS="-Ofast -m64 -march=native -mtune=native -flto -funroll-loops -ffunction-sections -fdata-sections -Wl,--gc-sections" -DCMAKE_INSTALL_PREFIX=./installed ..
-	cmake --build . --config Release --target brotlienc
-	cd ../../../..
-	export CURRENT_DIR=$(pwd)
-	cd nginx-1.24.0
-	./configure --sbin-path=/usr/sbin/nginx --conf-path=/usr/local/nginx/nginx.conf --pid-path=/usr/local/nginx/nginx.pid --with-http_ssl_module --with-stream --with-mail=dynamic --with-http_realip_module --with-compat --add-module=${CURRENT_DIR}/ngx_brotli
-	sudo make && sudo make install
-	```
-	To run it as a service, create an Nginx systemd unit file by running `sudo nano /lib/systemd/system/nginx.service` and adding the following content:
-	```
-	[Unit]
-	Description=The NGINX HTTP and reverse proxy server
-	After=syslog.target network-online.target remote-fs.target nss-lookup.target
-	Wants=network-online.target
+	If you want to use [brotli compression](https://en.wikipedia.org/wiki/Brotli) with NGINX (better compression rates for the frontend), you have to install NGINX and the brotli module from another source with:
 
-	[Service]
-	Type=forking
-	PIDFile=/usr/local/nginx/nginx.pid
-	ExecStartPre=/usr/sbin/nginx -t
-	ExecStart=/usr/sbin/nginx
-	ExecReload=/usr/sbin/nginx -s reload
-	ExecStop=/bin/kill -s QUIT $MAINPID
-	PrivateTmp=true
-
-	[Install]
-	WantedBy=multi-user.target
 	```
-	Then run `sudo systemctl start nginx` to start the server. To start it automatically at boot, run `sudo systemctl enable nginx`.
+	sudo apt remove -y nginx nginx-common nginx-core
+	sudo add-apt-repository ppa:ondrej/nginx-mainline -y
+	sudo apt update -y
+	sudo apt install -y nginx libnginx-mod-brotli
+	```
+
+	Otherwise, you can install NGINX normally with `sudo apt-get install nginx`.
 
 2. Configure your database permissions.
 

--- a/nginx.service
+++ b/nginx.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=The NGINX HTTP and reverse proxy server
+After=syslog.target network-online.target remote-fs.target nss-lookup.target
+Wants=network-online.target
+
+[Service]
+Type=forking
+PIDFile=/usr/local/nginx/nginx.pid
+ExecStartPre=/usr/sbin/nginx -t
+ExecStart=/usr/sbin/nginx
+ExecReload=/usr/sbin/nginx -s reload
+ExecStop=/bin/kill -s QUIT $MAINPID
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target

--- a/skyportal/tests/frontend/test_brotli.py
+++ b/skyportal/tests/frontend/test_brotli.py
@@ -8,10 +8,6 @@ server_url = f'http://localhost:{cfg["ports.app"]}'
 
 
 def test_brotli():
-    # Test that the server is using Brotli compression
-    # when requested by the client
     r = requests.get(server_url, headers={"Accept-Encoding": "br"})
-    print(r.status_code)
-    print(r.headers)
     assert r.status_code == 200
     assert r.headers.get("Content-Encoding") == "br"

--- a/skyportal/tests/frontend/test_brotli.py
+++ b/skyportal/tests/frontend/test_brotli.py
@@ -1,0 +1,17 @@
+import requests
+
+from baselayer.app.env import load_env
+
+_, cfg = load_env()
+
+server_url = f'http://localhost:{cfg["ports.app"]}'
+
+
+def test_brotli():
+    # Test that the server is using Brotli compression
+    # when requested by the client
+    r = requests.get(server_url, headers={"Accept-Encoding": "br"})
+    print(r.status_code)
+    print(r.headers)
+    assert r.status_code == 200
+    assert r.headers.get("Content-Encoding") == "br"


### PR DESCRIPTION
See https://github.com/cesium-ml/baselayer/pull/379

This PR adds the necessary lines in the dockerfile to install nginx with brotli support, and the documentation needed.

This is a draft, and thinks need to change before reviewing and/or merging. For example, I would like to move the `nginx.service` file to baselayer's nginx service.