### PR TITLE
Followup - WINTERAPI: implement DELETE + add target name in POST payload

### DIFF
--- a/skyportal/facility_apis/winter.py
+++ b/skyportal/facility_apis/winter.py
@@ -97,9 +97,6 @@ class WINTERRequest:
         # the WINTERAPI POST response has a "msg" key,
         # that contains Schedule name is <schedule_name> if successful
         if "msg" in content:
-            # just to that we are not sensible to the exact format of the message
-            # we look for the string "Schedule name is" and get what's after that
-            # then split by space and take the second element
             # it's in quote, so remove them and strip
             schedule_name = (
                 str(content["msg"].split('Schedule name is')[1])

--- a/skyportal/facility_apis/winter.py
+++ b/skyportal/facility_apis/winter.py
@@ -5,7 +5,7 @@ from requests.auth import HTTPBasicAuth
 from datetime import datetime, timedelta
 from astropy.time import Time
 
-from . import FollowUpAPI, FacilityTransaction
+from . import FollowUpAPI
 from baselayer.app.env import load_env
 from baselayer.app.flow import Flow
 from baselayer.log import make_log
@@ -157,9 +157,7 @@ class WINTERAPI(FollowUpAPI):
             Database session for this transaction
         """
 
-        from ..models import (
-            FollowupRequest,
-        )
+        from ..models import FollowupRequest, FacilityTransaction
 
         last_modified_by_id = request.last_modified_by_id
         obj_internal_key = request.obj.internal_key


### PR DESCRIPTION
- add a delete method to the WINTERAPI, that grabs the schedule name from the POST response (from facility transactions) and calls the `/too/delete` endpoint.
- add a method to grab said schedule name from the POST response
- send the target_name (obj_id) to WINTER when submitting a request (max 30 chars).