### PR TITLE
Follow-up requests constraints: not_if_duplicates as cone search

### DIFF
--- a/skyportal/handlers/api/followup_request.py
+++ b/skyportal/handlers/api/followup_request.py
@@ -408,8 +408,14 @@ def post_followup_request(
             existing_requests = session.scalars(
                 FollowupRequest.select(session.user_or_token).where(
                     FollowupRequest.allocation_id == data['allocation_id'],
-                    func.lower(FollowupRequest.status).contains("submitted").is_(True),
-                    func.lower(FollowupRequest.status).contains("completed").is_(True),
+                    sa.or_(
+                        func.lower(FollowupRequest.status)
+                        .contains("submitted")
+                        .is_(True),
+                        func.lower(FollowupRequest.status)
+                        .contains("completed")
+                        .is_(True),
+                    ),
                     FollowupRequest.obj_id.in_(
                         sa.select(Obj.id).where(
                             Obj.within(ca.Point(ra=obj.ra, dec=obj.dec), radius)


### PR DESCRIPTION
Just like for the other conditions, use a cone search instead of an exact match.

Also, change the queries from scalars().all() to scalars().first() to only get one match, as anyway our conditions are of the form "if any", meaning we don't need more than one.