### PR TITLE
Brotli install fix

### DIFF
--- a/.github/workflows/test_api_and_frontend.yaml
+++ b/.github/workflows/test_api_and_frontend.yaml
@@ -103,11 +103,13 @@ jobs:
           sudo apt install -y wget unzip firefox libcurl4-gnutls-dev libgnutls28-dev
 
           # if nginx is already installed, remove it
-          sudo apt remove -y nginx nginx-common nginx-core
+          sudo apt remove -y nginx nginx-common nginx-core nginx-full
+          sudo apt purge -y nginx nginx-common nginx-core nginx-full
 
-          sudo add-apt-repository ppa:ondrej/nginx-mainline -y
+          # add the PPA repository with brotli support for nginx
+          sudo add-apt-repository ppa:ondrej/nginx -y
           sudo apt update -y
-          sudo apt install -y nginx libnginx-mod-brotli
+          sudo apt install nginx libnginx-mod-http-brotli-static libnginx-mod-http-brotli-filter -y
 
           pip install pip==23.1.2
           pip install wheel numpy

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && \
 # we install nginx with brotli support from ppa:ondrej/nginx-mainline
 RUN add-apt-repository ppa:ondrej/nginx-mainline -y && \
 	apt update -y && \
-	apt install -y nginx libnginx-mod-brotli
+	apt install -y nginx libnginx-mod-http-brotli-static libnginx-mod-http-brotli-filter
 
 RUN apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \


### PR DESCRIPTION
Looks like installing the module with `libnginx-mod-brotli` creates some issues after an nginx update. We can simply install the 2 underlying modules separately, which works without creating any versions mismatch conflict.