### PR TITLE
Candidates Filter Form V2 Bugfix: program selection

### DIFF
--- a/static/js/components/FilterCandidateList.jsx
+++ b/static/js/components/FilterCandidateList.jsx
@@ -666,7 +666,7 @@ const FilterCandidateList = ({
                       )}
                     </IconButton>
                   </Tooltip>
-                  {errors.groupIDs && (
+                  {selectedGroupIDs.length === 0 && (
                     <FormValidationError message="Select at least one group." />
                   )}
                 </div>


### PR DESCRIPTION
I spotted an issue on preview, where searching for groups with the search bar would cause incorrect groups to be selected. 

This PR stops using the form to handle that selected group state so we don't need to hack our way around using indexes to map to group ids which is a mess.