### PR TITLE
Candidates List V2: use react-viewport-list to only render candidates that are in view

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "react-text-loop": "2.3.0",
     "react-to-print": "2.14.13",
     "react-transition-group": "4.4.5",
-    "react-viewport-list": "^7.1.2",
+    "react-viewport-list": "7.1.2",
     "react-window": "1.8.8",
     "redoc": "2.1.3",
     "redoc-cli": "0.13.21",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "react-text-loop": "2.3.0",
     "react-to-print": "2.14.13",
     "react-transition-group": "4.4.5",
+    "react-viewport-list": "^7.1.2",
     "react-window": "1.8.8",
     "redoc": "2.1.3",
     "redoc-cli": "0.13.21",

--- a/skyportal/tests/frontend/test_scanning_page.py
+++ b/skyportal/tests/frontend/test_scanning_page.py
@@ -58,16 +58,19 @@ def test_candidate_group_filtering(
     driver.scroll_to_element_and_click(group_checkbox)
     submit_button = driver.wait_for_xpath('//button[text()="Search"]')
     driver.scroll_to_element_and_click(submit_button)
-    for i in range(5):  # data-testid
-        driver.wait_for_xpath(f'//a[@data-testid="{candidate_id}_{i}"]')
+
+    driver.wait_for_xpath(
+        '//*[contains(., "Found 6 candidates.")]'
+    )  # the 5 candidates we added and the public candidate
+
     driver.scroll_to_element_and_click(group_checkbox)
     driver.click_xpath(
         f'//*[@data-testid="filteringFormGroupCheckbox-{new_group_id}"]',
         wait_clickable=False,
     )
     driver.scroll_to_element_and_click(submit_button)
-    for i in range(5):
-        driver.wait_for_xpath_to_disappear(f'//a[@data-testid="{candidate_id}_{i}"]')
+
+    driver.wait_for_xpath('//*[contains(., "Found 0 candidates.")]')
 
 
 @pytest.mark.flaky(reruns=2)
@@ -131,15 +134,19 @@ def test_candidate_saved_status_filtering(
         "//li[@data-value='notSavedToAnyAccessible']", scroll_parent=True
     )
     driver.click_xpath('//button[text()="Search"]')
-    for i in range(5):
-        driver.wait_for_xpath_to_disappear(f'//a[@data-testid="{candidate_id}_{i}"]')
+
+    driver.wait_for_xpath(
+        '//*[contains(., "Found 1 candidates.")]'
+    )  # the public candidate
 
     # Set to candidates is saved to any accessibe groups and submit again
     driver.click_xpath("//*[@data-testid='savedStatusSelect']")
     driver.click_xpath("//li[@data-value='savedToAnyAccessible']", scroll_parent=True)
     driver.click_xpath('//button[text()="Search"]')
-    for i in range(5):
-        driver.wait_for_xpath(f'//a[@data-testid="{candidate_id}_{i}"]')
+
+    driver.wait_for_xpath(
+        '//*[contains(., "Found 5 candidates.")]'
+    )  # the 5 candidates we added
 
 
 @pytest.mark.flaky(reruns=2)

--- a/static/js/components/CandidateList.jsx
+++ b/static/js/components/CandidateList.jsx
@@ -36,8 +36,8 @@ import { ra_to_hours, dec_to_dms } from "../units";
 
 import * as candidatesActions from "../ducks/candidates";
 
-const numPerPage = 2;
-const numPerPageOffset = 1;
+const numPerPage = 25;
+const numPerPageOffset = 5;
 
 const useStyles = makeStyles((theme) => ({
   listPaper: {
@@ -837,6 +837,8 @@ const CandidateList = () => {
   filterGroups?.forEach((g) => {
     groupIds.push(g.id);
   });
+
+  console.log("length of candidates", candidates?.length);
 
   return (
     <div>

--- a/static/js/components/CandidateList.jsx
+++ b/static/js/components/CandidateList.jsx
@@ -838,8 +838,6 @@ const CandidateList = () => {
     groupIds.push(g.id);
   });
 
-  console.log("length of candidates", candidates?.length);
-
   return (
     <div>
       <div>

--- a/static/js/components/FilterCandidateList.jsx
+++ b/static/js/components/FilterCandidateList.jsx
@@ -666,7 +666,7 @@ const FilterCandidateList = ({
                       )}
                     </IconButton>
                   </Tooltip>
-                  {errors.groupIDs && (
+                  {selectedGroupIDs.length === 0 && (
                     <FormValidationError message="Select at least one group." />
                   )}
                 </div>


### PR DESCRIPTION
I saw the impact of the "infinity scrolling" in production as soon as you start loading 50+ candidates that have a lot of data. This is an attempt at fixing that by only rendering what's in the view using [react-viewport-list](https://www.npmjs.com/package/react-viewport-list)