### PR TITLE
Empty altdata in follow-up triggering

### DIFF
--- a/skyportal/facility_apis/generic.py
+++ b/skyportal/facility_apis/generic.py
@@ -179,7 +179,7 @@ class GENERICAPI(FollowUpAPI):
 
         altdata = (
             request.allocation.altdata
-            if getattr(request.allocation, 'altdata', None) is not None
+            if getattr(request.allocation, 'altdata', None) not in [None, {}]
             else None
         )
 


### PR DESCRIPTION
This PR checks for empty altdata in the generic API allocations.