### PR TITLE
ZTF Forced Photometry: Flux weighted position

### DIFF
--- a/skyportal/facility_apis/ztf.py
+++ b/skyportal/facility_apis/ztf.py
@@ -148,7 +148,7 @@ class ZTFRequest:
         }
 
         ra, dec = None, None
-        position = request.payload.get("position", "Source")
+        position = request.payload.get("position", "Source (object's coordinates)")
         if "Flux weighted centroid" in position:
             # here we query the database to get the all the photometry rows for the object that:
             # 1. belong to an instrument with data stream(s)
@@ -212,7 +212,7 @@ class ZTFRequest:
                     error = "No photometry found that meets the criteria for flux weighted centroid calculation."
                     return target, error
 
-        elif "Source" in position:
+        elif "Source (object's coordinates)" in position:
             ra, dec = request.obj.ra, request.obj.dec
         else:
             error = "Unknown position type."
@@ -715,12 +715,12 @@ class ZTFAPI(FollowUpAPI):
             "position": {
                 "type": "string",
                 "enum": [
-                    "Source",
+                    "Source (object's coordinates)",
                     "Flux weighted centroid",
                     "Flux weighted centroid (alert photometry only)",
                     "Flux weighted centroid (ZTF alert photometry only)",
                 ],
-                "default": "Source",
+                "default": "Source (object's coordinates)",
             },
             "start_date": {
                 "type": "string",

--- a/skyportal/facility_apis/ztf.py
+++ b/skyportal/facility_apis/ztf.py
@@ -200,7 +200,7 @@ class ZTFRequest:
                 if len(photometry) > 0:
                     # calculate the weighted centroid based on the object's photometry
                     ras, decs, flux, fluxerr = np.array(photometry).T
-                    snr = flux / fluxerr
+                    snr = np.abs(flux / fluxerr)
                     ra, dec = np.sum(ras * snr) / np.sum(snr), np.sum(
                         decs * snr
                     ) / np.sum(snr)


### PR DESCRIPTION
Adds a dropdown to pick what position to use: the object's, flux weighted alerts only (ignoring FP), and flux weighted ZTF alerts only (ignoring FP).