### PR TITLE
fix dustmaps version 1.0.12 -> 1.0.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ pytest-randomly==3.15.0
 factory-boy==3.3.0
 astropy==5.2.1
 distributed==2023.4.1
-dustmaps==1.0.12
+dustmaps==1.0.13
 reproject==0.11.0
 avro-python3==1.10.2
 fastavro==1.9.4


### PR DESCRIPTION
With the 1.0.12 version errors when i try to lauch skyportal -> typo errors (md5sum -> md5) (md5extisting -> md5existing)