### PR TITLE
TNS Robots: Including testing in unique constraint

### DIFF
--- a/services/tns_retrieval_queue/tns_retrieval_queue.py
+++ b/services/tns_retrieval_queue/tns_retrieval_queue.py
@@ -468,8 +468,12 @@ def tns_watcher(queue):
     start_date = datetime.now() - timedelta(days=look_back_days)
     while True:
         # convert start date to isot format
-        start_date = start_date.strftime("%Y-%m-%dT%H:%M:%S")
-        tns_sources = get_recent_TNS(api_key, tns_headers, start_date, get_data=False)
+        tns_sources = get_recent_TNS(
+            api_key,
+            tns_headers,
+            start_date.strftime("%Y-%m-%dT%H:%M:%S"),
+            get_data=False,
+        )
         for tns_source in tns_sources:
             # add the tns_source to the queue
             queue.append(

--- a/services/tns_submission_queue/tns_submission_queue.py
+++ b/services/tns_submission_queue/tns_submission_queue.py
@@ -820,8 +820,12 @@ def process_submission_request(submission_request, session):
             submission_request, tnsrobot, user, session
         )
 
+        bot_name = tnsrobot.bot_name
+        # if there is testing or Testing, will not report in the bot name (in parentheses), remove it
+        if "(Testing, will not report)" in bot_name.lower().strip():
+            bot_name = bot_name.split("(Testing, will not report)")[0].strip()
         tns_headers = {
-            'User-Agent': f'tns_marker{{"tns_id":{tnsrobot.bot_id},"type":"bot", "name":"{tnsrobot.bot_name}"}}'
+            'User-Agent': f'tns_marker{{"tns_id":{tnsrobot.bot_id},"type":"bot", "name":"{bot_name}"}}'
         }
 
         photometry_options = validate_photometry_options(submission_request, tnsrobot)

--- a/services/tns_submission_queue/tns_submission_queue.py
+++ b/services/tns_submission_queue/tns_submission_queue.py
@@ -820,12 +820,8 @@ def process_submission_request(submission_request, session):
             submission_request, tnsrobot, user, session
         )
 
-        bot_name = tnsrobot.bot_name
-        # if there is testing or Testing, will not report in the bot name (in parentheses), remove it
-        if "(Testing, will not report)" in bot_name.lower().strip():
-            bot_name = bot_name.split("(Testing, will not report)")[0].strip()
         tns_headers = {
-            'User-Agent': f'tns_marker{{"tns_id":{tnsrobot.bot_id},"type":"bot", "name":"{bot_name}"}}'
+            'User-Agent': f'tns_marker{{"tns_id":{tnsrobot.bot_id},"type":"bot", "name":"{tnsrobot.bot_name}"}}'
         }
 
         photometry_options = validate_photometry_options(submission_request, tnsrobot)

--- a/skyportal/models/tns.py
+++ b/skyportal/models/tns.py
@@ -109,9 +109,10 @@ class TNSRobot(Base):
     )
 
 
-# we want a unique constraint on the bot_name, bot_id, source_group_id columns
+# we want a unique constraint on the bot_name, bot_id, source_group_id, testing columns
+# this way you can't have the same bot twice, except for testing
 TNSRobot.__table_args__ = (
-    sa.UniqueConstraint('bot_name', 'bot_id', 'source_group_id'),
+    sa.UniqueConstraint('bot_name', 'bot_id', 'source_group_id', 'testing'),
 )
 
 


### PR DESCRIPTION
That way we can have a copy of a TNS robot as long as that copy is in testing mode and not the existing bot (or vice versa).

Useful to have a copy of a bot in testing mode to test the auto-reporting while the real bot can still be used for manual reporting only.


TODO: try to improve the TNS to existing source matching, because the conesearch results from TNS contain no distance information or position, and we've matched some older TNS sources with newer ones. Without running a billion extra API calls, this could be as simple as just using a smaller conesearch radius, from 2 to 1 arcsec or less.