### PR TITLE
Observation plan queue bugfix:

### DIFF
--- a/services/observation_plan_queue/observation_plan_queue.py
+++ b/services/observation_plan_queue/observation_plan_queue.py
@@ -1,5 +1,6 @@
 import itertools
 import time
+import traceback
 
 import arrow
 import sqlalchemy as sa
@@ -53,7 +54,7 @@ def prioritize_requests(requests):
                 if allocation_id not in telescopeAllocationLookup:
                     telescopeAllocationLookup[
                         allocation_id
-                    ] = plan.allocation.instrument.telescope.current_time
+                    ] = plan.allocation.instrument.telescope.current_time()
 
         # now we loop over the plans. For plans with multiple plans we pick the allocation with the earliest start date and morning time
         # at the same time, we pick the plan to prioritize
@@ -137,6 +138,7 @@ def prioritize_requests(requests):
 
         return plan_with_priority["plan_id"]
     except Exception as e:
+        traceback.print_exc()
         log(f"Error occured prioritizing the observation plan queue: {e}")
         return 0
 
@@ -148,12 +150,39 @@ def service(*args, **kwargs):
         with DBSession() as session:
             try:
                 stmt = sa.select(ObservationPlanRequest).where(
-                    ObservationPlanRequest.status == "pending submission",
-                    ObservationPlanRequest.created_at
-                    > arrow.utcnow().shift(days=-1).datetime,
-                    # we only want to process plans that have been created in the last 24 hours
+                    # we only want to process plans that have been created in the last 72 hours
+                    sa.or_(
+                        sa.and_(
+                            ObservationPlanRequest.status == "pending submission",
+                            ObservationPlanRequest.created_at
+                            > arrow.utcnow().shift(days=-3).datetime,
+                        ),
+                        # or plans that have been "running" for more than 24 hours but less than 72 hours
+                        # this is a way to grab plans that have been stuck in the running state
+                        # and have not been processed
+                        sa.and_(
+                            ObservationPlanRequest.status == "running",
+                            ObservationPlanRequest.created_at
+                            < arrow.utcnow().shift(days=-1).datetime,
+                            ObservationPlanRequest.created_at
+                            > arrow.utcnow().shift(days=-3).datetime,
+                        ),
+                    )
                 )
-                single_requests = session.execute(stmt).scalars().unique().all()
+                single_requests = session.scalars(stmt).unique().all()
+
+                # reprocessing plans that were marked as running before (and probably stuck in that state)
+                # is lower priority, so if we have any pending submission plans, we prioritize those
+                # and remove the running plans from the list
+                if any(
+                    request.status == "pending submission"
+                    for request in single_requests
+                ):
+                    single_requests = [
+                        request
+                        for request in single_requests
+                        if request.status == "pending submission"
+                    ]
 
                 # requests is a list. We want to group that list of plans to be a list of list,
                 # we group based on the plans 'combined_id' which is a unique uuid for a group of plans
@@ -175,7 +204,7 @@ def service(*args, **kwargs):
                 ]
 
                 if len(requests) == 0:
-                    time.sleep(2)
+                    time.sleep(5)
                     continue
 
                 log(f"Prioritizing {len(requests)} observation plan requests...")
@@ -194,12 +223,14 @@ def service(*args, **kwargs):
                         )
                         plan_ids.append(plan_id)
                     except Exception as e:
+                        traceback.print_exc()
                         plan_request.status = 'failed to process'
                         log(f'Error processing observation plan: {e.args[0]}')
                         session.commit()
                         time.sleep(2)
                         continue
                     plan_request.status = 'complete'
+                    session.merge(plan_request)
                     session.commit()
 
                 else:

--- a/skyportal/facility_apis/observation_plan.py
+++ b/skyportal/facility_apis/observation_plan.py
@@ -1,4 +1,5 @@
 import time
+import traceback
 from astropy.time import Time
 import healpix_alchemy as ha
 import humanize
@@ -867,10 +868,19 @@ def generate_plan(
         log(f"Finished plan(s) for ID(s): {','.join(observation_plan_id_strings)}")
 
     except Exception as e:
+        traceback.print_exc()
         log(
             f"Failed to generate plans for ID(s): {','.join(observation_plan_id_strings)}: {str(e)}."
         )
         session.rollback()
+        # mark the request and plan as failed
+        for request in requests:
+            request.status = 'failed'
+            session.merge(request)
+        for plan in plans:
+            plan.status = 'failed'
+            session.merge(plan)
+        session.commit()
 
     session.close()
     Session.remove()
@@ -1092,6 +1102,36 @@ class MMAAPI(FollowUpAPI):
                     EventObservationPlan.plan_name == request.payload["queue_name"]
                 )
             ).first()
+
+            # if the request is marked as running but there is a plan that is complete,
+            # then mark the request as complete as well
+            if (
+                plan is not None
+                and plan.status == 'complete'
+                and request.status == 'running'
+            ):
+                request.status = 'complete'
+                session.merge(request)
+                session.commit()
+                log(
+                    f"Plan {plan.id} is already complete. Marking request {request.id} as complete."
+                )
+                return plan.id
+
+            # if the request is marked as running and there is already a plan that is pending submissions,
+            # then it is likely that processing the plan failed before
+            # so we delete the plan and create a new one
+            if (
+                plan is not None
+                and plan.status == 'pending submission'
+                and request.status == 'running'
+            ):
+                log(
+                    f"Plan {plan.id} has been pending submission for more than 24 hours. Deleting and creating a new plan."
+                )
+                session.delete(plan)
+                session.commit()
+                plan = None
 
             if plan is None:
                 # check payload


### PR DESCRIPTION
I noticed on the frontend that all the plans that have been generated recently where stuck in "running" state. What looks like happened is that we marked the plan as complete, and the request too but for some reason marking the request as complete in the queue did not work.

This PR fixes that with the pretty simple addition of a session.merge(), but also adds code in the facility_apis/observation_plans to reprocess plans or mark them as failed or complete when needed.