### PR TITLE
Source Views Dashboard Widget: don't count token source views

### DIFF
--- a/skyportal/handlers/api/internal/source_views.py
+++ b/skyportal/handlers/api/internal/source_views.py
@@ -12,7 +12,7 @@ default_prefs = {'maxNumSources': 10, 'sinceDaysAgo': 7}
 
 class SourceViewsHandler(BaseHandler):
     @classmethod
-    def get_top_source_views_and_ids(self, current_user, session):
+    def get_top_source_views_and_ids(cls, current_user, session):
         user_prefs = getattr(current_user, 'preferences', None) or {}
         top_sources_prefs = user_prefs.get('topSources', {})
         top_sources_prefs = {**default_prefs, **top_sources_prefs}
@@ -31,7 +31,10 @@ class SourceViewsHandler(BaseHandler):
                 ],
             )
             .group_by(SourceView.obj_id)
-            .filter(SourceView.created_at >= cutoff_day)
+            .filter(
+                SourceView.created_at >= cutoff_day,
+                SourceView.is_token.is_(False),
+            )
             .order_by(desc('views'))
             .limit(max_num_sources)
         ).all()

--- a/skyportal/handlers/api/tns.py
+++ b/skyportal/handlers/api/tns.py
@@ -1678,7 +1678,7 @@ class ObjTNSHandler(BaseHandler):
             ).first()
             if existing_submission_request is not None:
                 return self.error(
-                    f'TNSRobotSubmission request for obj_id {obj.id} and tnsrobot_id {tnsrobot.id} already exists and is in status {existing_submission_request.status}'
+                    f'TNSRobotSubmission request for obj_id {obj.id} and tnsrobot_id {tnsrobot.id} already exists and is: {existing_submission_request.status}'
                 )
             # create a TNSRobotSubmission entry with that information
             tnsrobot_submission = TNSRobotSubmission(

--- a/static/js/components/TNSATForm.jsx
+++ b/static/js/components/TNSATForm.jsx
@@ -223,10 +223,6 @@ const TNSATForm = ({ obj_id, submitCallback }) => {
     setSubmissionRequestInProcess(false);
     if (result.status === "success") {
       dispatch(showNotification("added to TNS submission queue"));
-    } else {
-      dispatch(
-        showNotification("Failed to add object to TNS submission queue"),
-      );
     }
     if (submitCallback) {
       submitCallback();

--- a/static/js/components/TNSATForm.jsx
+++ b/static/js/components/TNSATForm.jsx
@@ -219,14 +219,15 @@ const TNSATForm = ({ obj_id, submitCallback }) => {
       first_and_last_detections: formData.first_and_last_detections,
     };
     delete formData.first_and_last_detections;
-    const result = await dispatch(sourceActions.addSourceTNS(obj_id, formData));
-    setSubmissionRequestInProcess(false);
-    if (result.status === "success") {
-      dispatch(showNotification("added to TNS submission queue"));
-    }
-    if (submitCallback) {
-      submitCallback();
-    }
+    dispatch(sourceActions.addSourceTNS(obj_id, formData)).then((result) => {
+      setSubmissionRequestInProcess(false);
+      if (result.status === "success") {
+        dispatch(showNotification("added to TNS submission queue"));
+      }
+      if (submitCallback) {
+        submitCallback();
+      }
+    });
   };
 
   const tnsrobotLookUp = {};

--- a/static/js/components/TNSRobotsPage.jsx
+++ b/static/js/components/TNSRobotsPage.jsx
@@ -926,7 +926,7 @@ const TNSRobotsPage = () => {
       testing: {
         type: "boolean",
         title: "Testing Mode",
-        default: tnsrobotListLookup[tnsrobotToManage]?.testing || true,
+        default: tnsrobotListLookup[tnsrobotToManage]?.testing,
         description:
           "If enabled, the bot will not submit to TNS but only store the payload in the DB (useful for debugging).",
       },
@@ -983,6 +983,8 @@ const TNSRobotsPage = () => {
     title: "Owner Group(s)",
   };
   createSchema.required.push("owner_group_ids");
+  // change the default of testing to be true
+  createSchema.properties.testing.default = true;
 
   const validate = (formData, errors) => {
     const { source_group_id } = formData;


### PR DESCRIPTION
Some folks keep querying sources for months using scripts (at like a 1-hour cadence).

Though maybe I should just BAN ALL OF THEM USERS, given that we know how much frontend is king for SP, it makes total sense to only show frontend source views in the frontend, and not those registers by API calls.

This PR doesn't just that by ignoring token source views when querying for views in the internal API used by the dashboard widget.