### PR TITLE
Spectra plot: keep zoom level after layout updated

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -68,7 +68,7 @@ humanize==4.8.0
 xarray>=21.1
 simsurvey==0.7.5
 noaodatalab==2.20.0
-black==24.2.0
+black==24.3.0
 click==8.1.6
 arviz==0.16.1
 corner==2.2.1

--- a/services/tns_submission_queue/tns_submission_queue.py
+++ b/services/tns_submission_queue/tns_submission_queue.py
@@ -690,7 +690,7 @@ def build_at_report(
         phot_first = {
             "obsdate": astropy.time.Time(time_first, format='mjd').jd,
             "flux": mag_first,
-            "flux_err": magerr_first,
+            "flux_error": magerr_first,
             "flux_units": "1",
             "filter_value": filt_first,
             "instrument_value": instrument_first,
@@ -699,7 +699,7 @@ def build_at_report(
         phot_last = {
             "obsdate": astropy.time.Time(time_last, format='mjd').jd,
             "flux": mag_last,
-            "flux_err": magerr_last,
+            "flux_error": magerr_last,
             "flux_units": "1",
             "filter_value": filt_last,
             "instrument_value": instrument_last,
@@ -709,7 +709,7 @@ def build_at_report(
         phot_first = {
             "obsdate": astropy.time.Time(time_first, format='mjd').jd,
             "flux": mag_first,
-            "flux_err": magerr_first,
+            "flux_error": magerr_first,
             "flux_units": "1",
             "filter_value": filt_first,
             "instrument_value": instrument_first,

--- a/skyportal/models/instrument.py
+++ b/skyportal/models/instrument.py
@@ -1,4 +1,10 @@
-__all__ = ['Instrument', 'InstrumentField', 'InstrumentFieldTile', 'InstrumentLog']
+__all__ = [
+    'Instrument',
+    'InstrumentField',
+    'InstrumentFieldTile',
+    'InstrumentLog',
+    'InstrumentTNSRobot',
+]
 
 import re
 

--- a/skyportal/models/stream.py
+++ b/skyportal/models/stream.py
@@ -4,6 +4,7 @@ __all__ = [
     'StreamPhotometry',
     'StreamPhotometricSeries',
     'StreamInvitation',
+    'StreamTNSRobot',
 ]
 
 import sqlalchemy as sa

--- a/static/js/components/SpectraPlot.jsx
+++ b/static/js/components/SpectraPlot.jsx
@@ -418,6 +418,7 @@ const SpectraPlot = ({ spectra, redshift, mode, plotStyle }) => {
     const [newSpectra, newSpecStats] = prepareSpectra(spectra, spectrumTypes);
     setSpecStats(newSpecStats);
     setData(newSpectra);
+    setLayoutReset((prev) => prev + 1);
   }, [spectra]);
 
   useEffect(() => {

--- a/static/js/components/SpectraPlot.jsx
+++ b/static/js/components/SpectraPlot.jsx
@@ -458,11 +458,13 @@ const SpectraPlot = ({ spectra, redshift, mode, plotStyle }) => {
       );
       return line.x.map((x) => {
         const redshiftedX =
-          line?.fixed === true ? x : x * (1 + parseFloat(redshiftInput, 10));
+          line?.fixed === true
+            ? x
+            : x * (1 + (parseFloat(redshiftInput, 10) || 0));
         const shiftedX =
           line?.fixed === true
             ? x
-            : redshiftedX / (1 + parseFloat(vExpInput, 10) / C);
+            : redshiftedX / (1 + (parseFloat(vExpInput, 10) || 0) / C);
         return {
           type: "scatter",
           mode: "lines",
@@ -500,8 +502,8 @@ const SpectraPlot = ({ spectra, redshift, mode, plotStyle }) => {
                   i, // eslint-disable-line no-unused-vars
                 ) =>
                   (parseFloat(customWavelengthInput, 10) *
-                    (1 + parseFloat(redshiftInput, 10))) /
-                  (1 + parseFloat(vExpInput, 10) / C),
+                    (1 + (parseFloat(redshiftInput, 10) || 0))) /
+                  (1 + (parseFloat(vExpInput, 10) || 0) / C),
               ),
               y: [...Array(100).keys()].map(
                 (i) =>

--- a/static/js/components/SpectraPlot.jsx
+++ b/static/js/components/SpectraPlot.jsx
@@ -96,7 +96,7 @@ const SpectraPlot = ({ spectra, redshift, mode, plotStyle }) => {
 
   const [specStats, setSpecStats] = useState(null);
 
-  const [layoutReset, setLayoutReset] = useState(-1);
+  const [layoutReset, setLayoutReset] = useState(0);
 
   const { preferences } = useSelector((state) => state.profile);
 
@@ -418,7 +418,6 @@ const SpectraPlot = ({ spectra, redshift, mode, plotStyle }) => {
     const [newSpectra, newSpecStats] = prepareSpectra(spectra, spectrumTypes);
     setSpecStats(newSpecStats);
     setData(newSpectra);
-    setLayoutReset((prev) => prev + 1);
   }, [spectra]);
 
   useEffect(() => {
@@ -432,7 +431,7 @@ const SpectraPlot = ({ spectra, redshift, mode, plotStyle }) => {
       );
       setPlotData(traces);
     }
-  }, [data, types, specStats, redshift, smoothingInput]);
+  }, [data, types, specStats, smoothingInput]);
 
   useEffect(() => {
     if (

--- a/static/js/components/SpectraPlot.jsx
+++ b/static/js/components/SpectraPlot.jsx
@@ -96,7 +96,7 @@ const SpectraPlot = ({ spectra, redshift, mode, plotStyle }) => {
 
   const [specStats, setSpecStats] = useState(null);
 
-  const [layoutReset, setLayoutReset] = useState(0);
+  const [layoutReset, setLayoutReset] = useState(1);
 
   const { preferences } = useSelector((state) => state.profile);
 
@@ -379,6 +379,8 @@ const SpectraPlot = ({ spectra, redshift, mode, plotStyle }) => {
     if (!specStats_value || !spectrumType) {
       return {};
     }
+    redshift_value = parseFloat(redshift_value, 10);
+    vexp_value = parseFloat(vexp_value, 10);
     const newLayouts = {
       xaxis: {
         title: "Wavelength (Å)",


### PR DESCRIPTION
On the spectra plot, we want the top X axis (rest wavelength) stay in sync with the spectral lines we plot as the redshift and velocity inputs change. 

The only way to have a "dynamic layout" is to simply recreate the layout when needed. Ideally I wanted to only recreate the layout when it needs to be, without having to recreate it when we change the data that's being plotted (with smoothing for example). So, I had it stored in a state variable that the plot would take as an input. 

The problem there is that when the layout gets updated the plot is rendered and the user's current zoom is lost (goes back to the default, as per the new layout axes ranges). I tried to use the `uirevision` argument of the layout (https://plotly.com/javascript/uirevision/) to prevent reset of the zoom on layout change, but it initially didn't work.

Turns out that the problem is having the layout be a state variable we unpack in the layout argument of the <Plot> element. And just calling my `createLayout` method when passing it to the plot (and not using a state var) makes it work.

Also, the documentation for the `uirevision` is unclear, but basically it's a string or number, and as long as it is the same, none of the user's panning or zooming is reset when changing the axes or the data. So we use the `layoutReset` state var as a counter that we just increment of 1 every time we want the zoom to be reset (which happens when changing the type of spectrum displayed: source, galaxy, ... and double clicking the plot or "home" icon to explicitly reset the zoom).

If this proves to be a successful way (and not too heavy now that we call `createLayout` in the <Plot> itself, meaning its recomputed at every rerender) to keep a user's panning/zooming when updating the data that's displayed or the axes, we'll want to propagate that new way to handle plot reset to the other plotly plots.

*(PS: also made some tiny changes to the TNS submission queue to try to avoid some random object not in session errors I can't really wrap my head around, though it's likely because the microservice has 2 threads now).*