### PR TITLE
use latest ligo.skymap

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,7 @@ lxml==4.9.3
 suds-py3==1.4.5.0
 vcrpy==5.1.0
 aiosmtpd==1.4.5
-ligo.skymap>=0.6
+ligo.skymap==1.1.2
 healpy==1.16.6
 pygcn==1.1.2
 pysedm==0.31.0


### PR DESCRIPTION
ligo.skymap 0.6.0 is incompatible with latest astropy. We should be using latest version.