### PR TITLE
Issue 4819 gcn events too much white space

### DIFF
--- a/skyportal/handlers/api/gcn.py
+++ b/skyportal/handlers/api/gcn.py
@@ -1601,6 +1601,7 @@ class GcnEventHandler(BaseHandler):
 
             events = []
             for event in session.scalars(query).unique().all():
+                event.gcn_notices = sorted(event.gcn_notices, key=lambda notice: notice.date, reverse=True)
                 for notice in event.gcn_notices:
                     notice.notice_type = gcn.NoticeType(notice.notice_type).name
                 event_info = {

--- a/skyportal/handlers/api/gcn.py
+++ b/skyportal/handlers/api/gcn.py
@@ -1601,18 +1601,18 @@ class GcnEventHandler(BaseHandler):
 
             events = []
             for event in session.scalars(query).unique().all():
-                event_info = {**event.to_dict(), "tags": list(set(event.tags))}
-                event_info["localizations"] = sorted(
-                    (
+                for notice in event.gcn_notices:
+                    notice.notice_type = gcn.NoticeType(notice.notice_type).name
+                event_info = {
+                    **event.to_dict(), 
+                    "tags": list(set(event.tags)), 
+                    "localizations": sorted((
                         {
-                            **loc.to_dict(),
-                            "tags": [tag.to_dict() for tag in loc.tags],
-                        }
-                        for loc in event.localizations
-                    ),
-                    key=lambda x: x["created_at"],
-                    reverse=True,
-                )
+                            **loc.to_dict(), "tags": [tag.to_dict() for tag in loc.tags],
+                        } for loc in event.localizations ),
+                        key=lambda x: x["created_at"],
+                        reverse=True)
+                }
                 events.append(event_info)
 
             query_results = {"events": events, "totalMatches": int(total_matches)}

--- a/skyportal/handlers/api/gcn.py
+++ b/skyportal/handlers/api/gcn.py
@@ -1601,7 +1601,9 @@ class GcnEventHandler(BaseHandler):
 
             events = []
             for event in session.scalars(query).unique().all():
-                event.gcn_notices = sorted(event.gcn_notices, key=lambda notice: notice.date, reverse=True)
+                event.gcn_notices = sorted(
+                    event.gcn_notices, key=lambda notice: notice.date, reverse=True
+                )
                 for notice in event.gcn_notices:
                     notice.notice_type = gcn.NoticeType(notice.notice_type).name
                 event_info = {

--- a/skyportal/handlers/api/gcn.py
+++ b/skyportal/handlers/api/gcn.py
@@ -1604,14 +1604,19 @@ class GcnEventHandler(BaseHandler):
                 for notice in event.gcn_notices:
                     notice.notice_type = gcn.NoticeType(notice.notice_type).name
                 event_info = {
-                    **event.to_dict(), 
-                    "tags": list(set(event.tags)), 
-                    "localizations": sorted((
-                        {
-                            **loc.to_dict(), "tags": [tag.to_dict() for tag in loc.tags],
-                        } for loc in event.localizations ),
+                    **event.to_dict(),
+                    "tags": list(set(event.tags)),
+                    "localizations": sorted(
+                        (
+                            {
+                                **loc.to_dict(),
+                                "tags": [tag.to_dict() for tag in loc.tags],
+                            }
+                            for loc in event.localizations
+                        ),
                         key=lambda x: x["created_at"],
-                        reverse=True)
+                        reverse=True,
+                    ),
                 }
                 events.append(event_info)
 

--- a/static/js/components/GcnEvents.jsx
+++ b/static/js/components/GcnEvents.jsx
@@ -467,6 +467,7 @@ const GcnEvents = () => {
       options: {
         customBodyRenderLite: renderAliases,
         filter: false,
+        sort: false,
       },
     },
     {
@@ -475,6 +476,7 @@ const GcnEvents = () => {
       options: {
         customBodyRenderLite: renderGcnTags,
         filter: false,
+        sort: false,
       },
     },
     {
@@ -483,6 +485,7 @@ const GcnEvents = () => {
       options: {
         customBodyRenderLite: renderAllocationTriggers,
         filter: false,
+        sort: false,
       },
     },
     {
@@ -491,6 +494,7 @@ const GcnEvents = () => {
       options: {
         customBodyRenderLite: renderLocalizationTags,
         filter: false,
+        sort: false,
       },
     },
     {
@@ -499,6 +503,7 @@ const GcnEvents = () => {
       options: {
         customBodyRenderLite: renderLocalizations,
         filter: false,
+        sort: false,
       },
     },
     {
@@ -507,6 +512,7 @@ const GcnEvents = () => {
       options: {
         customBodyRenderLite: renderGcnNotices,
         filter: false,
+        sort: false,
       },
     },
   ];

--- a/static/js/components/GcnEvents.jsx
+++ b/static/js/components/GcnEvents.jsx
@@ -370,9 +370,9 @@ const GcnEvents = () => {
             </li>
         ))}
         {events[dataIndex]?.localizations?.length > 3 && (
-            <div onClick={() => setShowLocalizations(showLocalizations === false ? dataIndex : false)}
+            <div onClick={() => setShowLocalizations(showLocalizations === dataIndex ? false : dataIndex)}
                  style={{display: 'flex', justifyContent: 'center', alignItems: 'center', cursor: 'pointer'}}>
-              {showLocalizations === false ? <MoreHorizIcon /> : <ExpandLess />}
+              {showLocalizations === dataIndex ? <ExpandLess /> : <MoreHorizIcon />}
             </div>
         )}
       </ul>
@@ -391,9 +391,9 @@ const GcnEvents = () => {
           </li>
       ))}
       {events[dataIndex]?.gcn_notices?.length > 2 && (
-          <div onClick={() => setShowNotices(showNotices === false ? dataIndex : false)}
+          <div onClick={() => setShowNotices(showNotices === dataIndex ? false : dataIndex)}
                style={{display: 'flex', justifyContent: 'center', alignItems: 'center', cursor: 'pointer'}}>
-            {showNotices === false ? <MoreHorizIcon /> : <ExpandLess />}
+            {showNotices === dataIndex ? <ExpandLess /> : <MoreHorizIcon />}
           </div>
       )}
     </ul>

--- a/static/js/components/GcnEvents.jsx
+++ b/static/js/components/GcnEvents.jsx
@@ -68,7 +68,7 @@ const useStyles = makeStyles((theme) => ({
 const getMuiTheme = (theme) =>
   createTheme({
     palette: theme.palette,
-    overrides: {
+    components: {
       MUIDataTablePagination: {
         toolbar: {
           flexFlow: "row wrap",

--- a/static/js/components/GcnEvents.jsx
+++ b/static/js/components/GcnEvents.jsx
@@ -25,6 +25,7 @@ import MUIDataTable from "mui-datatables";
 import Dialog from "@mui/material/Dialog";
 import DialogContent from "@mui/material/DialogContent";
 import MuiDialogTitle from "@mui/material/DialogTitle";
+import Tooltip from "@mui/material/Tooltip";
 import Button from "./Button";
 
 import { filterOutEmptyValues } from "../API";
@@ -41,15 +42,15 @@ const useStyles = makeStyles((theme) => ({
     width: "100%",
     overflow: "scroll",
   },
-  eventTags: {
-    marginLeft: "0.5rem",
+  tags: {
+    margin: "0 1px 1px 0",
     "& > div": {
       margin: "0.25rem",
-      color: "white",
-      background: theme.palette.primary.main,
-    },
+    }
   },
   gcnEventLink: {
+    marginLeft: theme.spacing(-1.5), 
+    paddingLeft: theme.spacing(1.5),
     color:
       theme.palette.mode === "dark"
         ? theme.palette.secondary.main
@@ -62,6 +63,21 @@ const useStyles = makeStyles((theme) => ({
     justifyContent: "flex-start",
     marginTop: "1rem",
   },
+  list: {
+    listStyleType: "none",
+    paddingLeft: 0,
+    "& li": {
+      "&:not(:last-child)": {
+        borderBottom: "1px solid lightGray",
+      },
+      "& p": {
+        margin: 0,
+      },
+    },
+  },
+  smallText: {
+    fontSize:  "0.7rem"
+  }
 }));
 
 // Tweak responsive styling
@@ -69,6 +85,34 @@ const getMuiTheme = (theme) =>
   createTheme({
     palette: theme.palette,
     components: {
+      MUIDataTableToolbar: {
+        styleOverrides: {
+          root: {
+            maxHeight: "2rem",
+            padding: "0 0.75rem",
+            margin: 0,
+          }
+        },
+      },
+      MUIDataTableHeadCell: {
+        styleOverrides: {
+          root: {
+            padding: `${theme.spacing(1)} ${theme.spacing(1.5)}`
+          },
+        },
+      },
+      MUIDataTableBodyCell: {
+        styleOverrides: {
+          stackedParent: {
+            padding: `${theme.spacing(1)} ${theme.spacing(1.5)}`
+          },
+        },
+      },
+      MuiIconButton: {
+        root: {
+          padding: "0.5rem",
+        },
+      },
       MUIDataTablePagination: {
         toolbar: {
           flexFlow: "row wrap",
@@ -270,11 +314,12 @@ const GcnEvents = () => {
         size="small"
         key={tag}
         label={tag}
+        className={classes.tags}
         style={{
           backgroundColor:
-            gcn_tags_classes && tag in gcn_tags_classes
-              ? gcn_tags_classes[tag]
-              : "#999999",
+              gcn_tags_classes && tag in gcn_tags_classes
+                  ? gcn_tags_classes[tag]
+                  : "#999999"
         }}
       />
     ));
@@ -292,31 +337,29 @@ const GcnEvents = () => {
       });
     });
     const localizationTagsUnique = [...new Set(localizationTags)];
-
     return localizationTagsUnique.map((tag) => (
-      <Chip size="small" key={tag} label={tag} className={classes.eventTags} />
+      <Chip size="small" key={tag} label={tag} className={classes.tags}/>
     ));
   };
 
   const renderGcnNotices = (dataIndex) => (
-    <ul>
+    <ul className={classes.list}>
       {events[dataIndex]?.gcn_notices?.map((gcnNotice) => (
-        <li key={gcnNotice.id}>
-          {["date", "ivorn", "stream"].map((attr) => (
-            <p key={attr}>
-              {gcnNotice[attr]}
-            </p>
-          ))}
-        </li>
+          <li key={gcnNotice.id}>
+            <Tooltip title={gcnNotice["ivorn"]}>
+              <p>{gcnNotice["stream"]}</p>
+            </Tooltip>
+            <p className={classes.smallText}>{gcnNotice["date"]}</p>
+          </li>
       ))}
     </ul>
   );
 
   const renderLocalizations = (dataIndex) => (
-    <ul>
+    <ul className={classes.list}>
       {events[dataIndex]?.localizations?.map((loc) => (
         <li key={loc.id}>
-          {loc["localization_name"]}
+          <p>{loc["localization_name"]}</p>
         </li>
       ))}
     </ul>

--- a/static/js/components/GcnEvents.jsx
+++ b/static/js/components/GcnEvents.jsx
@@ -37,7 +37,7 @@ import DefaultGcnTagPage from "./DefaultGcnTagPage";
 import Crossmatch from "./CrossmatchGcnEvents";
 import GcnEventAllocationTriggers from "./GcnEventAllocationTriggers";
 import MoreHorizIcon from "@mui/icons-material/MoreHoriz";
-import {ExpandLess} from "@mui/icons-material";
+import ExpandLess from "@mui/icons-material/ExpandLess";
 
 const useStyles = makeStyles((theme) => ({
   container: {
@@ -95,7 +95,6 @@ const getMuiTheme = (theme) =>
       MUIDataTable: {
         styleOverrides: {
           root: {
-            marginRight: "2rem",
             '& p': {
               margin: 0
             },
@@ -124,7 +123,6 @@ const getMuiTheme = (theme) =>
             padding: `${theme.spacing(1)} ${theme.spacing(2.5)} ${theme.spacing(1)} ${theme.spacing(1.5)}`,
             verticalAlign: "top",
           },
-          
         },
       },
       MuiIconButton: {

--- a/static/js/components/GcnEvents.jsx
+++ b/static/js/components/GcnEvents.jsx
@@ -36,6 +36,8 @@ import NewGcnEvent from "./NewGcnEvent";
 import DefaultGcnTagPage from "./DefaultGcnTagPage";
 import Crossmatch from "./CrossmatchGcnEvents";
 import GcnEventAllocationTriggers from "./GcnEventAllocationTriggers";
+import MoreHorizIcon from "@mui/icons-material/MoreHoriz";
+import {ExpandLess} from "@mui/icons-material";
 
 const useStyles = makeStyles((theme) => ({
   container: {
@@ -49,8 +51,7 @@ const useStyles = makeStyles((theme) => ({
     }
   },
   gcnEventLink: {
-    marginLeft: theme.spacing(-1.5), 
-    paddingLeft: theme.spacing(1.5),
+    padding: 0,
     color:
       theme.palette.mode === "dark"
         ? theme.palette.secondary.main
@@ -66,18 +67,24 @@ const useStyles = makeStyles((theme) => ({
   list: {
     listStyleType: "none",
     paddingLeft: 0,
-    "& li": {
-      "&:not(:last-child)": {
-        borderBottom: "1px solid lightGray",
-      },
-      "& p": {
-        margin: 0,
+    margin: 0,
+    "& li:not(:first-child)": {
+      position: "relative",
+      marginTop: theme.spacing(2),
+      "&:before": {
+        content: `""`,
+        backgroundColor: theme.palette.grey[400],
+        position: "absolute",
+        top: theme.spacing(-1),
+        left: "0",
+        width: "20%",
+        height: "1px",
       },
     },
   },
   smallText: {
     fontSize:  "0.7rem"
-  }
+  },
 }));
 
 // Tweak responsive styling
@@ -85,6 +92,16 @@ const getMuiTheme = (theme) =>
   createTheme({
     palette: theme.palette,
     components: {
+      MUIDataTable: {
+        styleOverrides: {
+          root: {
+            marginRight: "2rem",
+            '& p': {
+              margin: 0
+            },
+          }
+        }
+      },
       MUIDataTableToolbar: {
         styleOverrides: {
           root: {
@@ -97,15 +114,17 @@ const getMuiTheme = (theme) =>
       MUIDataTableHeadCell: {
         styleOverrides: {
           root: {
-            padding: `${theme.spacing(1)} ${theme.spacing(1.5)}`
+            padding: `${theme.spacing(1)} ${theme.spacing(2.5)} ${theme.spacing(1)} ${theme.spacing(1.5)}`,
           },
         },
       },
       MUIDataTableBodyCell: {
         styleOverrides: {
           stackedParent: {
-            padding: `${theme.spacing(1)} ${theme.spacing(1.5)}`
+            padding: `${theme.spacing(1)} ${theme.spacing(2.5)} ${theme.spacing(1)} ${theme.spacing(1.5)}`,
+            verticalAlign: "top",
           },
+          
         },
       },
       MuiIconButton: {
@@ -185,6 +204,8 @@ const GcnEvents = () => {
   const gcn_tags_classes = useSelector((state) => state.config.gcnTagsClasses);
 
   const [openNew, setOpenNew] = useState(false);
+  const [showNotices, setShowNotices] = useState(false);
+  const [showLocalizations, setShowLocalizations] = useState(false);
   const [openCrossmatch, setOpenCrossmatch] = useState(false);
   const [openDefaultTag, setOpenDefaultTag] = useState(false);
 
@@ -342,26 +363,41 @@ const GcnEvents = () => {
     ));
   };
 
+  const renderLocalizations = (dataIndex) => (
+      <ul className={classes.list}>
+        {events[dataIndex]?.localizations?.map((loc, index) => (
+            <li key={loc.id}
+                style={ (showLocalizations !== dataIndex) && index > 2 ? { display: 'none' } : {}}>
+              <p>{loc["localization_name"]}</p>
+            </li>
+        ))}
+        {events[dataIndex]?.localizations?.length > 3 && (
+            <div onClick={() => setShowLocalizations(showLocalizations === false ? dataIndex : false)}
+                 style={{display: 'flex', justifyContent: 'center', alignItems: 'center', cursor: 'pointer'}}>
+              {showLocalizations === false ? <MoreHorizIcon /> : <ExpandLess />}
+            </div>
+        )}
+      </ul>
+  );
+
   const renderGcnNotices = (dataIndex) => (
     <ul className={classes.list}>
-      {events[dataIndex]?.gcn_notices?.map((gcnNotice) => (
-          <li key={gcnNotice.id}>
-            <Tooltip title={gcnNotice["ivorn"]}>
+      {events[dataIndex]?.gcn_notices?.map(( gcnNotice, index ) => (
+          <li key={gcnNotice.id}
+              style={(showNotices !== dataIndex) && index > 1 ? {display: 'none'} : {}}>
+            <Tooltip title={gcnNotice["ivorn"]} placement="left">
               <p>{gcnNotice["stream"]}</p>
             </Tooltip>
+            <p className={classes.smallText}>{gcnNotice["notice_type"]}</p>
             <p className={classes.smallText}>{gcnNotice["date"]}</p>
           </li>
       ))}
-    </ul>
-  );
-
-  const renderLocalizations = (dataIndex) => (
-    <ul className={classes.list}>
-      {events[dataIndex]?.localizations?.map((loc) => (
-        <li key={loc.id}>
-          <p>{loc["localization_name"]}</p>
-        </li>
-      ))}
+      {events[dataIndex]?.gcn_notices?.length > 2 && (
+          <div onClick={() => setShowNotices(showNotices === false ? dataIndex : false)}
+               style={{display: 'flex', justifyContent: 'center', alignItems: 'center', cursor: 'pointer'}}>
+            {showNotices === false ? <MoreHorizIcon /> : <ExpandLess />}
+          </div>
+      )}
     </ul>
   );
 

--- a/static/js/components/GcnEvents.jsx
+++ b/static/js/components/GcnEvents.jsx
@@ -302,9 +302,9 @@ const GcnEvents = () => {
     <ul>
       {events[dataIndex]?.gcn_notices?.map((gcnNotice) => (
         <li key={gcnNotice.id}>
-          {["date", "ivorn", "dateobs", "stream"].map((attr) => (
+          {["date", "ivorn", "stream"].map((attr) => (
             <p key={attr}>
-              {attr}: {gcnNotice[attr]}
+              {gcnNotice[attr]}
             </p>
           ))}
         </li>
@@ -316,11 +316,7 @@ const GcnEvents = () => {
     <ul>
       {events[dataIndex]?.localizations?.map((loc) => (
         <li key={loc.id}>
-          {["localization_name", "dateobs"].map((attr) => (
-            <p key={attr}>
-              {attr}: {loc[attr]}
-            </p>
-          ))}
+          {loc["localization_name"]}
         </li>
       ))}
     </ul>

--- a/static/js/components/GcnEvents.jsx
+++ b/static/js/components/GcnEvents.jsx
@@ -26,6 +26,8 @@ import Dialog from "@mui/material/Dialog";
 import DialogContent from "@mui/material/DialogContent";
 import MuiDialogTitle from "@mui/material/DialogTitle";
 import Tooltip from "@mui/material/Tooltip";
+import MoreHorizIcon from "@mui/icons-material/MoreHoriz";
+import ExpandLess from "@mui/icons-material/ExpandLess";
 import Button from "./Button";
 
 import { filterOutEmptyValues } from "../API";
@@ -36,8 +38,6 @@ import NewGcnEvent from "./NewGcnEvent";
 import DefaultGcnTagPage from "./DefaultGcnTagPage";
 import Crossmatch from "./CrossmatchGcnEvents";
 import GcnEventAllocationTriggers from "./GcnEventAllocationTriggers";
-import MoreHorizIcon from "@mui/icons-material/MoreHoriz";
-import ExpandLess from "@mui/icons-material/ExpandLess";
 
 const useStyles = makeStyles((theme) => ({
   container: {
@@ -48,7 +48,7 @@ const useStyles = makeStyles((theme) => ({
     margin: "0 1px 1px 0",
     "& > div": {
       margin: "0.25rem",
-    }
+    },
   },
   gcnEventLink: {
     padding: 0,
@@ -81,9 +81,17 @@ const useStyles = makeStyles((theme) => ({
         height: "1px",
       },
     },
+    "& div": {
+      display: "flex",
+      justifyContent: "center",
+      alignItems: "center",
+      "& a": {
+        cursor: "pointer",
+      },
+    },
   },
   smallText: {
-    fontSize:  "0.7rem"
+    fontSize: "0.7rem",
   },
 }));
 
@@ -95,11 +103,11 @@ const getMuiTheme = (theme) =>
       MUIDataTable: {
         styleOverrides: {
           root: {
-            '& p': {
-              margin: 0
+            "& p": {
+              margin: 0,
             },
-          }
-        }
+          },
+        },
       },
       MUIDataTableToolbar: {
         styleOverrides: {
@@ -107,20 +115,24 @@ const getMuiTheme = (theme) =>
             maxHeight: "2rem",
             padding: "0 0.75rem",
             margin: 0,
-          }
+          },
         },
       },
       MUIDataTableHeadCell: {
         styleOverrides: {
           root: {
-            padding: `${theme.spacing(1)} ${theme.spacing(2.5)} ${theme.spacing(1)} ${theme.spacing(1.5)}`,
+            padding: `${theme.spacing(1)} ${theme.spacing(2.5)} ${theme.spacing(
+              1,
+            )} ${theme.spacing(1.5)}`,
           },
         },
       },
       MUIDataTableBodyCell: {
         styleOverrides: {
           stackedParent: {
-            padding: `${theme.spacing(1)} ${theme.spacing(2.5)} ${theme.spacing(1)} ${theme.spacing(1.5)}`,
+            padding: `${theme.spacing(1)} ${theme.spacing(2.5)} ${theme.spacing(
+              1,
+            )} ${theme.spacing(1.5)}`,
             verticalAlign: "top",
           },
         },
@@ -202,8 +214,8 @@ const GcnEvents = () => {
   const gcn_tags_classes = useSelector((state) => state.config.gcnTagsClasses);
 
   const [openNew, setOpenNew] = useState(false);
-  const [showNotices, setShowNotices] = useState(false);
-  const [showLocalizations, setShowLocalizations] = useState(false);
+  const [showAllLocalizations, setShowAllLocalizations] = useState(false);
+  const [showAllNotices, setShowAllNotices] = useState(false);
   const [openCrossmatch, setOpenCrossmatch] = useState(false);
   const [openDefaultTag, setOpenDefaultTag] = useState(false);
 
@@ -336,9 +348,9 @@ const GcnEvents = () => {
         className={classes.tags}
         style={{
           backgroundColor:
-              gcn_tags_classes && tag in gcn_tags_classes
-                  ? gcn_tags_classes[tag]
-                  : "#999999"
+            gcn_tags_classes && tag in gcn_tags_classes
+              ? gcn_tags_classes[tag]
+              : "#999999",
         }}
       />
     ));
@@ -357,45 +369,61 @@ const GcnEvents = () => {
     });
     const localizationTagsUnique = [...new Set(localizationTags)];
     return localizationTagsUnique.map((tag) => (
-      <Chip size="small" key={tag} label={tag} className={classes.tags}/>
+      <Chip size="small" key={tag} label={tag} className={classes.tags} />
     ));
   };
 
+  const expandButton = (setShowAll, showAll, cellToProcess) => (
+    <div className={classes.expandButton}>
+      <IconButton
+        aria-label="expandButton"
+        onClick={() =>
+          setShowAll(showAll === cellToProcess ? false : cellToProcess)
+        }
+        size="small"
+      >
+        {showAll === cellToProcess ? <ExpandLess /> : <MoreHorizIcon />}
+      </IconButton>
+    </div>
+  );
+
   const renderLocalizations = (dataIndex) => (
-      <ul className={classes.list}>
-        {events[dataIndex]?.localizations?.map((loc, index) => (
-            <li key={loc.id}
-                style={ (showLocalizations !== dataIndex) && index > 2 ? { display: 'none' } : {}}>
-              <p>{loc["localization_name"]}</p>
-            </li>
-        ))}
-        {events[dataIndex]?.localizations?.length > 3 && (
-            <div onClick={() => setShowLocalizations(showLocalizations === dataIndex ? false : dataIndex)}
-                 style={{display: 'flex', justifyContent: 'center', alignItems: 'center', cursor: 'pointer'}}>
-              {showLocalizations === dataIndex ? <ExpandLess /> : <MoreHorizIcon />}
-            </div>
-        )}
-      </ul>
+    <ul className={classes.list}>
+      {events[dataIndex]?.localizations?.map((loc, index) => (
+        <li
+          key={loc.id}
+          style={
+            showAllLocalizations !== dataIndex && index > 2
+              ? { display: "none" }
+              : {}
+          }
+        >
+          <p>{loc.localization_name}</p>
+        </li>
+      ))}
+      {events[dataIndex]?.localizations?.length > 3 &&
+        expandButton(setShowAllLocalizations, showAllLocalizations, dataIndex)}
+    </ul>
   );
 
   const renderGcnNotices = (dataIndex) => (
     <ul className={classes.list}>
-      {events[dataIndex]?.gcn_notices?.map(( gcnNotice, index ) => (
-          <li key={gcnNotice.id}
-              style={(showNotices !== dataIndex) && index > 1 ? {display: 'none'} : {}}>
-            <Tooltip title={gcnNotice["ivorn"]} placement="left">
-              <p>{gcnNotice["stream"]}</p>
-            </Tooltip>
-            <p className={classes.smallText}>{gcnNotice["notice_type"]}</p>
-            <p className={classes.smallText}>{gcnNotice["date"]}</p>
-          </li>
+      {events[dataIndex]?.gcn_notices?.map((gcnNotice, index) => (
+        <li
+          key={gcnNotice.id}
+          style={
+            showAllNotices !== dataIndex && index > 1 ? { display: "none" } : {}
+          }
+        >
+          <Tooltip title={gcnNotice.ivorn} placement="left">
+            <p>{gcnNotice.stream}</p>
+          </Tooltip>
+          <p className={classes.smallText}>{gcnNotice.notice_type}</p>
+          <p className={classes.smallText}>{gcnNotice.date}</p>
+        </li>
       ))}
-      {events[dataIndex]?.gcn_notices?.length > 2 && (
-          <div onClick={() => setShowNotices(showNotices === dataIndex ? false : dataIndex)}
-               style={{display: 'flex', justifyContent: 'center', alignItems: 'center', cursor: 'pointer'}}>
-            {showNotices === dataIndex ? <ExpandLess /> : <MoreHorizIcon />}
-          </div>
-      )}
+      {events[dataIndex]?.gcn_notices?.length > 2 &&
+        expandButton(setShowAllNotices, showAllNotices, dataIndex)}
     </ul>
   );
 


### PR DESCRIPTION
#### This Pull Request fix this issue: GCN Events page: GCN Events list: too much white space and repeated info #4819 

- Updated and improved the display of Localizations and GCN Notices columns
- Removed the repetition of the ‘dateobs’
- Changed ‘overrides’ to ‘components’ for the getMuiTheme function due to its deprecation
- Added styles, removed margins, and added a tooltip to store the URL of the GCN notice
- Moved repeated code to new style functions
- Displayed the types of GCN notices
- Display only 3 localizations and 2 GCN Notices by default, with an option to expand them
- Removed the sort option for all columns except the ‘Date Observed’ column.