### PR TITLE
Astropy 6.0 breaking changes: MaskedArray -> MaskedNDArray

### DIFF
--- a/skyportal/handlers/api/allocation.py
+++ b/skyportal/handlers/api/allocation.py
@@ -6,6 +6,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import sqlalchemy as sa
 from astroplan.moon import moon_phase_angle
+from astropy.utils.masked import MaskedNDArray
 from marshmallow.exceptions import ValidationError
 from sqlalchemy import func
 
@@ -191,10 +192,15 @@ class AllocationHandler(BaseHandler):
                         thumbnail.to_dict() for thumbnail in request.obj.thumbnails
                     ]
                     request_data['set_time_utc'] = request.set_time().iso
-                    if isinstance(request_data['set_time_utc'], np.ma.MaskedArray):
+                    if isinstance(
+                        request_data['set_time_utc'], (np.ma.MaskedArray, MaskedNDArray)
+                    ):
                         request_data['set_time_utc'] = None
                     request_data['rise_time_utc'] = request.rise_time().iso
-                    if isinstance(request_data['rise_time_utc'], np.ma.MaskedArray):
+                    if isinstance(
+                        request_data['rise_time_utc'],
+                        (np.ma.MaskedArray, MaskedNDArray),
+                    ):
                         request_data['rise_time_utc'] = None
                     requests.append(request_data)
 

--- a/skyportal/handlers/api/telescope.py
+++ b/skyportal/handlers/api/telescope.py
@@ -1,8 +1,7 @@
-from marshmallow.exceptions import ValidationError
-from baselayer.app.access import permissions, auth_or_token
-
 from astropy.time import Time
+from marshmallow.exceptions import ValidationError
 
+from baselayer.app.access import permissions, auth_or_token
 from ..base import BaseHandler
 from ...models import Telescope
 

--- a/skyportal/models/telescope.py
+++ b/skyportal/models/telescope.py
@@ -11,6 +11,7 @@ import timezonefinder
 import astroplan
 from astropy import units as u
 from astropy import time as ap_time
+from astropy.utils.masked import MaskedNDArray
 
 from baselayer.app.models import (
     Base,
@@ -185,7 +186,12 @@ class Telescope(Base):
             return None
         if time is None:
             time = ap_time.Time.now()
-        return observer.sun_set_time(time, which='next')
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            t = observer.sun_set_time(time, which='next')
+            if isinstance(t.value, (np.ma.core.MaskedArray, MaskedNDArray)):
+                return None
+        return t
 
     def next_sunrise(self, time=None):
         """The astropy timestamp of the next sunrise after `time` at this site.
@@ -195,7 +201,12 @@ class Telescope(Base):
             return None
         if time is None:
             time = ap_time.Time.now()
-        return observer.sun_rise_time(time, which='next')
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            t = observer.sun_rise_time(time, which='next')
+            if isinstance(t.value, (np.ma.core.MaskedArray, MaskedNDArray)):
+                return None
+        return t
 
     def next_twilight_evening_nautical(self, time=None):
         """The astropy timestamp of the next evening nautical (-12 degree)
@@ -205,7 +216,12 @@ class Telescope(Base):
             return None
         if time is None:
             time = ap_time.Time.now()
-        return observer.twilight_evening_nautical(time, which='next')
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            t = observer.twilight_evening_nautical(time, which='next')
+            if isinstance(t.value, (np.ma.core.MaskedArray, MaskedNDArray)):
+                return None
+        return t
 
     def next_twilight_morning_nautical(self, time=None):
         """The astropy timestamp of the next morning nautical (-12 degree)
@@ -221,7 +237,7 @@ class Telescope(Base):
             # so this returns a MaskedArray and raises a warning.
             warnings.simplefilter("ignore")
             t = observer.twilight_morning_nautical(time, which='next')
-            if isinstance(t.value, np.ma.core.MaskedArray):
+            if isinstance(t.value, (np.ma.core.MaskedArray, MaskedNDArray)):
                 return None
         return t
 
@@ -236,7 +252,7 @@ class Telescope(Base):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             t = observer.twilight_evening_astronomical(time, which='next')
-            if isinstance(t.value, np.ma.core.MaskedArray):
+            if isinstance(t.value, (np.ma.core.MaskedArray, MaskedNDArray)):
                 return None
         return t
 
@@ -251,7 +267,7 @@ class Telescope(Base):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             t = observer.twilight_morning_astronomical(time, which='next')
-            if isinstance(t.value, np.ma.core.MaskedArray):
+            if isinstance(t.value, (np.ma.core.MaskedArray, MaskedNDArray)):
                 return None
         return t
 


### PR DESCRIPTION
Looks like astropy is using it's own datatypes for some of the masked arrays now, so we need to look for those too when we want to convert missing values to None, otherwise the response can't serialize that astropy masked dtype.