### PR TITLE
Astropy 6.0 - Observing run ephemeris bugfix

### DIFF
--- a/skyportal/handlers/api/observingrun.py
+++ b/skyportal/handlers/api/observingrun.py
@@ -1,4 +1,5 @@
 import numpy as np
+from astropy.utils.masked import MaskedNDArray
 from sqlalchemy.orm import joinedload
 from marshmallow.exceptions import ValidationError
 from baselayer.app.access import permissions, auth_or_token
@@ -182,8 +183,16 @@ class ObservingRunHandler(BaseHandler):
                     set_times = run.set_time(targets).isot
 
                     for d, rt, st in zip(data["assignments"], rise_times, set_times):
-                        d["rise_time_utc"] = rt if rt is not np.ma.masked else ''
-                        d["set_time_utc"] = st if st is not np.ma.masked else ''
+                        d["rise_time_utc"] = (
+                            rt
+                            if not isinstance(rt, (np.ma.MaskedArray, MaskedNDArray))
+                            else ''
+                        )
+                        d["set_time_utc"] = (
+                            st
+                            if not isinstance(st, (np.ma.MaskedArray, MaskedNDArray))
+                            else ''
+                        )
 
                 data = recursive_to_dict(data)
                 return self.success(data=data)


### PR DESCRIPTION
Just like for the instruments and telescopes, we check that the results from ephemeris calculations are not MaskedArray OR MaskedNDArray.