### PR TITLE
ObservingRunHandler GET: handle rise/set vectorized masked array

### DIFF
--- a/skyportal/handlers/api/observingrun.py
+++ b/skyportal/handlers/api/observingrun.py
@@ -1,5 +1,3 @@
-import numpy as np
-from astropy.utils.masked import MaskedNDArray
 from sqlalchemy.orm import joinedload
 from marshmallow.exceptions import ValidationError
 from baselayer.app.access import permissions, auth_or_token
@@ -184,13 +182,13 @@ class ObservingRunHandler(BaseHandler):
 
                     for d, rt, st in zip(data["assignments"], rise_times, set_times):
                         d["rise_time_utc"] = (
-                            rt
-                            if not isinstance(rt, (np.ma.MaskedArray, MaskedNDArray))
+                            rt.item()  # 0-dimentional array (basically a scalar)
+                            if not rt.mask.any()  # check that the value isn't masked (not rising at date)
                             else ''
                         )
                         d["set_time_utc"] = (
-                            st
-                            if not isinstance(st, (np.ma.MaskedArray, MaskedNDArray))
+                            st.item()
+                            if not st.mask.any()  # check that the value isn't masked (not setting at date)
                             else ''
                         )
 

--- a/skyportal/handlers/api/observingrun.py
+++ b/skyportal/handlers/api/observingrun.py
@@ -1,4 +1,5 @@
 import numpy as np
+from astropy.utils.masked import MaskedNDArray
 from sqlalchemy.orm import joinedload
 from marshmallow.exceptions import ValidationError
 from baselayer.app.access import permissions, auth_or_token
@@ -182,8 +183,16 @@ class ObservingRunHandler(BaseHandler):
                     set_times = run.set_time(targets).isot
 
                     for d, rt, st in zip(data["assignments"], rise_times, set_times):
-                        d["rise_time_utc"] = rt if rt is not np.ma.masked else ''
-                        d["set_time_utc"] = st if st is not np.ma.masked else ''
+                        d["rise_time_utc"] = (
+                            rt
+                            if not isinstance(rt, (np.ma.MaskedArray, MaskedNDArray))
+                            else ''
+                        )
+                        d["set_time_utc"] = (
+                            st
+                            if not isinstance(st, (np.ma.MaskedArray, MaskedNDArray))
+                            else ''
+                        )
 
                 data = recursive_to_dict(data)
                 return self.success(data=data)

--- a/skyportal/handlers/api/observingrun.py
+++ b/skyportal/handlers/api/observingrun.py
@@ -181,16 +181,26 @@ class ObservingRunHandler(BaseHandler):
                     set_times = run.set_time(targets).isot
 
                     for d, rt, st in zip(data["assignments"], rise_times, set_times):
-                        d["rise_time_utc"] = (
-                            rt.item()  # 0-dimensional array (basically a scalar)
-                            if not rt.mask.any()  # check that the value isn't masked (not rising at date)
-                            else ''
-                        )
-                        d["set_time_utc"] = (
-                            st.item()
-                            if not st.mask.any()  # check that the value isn't masked (not setting at date)
-                            else ''
-                        )
+                        # we can an attribute error in the case where rt and st are not arrays
+                        # this can happen if the observing run's date is missing or incorrect
+                        # in the case of unit tests for example, or a "dubious" year for time-based packages
+                        # (which is often anything before 1900, or after 2100)
+                        try:
+                            d["rise_time_utc"] = (
+                                rt.item()  # 0-dimensional array (basically a scalar)
+                                if not rt.mask.any()  # check that the value isn't masked (not rising at date)
+                                else ''
+                            )
+                        except AttributeError:
+                            d["rise_time_utc"] = ''
+                        try:
+                            d["set_time_utc"] = (
+                                st.item()
+                                if not st.mask.any()  # check that the value isn't masked (not setting at date)
+                                else ''
+                            )
+                        except AttributeError:
+                            d["set_time_utc"] = ''
 
                 data = recursive_to_dict(data)
                 return self.success(data=data)


### PR DESCRIPTION
https://github.com/skyportal/skyportal/pull/4875 stopped the handler from crashing, but looks like as soon as one target is not visible, since we reshape the masked array we end up with all the value being 0-dimensional masked arrays, even those that might have a value that's usable.

This PR deals with those appropriately, checking if the 0-dimensional array (which is just a scalar) doesn't have its only value masked.