### PR TITLE
GaiaQuery class: verify that server is accessible

### DIFF
--- a/skyportal/utils/offset.py
+++ b/skyportal/utils/offset.py
@@ -90,7 +90,7 @@ class GaiaQuery:
             requests.head(
                 "http://" + str(g._Tap__connHandler.get_host_url()), timeout=5
             )
-            
+
             q = f"SELECT TOP 1 ra, dec from {self.main_db}.gaia_source"
             job = g.launch_job(q)
             _ = job.get_results()

--- a/skyportal/utils/offset.py
+++ b/skyportal/utils/offset.py
@@ -87,7 +87,7 @@ class GaiaQuery:
             g = Gaia
             # we verify with an HTTP request that the server is even accessible
             # if not, should raise a ConnectionError or a ReadTimeout
-            r = requests.head(
+            requests.head(
                 "http://" + str(g._Tap__connHandler.get_host_url()), timeout=5
             )
             


### PR DESCRIPTION
Currently, we launch a job to the server and if it times out we use the backup server. Except that with the python package we are using to query Gaia, the timeout is one minute, which of course exceeds our max timeout expected from our webapp: 30s.

I do not see a way to use a different timeout with that package, so this PR adds a quick line that runs a HEAD HTTP call to the server URL to see if it's up and running, with no more than 5 seconds.

The issue is that we can't verify that this works until their server is up and running again, but **what I can say for sure is that with this addition we connect to the backup quickly enough to get starlists and finding charts, which are all failing right now.**