### PR TITLE
Obj Coordinates update: thumbnails delete permission fix

### DIFF
--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -12,7 +12,6 @@ import arrow
 import astropy
 import astropy.units as u
 import asyncio
-from baselayer.baselayer_template_app.baselayer.app.models import session_context_id
 import conesearch_alchemy as ca
 import healpix_alchemy as ha
 import matplotlib.pyplot as plt
@@ -43,6 +42,7 @@ from twilio.base.exceptions import TwilioException
 from baselayer.app.access import auth_or_token, permissions
 from baselayer.app.env import load_env
 from baselayer.app.flow import Flow
+from baselayer.app.models import session_context_id
 from baselayer.app.model_util import recursive_to_dict
 from baselayer.log import make_log
 

--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -131,10 +131,6 @@ def run_async(func, *args, **kwargs):
         kwargs pased to the method
     """
 
-    # run a function asynchronously
-    # defining a wrapper function to set the session context id
-    # this way the DBSession context is unique to each async function call
-    # avoiding conflicts between different async functions, and the main thread
     def wrapper():
         session_context_id.set(str(uuid.uuid4()))
         try:

--- a/skyportal/handlers/api/sources.py
+++ b/skyportal/handlers/api/sources.py
@@ -1665,6 +1665,8 @@ async def get_sources(
                 return data
 
             sources, total_matches = [], len(all_source_ids)
+
+            data['totalMatches'] = total_matches
             if start > total_matches:
                 return data
             if end > total_matches:

--- a/skyportal/utils/asynchronous.py
+++ b/skyportal/utils/asynchronous.py
@@ -1,0 +1,36 @@
+import uuid
+
+import asyncio
+
+from baselayer.app.models import session_context_id
+from baselayer.log import make_log
+
+log = make_log("async")
+
+
+def run_async(func, *args, **kwargs):
+    """Run any method using the database asynchronously, in its own session scope
+
+    Parameters
+    ----------
+    func: function
+        The function to call in its own async scope
+    args: list
+        Arguments passed to the method, in order
+    kwargs: dict
+        kwargs pased to the method
+    """
+
+    def wrapper():
+        session_context_id.set(str(uuid.uuid4()))
+        try:
+            func(*args, **kwargs)
+        except Exception as e:
+            log(f"Error running async function {func.__name__}: {e}")
+
+    try:
+        event_loop = asyncio.get_event_loop()
+    except Exception:
+        event_loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(event_loop)
+    event_loop.run_in_executor(None, wrapper)

--- a/static/js/ducks/source.js
+++ b/static/js/ducks/source.js
@@ -122,6 +122,7 @@ const ADD_GCN_CROSSMATCH = "skyportal/ADD_GCN_CROSSMATCH";
 const FETCH_LOADED_SOURCE_POSITION = "skyportal/FETCH_LOADED_SOURCE_POSITION";
 const FETCH_LOADED_SOURCE_POSITION_OK =
   "skyportal/FETCH_LOADED_SOURCE_POSITION_OK";
+const REFRESH_SOURCE_POSITION = "skyportal/REFRESH_SOURCE_POSITION";
 
 export function fetchPosition(id) {
   return API.GET(`/api/sources/${id}/position`, FETCH_LOADED_SOURCE_POSITION);
@@ -521,6 +522,11 @@ messageHandler.add((actionType, payload, dispatch, getState) => {
     const loaded_obj_key = source?.internal_key;
     if (loaded_obj_key === payload.obj_key) {
       dispatch(fetchSource(source.id));
+    }
+  } else if (actionType === REFRESH_SOURCE_POSITION) {
+    const loaded_obj_key = source?.internal_key;
+    if (loaded_obj_key === payload.obj_key) {
+      dispatch(fetchPosition(source.id));
     }
   } else if (actionType === REFRESH_OBJ_ANALYSES) {
     const loaded_obj_key = source?.internal_key;


### PR DESCRIPTION
Addresses #4884, where a user without delete permissions for thumbnails couldn't remove let the handler remove the public_url ones (sdss, ls, ps1) when updating the coordinates of a source.

This PR fixes that by adding a new decorator named `run_async`. This decorator can take any method and its argument, and will run them in an async process where it will set a unique context for the DBSession created in the method passed to the decorator. This ensures that we can run async processes which DBSessions aren't shared with the main thread or other threads, and therefore don't get killed in the middle of an async operation when the main thread or other threads use the same session. Here, each thread has it's own scope for its session, avoiding this problem entirely.

If this new decorator proves to work as expected, we'll want to add it everywhere we start an async thread, which is a lot of places but here are those that come to mind as a priority:
- follow-up requests
- GCN events