### PR TITLE
SourcesConfirmedInGCN: don't validate sources spatially

### DIFF
--- a/skyportal/handlers/api/sources_confirmed_in_gcn.py
+++ b/skyportal/handlers/api/sources_confirmed_in_gcn.py
@@ -6,7 +6,8 @@ from marshmallow.exceptions import ValidationError
 from baselayer.app.access import auth_or_token, permissions
 from baselayer.log import make_log
 from ..base import BaseHandler
-from .source import get_sources, MAX_SOURCES_PER_PAGE
+from .source import MAX_SOURCES_PER_PAGE
+from .sources import get_sources
 
 from ...models import (
     GcnEvent,

--- a/skyportal/handlers/api/sources_confirmed_in_gcn.py
+++ b/skyportal/handlers/api/sources_confirmed_in_gcn.py
@@ -6,8 +6,6 @@ from marshmallow.exceptions import ValidationError
 from baselayer.app.access import auth_or_token, permissions
 from baselayer.log import make_log
 from ..base import BaseHandler
-from .source import MAX_SOURCES_PER_PAGE
-from .sources import get_sources
 
 from ...models import (
     GcnEvent,
@@ -326,24 +324,6 @@ class SourcesConfirmedInGCNHandler(BaseHandler):
 
         with self.Session() as session:
             try:
-                sources = await get_sources(
-                    user_id=self.associated_user_object.id,
-                    session=session,
-                    first_detected_date=start_date,
-                    last_detected_date=end_date,
-                    localization_dateobs=dateobs,
-                    localization_name=localization_name,
-                    localization_cumprob=localization_cumprob,
-                    page_number=1,
-                    num_per_page=MAX_SOURCES_PER_PAGE,
-                    sourceID=source_id,
-                )
-
-                sources = sources['sources']
-
-                if len(sources) == 0:
-                    return self.error("No sources found, can't confirm/reject")
-
                 stmt = Localization.select(session.user_or_token).where(
                     Localization.localization_name == localization_name,
                     Localization.dateobs == dateobs,


### PR DESCRIPTION
The current handler verifies if a source being confirmed as inside of a GCN handler is spatially coincident with the localization. Aside from being unnecessary for all use cases we had so far, this extra validation step comes with some assumptions as to what the first and last detection to use (and min nb detections) when querying the sources in the localization are, which can come with some issues.

In this PR we simply remove this extra check.