### PR TITLE
Facility requests: various bugfixes

### DIFF
--- a/skyportal/facility_apis/winter.py
+++ b/skyportal/facility_apis/winter.py
@@ -91,20 +91,20 @@ class WINTERRequest:
 
         return target
 
-    def schedule_name(request):
+    def schedule_name(self, request):
         content = request.transactions[0].response["content"]
         content = json.loads(content)
         # the WINTERAPI POST response has a "msg" key,
         # that contains Schedule name is <schedule_name> if successful
         if "msg" in content:
             # it's in quote, so remove them and strip
-            schedule_name = (
+            name = (
                 str(content["msg"].split('Schedule name is')[1])
                 .split(' ')[1]
                 .split('\'')[1]
                 .strip()
             )
-            return schedule_name
+            return name
         else:
             raise ValueError(
                 'Failed to delete request from WINTER, no schedule name found in POST response.'
@@ -172,7 +172,7 @@ class WINTERAPI(FollowUpAPI):
                 raise ValueError('Missing allocation information.')
 
             req = WINTERRequest()
-            schedule_name = req.schedule_name(request)
+            name = req.schedule_name(request)
 
             url = urllib.parse.urljoin(WINTER_URL, 'too/delete')
             r = requests.delete(
@@ -180,7 +180,7 @@ class WINTERAPI(FollowUpAPI):
                 params={
                     'program_name': altdata['program_name'],
                     'program_api_key': altdata['program_api_key'],
-                    'schedule_name': schedule_name,
+                    'schedule_name': name,
                 },
                 auth=HTTPBasicAuth(altdata['username'], altdata['password']),
             )

--- a/skyportal/facility_apis/ztf.py
+++ b/skyportal/facility_apis/ztf.py
@@ -369,9 +369,18 @@ def commit_photometry(
             'diffmaglim',
             'zpdiff',
             'filter',
+            'procstatus',
         }
         if not desired_columns.issubset(set(df.columns)):
             raise ValueError('Missing expected column')
+
+        # filter on the procstatus, only keeping data where procstatus = 0
+        valid_index = [
+            i for i, x in enumerate(df['procstatus']) if str(x).strip() == '0'
+        ]
+        df = df.iloc[valid_index]
+        df.drop(columns=['procstatus'], inplace=True)
+
         df.rename(
             columns={'diffmaglim': 'limiting_mag'},
             inplace=True,


### PR DESCRIPTION
* ZTF: for FP lightcurves with an overall non-zero procstatus, make sure to filter out individual datapoints that don't have a procstatus=0, to avoid bad substractions and things of that nature.
* WNTR: fix the class method call to retrieve the schedule_name from the response from the POST method that runs when sending a target to WNTR.