### PR TITLE
Observing run API GET: dtype bugfix

### DIFF
--- a/skyportal/handlers/api/observingrun.py
+++ b/skyportal/handlers/api/observingrun.py
@@ -183,9 +183,6 @@ class ObservingRunHandler(BaseHandler):
                     rise_times = run.rise_time(targets).isot
                     set_times = run.set_time(targets).isot
 
-                    print(rise_times)
-                    print(set_times)
-
                     for d, rt, st in zip(data["assignments"], rise_times, set_times):
                         # we can an attribute error in the case where rt and st are not arrays
                         # this can happen if the observing run's date is missing or incorrect


### PR DESCRIPTION
Earlier this week we had issues where runs where a target would never rise/set would not return rise/set for any of the targets, because all of the individual rise/set would be masked arrays. When fixing it, it ended up causing troubles for runs where the targets are ALL visible, and none of the items end up having masked arrays to look at.

This PR fixes that