### PR TITLE
Observation plan request send/delete: various bugfixes

### DIFF
--- a/skyportal/handlers/api/observation.py
+++ b/skyportal/handlers/api/observation.py
@@ -1512,7 +1512,7 @@ class ObservationExternalAPIHandler(BaseHandler):
     def delete(self, allocation_id):
         """
         ---
-        description: Retrieve queued observations from external API
+        description: Delete queued observations from external API
         tags:
           - observations
         parameters:
@@ -1570,11 +1570,10 @@ class ObservationExternalAPIHandler(BaseHandler):
                 return self.error('Cannot delete queues from this Instrument.')
 
             try:
-                # we now retrieve and commit to the database the
-                # executed observations
                 instrument.api_class_obsplan.remove_queue(
                     allocation, queue_name, self.associated_user_object.username
                 )
+                return self.success()
             except Exception as e:
                 return self.error(f"Error in querying instrument API: {e}")
 


### PR DESCRIPTION
- When sending a plan to the scheduler, don't show an error due to a unique index on the GCNTrigger table
- When deleting queued observations from ZTF, based on the queue name, mark any associated observation plans as "deleted from telescope queue" to avoid having plans on a GCN page look like they are still in the queue when they aren't anymore.