### PR TITLE
Period plot: units

### DIFF
--- a/static/js/components/PhotometryPlot.jsx
+++ b/static/js/components/PhotometryPlot.jsx
@@ -89,7 +89,6 @@ const useStyles = makeStyles((theme) => ({
     [theme.breakpoints.down("md")]: {
       gridTemplateColumns: "1fr 1fr 1fr",
       display: "grid",
-      // put the gridColumn to span 3 for the first child
       "& > :first-child": {
         gridColumn: "span 2",
       },

--- a/static/js/components/PhotometryPlot.jsx
+++ b/static/js/components/PhotometryPlot.jsx
@@ -1305,7 +1305,6 @@ const PhotometryPlot = ({
                 style={{ minWidth: "8rem", width: "100%" }}
                 size="small"
               />
-              {/* an MUI Select to pick a unit for the period, with options ranging from minutes, hours, days */}
               <Select
                 value={periodUnit}
                 onChange={(e) => setPeriodUnit(e.target.value)}

--- a/static/js/components/PhotometryPlot.jsx
+++ b/static/js/components/PhotometryPlot.jsx
@@ -34,9 +34,9 @@ import { BASE_LAYOUT, PHOT_ZP, smoothing_func, mjdnow, rgba } from "../utils";
 
 // convert any unit to days
 const periodUnitDividers = {
-  minutes: 60 * 24,
-  hours: 24,
-  days: 1,
+  minutes: 60.0 * 24.0,
+  hours: 24.0,
+  days: 1.0,
 };
 
 const Plot = createPlotlyComponent(Plotly);

--- a/static/js/components/PhotometryPlot.jsx
+++ b/static/js/components/PhotometryPlot.jsx
@@ -1309,7 +1309,7 @@ const PhotometryPlot = ({
               <Select
                 value={periodUnit}
                 onChange={(e) => setPeriodUnit(e.target.value)}
-                style={{ width: "6rem" }}
+                style={{ width: "8rem" }}
                 size="small"
               >
                 <MenuItem value="minutes">minutes</MenuItem>

--- a/static/js/components/PhotometryPlot.jsx
+++ b/static/js/components/PhotometryPlot.jsx
@@ -12,9 +12,12 @@ import Typography from "@mui/material/Typography";
 import SaveAsIcon from "@mui/icons-material/SaveAs";
 import IconButton from "@mui/material/IconButton";
 import Switch from "@mui/material/Switch";
+import Select from "@mui/material/Select";
+import MenuItem from "@mui/material/MenuItem";
 import Tabs from "@mui/material/Tabs";
 import Tab from "@mui/material/Tab";
 import makeStyles from "@mui/styles/makeStyles";
+import { useTheme } from "@mui/material/styles";
 
 import Dialog from "@mui/material/Dialog";
 import DialogContent from "@mui/material/DialogContent";
@@ -29,9 +32,16 @@ import Button from "./Button";
 import { addAnnotation } from "../ducks/source";
 import { BASE_LAYOUT, PHOT_ZP, smoothing_func, mjdnow, rgba } from "../utils";
 
+// convert any unit to days
+const periodUnitDividers = {
+  minutes: 60 * 24,
+  hours: 24,
+  days: 1,
+};
+
 const Plot = createPlotlyComponent(Plotly);
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles((theme) => ({
   gridContainer: {
     display: "grid",
     gridAutoFlow: "row",
@@ -61,6 +71,32 @@ const useStyles = makeStyles(() => ({
       width: "7rem",
       marginTop: 0,
       marginBottom: 0,
+    },
+  },
+  periodContainer: {
+    display: "flex",
+    flexDirection: "row",
+    justifyContent: "flex-start",
+    alignItems: "center",
+    gap: "1rem",
+    width: "100%",
+    paddingLeft: "0.5rem",
+    "& > .MuiTextField-root": {
+      width: "7rem",
+      marginTop: 0,
+      marginBottom: 0,
+    },
+    [theme.breakpoints.down("md")]: {
+      gridTemplateColumns: "1fr 1fr 1fr",
+      display: "grid",
+      // put the gridColumn to span 3 for the first child
+      "& > :first-child": {
+        gridColumn: "span 2",
+      },
+      "& > :last-child": {
+        gridColumn: "span 3",
+      },
+      paddingBottom: "0.5rem",
     },
   },
   switchContainer: {
@@ -181,7 +217,8 @@ const PhotometryPlot = ({
   plotStyle,
   magsys,
 }) => {
-  const classes = useStyles();
+  const theme = useTheme();
+  const classes = useStyles(theme);
   const [data, setData] = useState(null);
   const [plotData, setPlotData] = useState(null);
 
@@ -189,6 +226,7 @@ const PhotometryPlot = ({
   const [markerSize, setMarkerSize] = useState(6);
 
   const [period, setPeriod] = useState(1);
+  const [periodUnit, setPeriodUnit] = useState("days");
   const [phase, setPhase] = useState(2);
   const [smoothing, setSmoothing] = useState(0);
 
@@ -386,6 +424,7 @@ const PhotometryPlot = ({
     photometryStats,
     plotType,
     periodValue,
+    periodUnitValue,
     smoothingValue,
     phaseValue,
     showNonDetectionsValue,
@@ -565,8 +604,11 @@ const PhotometryPlot = ({
           const colorInteriorNonDet = rgba(colorRGB, 0.1);
           const colorInteriorDet = rgba(colorRGB, 0.3);
 
+          const scaledPeriodValue =
+            periodValue / periodUnitDividers[periodUnit];
+
           const phases = groupedPhotometry[key].map(
-            (point) => (point.mjd % periodValue) / periodValue,
+            (point) => (point.mjd % scaledPeriodValue) / scaledPeriodValue,
           );
 
           // split the y in det and non det
@@ -808,6 +850,7 @@ const PhotometryPlot = ({
         newPhotStats,
         tabToPlotType(tabIndex),
         period,
+        periodUnit,
         smoothing,
         phase,
         showNonDetections,
@@ -860,6 +903,7 @@ const PhotometryPlot = ({
         photStats,
         tabToPlotType(tabIndex),
         period,
+        periodUnit,
         smoothing,
         phase,
         showNonDetections,
@@ -887,6 +931,7 @@ const PhotometryPlot = ({
         photStats,
         tabToPlotType(tabIndex),
         period,
+        periodUnit,
         smoothing,
         phase,
         showNonDetections,
@@ -895,7 +940,7 @@ const PhotometryPlot = ({
       );
       setPlotData(traces);
     }
-  }, [period, smoothing]);
+  }, [period, periodUnit, smoothing]);
 
   useEffect(() => {
     if (initialized && annotations !== null) {
@@ -1234,8 +1279,8 @@ const PhotometryPlot = ({
         </div>
         {tabIndex === 2 && (
           <div className={classes.gridItem} style={{ gridColumn: "span 3" }}>
-            <Typography id="input-slider">Period (days)</Typography>
-            <div className={classes.sliderContainer}>
+            <Typography id="input-slider">Period</Typography>
+            <div className={classes.periodContainer}>
               <Slider
                 value={period}
                 onChange={(e, newValue) => setPeriod(newValue)}
@@ -1244,6 +1289,7 @@ const PhotometryPlot = ({
                 step={0.1}
                 min={0.1}
                 max={365}
+                style={{ minWidth: "14rem", width: "100%" }}
               />
               <TextField
                 value={period}
@@ -1256,9 +1302,20 @@ const PhotometryPlot = ({
                   max: 365,
                   "aria-labelledby": "input-slider",
                 }}
-                style={{ width: "12rem" }}
+                style={{ minWidth: "8rem", width: "100%" }}
                 size="small"
               />
+              {/* an MUI Select to pick a unit for the period, with options ranging from minutes, hours, days */}
+              <Select
+                value={periodUnit}
+                onChange={(e) => setPeriodUnit(e.target.value)}
+                style={{ width: "6rem" }}
+                size="small"
+              >
+                <MenuItem value="minutes">minutes</MenuItem>
+                <MenuItem value="hours">hours</MenuItem>
+                <MenuItem value="days">days</MenuItem>
+              </Select>
               <Button
                 onClick={() => setPeriod(period * 2)}
                 variant="contained"


### PR DESCRIPTION
Pick units from: minutes, hours, days when plotting a period-folded photometry plot. Defaults to the current option with it per day.

<img width="837" alt="image" src="https://github.com/skyportal/skyportal/assets/49785117/d762c64e-3827-40d1-ada0-f722144ba409">
