### PR TITLE
WIP - SourceHandler POST: save sources as another user (admin-only)

### DIFF
--- a/skyportal/facility_apis/swift.py
+++ b/skyportal/facility_apis/swift.py
@@ -25,7 +25,7 @@ env, cfg = load_env()
 
 
 # Submission URL
-API_URL = f"{cfg['app.swift.protocol']}://{cfg['app.swift.host']}:{cfg['app.swift.port']}/toop/submit_json.php"
+API_URL = f"{cfg['app.swift.protocol']}://{cfg['app.swift.host']}:{cfg['app.swift.port']}/toop/submit_api.php"
 XRT_URL = f"{cfg['app.swift_xrt_endpoint']}/run_userobject.php"
 
 log = make_log('facility_apis/swift')


### PR DESCRIPTION
In the context of BTSbot, we need to have Kowalski (ZTF's alert broker) to save candidates as sources but not using the dedicated Kowalski account. However, for obvious security reasons, we don't want to start sending user tokens to Kowalski, and for technical reasons, we don't want to split the unique API call to save sources in multiple API calls per user we want to save the objects as.

Instead, we just add an admin-only API query argument that allows super admins to save objects to groups as sources just like we usually would, but specifying users to use as the `saved_by` for each sources.

If a non-admin user tries to use that argument it will raise an error. If one of the user to use as the `saved_by` does not exist or does not have access to the group to which we are saving, do not error out but use the current user instead.  The reason why we don't raise an error is to not cancel saving the object as a source to the other groups if one of them has an incorrect user specified, which could create lots of issues with daily operations if a user is deleted (or leaves a group) at some point.

We'll also open a PR on Fritz and Kowalski to let Fritz specify a user id (optional) for the Kowalski filter's autosaving feature, and for Kowalski to read it and inject it in the usual POST request to the `/sources` endpoint we modified here.

