### PR TITLE
Followup APIs: priorityOrder

### DIFF
--- a/skyportal/facility_apis/_base.py
+++ b/skyportal/facility_apis/_base.py
@@ -78,10 +78,15 @@ class _Base:
             formSchemaForcedPhotometry = cls.form_json_schema_forced_photometry
         except AttributeError:
             formSchemaForcedPhotometry = None
+        try:
+            priority_order = cls.priority_order
+        except AttributeError:
+            priority_order = None
         return {
             'methodsImplemented': cls.implements(),
             'formSchema': formSchema,
             'formSchemaForcedPhotometry': formSchemaForcedPhotometry,
             'uiSchema': cls.ui_json_schema,
             'aliasLookup': cls.alias_lookup,
+            'priorityOrder': priority_order,
         }

--- a/skyportal/facility_apis/interface.py
+++ b/skyportal/facility_apis/interface.py
@@ -175,3 +175,8 @@ class FollowUpAPI(_Base):
     # mapping of any jsonschema property names to how they shoud be rendered
     # on the frontend. example - {"observation_mode": "Observation Mode"}
     alias_lookup = {}
+
+    # the order of the priority if it is a parameter of the form:
+    # - "asc" means that higher priority is more urgent (default if not provided),
+    # - "desc" means that lower priority is more urgent
+    priorityOrder = "asc"

--- a/skyportal/facility_apis/swift.py
+++ b/skyportal/facility_apis/swift.py
@@ -162,7 +162,7 @@ class UVOTXRTRequest:
         too.exp_time_just = request.payload["exp_time_just"]
         too.immediate_objective = request.payload["immediate_objective"]
 
-        if request.payload["urgency"] not in ["0", "1", "2", "3", "4"]:
+        if str(request.payload["urgency"]) not in ["0", "1", "2", "3", "4"]:
             raise ValueError('urgency not one of 0, 1, 2, 3, or 4.')
         too.urgency = int(request.payload["urgency"])
 
@@ -709,3 +709,5 @@ class UVOTXRTAPI(FollowUpAPI):
     }
 
     ui_json_schema = {"observation_choices": {"ui:widget": "checkboxes"}}
+
+    priorityOrder = "desc"


### PR DESCRIPTION
add a priorityOrder field to all followup requests API, to (internall…y) keep track of the priority/urgency order. Used by Fritz to tell Kowalski what priority order to use when updating automated triggers