### PR TITLE
Bot users: visibility across the frontend

### DIFF
--- a/skyportal/handlers/api/user.py
+++ b/skyportal/handlers/api/user.py
@@ -366,6 +366,7 @@ class UserHandler(BaseHandler):
                 if user.contact_phone:
                     return_values[-1]["contact_phone"] = user.contact_phone.e164
                 return_values[-1]["contact_email"] = user.contact_email
+                return_values[-1]["gravatar_url"] = user.gravatar_url
                 # Only Sys admins can see other users' group memberships for all groups and stream access
                 # if not sys admin, restrict to only the groups the current user is a member of
                 if self.current_user.is_system_admin:

--- a/skyportal/models/annotation.py
+++ b/skyportal/models/annotation.py
@@ -92,7 +92,13 @@ class AnnotationMixin:
     def construct_author_info_dict(self):
         return {
             field: getattr(self.author, field)
-            for field in ('username', 'first_name', 'last_name', 'gravatar_url')
+            for field in (
+                'username',
+                'first_name',
+                'last_name',
+                'gravatar_url',
+                'is_bot',
+            )
         }
 
 

--- a/skyportal/models/comment.py
+++ b/skyportal/models/comment.py
@@ -120,7 +120,13 @@ class CommentMixin:
     def construct_author_info_dict(self):
         return {
             field: getattr(self.author, field)
-            for field in ('username', 'first_name', 'last_name', 'gravatar_url')
+            for field in (
+                'username',
+                'first_name',
+                'last_name',
+                'gravatar_url',
+                'is_bot',
+            )
         }
 
     def get_attachment_path(self):

--- a/skyportal/models/user_token.py
+++ b/skyportal/models/user_token.py
@@ -28,7 +28,7 @@ from .invitation import Invitation
 def basic_user_display_info(user):
     return {
         field: getattr(user, field)
-        for field in ('username', 'first_name', 'last_name', 'gravatar_url')
+        for field in ('username', 'first_name', 'last_name', 'gravatar_url', 'is_bot')
     }
 
 

--- a/static/js/components/CommentListMobile.jsx
+++ b/static/js/components/CommentListMobile.jsx
@@ -356,6 +356,7 @@ const CommentListMobile = ({
                         lastName={author.last_name}
                         username={author.username}
                         gravatarUrl={author.gravatar_url}
+                        isBot={author.is_bot || false}
                       />
                     </div>
                     <div
@@ -447,6 +448,7 @@ const CommentListMobile = ({
                         lastName={author.last_name}
                         username={author.username}
                         gravatarUrl={author.gravatar_url}
+                        isBot={author.is_bot || false}
                       />
                     </div>
                     <div className={styles.commentContent}>

--- a/static/js/components/CommentListMobile.jsx
+++ b/static/js/components/CommentListMobile.jsx
@@ -356,7 +356,7 @@ const CommentListMobile = ({
                         lastName={author.last_name}
                         username={author.username}
                         gravatarUrl={author.gravatar_url}
-                        isBot={author.is_bot || false}
+                        isBot={author?.is_bot || false}
                       />
                     </div>
                     <div
@@ -448,7 +448,7 @@ const CommentListMobile = ({
                         lastName={author.last_name}
                         username={author.username}
                         gravatarUrl={author.gravatar_url}
-                        isBot={author.is_bot || false}
+                        isBot={author?.is_bot || false}
                       />
                     </div>
                     <div className={styles.commentContent}>

--- a/static/js/components/CompactCommentList.jsx
+++ b/static/js/components/CompactCommentList.jsx
@@ -71,6 +71,7 @@ const CompactCommentList = ({
           lastName={author.last_name}
           username={author.username}
           gravatarUrl={author.gravatar_url}
+          isBot={author.is_bot || false}
         />
       </div>
       <div

--- a/static/js/components/CompactCommentList.jsx
+++ b/static/js/components/CompactCommentList.jsx
@@ -71,7 +71,7 @@ const CompactCommentList = ({
           lastName={author.last_name}
           username={author.username}
           gravatarUrl={author.gravatar_url}
-          isBot={author.is_bot || false}
+          isBot={author?.is_bot || false}
         />
       </div>
       <div

--- a/static/js/components/NewsFeed.jsx
+++ b/static/js/components/NewsFeed.jsx
@@ -109,6 +109,7 @@ const NewsFeedItem = ({ item }) => {
           lastName={item.author_info.last_name}
           username={item.author_info.username}
           gravatarUrl={item.author_info.gravatar_url}
+          isBot={item.author_info?.is_bot || false}
         />
       );
       entryTitle = null;
@@ -253,6 +254,7 @@ NewsFeedItem.propTypes = {
       first_name: PropTypes.string,
       last_name: PropTypes.string,
       gravatar_url: PropTypes.string.isRequired,
+      is_bot: PropTypes.bool,
     }),
   }).isRequired,
 };

--- a/static/js/components/RegularCommentList.jsx
+++ b/static/js/components/RegularCommentList.jsx
@@ -76,6 +76,7 @@ const RegularCommentList = ({
           lastName={author.last_name}
           username={author.username}
           gravatarUrl={author.gravatar_url}
+          isBot={author?.is_bot || false}
         />
       </div>
       <div className={styles.commentContent}>

--- a/static/js/components/TNSRobotSubmissionsPage.jsx
+++ b/static/js/components/TNSRobotSubmissionsPage.jsx
@@ -258,13 +258,6 @@ const TNSRobotSubmissionsPage = () => {
             >
               {status}
             </Typography>
-            // <Chip
-            //   label={<Typography variant="body2">{status}</Typography>}
-            //   style={{
-            //     backgroundColor: colors[1],
-            //     color: colors[0],
-            //   }}
-            // />
           );
         },
       },

--- a/static/js/components/TNSRobotSubmissionsPage.jsx
+++ b/static/js/components/TNSRobotSubmissionsPage.jsx
@@ -8,7 +8,7 @@ import CircularProgress from "@mui/material/CircularProgress";
 import IconButton from "@mui/material/IconButton";
 import HistoryEduIcon from "@mui/icons-material/HistoryEdu";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
-import SmartToyIcon from "@mui/icons-material/SmartToy";
+import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
 import Dialog from "@mui/material/Dialog";
 import DialogTitle from "@mui/material/DialogTitle";
 import DialogContent from "@mui/material/DialogContent";
@@ -21,6 +21,7 @@ import ReactJson from "react-json-view";
 import { Typography } from "@mui/material";
 import Button from "./Button";
 
+import UserAvatar from "./UserAvatar";
 import { userLabel } from "./TNSRobotsPage";
 
 import * as tnsrobotsActions from "../ducks/tnsrobots";
@@ -34,6 +35,23 @@ const useStyles = makeStyles(() => ({
     flexDirection: "row",
   },
 }));
+
+function getStatusColors(status) {
+  // if it starts with success, green
+  if (status.startsWith("success")) {
+    return ["black", "MediumAquaMarine"];
+  }
+  // if any of these strings are present, yellow
+  if (status.includes("already posted to TNS")) {
+    return ["black", "Orange"];
+  }
+  // if it starts with error, red
+  if (status.startsWith("error")) {
+    return ["white", "Crimson"];
+  }
+  // else grey
+  return ["black", "LightGrey"];
+}
 
 const TNSRobotSubmissionsPage = () => {
   const classes = useStyles();
@@ -169,12 +187,27 @@ const TNSRobotSubmissionsPage = () => {
                   display: "flex",
                   flexDirection: "row",
                   alignItems: "center",
-                  gap: "0.5rem",
+                  gap: "0.75rem",
                 }}
               >
+                {usersLookup[user_id]?.username &&
+                  usersLookup[user_id]?.gravatar_url && (
+                    <UserAvatar
+                      size={28}
+                      firstName={usersLookup[user_id]?.first_name}
+                      lastName={usersLookup[user_id]?.last_name}
+                      username={usersLookup[user_id]?.username}
+                      gravatarUrl={usersLookup[user_id]?.gravatar_url}
+                      isBot={usersLookup[user_id]?.is_bot || false}
+                    />
+                  )}
                 {userLabel(usersLookup[user_id])}
-                <Tooltip title="This submission was triggered automatically when the user saved the source.">
-                  <SmartToyIcon fontSize="small" style={{ color: "gray" }} />
+                <Tooltip
+                  title={`This submission was triggered automatically when the ${
+                    usersLookup[user_id]?.is_bot === true ? "BOT" : ""
+                  } user saved the source.`}
+                >
+                  <AutoAwesomeIcon fontSize="small" style={{ color: "gray" }} />
                 </Tooltip>
               </div>
             );
@@ -209,6 +242,31 @@ const TNSRobotSubmissionsPage = () => {
       options: {
         filter: false,
         sort: true,
+        customBodyRenderLite: (dataIndex) => {
+          const { status } = tnsrobot_submissions[dataIndex];
+          const colors = getStatusColors(status);
+          return (
+            <Typography
+              variant="body2"
+              style={{
+                backgroundColor: colors[1],
+                color: colors[0],
+                padding: "0.25rem 0.75rem 0.25rem 0.75rem",
+                borderRadius: "1rem",
+                maxWidth: "fit-content",
+              }}
+            >
+              {status}
+            </Typography>
+            // <Chip
+            //   label={<Typography variant="body2">{status}</Typography>}
+            //   style={{
+            //     backgroundColor: colors[1],
+            //     color: colors[0],
+            //   }}
+            // />
+          );
+        },
       },
     },
     {

--- a/static/js/components/TNSRobotsPage.jsx
+++ b/static/js/components/TNSRobotsPage.jsx
@@ -53,6 +53,9 @@ const userLabel = (user) => {
   if (!user) {
     return "loading...";
   }
+  if (user.is_bot === true) {
+    return `${user.username}`;
+  }
   if (!(user.first_name && user.last_name)) {
     return `${user.username}${
       user.affiliations?.length > 0 ? ` (${user.affiliations[0]})` : ""

--- a/static/js/components/TopSavers.jsx
+++ b/static/js/components/TopSavers.jsx
@@ -207,6 +207,7 @@ const TopSaversList = ({ savers, styles }) => {
           lastName={author.last_name}
           username={author.username}
           gravatarUrl={author.gravatar_url}
+          isBot={author?.is_bot || false}
         />
         <p>{author.username}</p>
       </div>

--- a/static/js/components/UserAvatar.jsx
+++ b/static/js/components/UserAvatar.jsx
@@ -24,7 +24,7 @@ const useStyles = makeStyles((theme) => ({
   },
   badge: (props) => ({
     fontSize: `${Math.max(parseInt(parseFloat(props.size) / 2, 10), 10)}px`,
-    color: theme.palette.getContrastText(props.usercolor),
+    color: "#555555",
   }),
 }));
 

--- a/static/js/components/UserAvatar.jsx
+++ b/static/js/components/UserAvatar.jsx
@@ -82,8 +82,6 @@ const UserAvatar = ({
     tooltipText = `[Bot] ${tooltipText}`;
   }
 
-  // the smart icon should be centered at the top of the avatar, overlapping
-  // the avatar
   if (isBot) {
     return (
       <Tooltip title={tooltipText} arrow placement="top-start">

--- a/static/js/components/UserAvatar.jsx
+++ b/static/js/components/UserAvatar.jsx
@@ -3,6 +3,8 @@ import PropTypes from "prop-types";
 import makeStyles from "@mui/styles/makeStyles";
 import Avatar from "@mui/material/Avatar";
 import Tooltip from "@mui/material/Tooltip";
+import SmartToyIcon from "@mui/icons-material/SmartToy";
+import Badge from "@mui/material/Badge";
 
 const useStyles = makeStyles((theme) => ({
   avatar: (props) => ({
@@ -20,6 +22,10 @@ const useStyles = makeStyles((theme) => ({
   avatarImg: {
     zIndex: 5,
   },
+  badge: (props) => ({
+    fontSize: `${Math.max(parseInt(parseFloat(props.size) / 2, 10), 10)}px`,
+    color: theme.palette.getContrastText(props.usercolor),
+  }),
 }));
 
 // Return true if all characters in a string are Korean characters
@@ -29,15 +35,23 @@ export const isAllKoreanCharacters = (str) =>
   );
 
 const getInitials = (firstName, lastName) => {
-  // Korean names are almost always <=2 characters; last names are written first,
+  // Korean last names are almost always <=2 characters; last names are written first,
   // so using the full first name is a more natural "initials" than (firstName[0], lastName[0])
+  // also, first names have more chance to be unique as a lot of last names are very common
   if (isAllKoreanCharacters(firstName)) {
     return firstName;
   }
   return `${firstName?.charAt(0)}${lastName?.charAt(0)}`;
 };
 
-const UserAvatar = ({ size, firstName, lastName, username, gravatarUrl }) => {
+const UserAvatar = ({
+  size,
+  firstName,
+  lastName,
+  username,
+  gravatarUrl,
+  isBot,
+}) => {
   // use the hash of the username (which is in the gravatarUrl) to
   // select a unique color for this user
   function bgcolor() {
@@ -64,6 +78,35 @@ const UserAvatar = ({ size, firstName, lastName, username, gravatarUrl }) => {
   if (firstName && lastName) {
     tooltipText += ` (${firstName} ${lastName})`;
   }
+  if (isBot) {
+    tooltipText = `[Bot] ${tooltipText}`;
+  }
+
+  // the smart icon should be centered at the top of the avatar, overlapping
+  // the avatar
+  if (isBot) {
+    return (
+      <Tooltip title={tooltipText} arrow placement="top-start">
+        <Badge
+          overlap="circular"
+          anchorOrigin={{ vertical: "top", horizontal: "right" }}
+          badgeContent={
+            <SmartToyIcon fontSize="small" className={classes.badge} />
+          }
+        >
+          <Avatar
+            alt={backUpLetters}
+            src={`${gravatarUrl}&s=${size}`}
+            size={size}
+            classes={{
+              root: classes.avatar,
+              img: classes.avatarImg,
+            }}
+          />
+        </Badge>
+      </Tooltip>
+    );
+  }
 
   return (
     <Tooltip title={tooltipText} arrow placement="top-start">
@@ -86,11 +129,13 @@ UserAvatar.propTypes = {
   lastName: PropTypes.string,
   username: PropTypes.string.isRequired,
   gravatarUrl: PropTypes.string.isRequired,
+  isBot: PropTypes.bool,
 };
 
 UserAvatar.defaultProps = {
   firstName: null,
   lastName: null,
+  isBot: false,
 };
 
 export default UserAvatar;

--- a/static/js/components/UserProfileInfo.jsx
+++ b/static/js/components/UserProfileInfo.jsx
@@ -74,6 +74,7 @@ const UserProfileInfo = () => {
             lastName={profile.last_name}
             username={profile.username}
             gravatarUrl={profile.gravatar_url}
+            isBot={profile?.is_bot || false}
           />
           &nbsp;&nbsp;
           <div style={{ display: "flex", flexDirection: "column" }}>


### PR DESCRIPTION
Add a bunch of visual cues to make the difference between bot and non-bot users on:
- UserAvatar
- list of users across different TNS related components

This PR also adds a color coding to the statuses shown on the TNSRobotSubmissions page

Here are some screenshots:
![image](https://github.com/skyportal/skyportal/assets/49785117/d8635148-6d7e-4c2d-8918-0e133cf764b4)
![image](https://github.com/skyportal/skyportal/assets/49785117/38b0ca4a-c12f-4dc1-87e5-5ddfd47a67ba)
![image](https://github.com/skyportal/skyportal/assets/49785117/0abf615d-e2e4-4b9a-8988-a1c0869428a0)
