### PR TITLE
Centroid Plot V2 (with plotly)

### DIFF
--- a/skyportal/tests/frontend/sources_and_observingruns_etc/test_sources.py
+++ b/skyportal/tests/frontend/sources_and_observingruns_etc/test_sources.py
@@ -553,6 +553,8 @@ def test_show_starlist(driver, user, public_source):
 def test_centroid_plot(
     driver, user, public_source, public_group, ztf_camera, upload_data_token
 ):
+    discovery_ra = public_source.ra
+    discovery_dec = public_source.dec
     # Put in some actual photometry data first
     status, data = api(
         'POST',
@@ -566,9 +568,13 @@ def test_centroid_plot(
             'filter': ['ztfg', 'ztfg', 'ztfg'],
             'zp': [25.0, 30.0, 21.2],
             'magsys': ['ab', 'ab', 'ab'],
-            'ra': [264.19482957057863, 264.1948483167286, 264.19475131195185],
+            'ra': [discovery_ra + 0.0001, discovery_ra + 0.0002, discovery_ra + 0.0003],
             'ra_unc': 0.17,
-            'dec': [50.54773905413207, 50.547910537435854, 50.547856056708355],
+            'dec': [
+                discovery_dec + 0.0001,
+                discovery_dec + 0.0002,
+                discovery_dec + 0.0003,
+            ],
             'dec_unc': 0.2,
             'group_ids': [public_group.id],
         },
@@ -581,44 +587,30 @@ def test_centroid_plot(
     driver.get(f"/become_user/{user.id}")
     driver.get(f"/source/{public_source.id}")
 
-    try:
-        # Look for Suspense fallback to show
-        loading_text = "Loading centroid plot..."
-        driver.wait_for_xpath(f'//div[text()="{loading_text}"]')
-        driver.wait_for_xpath_to_disappear(f'//div[text()="{loading_text}"]')
+    plotly_div = driver.wait_for_xpath('//div[@id="centroid-plot"]')
 
-    except TimeoutException:
-        # The plot may have loaded too quickly to catch the Suspense div
-        driver.wait_for_xpath_to_disappear(f'//div[text()="{loading_text}"]')
+    # We can simply export the Plotly.js plot to an img and compare
+    # it with an expected img of the plot we have saved earlier.
+    generated_plot_data = plotly_div.screenshot_as_png
+    generated_plot = Image.open(BytesIO(generated_plot_data))
 
-    finally:
-        component_class_xpath = "//div[contains(@data-testid, 'centroid-plot-div')]"
-        vegaplot_div = driver.wait_for_xpath(component_class_xpath)
-        assert vegaplot_div.is_displayed()
+    expected_plot_path = os.path.abspath(
+        "skyportal/tests/data/centroid_plot_expected.png"
+    )
 
-        # Since Vega uses a <canvas> element, we can't examine individual
-        # components of the plot through the DOM, so just compare an image of
-        # the plot to the saved baseline
-        generated_plot_data = vegaplot_div.screenshot_as_png
-        generated_plot = Image.open(BytesIO(generated_plot_data))
+    # Use this commented line to save a new version of the expected plot
+    # if changes have been made to the component:
+    # temporarily generate the plot we will test against
+    # generated_plot.save(expected_plot_path)
 
-        expected_plot_path = os.path.abspath(
-            "skyportal/tests/data/centroid_plot_expected.png"
-        )
+    if not os.path.exists(expected_plot_path):
+        pytest.fail("Missing centroid plot baseline image for comparison")
+    expected_plot = Image.open(expected_plot_path)
 
-        # Use this commented line to save a new version of the expected plot
-        # if changes have been made to the component:
-        # temporarily generate the plot we will test against
-        generated_plot.save(expected_plot_path)
-
-        if not os.path.exists(expected_plot_path):
-            pytest.fail("Missing centroid plot baseline image for comparison")
-        expected_plot = Image.open(expected_plot_path)
-
-        difference = ImageChops.difference(
-            generated_plot.convert('RGB'), expected_plot.convert('RGB')
-        )
-        assert difference.getbbox() is None
+    difference = ImageChops.difference(
+        generated_plot.convert('RGB'), expected_plot.convert('RGB')
+    )
+    assert difference.getbbox() is None
 
 
 def test_dropdown_facility_change(driver, user, public_source):

--- a/static/js/components/CentroidPlot.jsx
+++ b/static/js/components/CentroidPlot.jsx
@@ -1,18 +1,41 @@
-import React from "react";
-import { useSelector } from "react-redux";
+import React, { useState, useEffect } from "react";
+import { useSelector, useDispatch } from "react-redux";
 import PropTypes from "prop-types";
-import { useTheme } from "@mui/material/styles";
 import makeStyles from "@mui/styles/makeStyles";
-import embed from "vega-embed";
 import * as d3 from "d3";
-import convertLength from "convert-css-length";
+import Typography from "@mui/material/Typography";
+
+import Plotly from "plotly.js-basic-dist";
+import createPlotlyComponent from "react-plotly.js/factory";
+
+import { PHOT_ZP } from "../utils";
+
+import * as archiveActions from "../ducks/archive";
+
+const Plot = createPlotlyComponent(Plotly);
 
 const useStyles = makeStyles(() => ({
-  centroidPlotDiv: (props) => ({
-    width: props.width,
-    height: props.height,
-  }),
+  plotContainer: {
+    width: "100%",
+    height: "100%",
+  },
 }));
+
+const catalogColors = {
+  AllWISE: "#2f5492",
+  Gaia_EDR3: "#FF00FF",
+  PS1_DR1: "#3bbed5",
+  PS1_PSC: "#d62728",
+  GALEX: "#6607c2",
+  TNS: "#ed6cf6",
+};
+
+function groupBy(arr, key) {
+  return arr.reduce((acc, x) => {
+    (acc[x[key]] = acc[x[key]] || []).push(x);
+    return acc;
+  }, {});
+}
 
 // Helper functions for computing plot points (taken from GROWTH marshall)
 const gcirc = (ra1, dec1, ra2, dec2) => {
@@ -38,351 +61,417 @@ const gcirc = (ra1, dec1, ra2, dec2) => {
   );
 };
 
-const relativeCoord = (ra, dec, refRA, refDec) => {
-  const delRA = gcirc(ra, dec, refRA, dec) * 3600 * -Math.sign(ra - refRA);
-  const delDec = gcirc(ra, dec, ra, refDec) * 3600 * Math.sign(dec - refDec);
-  return { delRA, delDec };
-};
+const calculateCentroid = (
+  photometry,
+  fallbackRA,
+  fallbackDec,
+  how = "snr2",
+  maxOffset = 0.5,
+  sigmaClip = 4.0,
+) => {
+  // Calculates the best position for a source from its photometric
+  // points. Only small adjustments from the fallback position are
+  // expected.
 
-// Temporary function for draft
-const getReferencePoint = (ras, decs) => {
-  const refRA = d3.median(ras);
-  const refDec = d3.median(decs);
-
-  return { refRA, refDec };
-};
-
-const getCirclePoints = (delRaGroup, delDecGroup) => {
-  const thetas = d3.range(0, 2.01 * Math.PI, 0.01);
-  const C = Math.max(d3.deviation(delRaGroup), d3.deviation(delDecGroup));
-  const medianRA = d3.median(delRaGroup);
-  const medianDec = d3.median(delDecGroup);
-
-  const points = thetas?.map((theta) => {
-    const xx = medianRA + C * Math.cos(theta);
-    const yy = medianDec + C * Math.sin(theta);
-    return { xx, yy, theta };
-  });
-
-  return points;
-};
-
-const getMessages = (delRaGroup, delDecGroup) => {
-  const offset = Math.sqrt(
-    d3.median(delRaGroup) ** 2 + d3.median(delDecGroup) ** 2,
-  );
-  const C = Math.max(d3.deviation(delRaGroup), d3.deviation(delDecGroup));
-  const maxDelRA = Math.max.apply(null, delRaGroup.map(Math.abs));
-  const maxDelDec = Math.max.apply(null, delDecGroup.map(Math.abs));
-
-  const limit = Math.max(maxDelRA, maxDelDec);
-
-  const offsetMessage = {
-    x: limit * 0.6,
-    y: limit,
-    message: `offset = ${offset.toFixed(2)} \u00B1 ${C.toFixed(2)}`,
-  };
-
-  return [offsetMessage];
-};
-
-// The Vega-Lite specifications for the centroid plot
-const spec = (inputData, textColor, titleFontSize, labelFontSize) => ({
-  $schema: "https://vega.github.io/schema/vega-lite/v5.2.0.json",
-  width: "container",
-  height: "container",
-  background: "transparent",
-  layer: [
-    // Render nuclear-to-host circle
-    {
-      data: {
-        values: inputData.circlePoints,
-      },
-      transform: [
-        { calculate: "0.8 * cos(datum.theta)", as: "x" },
-        { calculate: "0.8 * sin(datum.theta)", as: "y" },
-      ],
-      mark: {
-        type: "line",
-      },
-      encoding: {
-        x: {
-          field: "x",
-          type: "quantitative",
-        },
-        y: {
-          field: "y",
-          type: "quantitative",
-        },
-        order: { field: "theta", type: "quantitative" },
-        fill: {
-          value: "#ccd2db",
-        },
-        fillOpacity: { value: 0.5 },
-        strokeOpacity: { value: 0 },
-      },
-    },
-
-    // Render 1 sigma boundary circle
-    {
-      data: {
-        values: inputData.circlePoints,
-      },
-      mark: {
-        type: "line",
-        point: "true",
-      },
-      encoding: {
-        x: {
-          field: "xx",
-          type: "quantitative",
-        },
-        y: {
-          field: "yy",
-          type: "quantitative",
-        },
-        order: { field: "theta", type: "quantitative" },
-        color: {
-          value: "red",
-          legend: {
-            values: ["\u03A3"],
-            orient: "bottom-right",
-          },
-        },
-        strokeWidth: { value: 2 },
-      },
-    },
-
-    // Render main scatter plot
-    {
-      data: {
-        values: inputData.photometryData,
-      },
-      selection: {
-        grid: {
-          type: "interval",
-          bind: "scales",
-        },
-      },
-      mark: {
-        type: "point",
-        filled: true,
-      },
-      encoding: {
-        x: {
-          field: "delRA",
-          type: "quantitative",
-          axis: {
-            title: "\u0394RA (arcsec)",
-            titleFontSize,
-            labelFontSize,
-            titlePadding: 8,
-            labelColor: textColor,
-            tickColor: textColor,
-            titleColor: textColor,
-          },
-        },
-        y: {
-          field: "delDec",
-          type: "quantitative",
-          axis: {
-            title: "\u0394Dec (arcsec)",
-            titleFontSize,
-            labelFontSize,
-            titlePadding: 8,
-            labelColor: textColor,
-            tickColor: textColor,
-            titleColor: textColor,
-          },
-        },
-        tooltip: [
-          { field: "id", type: "quantitative" },
-          { field: "filter", type: "nominal" },
-          { field: "delRA", type: "quantitative" },
-          { field: "delDec", type: "quantitative" },
-          { field: "ra", type: "quantitative", title: "RA" },
-          { field: "dec", type: "quantitative", title: "Dec" },
-        ],
-        color: {
-          field: "filter",
-          type: "nominal",
-          scale: { range: ["#2f5492", "#ff7f0e", "#2ca02c"] },
-          legend: {
-            title: "Filter",
-            titleFontSize,
-            labelFontSize,
-            titleLimit: 240,
-            labelLimit: 240,
-            rowPadding: 4,
-            orient: "bottom",
-            labelColor: textColor,
-            titleColor: textColor,
-          },
-        },
-        shape: {
-          field: "filter",
-          type: "nominal",
-          scale: { range: ["circle", "square", "triangle"] },
-        },
-        size: { value: 35 },
-        fillOpacity: { value: 1.0 },
-        strokeOpacity: { value: 0 },
-      },
-    },
-
-    // Render center point (nearest object position relative to mode of the
-    // nearest references) - currently just the one reference
-    {
-      data: {
-        values: inputData.centerPoint,
-      },
-      mark: {
-        type: "point",
-        shape: "cross",
-        size: "100",
-      },
-      encoding: {
-        x: {
-          field: "delRA",
-          type: "quantitative",
-        },
-        y: {
-          field: "delDec",
-          type: "quantitative",
-        },
-        fill: { value: "black" },
-      },
-    },
-
-    // Render text messages
-    {
-      data: {
-        values: inputData.messages,
-      },
-      mark: {
-        type: "text",
-        fontSize: 14,
-        fontWeight: 500,
-      },
-      encoding: {
-        text: { field: "message", type: "nominal" },
-        color: { value: textColor },
-        x: {
-          field: "x",
-          type: "quantitative",
-        },
-        y: {
-          field: "y",
-          type: "quantitative",
-        },
-      },
-    },
-  ],
-});
-
-const processData = (photometry) => {
-  // Only take points with a non-null RA and Dec
-  const filteredPhotometry = photometry?.filter(
-    (point) => point.ra && point.dec,
-  );
-
-  if (filteredPhotometry.length === 0) {
-    return {
-      photometryData: [],
-    };
+  if (!photometry || photometry.length === 0) {
+    return { refRA: null, refDec: null };
   }
 
-  const ras = Object.values(filteredPhotometry).map((point) => point.ra);
-  const decs = Object.values(filteredPhotometry).map((point) => point.dec);
+  // remove observations with distances more than maxOffset away from the median
+  const medianRA = d3.median(photometry.map((p) => p.ra));
+  const medianDec = d3.median(photometry.map((p) => p.dec));
 
-  // For now, set single reference nearest object to median values for the RA
-  // and Dec in the photometry
-  const { refRA, refDec } = getReferencePoint(ras, decs);
+  // make sure that the median itself is not too far from the fallback position
+  if (gcirc(medianRA, medianDec, fallbackRA, fallbackDec) > maxOffset) {
+    return { refRA: fallbackRA, refDec: fallbackDec };
+  }
 
-  const computeDeltas = (delRaGroup, delDecGroup) => (point) => {
-    const { delRA, delDec } = relativeCoord(point.ra, point.dec, refRA, refDec);
-    delRaGroup.push(delRA);
-    delDecGroup.push(delDec);
-    return {
-      ...point,
-      delRA,
-      delDec,
-    };
-  };
-
-  const delRaGroup = [];
-  const delDecGroup = [];
-  const photometryAsArray = Object.values(filteredPhotometry).map(
-    computeDeltas(delRaGroup, delDecGroup),
+  let points = photometry.filter(
+    (p) => gcirc(medianRA, medianDec, p.ra, p.dec) <= maxOffset,
   );
 
-  // Sigma circle
-  const circlePoints = getCirclePoints(delRaGroup, delDecGroup);
+  // add a ra_offset, dec_offset, and offset_arcsec to each point
+  // and remove those with an offset_arcsec > maxOffset
+  points = points.map((p) => {
+    const newPoint = { ...p };
+    newPoint.ra_offset =
+      Math.cos((medianDec / 180) * Math.PI) * (p.ra - medianRA) * 3600;
+    newPoint.dec_offset = (p.dec - medianDec) * 3600;
+    newPoint.offset_arcsec = Math.sqrt(
+      newPoint.ra_offset ** 2 + newPoint.dec_offset ** 2,
+    );
+    return newPoint;
+  });
+  points = points.filter((p) => p.offset_arcsec <= maxOffset);
 
-  // Text notifications
-  const messages = getMessages(delRaGroup, delDecGroup);
+  // remove outliers
+  if (points.length > 4 && sigmaClip > 0) {
+    const std = d3.deviation(points.map((p) => p.offset_arcsec));
+    points = points.filter((p) => p.offset_arcsec < sigmaClip * std);
+  }
 
-  const centerPoint = relativeCoord(refRA, refDec, refRA, refDec);
+  // if how == invvar, remove the points with ra_unc or dec_unc == 0 or missing
+  if (how === "invvar") {
+    points = points.filter((p) => p.ra_unc >= 0 && p.dec_unc >= 0);
+  }
+
+  if (points.length === 0) {
+    return { refRA: fallbackRA, refDec: fallbackDec };
+  }
+
+  let differenceRA = null;
+  let differenceDec = null;
+  // based on the strategy to use (how parameter), calculate the centroid
+  if (how === "snr2") {
+    // use the SNR^2 as the weight to compute the average
+    differenceRA =
+      d3.sum(points.map((p) => p.ra * p.snr ** 2)) /
+      d3.sum(points.map((p) => p.snr ** 2));
+    differenceDec =
+      d3.sum(points.map((p) => p.dec * p.snr ** 2)) /
+      d3.sum(points.map((p) => p.snr ** 2));
+  } else if (how === "invvar") {
+    // use the inverse variance as the weight to compute the average
+    differenceRA =
+      d3.sum(points.map((p) => p.ra * (1 / p.ra_unc ** 2))) /
+      d3.sum(points.map((p) => 1 / p.ra_unc ** 2));
+    differenceDec =
+      d3.sum(points.map((p) => p.dec * (1 / p.dec_unc ** 2))) /
+      d3.sum(points.map((p) => 1 / p.dec_unc ** 2));
+  } else {
+    // log a warning if the how parameter is not recognized
+    console.log(
+      `Warning: do not recognize ${how} as a valid way to weight astrometry, using median as centroid instead.`,
+    );
+    // return the median position
+    return { refRA: medianRA, refDec: medianDec };
+  }
 
   return {
-    photometryData: photometryAsArray,
-    circlePoints,
-    centerPoint,
-    messages,
+    // ra: med_ra + diff_ra / (np.cos(np.radians(med_dec)) * 3600.0),
+    ra:
+      medianRA + differenceRA / (Math.cos((medianDec / 180) * Math.PI) * 3600),
+    dec: medianDec + differenceDec / 3600,
   };
 };
 
-const CentroidPlot = ({ sourceId, size }) => {
-  // Add some extra height for the legend
-  const theme = useTheme();
-  const rootFont = theme.typography.htmlFontSize;
-  const convert = convertLength(rootFont);
-  const newHeight = parseFloat(convert(size, "px")) + rootFont * 2;
-  const classes = useStyles({ width: size, height: `${newHeight}px` });
+const prepareData = (photometry, fallbackRA, fallbackDec) => {
+  if (!photometry || photometry.length === 0) {
+    return { refRA: null, refDec: null, oneSigmaCircle: null };
+  }
+  // keep only the points with a mag and magerr
+  // and ra, dec
+  // and that are not forced photometry
+  let points = photometry.filter(
+    (p) =>
+      p.mag !== null &&
+      p.magerr !== null &&
+      p.ra !== null &&
+      p.dec !== null &&
+      !Number.isNaN(p.mag) &&
+      !Number.isNaN(p.magerr) &&
+      !Number.isNaN(p.ra) &&
+      !Number.isNaN(p.dec) &&
+      !["fp", "alert_fp"].includes(p.origin),
+  );
+  if (points.length === 0) {
+    return { refRA: null, refDec: null, points: [], oneSigmaCircle: null };
+  }
+  // calculate the flux and fluxerr for these points
+  points = points.map((p) => {
+    const newPoint = { ...p };
+    newPoint.flux = 10 ** (-0.4 * (p.mag - PHOT_ZP));
+    newPoint.fluxerr = (newPoint.magerr / (2.5 / Math.log(10))) * newPoint.flux;
+    newPoint.snr = newPoint.flux / newPoint.fluxerr;
+    return newPoint;
+  });
+  // remove those with a snr < 3.0 and valid flux and fluxerr
+  points = points.filter(
+    (p) => p.snr >= 3.0 && p.flux !== null && p.fluxerr !== null,
+  );
+  if (points.length === 0) {
+    return { refRA: null, refDec: null, points: [], oneSigmaCircle: null };
+  }
+  const { refRA, refDec } = calculateCentroid(
+    points,
+    "snr2",
+    5,
+    fallbackRA,
+    fallbackDec,
+  );
 
-  const photometry = useSelector((state) => state.photometry[sourceId]);
-
-  const plotData = photometry ? processData(photometry) : null;
-
-  if (plotData) {
-    if (plotData.photometryData.length > 0) {
-      return (
-        <div
-          className={classes.centroidPlotDiv}
-          data-testid="centroid-plot-div"
-          ref={(node) => {
-            if (node) {
-              embed(
-                node,
-                spec(
-                  plotData,
-                  theme.palette.text.primary,
-                  theme.plotFontSizes.titleFontSize,
-                  theme.plotFontSizes.labelFontSize,
-                ),
-                {
-                  actions: false,
-                },
-              );
-            }
-          }}
-        />
-      );
-    }
-
-    return <div>No photometry points with RA and Dec found.</div>;
+  // if ra and dec are null, return
+  if (refRA === null || refDec === null) {
+    return { refRA: null, refDec: null, points: [], oneSigmaCircle: null };
   }
 
-  return null;
+  // to each point, compute the delta in ra and dec in arcsec
+  // and the ra_offset and dec_offset in arcsec
+  points = points.map((p) => {
+    const newPoint = { ...p };
+    newPoint.ra_offset =
+      Math.cos((refDec / 180) * Math.PI) * (p.ra - refRA) * 3600;
+    newPoint.dec_offset = (p.dec - refDec) * 3600;
+    newPoint.offset_arcsec = Math.sqrt(
+      newPoint.ra_offset ** 2 + newPoint.dec_offset ** 2,
+    );
+    newPoint.deltaRA =
+      gcirc(p.ra, p.dec, refRA, p.dec) * 3600 * -Math.sign(p.ra - refRA);
+    newPoint.deltaDec =
+      gcirc(p.ra, p.dec, p.ra, refDec) * 3600 * Math.sign(p.dec - refDec);
+    return newPoint;
+  });
+
+  // compute the radius (in arcsec) of the 1 sigma boundary circle
+  // for the centroid using the deltaRA and deltaDec
+  // of the points that are within the max offset (0.5 arcsec)
+  const oneSigmaCircle = Math.max(
+    ...points
+      .filter((p) => p.offset_arcsec <= 0.5)
+      .map((p) => Math.sqrt(p.deltaRA ** 2 + p.deltaDec ** 2)),
+  );
+
+  return { refRA, refDec, points, oneSigmaCircle };
 };
 
-CentroidPlot.propTypes = {
+const CentroidPlotV2 = ({ sourceId }) => {
+  const dispatch = useDispatch();
+  const classes = useStyles();
+
+  const { id, ra, dec } = useSelector((state) => state.source);
+  const photometry = useSelector((state) => state.photometry[sourceId]);
+  const config = useSelector((state) => state.config);
+
+  // no crossMatches in the default SkyPortal, but can be added by SkyPortal-based
+  // apps on top of the basic SkyPortal
+  const crossMatches = useSelector((state) => state.cross_matches);
+  const [filter2color, setFilter2Color] = useState(null);
+
+  const radius = 10.0;
+
+  useEffect(() => {
+    if (!filter2color && config?.bandpassesColors) {
+      setFilter2Color(config?.bandpassesColors);
+    }
+  }, [config, filter2color]);
+
+  useEffect(() => {
+    if (id === sourceId && ra && dec) {
+      dispatch(archiveActions.fetchCrossMatches({ ra, dec, radius }));
+    }
+  }, [id]);
+
+  if (!filter2color) {
+    return (
+      <div className={classes.plotContainer}>
+        <Typography variant="body1">
+          No valid filter to color mapping
+        </Typography>
+      </div>
+    );
+  }
+
+  if (id === null || ra === null || dec === null || id !== sourceId) {
+    return (
+      <div className={classes.plotContainer}>
+        <Typography variant="body1">
+          No valid source selected to compute the centroid
+        </Typography>
+      </div>
+    );
+  }
+
+  const { refRA, refDec, points, oneSigmaCircle } = prepareData(
+    photometry,
+    ra,
+    dec,
+  );
+
+  if (!refRA || !refDec || !points || points.length === 0) {
+    return (
+      <div className={classes.plotContainer}>
+        <Typography variant="body1">
+          No valid photometry data to compute the centroid
+        </Typography>
+      </div>
+    );
+  }
+
+  const traces = [];
+
+  // group the photometry points per filter, returns a dict with the filter as key and the points as value
+  const groupedPoints = groupBy(points, "filter");
+  Object.keys(groupedPoints).forEach((filter) => {
+    const colorRGB = filter2color[filter] || [0, 0, 0];
+    traces.push({
+      x: groupedPoints[filter].map((p) => p.deltaRA),
+      y: groupedPoints[filter].map((p) => p.deltaDec),
+      mode: "markers",
+      type: "scatter",
+      marker: {
+        size: 6,
+        color: `rgb(${colorRGB.join(",")})`,
+        opacity: 0.9,
+      },
+      name: filter,
+    });
+  });
+
+  if (
+    crossMatches &&
+    typeof crossMatches === "object" &&
+    Object.keys(crossMatches)?.length > 0
+  ) {
+    // cross_matches are already grouped by catalog (instead of filter)
+    Object.keys(crossMatches).forEach((catalog) => {
+      if (crossMatches[catalog]?.length > 0) {
+        const catalogPoints = crossMatches[catalog].map((cm) => {
+          const newPoint = { ...cm };
+          newPoint.ra_offset =
+            Math.cos((refDec / 180) * Math.PI) * (cm.ra - refRA) * 3600;
+          newPoint.dec_offset = (cm.dec - refDec) * 3600;
+          newPoint.offset_arcsec = Math.sqrt(
+            newPoint.ra_offset ** 2 + newPoint.dec_offset ** 2,
+          );
+          newPoint.deltaRA =
+            gcirc(cm.ra, cm.dec, refRA, cm.dec) *
+            3600 *
+            -Math.sign(cm.ra - refRA);
+          newPoint.deltaDec =
+            gcirc(cm.ra, cm.dec, cm.ra, refDec) *
+            3600 *
+            Math.sign(cm.dec - refDec);
+          return newPoint;
+        });
+
+        const color = catalogColors[catalog] || "black";
+
+        traces.push({
+          x: catalogPoints.map((p) => p.deltaRA),
+          y: catalogPoints.map((p) => p.deltaDec),
+          mode: "markers",
+          type: "scatter",
+          marker: {
+            size: 12,
+            color,
+            opacity: 1,
+            symbol: "star",
+          },
+          name: catalog,
+        });
+      }
+    });
+  }
+
+  const shapes = [];
+
+  if (oneSigmaCircle) {
+    // 1 sigma boundary circle
+    shapes.push({
+      type: "circle",
+      xref: "x",
+      yref: "y",
+      x0: -oneSigmaCircle,
+      y0: -oneSigmaCircle,
+      x1: oneSigmaCircle,
+      y1: oneSigmaCircle,
+      fillcolor: "rgba(204, 210, 219, 0.15)",
+      line: {
+        color: "rgba(204, 210, 219, 0.3)",
+      },
+    });
+
+    // nuclear-to-host circle (0.2 * oneSigmaCircle)
+    shapes.push({
+      type: "circle",
+      xref: "x",
+      yref: "y",
+      x0: -0.2 * oneSigmaCircle,
+      y0: -0.2 * oneSigmaCircle,
+      x1: 0.2 * oneSigmaCircle,
+      y1: 0.2 * oneSigmaCircle,
+      // darker blue
+      line: {
+        color: "rgba(0, 0, 255, 0.3)",
+        width: 3,
+      },
+    });
+  }
+
+  return (
+    // <div className={classes.plotContainer}>
+    // <div
+    //   style={{
+    //     width: "100%",
+    //     height: "100%",
+    //     overflowX: "scroll",
+    //   }}
+    // >
+    <div
+      style={{
+        width: "100%",
+        height: "50vh",
+        overflowX: "scroll",
+      }}
+    >
+      <Plot
+        data={traces}
+        layout={{
+          // width: newHeight + 80,
+          // height: newHeight,
+          xaxis: {
+            title: "\u0394RA (arcsec)",
+            range: [-oneSigmaCircle, oneSigmaCircle],
+          },
+          yaxis: {
+            title: "\u0394Dec (arcsec)",
+            scaleanchor: "x",
+            range: [-oneSigmaCircle, oneSigmaCircle],
+          },
+          legend: {
+            title: {
+              text: "Filter/Catalog",
+              font: { size: 14 },
+            },
+            font: { size: 14 },
+            tracegroupgap: 0,
+          },
+          showlegend: true,
+          autosize: true,
+          margin: {
+            l: 60,
+            r: 30,
+            b: 40,
+            t: 30,
+            pad: 5,
+          },
+          scene: {
+            aspectmode: "manual",
+            aspectratio: {
+              x: 1,
+              y: 1,
+            },
+          },
+          dragmode: "pan",
+          shapes,
+        }}
+        config={{
+          responsive: true,
+          displaylogo: false,
+          showAxisDragHandles: false,
+          scrollZoom: true,
+          modeBarButtonsToRemove: ["zoom2d", "autoScale2d", "lasso2d"],
+          doubleClick: "reset",
+        }}
+        useResizeHandler
+        style={{ width: "100%", height: "100%" }}
+      />
+    </div>
+  );
+};
+
+CentroidPlotV2.propTypes = {
   sourceId: PropTypes.string.isRequired,
-  size: PropTypes.string,
 };
 
-CentroidPlot.defaultProps = {
-  size: "300px",
-};
-
-export default CentroidPlot;
+export default CentroidPlotV2;

--- a/static/js/components/CentroidPlot.jsx
+++ b/static/js/components/CentroidPlot.jsx
@@ -299,7 +299,7 @@ const prepareData = (photometry, fallbackRA, fallbackDec) => {
   return { refRA, refDec, points, oneSigmaCircle, stdCircle };
 };
 
-const CentroidPlot = ({ sourceId }) => {
+const CentroidPlot = ({ sourceId, plotStyle }) => {
   const dispatch = useDispatch();
   const classes = useStyles();
 
@@ -454,7 +454,7 @@ const CentroidPlot = ({ sourceId }) => {
         id="centroid-plot"
         style={{
           width: "100%",
-          height: "50vh",
+          height: plotStyle?.height || "50vh",
           overflowX: "scroll",
         }}
       >
@@ -521,6 +521,15 @@ const CentroidPlot = ({ sourceId }) => {
 
 CentroidPlot.propTypes = {
   sourceId: PropTypes.string.isRequired,
+  plotStyle: PropTypes.shape({
+    height: PropTypes.string,
+  }),
+};
+
+CentroidPlot.defaultProps = {
+  plotStyle: {
+    height: "50vh",
+  },
 };
 
 export default CentroidPlot;

--- a/static/js/components/CentroidPlot.jsx
+++ b/static/js/components/CentroidPlot.jsx
@@ -150,6 +150,7 @@ const calculateCentroid = (
 };
 
 const prepareData = (photometry, fallbackRA, fallbackDec) => {
+  console.log(photometry);
   if (!photometry || photometry.length === 0) {
     return { refRA: null, refDec: null, oneSigmaCircle: null, stdCircle: null };
   }
@@ -334,7 +335,12 @@ const CentroidPlotV2 = ({ sourceId }) => {
   }, [id]);
 
   useEffect(() => {
-    if (photometry?.length > 0 && ra && dec && filter2color) {
+    if (
+      photometry?.length > 0 &&
+      !Number.isNaN(ra) &&
+      !Number.isNaN(dec) &&
+      filter2color
+    ) {
       const { refRA, refDec, points, oneSigmaCircle, stdCircle } = prepareData(
         photometry,
         ra,
@@ -453,6 +459,7 @@ const CentroidPlotV2 = ({ sourceId }) => {
   return (
     <div className={classes.plotContainer}>
       <div
+        id="centroid-plot"
         style={{
           width: "100%",
           height: "50vh",

--- a/static/js/components/CentroidPlot.jsx
+++ b/static/js/components/CentroidPlot.jsx
@@ -134,7 +134,6 @@ const calculateCentroid = (
   }
 
   return {
-    // ra: med_ra + diff_ra / (np.cos(np.radians(med_dec)) * 3600.0),
     refRA:
       medianRA + differenceRA / (Math.cos((medianDec / 180) * Math.PI) * 3600),
     refDec: medianDec + differenceDec / 3600,
@@ -300,7 +299,7 @@ const prepareData = (photometry, fallbackRA, fallbackDec) => {
   return { refRA, refDec, points, oneSigmaCircle, stdCircle };
 };
 
-const CentroidPlotV2 = ({ sourceId }) => {
+const CentroidPlot = ({ sourceId }) => {
   const dispatch = useDispatch();
   const classes = useStyles();
 
@@ -371,7 +370,7 @@ const CentroidPlotV2 = ({ sourceId }) => {
 
   if (!filter2color) {
     return (
-      <div className={classes.plotContainer}>
+      <div className={classes.plotContainer} id="no-centroid-plot">
         <Typography variant="body1">
           No valid filter to color mapping
         </Typography>
@@ -381,7 +380,7 @@ const CentroidPlotV2 = ({ sourceId }) => {
 
   if (id === null || ra === null || dec === null || id !== sourceId) {
     return (
-      <div className={classes.plotContainer}>
+      <div className={classes.plotContainer} id="no-centroid-plot">
         <Typography variant="body1">
           No valid source selected to compute the centroid
         </Typography>
@@ -391,7 +390,7 @@ const CentroidPlotV2 = ({ sourceId }) => {
 
   if (!data?.refRA && !data?.refDec) {
     return (
-      <div className={classes.plotContainer}>
+      <div className={classes.plotContainer} id="no-centroid-plot">
         <Typography variant="body1">
           No valid photometry data to compute the centroid
         </Typography>
@@ -520,8 +519,8 @@ const CentroidPlotV2 = ({ sourceId }) => {
   );
 };
 
-CentroidPlotV2.propTypes = {
+CentroidPlot.propTypes = {
   sourceId: PropTypes.string.isRequired,
 };
 
-export default CentroidPlotV2;
+export default CentroidPlot;

--- a/static/js/components/CentroidPlotPlugins.jsx
+++ b/static/js/components/CentroidPlotPlugins.jsx
@@ -4,7 +4,8 @@ import makeStyles from "@mui/styles/makeStyles";
 import Typography from "@mui/material/Typography"; // eslint-disable-line no-unused-vars
 
 // import * as archiveActions from "../ducks/archive";
-// the import above is needs to be implemented in the codebase where this plugin is used
+// IMPORTANT: the file imported above needs to be added to same codebase where the UI plugin will be overwritten.
+//            It should add the `cross_match` key to the redux store, along with methods to populate that field.
 
 // list of cross-match catalogs to hide
 const hiddenCrossMatches = ["PS1_PSC"]; // eslint-disable-line no-unused-vars

--- a/static/js/components/CentroidPlotPlugins.jsx
+++ b/static/js/components/CentroidPlotPlugins.jsx
@@ -1,70 +1,22 @@
-import React from "react";
+import React from "react"; // eslint-disable-line no-unused-vars
 import PropTypes from "prop-types";
 import makeStyles from "@mui/styles/makeStyles";
-import Typography from "@mui/material/Typography";
+import Typography from "@mui/material/Typography"; // eslint-disable-line no-unused-vars
 
-import * as archiveActions from "../ducks/archive";
+// import * as archiveActions from "../ducks/archive";
+// the import above is needs to be implemented in the codebase where this plugin is used
 
-const hiddenCrossMatches = ["PS1_PSC"];
+// list of cross-match catalogs to hide
+const hiddenCrossMatches = ["PS1_PSC"]; // eslint-disable-line no-unused-vars
 
-const crossMatchesColors = {
-  AllWISE: "#2f5492",
-  Gaia_EDR3: "#FF00FF",
-  PS1_DR1: "#3bbed5",
-  PS1_PSC: "#d62728",
-  GALEX: "#6607c2",
-  TNS: "#ed6cf6",
-};
+// map the cross-match catalog names to the colors to use for plotting them
+const crossMatchesColors = {}; // eslint-disable-line no-unused-vars
 
-const crossMatchesLabels = {
-  AllWISE: {
-    name: "designation",
-    ra_unc: "sigra",
-    dec_unc: "sigdec",
-    w1: "w1mpro",
-    w2: "w2mpro",
-    w3: "w3mpro",
-    w4: "w4mpro",
-  },
-  Gaia_EDR3: {
-    name: "designation",
-    ra_unc: "ra_error",
-    dec_unc: "dec_error",
-    parallax: "parallax",
-    parallax_unc: "parallax_error",
-    pm: "pm",
-    phot_bp_mean_mag: "phot_bp_mean_mag",
-    phot_rp_mean_mag: "phot_rp_mean_mag",
-  },
-  PS1_DR1: {
-    name: "_id",
-    ra_unc: "raMeanErr",
-    dec_unc: "decMeanErr",
-    nDetections: "nDetections",
-  },
-  GALEX: {
-    name: "name",
-    FUVmag: "FUVmag",
-    NUVmag: "NUVmag",
-  },
-  "2MASS_PSC": {
-    name: "designation",
-    j_mag: "j_m",
-    j_mag_unc: "j_msigcom",
-    h_mag: "h_m",
-    h_mag_unc: "h_msigcom",
-    k_mag: "k_m",
-    k_mag_unc: "k_msigcom",
-  },
-  TNS: {
-    name: "name",
-    discoverymag: "discoverymag",
-    discoverydate: "discoverydate",
-    internal_names: "internal_names",
-  },
-};
+// map the fields names to display for each cross-match source to the actual field names
+const crossMatchesLabels = {}; // eslint-disable-line no-unused-vars
 
-const radius = 10.0;
+// max radius in arcseconds to use for cross-matching
+const radius = 10.0; // eslint-disable-line no-unused-vars
 
 const useStyles = makeStyles(() => ({
   pluginContainer: {
@@ -74,136 +26,22 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-// Helper functions for computing plot points (taken from GROWTH marshall)
-const gcirc = (ra1, dec1, ra2, dec2) => {
-  // input deg, haversine formula, return deg
-  ra1 = (ra1 / 180) * Math.PI;
-  dec1 = (dec1 / 180) * Math.PI;
-  ra2 = (ra2 / 180) * Math.PI;
-  dec2 = (dec2 / 180) * Math.PI;
-  const delDec2 = (dec2 - dec1) * 0.5;
-  const delRA2 = (ra2 - ra1) * 0.5;
-  return (
-    (360 *
-      Math.asin(
-        Math.sqrt(
-          Math.sin(delDec2) * Math.sin(delDec2) +
-            Math.cos(dec1) *
-              Math.cos(dec2) *
-              Math.sin(delRA2) *
-              Math.sin(delRA2),
-        ),
-      )) /
-    Math.PI
-  );
-};
-
+// eslint-disable-next-line no-unused-vars
 function getCrossMatches(ra, dec, dispatch) {
-  dispatch(archiveActions.fetchCrossMatches({ ra, dec, radius }));
+  // implement logic to fetch cross matches from the archive
+  // and add them to the redux store's "cross_matches" key
+  return null;
 }
 
+// eslint-disable-next-line no-unused-vars
 function getCrossMatchesTraces(crossMatches, refRA, refDec) {
   const traces = [];
-  // cross_matches are already grouped by catalog (instead of filter)
-  Object.keys(crossMatches).forEach((catalog) => {
-    if (
-      crossMatches[catalog]?.length > 0 &&
-      !hiddenCrossMatches.includes(catalog) &&
-      crossMatchesLabels[catalog]
-    ) {
-      const catalogPoints = crossMatches[catalog].map((cm) => {
-        const newPoint = { ...cm };
-        newPoint.ra_offset =
-          Math.cos((refDec / 180) * Math.PI) * (cm.ra - refRA) * 3600;
-        newPoint.dec_offset = (cm.dec - refDec) * 3600;
-        newPoint.offset_arcsec = Math.sqrt(
-          newPoint.ra_offset ** 2 + newPoint.dec_offset ** 2,
-        );
-        newPoint.deltaRA =
-          gcirc(cm.ra, cm.dec, refRA, cm.dec) *
-          3600 *
-          -Math.sign(cm.ra - refRA);
-        newPoint.deltaDec =
-          gcirc(cm.ra, cm.dec, cm.ra, refDec) *
-          3600 *
-          Math.sign(cm.dec - refDec);
-        let text = `Catalog: ${catalog}`;
-
-        if (
-          crossMatchesLabels[catalog].name &&
-          cm[crossMatchesLabels[catalog].name]
-        ) {
-          text += `<br>Name: ${cm[crossMatchesLabels[catalog].name]}`;
-        }
-        if (
-          crossMatchesLabels[catalog].ra_unc &&
-          !Number.isNaN(parseFloat(cm[crossMatchesLabels[catalog].ra_unc], 10))
-        ) {
-          text += `<br>RA: ${cm.ra.toFixed(6)} ± ${parseFloat(
-            cm[crossMatchesLabels[catalog].ra_unc],
-            10,
-          ).toFixed(4)}`;
-        } else {
-          text += `<br>RA: ${cm.ra.toFixed(6)}`;
-        }
-        if (
-          crossMatchesLabels[catalog].dec_unc &&
-          !Number.isNaN(parseFloat(cm[crossMatchesLabels[catalog].dec_unc], 10))
-        ) {
-          text += `<br>Dec: ${cm.dec.toFixed(6)} ± ${parseFloat(
-            cm[crossMatchesLabels[catalog].dec_unc],
-            10,
-          ).toFixed(4)}`;
-        } else {
-          text += `<br>Dec: ${cm.dec.toFixed(6)}`;
-        }
-        // then loop over all the other fields
-        Object.keys(crossMatchesLabels[catalog]).forEach((key) => {
-          if (
-            key !== "name" &&
-            key !== "ra_unc" &&
-            key !== "dec_unc" &&
-            cm[crossMatchesLabels[catalog][key]]
-          ) {
-            text += `<br>${key}: ${cm[crossMatchesLabels[catalog][key]]}`;
-          }
-        });
-        text += `<br>RA offset: ${newPoint.ra_offset.toFixed(4)}"`;
-        text += `<br>Dec offset: ${newPoint.dec_offset.toFixed(4)}"`;
-        text += `<br>Offset: ${newPoint.offset_arcsec.toFixed(4)}"`;
-        newPoint.text = text;
-        return newPoint;
-      });
-
-      const color = crossMatchesColors[catalog] || "black";
-
-      traces.push({
-        x: catalogPoints.map((p) => p.deltaRA),
-        y: catalogPoints.map((p) => p.deltaDec),
-        mode: "markers",
-        type: "scatter",
-        marker: {
-          size: 12,
-          color,
-          opacity: 1,
-          symbol: "star",
-        },
-        name: catalog,
-        hoverlabel: {
-          bgcolor: "white",
-          font: { size: 14 },
-          align: "left",
-        },
-        text: catalogPoints.map((p) => p.text),
-        hovertemplate: "%{text}<extra></extra>",
-      });
-    }
-  });
+  // implement logic to display cross matches on the centroid plot
   return traces;
 }
 
 const CentroidPlotPlugins = ({ crossMatches, refRA, refDec }) => {
-  const classes = useStyles();
+  const classes = useStyles(); // eslint-disable-line no-unused-vars
   if (
     !crossMatches ||
     Object.keys(crossMatches).length === 0 ||
@@ -213,50 +51,9 @@ const CentroidPlotPlugins = ({ crossMatches, refRA, refDec }) => {
     return null;
   }
 
-  // for each catalog, get the nearest source and compute the offset
-  const nearestOffsets = {};
-  Object.keys(crossMatches).forEach((catalog) => {
-    if (
-      crossMatches[catalog]?.length > 0 &&
-      !hiddenCrossMatches.includes(catalog)
-    ) {
-      // we compute the offset_arcsec for each source in the catalog
-      // and then sort by offset_arcsec to get the nearest source
-      nearestOffsets[catalog] = crossMatches[catalog] // eslint-disable-line prefer-destructuring
-        .map((cm) => {
-          const ra_offset =
-            Math.cos((refDec / 180) * Math.PI) * (cm.ra - refRA) * 3600;
-          const dec_offset = (cm.dec - refDec) * 3600;
-          const offset_arcsec = Math.sqrt(ra_offset ** 2 + dec_offset ** 2);
-          return { ...cm, offset_arcsec };
-        })
-        .sort((a, b) => a.offset_arcsec - b.offset_arcsec)[0];
-    }
-  });
+  // Implement plugin to display information under the centroid plot
 
-  if (Object.keys(nearestOffsets).length === 0) {
-    return null;
-  }
-
-  return (
-    <div className={classes.pluginContainer}>
-      <Typography variant="h6">
-        Offsets from nearest sources in reference catalogs:
-      </Typography>
-      <div>
-        {Object.keys(nearestOffsets).map((catalog) => {
-          const offset = nearestOffsets[catalog];
-          return (
-            <div key={catalog}>
-              <Typography variant="body1">
-                {catalog}: {offset.offset_arcsec.toFixed(2)}&quot;
-              </Typography>
-            </div>
-          );
-        })}
-      </div>
-    </div>
-  );
+  return null;
 };
 
 CentroidPlotPlugins.propTypes = {

--- a/static/js/components/CentroidPlotPlugins.jsx
+++ b/static/js/components/CentroidPlotPlugins.jsx
@@ -1,0 +1,274 @@
+import React from "react";
+import PropTypes from "prop-types";
+import makeStyles from "@mui/styles/makeStyles";
+import Typography from "@mui/material/Typography";
+
+import * as archiveActions from "../ducks/archive";
+
+const hiddenCrossMatches = ["PS1_PSC"];
+
+const crossMatchesColors = {
+  AllWISE: "#2f5492",
+  Gaia_EDR3: "#FF00FF",
+  PS1_DR1: "#3bbed5",
+  PS1_PSC: "#d62728",
+  GALEX: "#6607c2",
+  TNS: "#ed6cf6",
+};
+
+const crossMatchesLabels = {
+  AllWISE: {
+    name: "designation",
+    ra_unc: "sigra",
+    dec_unc: "sigdec",
+    w1: "w1mpro",
+    w2: "w2mpro",
+    w3: "w3mpro",
+    w4: "w4mpro",
+  },
+  Gaia_EDR3: {
+    name: "designation",
+    ra_unc: "ra_error",
+    dec_unc: "dec_error",
+    parallax: "parallax",
+    parallax_unc: "parallax_error",
+    pm: "pm",
+    phot_bp_mean_mag: "phot_bp_mean_mag",
+    phot_rp_mean_mag: "phot_rp_mean_mag",
+  },
+  PS1_DR1: {
+    name: "_id",
+    ra_unc: "raMeanErr",
+    dec_unc: "decMeanErr",
+    nDetections: "nDetections",
+  },
+  GALEX: {
+    name: "name",
+    FUVmag: "FUVmag",
+    NUVmag: "NUVmag",
+  },
+  "2MASS_PSC": {
+    name: "designation",
+    j_mag: "j_m",
+    j_mag_unc: "j_msigcom",
+    h_mag: "h_m",
+    h_mag_unc: "h_msigcom",
+    k_mag: "k_m",
+    k_mag_unc: "k_msigcom",
+  },
+  TNS: {
+    name: "name",
+    discoverymag: "discoverymag",
+    discoverydate: "discoverydate",
+    internal_names: "internal_names",
+  },
+};
+
+const radius = 10.0;
+
+const useStyles = makeStyles(() => ({
+  pluginContainer: {
+    paddingTop: "0.5em",
+    width: "100%",
+    height: "100%",
+  },
+}));
+
+// Helper functions for computing plot points (taken from GROWTH marshall)
+const gcirc = (ra1, dec1, ra2, dec2) => {
+  // input deg, haversine formula, return deg
+  ra1 = (ra1 / 180) * Math.PI;
+  dec1 = (dec1 / 180) * Math.PI;
+  ra2 = (ra2 / 180) * Math.PI;
+  dec2 = (dec2 / 180) * Math.PI;
+  const delDec2 = (dec2 - dec1) * 0.5;
+  const delRA2 = (ra2 - ra1) * 0.5;
+  return (
+    (360 *
+      Math.asin(
+        Math.sqrt(
+          Math.sin(delDec2) * Math.sin(delDec2) +
+            Math.cos(dec1) *
+              Math.cos(dec2) *
+              Math.sin(delRA2) *
+              Math.sin(delRA2),
+        ),
+      )) /
+    Math.PI
+  );
+};
+
+function getCrossMatches(ra, dec, dispatch) {
+  dispatch(archiveActions.fetchCrossMatches({ ra, dec, radius }));
+}
+
+function getCrossMatchesTraces(crossMatches, refRA, refDec) {
+  const traces = [];
+  // cross_matches are already grouped by catalog (instead of filter)
+  Object.keys(crossMatches).forEach((catalog) => {
+    if (
+      crossMatches[catalog]?.length > 0 &&
+      !hiddenCrossMatches.includes(catalog) &&
+      crossMatchesLabels[catalog]
+    ) {
+      const catalogPoints = crossMatches[catalog].map((cm) => {
+        const newPoint = { ...cm };
+        newPoint.ra_offset =
+          Math.cos((refDec / 180) * Math.PI) * (cm.ra - refRA) * 3600;
+        newPoint.dec_offset = (cm.dec - refDec) * 3600;
+        newPoint.offset_arcsec = Math.sqrt(
+          newPoint.ra_offset ** 2 + newPoint.dec_offset ** 2,
+        );
+        newPoint.deltaRA =
+          gcirc(cm.ra, cm.dec, refRA, cm.dec) *
+          3600 *
+          -Math.sign(cm.ra - refRA);
+        newPoint.deltaDec =
+          gcirc(cm.ra, cm.dec, cm.ra, refDec) *
+          3600 *
+          Math.sign(cm.dec - refDec);
+        let text = `Catalog: ${catalog}`;
+
+        if (
+          crossMatchesLabels[catalog].name &&
+          cm[crossMatchesLabels[catalog].name]
+        ) {
+          text += `<br>Name: ${cm[crossMatchesLabels[catalog].name]}`;
+        }
+        if (
+          crossMatchesLabels[catalog].ra_unc &&
+          !Number.isNaN(parseFloat(cm[crossMatchesLabels[catalog].ra_unc], 10))
+        ) {
+          text += `<br>RA: ${cm.ra.toFixed(6)} ± ${parseFloat(
+            cm[crossMatchesLabels[catalog].ra_unc],
+            10,
+          ).toFixed(4)}`;
+        } else {
+          text += `<br>RA: ${cm.ra.toFixed(6)}`;
+        }
+        if (
+          crossMatchesLabels[catalog].dec_unc &&
+          !Number.isNaN(parseFloat(cm[crossMatchesLabels[catalog].dec_unc], 10))
+        ) {
+          text += `<br>Dec: ${cm.dec.toFixed(6)} ± ${parseFloat(
+            cm[crossMatchesLabels[catalog].dec_unc],
+            10,
+          ).toFixed(4)}`;
+        } else {
+          text += `<br>Dec: ${cm.dec.toFixed(6)}`;
+        }
+        // then loop over all the other fields
+        Object.keys(crossMatchesLabels[catalog]).forEach((key) => {
+          if (
+            key !== "name" &&
+            key !== "ra_unc" &&
+            key !== "dec_unc" &&
+            cm[crossMatchesLabels[catalog][key]]
+          ) {
+            text += `<br>${key}: ${cm[crossMatchesLabels[catalog][key]]}`;
+          }
+        });
+        text += `<br>RA offset: ${newPoint.ra_offset.toFixed(4)}"`;
+        text += `<br>Dec offset: ${newPoint.dec_offset.toFixed(4)}"`;
+        text += `<br>Offset: ${newPoint.offset_arcsec.toFixed(4)}"`;
+        newPoint.text = text;
+        return newPoint;
+      });
+
+      const color = crossMatchesColors[catalog] || "black";
+
+      traces.push({
+        x: catalogPoints.map((p) => p.deltaRA),
+        y: catalogPoints.map((p) => p.deltaDec),
+        mode: "markers",
+        type: "scatter",
+        marker: {
+          size: 12,
+          color,
+          opacity: 1,
+          symbol: "star",
+        },
+        name: catalog,
+        hoverlabel: {
+          bgcolor: "white",
+          font: { size: 14 },
+          align: "left",
+        },
+        text: catalogPoints.map((p) => p.text),
+        hovertemplate: "%{text}<extra></extra>",
+      });
+    }
+  });
+  return traces;
+}
+
+const CentroidPlotPlugins = ({ crossMatches, refRA, refDec }) => {
+  const classes = useStyles();
+  if (
+    !crossMatches ||
+    Object.keys(crossMatches).length === 0 ||
+    !refRA ||
+    !refDec
+  ) {
+    return null;
+  }
+
+  // for each catalog, get the nearest source and compute the offset
+  const nearestOffsets = {};
+  Object.keys(crossMatches).forEach((catalog) => {
+    if (
+      crossMatches[catalog]?.length > 0 &&
+      !hiddenCrossMatches.includes(catalog)
+    ) {
+      // we compute the offset_arcsec for each source in the catalog
+      // and then sort by offset_arcsec to get the nearest source
+      nearestOffsets[catalog] = crossMatches[catalog] // eslint-disable-line prefer-destructuring
+        .map((cm) => {
+          const ra_offset =
+            Math.cos((refDec / 180) * Math.PI) * (cm.ra - refRA) * 3600;
+          const dec_offset = (cm.dec - refDec) * 3600;
+          const offset_arcsec = Math.sqrt(ra_offset ** 2 + dec_offset ** 2);
+          return { ...cm, offset_arcsec };
+        })
+        .sort((a, b) => a.offset_arcsec - b.offset_arcsec)[0];
+    }
+  });
+
+  if (Object.keys(nearestOffsets).length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={classes.pluginContainer}>
+      <Typography variant="h6">
+        Offsets from nearest sources in reference catalogs:
+      </Typography>
+      <div>
+        {Object.keys(nearestOffsets).map((catalog) => {
+          const offset = nearestOffsets[catalog];
+          return (
+            <div key={catalog}>
+              <Typography variant="body1">
+                {catalog}: {offset.offset_arcsec.toFixed(2)}&quot;
+              </Typography>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+CentroidPlotPlugins.propTypes = {
+  crossMatches: PropTypes.shape({}),
+  refRA: PropTypes.number.isRequired,
+  refDec: PropTypes.number.isRequired,
+};
+
+CentroidPlotPlugins.defaultProps = {
+  crossMatches: {},
+};
+
+export default CentroidPlotPlugins;
+
+export { getCrossMatches, getCrossMatchesTraces };

--- a/static/js/components/PhotometryPlot.jsx
+++ b/static/js/components/PhotometryPlot.jsx
@@ -481,11 +481,11 @@ const PhotometryPlot = ({
 
           const detectionisFP =
             detections?.length > 0 &&
-            ["fp", "fp_alert"].includes(detections[0].origin);
+            ["fp", "alert_fp"].includes(detections[0].origin);
 
           const upperLimitisFP =
             upperLimits?.length > 0 &&
-            ["fp", "fp_alert"].includes(upperLimits[0].origin);
+            ["fp", "alert_fp"].includes(upperLimits[0].origin);
 
           const upperLimitsTrace = {
             dataType: "upperLimits",

--- a/static/js/components/Source.jsx
+++ b/static/js/components/Source.jsx
@@ -625,7 +625,12 @@ const SourceContent = ({ source }) => {
                 </div>
               }
             >
-              <CentroidPlot sourceId={source.id} />
+              <CentroidPlot
+                sourceId={source.id}
+                plotStyle={{
+                  height: "50vh",
+                }}
+              />
             </Suspense>
           </AccordionDetails>
         </Accordion>

--- a/static/js/components/Source.jsx
+++ b/static/js/components/Source.jsx
@@ -625,11 +625,7 @@ const SourceContent = ({ source }) => {
                 </div>
               }
             >
-              <CentroidPlot
-                className={classes.smallPlot}
-                sourceId={source.id}
-                size="21.875rem"
-              />
+              <CentroidPlot sourceId={source.id} />
             </Suspense>
           </AccordionDetails>
         </Accordion>

--- a/static/js/components/TNSRobotSubmissionsPage.jsx
+++ b/static/js/components/TNSRobotSubmissionsPage.jsx
@@ -38,7 +38,7 @@ const useStyles = makeStyles(() => ({
 
 function getStatusColors(status) {
   // if it starts with success, green
-  if (status.startsWith("success")) {
+  if (status.startsWith("complete")) {
     return ["black", "MediumAquaMarine"];
   }
   // if any of these strings are present, yellow
@@ -180,28 +180,28 @@ const TNSRobotSubmissionsPage = () => {
         sort: true,
         customBodyRenderLite: (dataIndex) => {
           const { user_id } = tnsrobot_submissions[dataIndex];
-          if (tnsrobot_submissions[dataIndex].auto_submission) {
-            return (
-              <div
-                style={{
-                  display: "flex",
-                  flexDirection: "row",
-                  alignItems: "center",
-                  gap: "0.75rem",
-                }}
-              >
-                {usersLookup[user_id]?.username &&
-                  usersLookup[user_id]?.gravatar_url && (
-                    <UserAvatar
-                      size={28}
-                      firstName={usersLookup[user_id]?.first_name}
-                      lastName={usersLookup[user_id]?.last_name}
-                      username={usersLookup[user_id]?.username}
-                      gravatarUrl={usersLookup[user_id]?.gravatar_url}
-                      isBot={usersLookup[user_id]?.is_bot || false}
-                    />
-                  )}
-                {userLabel(usersLookup[user_id])}
+          return (
+            <div
+              style={{
+                display: "flex",
+                flexDirection: "row",
+                alignItems: "center",
+                gap: "0.75rem",
+              }}
+            >
+              {usersLookup[user_id]?.username &&
+                usersLookup[user_id]?.gravatar_url && (
+                  <UserAvatar
+                    size={28}
+                    firstName={usersLookup[user_id]?.first_name}
+                    lastName={usersLookup[user_id]?.last_name}
+                    username={usersLookup[user_id]?.username}
+                    gravatarUrl={usersLookup[user_id]?.gravatar_url}
+                    isBot={usersLookup[user_id]?.is_bot || false}
+                  />
+                )}
+              {userLabel(usersLookup[user_id])}
+              {tnsrobot_submissions[dataIndex].auto_submission && (
                 <Tooltip
                   title={`This submission was triggered automatically when the ${
                     usersLookup[user_id]?.is_bot === true ? "BOT" : ""
@@ -209,10 +209,9 @@ const TNSRobotSubmissionsPage = () => {
                 >
                   <AutoAwesomeIcon fontSize="small" style={{ color: "gray" }} />
                 </Tooltip>
-              </div>
-            );
-          }
-          return userLabel(usersLookup[user_id]);
+              )}
+            </div>
+          );
         },
       },
     },

--- a/static/js/components/TopSavers.jsx
+++ b/static/js/components/TopSavers.jsx
@@ -202,7 +202,7 @@ const TopSaversList = ({ savers, styles }) => {
     return (
       <div className={styles.saverInfo}>
         <UserAvatar
-          size={24}
+          size={32}
           firstName={author.first_name}
           lastName={author.last_name}
           username={author.username}

--- a/static/js/components/UserAvatar.jsx
+++ b/static/js/components/UserAvatar.jsx
@@ -20,10 +20,10 @@ const useStyles = makeStyles((theme) => ({
     },
   }),
   avatarImg: {
-    zIndex: 5,
+    zIndex: 1,
   },
   badge: (props) => ({
-    fontSize: `${Math.max(parseInt(parseFloat(props.size) / 2, 10), 10)}px`,
+    fontSize: `${Math.max(parseInt(parseFloat(props.size) / 1.8, 10), 10)}px`,
     color: "#555555",
   }),
 }));


### PR DESCRIPTION
Migrating the vega centroid plot to a much more customizable one with plotly, implementing some of the feed back from the October 2023 ZTF team meeting.

I still don't really know for sure:
- how I should compute the centroid: I implemented the hopefully smarter method we've been using the starlists, finding charts, ... in the frontend too which in theory is better than using a simple median/avg
- what the current red and blue circle represent. I think that the blue one is a 1-sigma circle (so basically a circle around the photometry. Only modification I made here is to only include the photometry that's not further than the 0.5" max offset (same as enforced while calculated the centroid), effectively applying a 0.5" upper bound on that circle. For the red circle, I honestly don't know yet, still need to figure that one out. The current code really lacks comments!
- maybe find a smarter way to have some kind of centroid plugins to add the archival stuff in Fritz without having to overwrite the whole component. Probably possible, but rules out useEffects given how this is written I think, but that might be fine.

**TODO**: a good clean-up/re-write to simplify and duplicate some of the logic to speed it up 🚀 