### PR TITLE
get_observations method: remove heavy joinedload statements

### DIFF
--- a/skyportal/handlers/api/observation.py
+++ b/skyportal/handlers/api/observation.py
@@ -369,16 +369,10 @@ def get_observations(
             )
         )
     else:
-        obs_query = (
-            Observation.select(
-                session.user_or_token,
-                mode="read",
-            )
-            .options(joinedload(Observation.field))
-            .options(
-                joinedload(Observation.instrument).joinedload(Instrument.telescope)
-            )
-        )
+        obs_query = Observation.select(
+            session.user_or_token,
+            mode="read",
+        ).options(joinedload(Observation.field))
 
     obs_query = obs_query.where(Observation.obstime >= start_date)
     obs_query = obs_query.where(Observation.obstime <= end_date)
@@ -775,21 +769,18 @@ def get_observations(
     obs_query = obs_query.order_by(order_by)
 
     if n_per_page is not None:
-        obs_query = (
-            obs_query.distinct()
-            .limit(n_per_page)
-            .offset((page_number - 1) * n_per_page)
-        )
+        obs_query = obs_query.limit(n_per_page).offset((page_number - 1) * n_per_page)
 
     t0 = time.time()
     observations = session.scalars(obs_query).all()
 
     observations_list = []
     for o in observations:
-        obs_dict = o.to_dict()
-        obs_dict['field'] = obs_dict['field'].to_dict()
-        obs_dict['instrument'] = obs_dict['instrument'].to_dict()
-        observations_list.append(obs_dict)
+        o = {
+            **o.to_dict(),
+            "field": o.field.to_dict(),
+        }
+        observations_list.append(o)
 
     data = {
         "observations": observations_list,

--- a/skyportal/handlers/api/observation.py
+++ b/skyportal/handlers/api/observation.py
@@ -355,27 +355,13 @@ def get_observations(
     else:
         raise ValueError('observation_status should be executed or queued')
 
-    if includeGeoJSON:
-        obs_query = (
-            Observation.select(
-                session.user_or_token,
-                mode="read",
-            )
-            .options(
-                joinedload(Observation.field).undefer(InstrumentField.contour_summary)
-            )
-            .options(
-                joinedload(Observation.instrument).joinedload(Instrument.telescope)
-            )
-        )
-    else:
-        obs_query = Observation.select(
-            session.user_or_token,
-            mode="read",
-        ).options(joinedload(Observation.field))
-
-    obs_query = obs_query.where(Observation.obstime >= start_date)
-    obs_query = obs_query.where(Observation.obstime <= end_date)
+    obs_query = Observation.select(
+        session.user_or_token,
+        mode="read",
+    ).where(
+        Observation.obstime >= start_date,
+        Observation.obstime <= end_date,
+    )
 
     # optional: slice by Instrument
     if telescope_name is not None and instrument_name is not None:

--- a/static/js/components/ExecutedObservationsTable.jsx
+++ b/static/js/components/ExecutedObservationsTable.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import PropTypes from "prop-types";
 import { useNavigate } from "react-router-dom";
 import Paper from "@mui/material/Paper";
@@ -84,34 +84,55 @@ const ExecutedObservationsTable = ({
   const navigate = useNavigate();
   const dispatch = useDispatch();
 
-  const renderTelescope = (dataIndex) => {
-    const { instrument } = observations[dataIndex];
+  const { instrumentList } = useSelector((state) => state.instruments);
 
-    return <div>{instrument.telescope ? instrument.telescope.name : ""}</div>;
+  const instrumentsLookup = {};
+  if (instrumentList) {
+    instrumentList.forEach((instrument) => {
+      instrumentsLookup[instrument.id] = instrument;
+    });
+  }
+
+  const renderTelescope = (dataIndex) => {
+    const { instrument_id } = observations[dataIndex];
+
+    const instrument = instrumentsLookup[instrument_id] || null;
+
+    if (!instrument) {
+      return <div>Loading...</div>;
+    }
+
+    return <div>{instrument?.telescope?.name || ""}</div>;
   };
 
   const renderInstrument = (dataIndex) => {
-    const { instrument } = observations[dataIndex];
+    const { instrument_id } = observations[dataIndex];
 
-    return <div>{instrument ? instrument.name : ""}</div>;
+    const instrument = instrumentsLookup[instrument_id] || null;
+
+    if (!instrument) {
+      return <div>Loading...</div>;
+    }
+
+    return <div>{instrument?.name || ""}</div>;
   };
 
   const renderFieldID = (dataIndex) => {
     const { field } = observations[dataIndex];
 
-    return <div>{field ? field.field_id.toFixed(0) : ""}</div>;
+    return <div>{field ? field?.field_id?.toFixed(0) : ""}</div>;
   };
 
   const renderRA = (dataIndex) => {
     const { field } = observations[dataIndex];
 
-    return <div>{field ? field.ra.toFixed(5) : ""}</div>;
+    return <div>{field ? field?.ra?.toFixed(5) : ""}</div>;
   };
 
   const renderDeclination = (dataIndex) => {
     const { field } = observations[dataIndex];
 
-    return <div>{field ? field.dec.toFixed(5) : ""}</div>;
+    return <div>{field ? field?.dec?.toFixed(5) : ""}</div>;
   };
 
   const renderSeeing = (dataIndex) => {
@@ -304,24 +325,34 @@ const ExecutedObservationsTable = ({
     customFilterDialogFooter: customFilterDisplay,
     onDownload: (buildHead, buildBody) => {
       const renderTelescopeDownload = (observation) => {
-        const { instrument } = observation;
-        return instrument.telescope ? instrument.telescope.name : "";
+        const { instrument_id } = observation;
+        const instrument = instrumentsLookup[instrument_id] || null;
+
+        if (!instrument) {
+          return "";
+        }
+        return instrument?.telescope?.name || "";
       };
       const renderInstrumentDownload = (observation) => {
-        const { instrument } = observation;
-        return instrument ? instrument.name : "";
+        const { instrument_id } = observation;
+        const instrument = instrumentsLookup[instrument_id] || null;
+
+        if (!instrument) {
+          return "";
+        }
+        return instrument?.name || "";
       };
       const renderFieldIDDownload = (observation) => {
         const { field } = observation;
-        return field ? field.field_id : "";
+        return field ? field?.field_id : "";
       };
       const renderRADownload = (observation) => {
         const { field } = observation;
-        return field ? field.ra : "";
+        return field ? field?.ra : "";
       };
       const renderDeclinationDownload = (observation) => {
         const { field } = observation;
-        return field ? field.dec : "";
+        return field ? field?.dec : "";
       };
       downloadCallback().then((data) => {
         // if there is no data, cancel download

--- a/static/js/components/QueuedObservationsTable.jsx
+++ b/static/js/components/QueuedObservationsTable.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import { useSelector } from "react-redux";
 import Paper from "@mui/material/Paper";
 import {
   createTheme,
@@ -73,34 +74,55 @@ const QueuedObservationsTable = ({
   const classes = useStyles();
   const theme = useTheme();
 
-  const renderTelescope = (dataIndex) => {
-    const { instrument } = observations[dataIndex];
+  const { instrumentList } = useSelector((state) => state.instruments);
 
-    return <div>{instrument.telescope ? instrument.telescope.name : ""}</div>;
+  const instrumentsLookup = {};
+  if (instrumentList) {
+    instrumentList.forEach((instrument) => {
+      instrumentsLookup[instrument.id] = instrument;
+    });
+  }
+
+  const renderTelescope = (dataIndex) => {
+    const { instrument_id } = observations[dataIndex];
+
+    const instrument = instrumentsLookup[instrument_id] || null;
+
+    if (!instrument) {
+      return <div>Loading...</div>;
+    }
+
+    return <div>{instrument?.telescope?.name || ""}</div>;
   };
 
   const renderInstrument = (dataIndex) => {
-    const { instrument } = observations[dataIndex];
+    const { instrument_id } = observations[dataIndex];
 
-    return <div>{instrument ? instrument.name : ""}</div>;
+    const instrument = instrumentsLookup[instrument_id] || null;
+
+    if (!instrument) {
+      return <div>Loading...</div>;
+    }
+
+    return <div>{instrument?.name || ""}</div>;
   };
 
   const renderFieldID = (dataIndex) => {
     const { field } = observations[dataIndex];
 
-    return <div>{field ? field.field_id.toFixed(0) : ""}</div>;
+    return <div>{field ? field?.field_id?.toFixed(0) : ""}</div>;
   };
 
   const renderRA = (dataIndex) => {
     const { field } = observations[dataIndex];
 
-    return <div>{field ? field.ra.toFixed(5) : ""}</div>;
+    return <div>{field ? field?.ra?.toFixed(5) : ""}</div>;
   };
 
   const renderDeclination = (dataIndex) => {
     const { field } = observations[dataIndex];
 
-    return <div>{field ? field.dec.toFixed(5) : ""}</div>;
+    return <div>{field ? field?.dec?.toFixed(5) : ""}</div>;
   };
 
   const customFilterDisplay = () => (
@@ -200,24 +222,34 @@ const QueuedObservationsTable = ({
     customFilterDialogFooter: customFilterDisplay,
     onDownload: (buildHead, buildBody) => {
       const renderTelescopeDownload = (observation) => {
-        const { instrument } = observation;
-        return instrument.telescope ? instrument.telescope.name : "";
+        const { instrument_id } = observation;
+        const instrument = instrumentsLookup[instrument_id] || null;
+
+        if (!instrument) {
+          return "";
+        }
+        return instrument?.telescope?.name || "";
       };
       const renderInstrumentDownload = (observation) => {
-        const { instrument } = observation;
-        return instrument ? instrument.name : "";
+        const { instrument_id } = observation;
+        const instrument = instrumentsLookup[instrument_id] || null;
+
+        if (!instrument) {
+          return "";
+        }
+        return instrument?.name || "";
       };
       const renderFieldIDDownload = (observation) => {
         const { field } = observation;
-        return field ? field.field_id : "";
+        return field ? field?.field_id : "";
       };
       const renderRADownload = (observation) => {
         const { field } = observation;
-        return field ? field.ra : "";
+        return field ? field?.ra : "";
       };
       const renderDeclinationDownload = (observation) => {
         const { field } = observation;
-        return field ? field.dec : "";
+        return field ? field?.dec : "";
       };
       downloadCallback().then((data) => {
         // if there is no data, cancel download


### PR DESCRIPTION
I noticed in prod really heavy queries hammering the DB on a daily basis around the same time that we ingest observations. I thought that was the issue but looking at the exact query logged by the gcloud console it looks more like something is fetching observations with a lot of nested joinedloads which are unnecessary during the query itself most of the time and where the relationships could just be lazy loaded when accessed later on (which is the default behavior).

All the joinedloads on the ExecutedObservations or QueuedObservations from the `get_observations` method are removed, and now only the fields are accessed after the query. Adding the instruments and their telescope to every single observations seems super overkill, especially given how easy it is to fetch those separately and just match by instrument_id later on.