### PR TITLE
GroupSources frontend: minor fix

### DIFF
--- a/skyportal/handlers/api/sources.py
+++ b/skyportal/handlers/api/sources.py
@@ -1606,6 +1606,10 @@ async def get_sources(
             'numPerPage': num_per_page,
         }
 
+        # when querying for group sources, return the group_id used
+        if len(group_ids) == 1:
+            data['group_id'] = int(group_ids[0])
+
         if save_summary:
             all_source_ids = []
             if len(localization_queries) > 0:
@@ -2388,6 +2392,10 @@ async def get_sources(
                 'pageNumber': page_number,
                 'numPerPage': num_per_page,
             }
+
+            # when querying for group sources, return the group_id used
+            if len(group_ids) == 1:
+                data['group_id'] = int(group_ids[0])
 
             if includeGeoJSON:
                 startTime = time.time()

--- a/static/js/components/group/GroupSources.jsx
+++ b/static/js/components/group/GroupSources.jsx
@@ -72,7 +72,12 @@ const GroupSources = ({ route }) => {
     fetchData();
   }, [route.id, dispatch]);
 
-  if (!savedSourcesState.sources || !pendingSourcesState.sources) {
+  if (
+    !savedSourcesState.sources ||
+    !pendingSourcesState.sources ||
+    savedSourcesState.group_id !== parseInt(route.id, 10) ||
+    pendingSourcesState?.group_id !== parseInt(route.id, 10)
+  ) {
     return (
       <div>
         <CircularProgress color="secondary" />


### PR DESCRIPTION
when querying for group sources (so with group_ids length = 1), return the group_id used in the query response to read it from the redux and not show another group's sources when opening the group source page