### PR TITLE
Instrument API classes: render_frontend_info kwargs

### DIFF
--- a/skyportal/facility_apis/_base.py
+++ b/skyportal/facility_apis/_base.py
@@ -69,9 +69,9 @@ class _Base:
 
     # subclasses should not modify this
     @classmethod
-    def frontend_render_info(cls, instrument, user):
+    def frontend_render_info(cls, instrument, user, **kwargs):
         try:
-            formSchema = cls.custom_json_schema(instrument, user)
+            formSchema = cls.custom_json_schema(instrument, user, **kwargs)
         except AttributeError:
             formSchema = cls.form_json_schema
         try:

--- a/skyportal/facility_apis/generic.py
+++ b/skyportal/facility_apis/generic.py
@@ -451,7 +451,7 @@ class GENERICAPI(FollowUpAPI):
                 'skyportal/REFRESH_FOLLOWUP_REQUESTS',
             )
 
-    def custom_json_schema(instrument, user):
+    def custom_json_schema(instrument, user, **kwargs):
         form_json_schema = {
             "type": "object",
             "properties": {

--- a/skyportal/facility_apis/observation_plan.py
+++ b/skyportal/facility_apis/observation_plan.py
@@ -431,10 +431,14 @@ class MMAAPI(FollowUpAPI):
         DBSession().delete(req)
         DBSession().commit()
 
-    def custom_json_schema(instrument, user):
+    def custom_json_schema(instrument, user, **kwargs):
         from ..models import DBSession, Galaxy, InstrumentField
 
-        galaxies = [g for g, in DBSession().query(Galaxy.catalog_name).distinct().all()]
+        galaxy_catalogs = kwargs.get("galaxy_catalog_names", [])
+        if not isinstance(galaxy_catalogs, list) or len(galaxy_catalogs) == 0:
+            galaxy_catalogs = [
+                g for g, in DBSession().query(Galaxy.catalog_name).distinct().all()
+            ]
         end_date = instrument.telescope.next_sunrise()
         if end_date is None:
             end_date = str(datetime.utcnow() + timedelta(days=1))
@@ -662,8 +666,10 @@ class MMAAPI(FollowUpAPI):
                                 },
                                 "galaxy_catalog": {
                                     "type": "string",
-                                    "enum": galaxies,
-                                    "default": galaxies[0] if len(galaxies) > 0 else "",
+                                    "enum": galaxy_catalogs,
+                                    "default": galaxy_catalogs[0]
+                                    if len(galaxy_catalogs) > 0
+                                    else "",
                                 },
                                 "galaxy_sorting": {
                                     "type": "string",

--- a/skyportal/facility_apis/slack.py
+++ b/skyportal/facility_apis/slack.py
@@ -189,7 +189,7 @@ class SLACKAPI(FollowUpAPI):
                 'skyportal/REFRESH_FOLLOWUP_REQUESTS',
             )
 
-    def custom_json_schema(instrument, user):
+    def custom_json_schema(instrument, user, **kwargs):
         form_json_schema = {
             "type": "object",
             "properties": {

--- a/skyportal/facility_apis/ztf.py
+++ b/skyportal/facility_apis/ztf.py
@@ -1101,8 +1101,8 @@ class ZTFMMAAPI(MMAAPI):
         if r.status_code != 200:
             raise ValueError(f'Error deleting skymap: {r.text}')
 
-    def custom_json_schema(instrument, user):
-        form_json_schema = MMAAPI.custom_json_schema(instrument, user)
+    def custom_json_schema(instrument, user, **kwargs):
+        form_json_schema = MMAAPI.custom_json_schema(instrument, user, **kwargs)
 
         # we make sure that all the boolean properties come last, which helps with the display
         non_boolean_properties = {

--- a/skyportal/handlers/api/internal/plot.py
+++ b/skyportal/handlers/api/internal/plot.py
@@ -36,24 +36,31 @@ class AirmassHandler(BaseHandler):
 class PlotAssignmentAirmassHandler(AirmassHandler):
     @auth_or_token
     async def get(self, assignment_id):
-        assignment = ClassicalAssignment.get_if_accessible_by(
-            assignment_id, self.current_user, raise_if_none=True
-        )
-        obj = assignment.obj
-        telescope = assignment.run.instrument.telescope
-        time = assignment.run.calendar_noon
+        with self.Session() as session:
+            assignment = session.scalar(
+                ClassicalAssignment.select(session.user_or_token).where(
+                    ClassicalAssignment.id == assignment_id
+                )
+            )
+            if assignment is None:
+                return self.error(
+                    'Invalid assignment ID, or you do not have access to this assignment.'
+                )
 
-        sunrise = telescope.next_sunrise(time=time)
-        sunset = telescope.next_sunset(time=time)
+            obj = assignment.obj
+            telescope = assignment.run.instrument.telescope
+            time = assignment.run.calendar_noon
 
-        if sunset > sunrise:
-            sunset = telescope.observer.sun_set_time(time, which='previous')
+            sunrise = telescope.next_sunrise(time=time)
+            sunset = telescope.next_sunset(time=time)
 
-        json = self.calculate_airmass(obj, telescope, sunrise, sunset).to_dict(
-            orient='records'
-        )
-        self.verify_and_commit()
-        return self.success(data=json)
+            if sunset > sunrise:
+                sunset = telescope.observer.sun_set_time(time, which='previous')
+
+            json = self.calculate_airmass(obj, telescope, sunrise, sunset).to_dict(
+                orient='records'
+            )
+            return self.success(data=json)
 
 
 class PlotObjTelAirmassHandler(AirmassHandler):
@@ -68,27 +75,40 @@ class PlotObjTelAirmassHandler(AirmassHandler):
         else:
             time = ap_time.Time.now()
 
-        obj = Obj.get_if_accessible_by(obj_id, self.current_user, raise_if_none=True)
         try:
             telescope_id = int(telescope_id)
         except TypeError:
             return self.error(f'Invalid telescope id: {telescope_id}, must be integer.')
 
-        telescope = Telescope.get_if_accessible_by(
-            telescope_id, self.current_user, raise_if_none=True
-        )
+        with self.Session() as session:
+            obj = session.scalar(
+                Obj.select(session.user_or_token).where(Obj.id == obj_id)
+            )
+            if obj is None:
+                return self.error(
+                    f'Invalid object ID {obj_id}, or you do not have access to this object.'
+                )
 
-        sunrise = telescope.next_sunrise(time=time)
-        sunset = telescope.next_sunset(time=time)
+            telescope = session.scalar(
+                Telescope.select(session.user_or_token).where(
+                    Telescope.id == telescope_id
+                )
+            )
+            if telescope is None:
+                return self.error(
+                    f'Could not retrieve telescope with ID {telescope_id}.'
+                )
 
-        if sunset > sunrise:
-            sunset = telescope.observer.sun_set_time(time, which='previous')
+            sunrise = telescope.next_sunrise(time=time)
+            sunset = telescope.next_sunset(time=time)
 
-        json = self.calculate_airmass(obj, telescope, sunrise, sunset).to_dict(
-            orient='records'
-        )
-        self.verify_and_commit()
-        return self.success(data=json)
+            if sunset > sunrise:
+                sunset = telescope.observer.sun_set_time(time, which='previous')
+
+            json = self.calculate_airmass(obj, telescope, sunrise, sunset).to_dict(
+                orient='records'
+            )
+            return self.success(data=json)
 
 
 class PlotHoursBelowAirmassHandler(AirmassHandler):
@@ -98,45 +118,60 @@ class PlotHoursBelowAirmassHandler(AirmassHandler):
         if threshold is None:
             threshold = 2.9
 
-        obj = Obj.get_if_accessible_by(obj_id, self.current_user, raise_if_none=True)
         try:
             telescope_id = int(telescope_id)
         except TypeError:
             return self.error(f'Invalid telescope id: {telescope_id}, must be integer.')
 
-        telescope = Telescope.get_if_accessible_by(
-            telescope_id, self.current_user, raise_if_none=True
-        )
+        with self.Session() as session:
+            obj = session.scalar(
+                Obj.select(session.user_or_token).where(Obj.id == obj_id)
+            )
+            if obj is None:
+                return self.error(
+                    f'Invalid object ID {obj_id}, or you do not have access to this object.'
+                )
 
-        year = datetime.date.today().year
-        year_start = datetime.datetime(year, 1, 1, 0, 0, 0)
+            telescope = session.scalar(
+                Telescope.select(session.user_or_token).where(
+                    Telescope.id == telescope_id
+                )
+            )
+            if telescope is None:
+                return self.error(
+                    f'Could not retrieve telescope with ID {telescope_id}.'
+                )
 
-        json = []
-        # Sample every 7 days for the year
-        deltat = 7
-        for day in range(365 // deltat):
-            day = year_start + datetime.timedelta(days=day * deltat)
-            day = ap_time.Time(day.isoformat(), format='isot')
+            year = datetime.date.today().year
+            year_start = datetime.datetime(year, 1, 1, 0, 0, 0)
 
-            # Get sunrise/sunset times for that day
-            sunrise = telescope.next_sunrise(time=day)
-            sunset = telescope.next_sunset(time=day)
-            # check if is in middle of night
-            if (sunrise - sunset).to_value('hr') < 0:
-                sunrise = sunrise + ap_time.TimeDelta(1 * u.day)
+            json = []
+            # Sample every 7 days for the year
+            deltat = 7
+            for day in range(365 // deltat):
+                day = year_start + datetime.timedelta(days=day * deltat)
+                day = ap_time.Time(day.isoformat(), format='isot')
 
-            # Compute airmasses for that day
-            sample_size = 60
-            df = self.calculate_airmass(obj, telescope, sunrise, sunset, sample_size)
+                # Get sunrise/sunset times for that day
+                sunrise = telescope.next_sunrise(time=day)
+                sunset = telescope.next_sunset(time=day)
+                # check if is in middle of night
+                if (sunrise - sunset).to_value('hr') < 0:
+                    sunrise = sunrise + ap_time.TimeDelta(1 * u.day)
 
-            # Compute hours below airmass
-            num_times_below = df.loc[df["airmass"] < threshold].shape[0]
-            total_hours = (sunrise - sunset).to_value('hr')
-            hours_below = num_times_below / sample_size * total_hours
-            json.append({"date": day.isot, "hours_below": hours_below})
+                # Compute airmasses for that day
+                sample_size = 60
+                df = self.calculate_airmass(
+                    obj, telescope, sunrise, sunset, sample_size
+                )
 
-        self.verify_and_commit()
-        return self.success(data=json)
+                # Compute hours below airmass
+                num_times_below = df.loc[df["airmass"] < threshold].shape[0]
+                total_hours = (sunrise - sunset).to_value('hr')
+                hours_below = num_times_below / sample_size * total_hours
+                json.append({"date": day.isot, "hours_below": hours_below})
+
+            return self.success(data=json)
 
 
 class FilterWavelengthHandler(BaseHandler):

--- a/skyportal/handlers/api/internal/robotic_instruments.py
+++ b/skyportal/handlers/api/internal/robotic_instruments.py
@@ -18,7 +18,7 @@ class RoboticInstrumentsHandler(BaseHandler):
                         )
                     ).all()
                     retval = {
-                        i.id: i.api_class.frontend_render_info(i, self.current_user)
+                        i.id: i.api_class.frontend_render_info(i, session.user_or_token)
                         for i in instruments
                     }
                 elif apitype == "api_classname_obsplan":
@@ -37,7 +37,7 @@ class RoboticInstrumentsHandler(BaseHandler):
                     retval = {
                         i.id: i.api_class_obsplan.frontend_render_info(
                             i,
-                            self.current_user,
+                            session.user_or_token,
                             galaxy_catalog_names=galaxy_catalog_names,
                         )
                         for i in instruments

--- a/skyportal/handlers/api/internal/robotic_instruments.py
+++ b/skyportal/handlers/api/internal/robotic_instruments.py
@@ -1,4 +1,6 @@
-from ....models import Instrument
+import sqlalchemy as sa
+
+from ....models import Instrument, Galaxy
 from baselayer.app.access import auth_or_token
 from ...base import BaseHandler
 
@@ -25,9 +27,18 @@ class RoboticInstrumentsHandler(BaseHandler):
                             Instrument.api_classname_obsplan.isnot(None)
                         )
                     ).all()
+
+                    # we retrieve the list of unique galaxy catalog names here
+                    # and pass them to the frontend_render_info method
+                    # to avoid having to run that query for each instrument
+                    galaxy_catalog_names = session.scalars(
+                        sa.select(Galaxy.catalog_name).distinct()
+                    ).all()
                     retval = {
                         i.id: i.api_class_obsplan.frontend_render_info(
-                            i, self.current_user
+                            i,
+                            self.current_user,
+                            galaxy_catalog_names=galaxy_catalog_names,
                         )
                         for i in instruments
                     }

--- a/skyportal/handlers/api/internal/source_savers.py
+++ b/skyportal/handlers/api/internal/source_savers.py
@@ -13,7 +13,7 @@ default_prefs = {'maxNumSavers': 100, 'sinceDaysAgo': 7, 'candidatesOnly': True}
 
 class SourceSaverHandler(BaseHandler):
     @classmethod
-    def get_top_source_savers(self, current_user, session, user_options):
+    def get_top_source_savers(cls, current_user, session, user_options):
         user_prefs = getattr(current_user, 'preferences', None) or {}
         top_savers_prefs = user_prefs.get('topSavers', {})
         top_savers_prefs = {**default_prefs, **top_savers_prefs, **user_options}


### PR DESCRIPTION
adds kwargs to the render_frontend_info method of all instrument API classes. That way, reusable quantities (like unique galaxy catalog names that some instruments take as a parameter) can be computed once before we loop on each instrument and build the rjsf form for each.