### PR TITLE
Python Requirements: add brotli==1.1.0 (so requests can use `br` encoding)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -87,6 +87,7 @@ tiktoken==0.5.2
 simplejson==3.19.2
 langchain==0.1.14
 langchain-openai==0.0.6
+brotli==1.1.0
 pinecone-client==4.1.0
 pydantic==2.7.1
 sentry-sdk==2.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -87,8 +87,8 @@ tiktoken==0.5.2
 simplejson==3.19.2
 langchain==0.1.14
 langchain-openai==0.0.6
-brotli==1.1.0
 pinecone-client==4.1.0
 pydantic==2.7.1
 sentry-sdk==2.5.1
 typing-inspect==0.9.0
+brotli==1.1.0


### PR DESCRIPTION
Python Requirements: add brotli==1.1.0 so requests can use `br` encoding