### PR TITLE
Do not require specific permission to make an observation plan

### DIFF
--- a/skyportal/handlers/api/observation_plan.py
+++ b/skyportal/handlers/api/observation_plan.py
@@ -532,7 +532,7 @@ def post_observation_plan(
 
 
 class ObservationPlanRequestHandler(BaseHandler):
-    @permissions(['Manage observation plans'])
+    @auth_or_token
     def post(self):
         """
         ---


### PR DESCRIPTION
This PR ensures that we do not require specific permission to make an observation plan. 