### PR TITLE
DNM: get_sources(): implement caching again

### DIFF
--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -515,6 +515,7 @@ services:
 misc:
   days_to_keep_unsaved_candidates: 7
   minutes_to_keep_candidate_query_cache: 60
+  minutes_to_keep_source_query_cache: 60
   minutes_to_keep_annotations_info_query_cache: 360
   minutes_to_keep_localization_instrument_query_cache: 1440
   max_items_in_localization_instrument_query_cache: 100


### PR DESCRIPTION
When I rewrote the `get_sources()` method, given how fast it was I did not implement caching again.

This PR implements it here. I am not sure whether or not it will be of any use to be honest (given how fast the queries are right now). On queries with very little to no filters it might take longer to read from file than to run a query, but we'll see! Might as well have it and we can test it in production with lots of data.

⚠️ DO NOT MERGE: I see some changes that I did not make pop on git. Maybe git is just not matching the lines right but I need to look into it.