### PR TITLE
Websocket action: photometry refresh action name

### DIFF
--- a/skyportal/handlers/api/photometric_series.py
+++ b/skyportal/handlers/api/photometric_series.py
@@ -1886,7 +1886,7 @@ class PhotometricSeriesHandler(BaseHandler):
             session.commit()
 
             self.push_all(
-                action="skyportal/FETCH_SOURCE_PHOTOMETRY",
+                action="skyportal/REFRESH_SOURCE_PHOTOMETRY",
                 payload={"obj_id": obj_id},
             )
 

--- a/skyportal/handlers/api/photometry.py
+++ b/skyportal/handlers/api/photometry.py
@@ -941,7 +941,7 @@ def insert_new_photometry_data(
 
             flow.push(
                 '*',
-                'skyportal/FETCH_SOURCE_PHOTOMETRY',
+                'skyportal/REFRESH_SOURCE_PHOTOMETRY',
                 payload={'obj_id': obj_id},
             )
 
@@ -1762,7 +1762,7 @@ class PhotometryHandler(BaseHandler):
 
                 flow.push(
                     '*',
-                    'skyportal/FETCH_SOURCE_PHOTOMETRY',
+                    'skyportal/REFRESH_SOURCE_PHOTOMETRY',
                     payload={'obj_id': photometry.obj_id, 'magsys': magsys},
                 )
 
@@ -1822,7 +1822,7 @@ class PhotometryHandler(BaseHandler):
             session.commit()
 
             self.push_all(
-                action="skyportal/FETCH_SOURCE_PHOTOMETRY",
+                action="skyportal/REFRESH_SOURCE_PHOTOMETRY",
                 payload={"obj_id": obj_id},
             )
 

--- a/skyportal/handlers/api/photometry_validation.py
+++ b/skyportal/handlers/api/photometry_validation.py
@@ -159,7 +159,7 @@ class PhotometryValidationHandler(BaseHandler):
                 session.commit()
 
             self.push_all(
-                action='skyportal/FETCH_SOURCE_PHOTOMETRY',
+                action='skyportal/REFRESH_SOURCE_PHOTOMETRY',
                 payload={'obj_id': phot.obj.id},
             )
             return self.success(data={'id': photometry_validation.id})
@@ -255,7 +255,7 @@ class PhotometryValidationHandler(BaseHandler):
             session.commit()
 
             self.push_all(
-                action='skyportal/FETCH_SOURCE_PHOTOMETRY',
+                action='skyportal/REFRESH_SOURCE_PHOTOMETRY',
                 payload={'obj_id': photometry_validation.photometry.obj.id},
             )
             return self.success(data={'id': photometry_validation.id})
@@ -326,7 +326,7 @@ class PhotometryValidationHandler(BaseHandler):
             session.commit()
 
             self.push_all(
-                action='skyportal/FETCH_SOURCE_PHOTOMETRY',
+                action='skyportal/REFRESH_SOURCE_PHOTOMETRY',
                 payload={'obj_id': obj_id},
             )
             return self.success(data={'id': photometry_validation_id})

--- a/skyportal/handlers/api/sharing.py
+++ b/skyportal/handlers/api/sharing.py
@@ -117,12 +117,12 @@ class SharingHandler(BaseHandler):
         phot_obj_ids = set(phot_obj_ids)
         for obj_id in phot_obj_ids:
             self.push(
-                action="skyportal/FETCH_SOURCE_PHOTOMETRY", payload={"obj_id": obj_id}
+                action="skyportal/REFRESH_SOURCE_PHOTOMETRY", payload={"obj_id": obj_id}
             )
 
         for obj_id in spec_obj_ids:
             self.push(
-                action="skyportal/FETCH_SOURCE_SPECTRA", payload={"obj_id": obj_id}
+                action="skyportal/REFRESH_SOURCE_SPECTRA", payload={"obj_id": obj_id}
             )
 
         return self.success()

--- a/static/js/ducks/photometry.js
+++ b/static/js/ducks/photometry.js
@@ -9,6 +9,8 @@ const FETCH_FILTER_WAVELENGTHS = "skyportal/FETCH_FILTER_WAVELENGTHS";
 const FETCH_ALL_ORIGINS = "skyportal/FETCH_ALL_ORIGINS";
 const FETCH_ALL_ORIGINS_OK = "skyportal/FETCH_ALL_ORIGINS_OK";
 
+const REFRESH_SOURCE_PHOTOMETRY = "skyportal/REFRESH_SOURCE_PHOTOMETRY";
+
 const DELETE_PHOTOMETRY = "skyportal/DELETE_PHOTOMETRY";
 
 const SUBMIT_PHOTOMETRY = "skyportal/SUBMIT_PHOTOMETRY";
@@ -59,14 +61,16 @@ export function updatePhotometry(id, photometry) {
 
 // Websocket message handler
 messageHandler.add((actionType, payload, dispatch, getState) => {
-  if (actionType === FETCH_SOURCE_PHOTOMETRY) {
+  if (actionType === REFRESH_SOURCE_PHOTOMETRY) {
     // check if the source photometry is already in the store
     // or if the source that is loaded is the one that is being
     // specified in the payload's obj_id
     const { source } = getState();
     const { obj_id, magsys } = payload;
     if (source?.id && source.id === obj_id) {
-      dispatch(fetchSourcePhotometry(payload.obj_id, { magsys }));
+      dispatch(
+        fetchSourcePhotometry(payload.obj_id, { magsys: magsys || "ab" }),
+      );
     }
   }
 });


### PR DESCRIPTION
We had this weird situation where the `FETCH_SOURCE_PHOTOMETRY` emitted by the function to well fetch photometry, was also used as the action name for the websocket. It's confusing to read it (as it differs from everywhere else in the app) and it (though fortunately it looks like it doesn't) trigger some funky never ending refresh loop.

This PR updates `FETCH_SOURCE_PHOTOMETRY` to `REFRESH_SOURCE_PHOTOMETRY` for all the backend -> frontend updating logic with websockets.