### PR TITLE
strip out start of notice_type

### DIFF
--- a/services/gcn_service/gcn_service.py
+++ b/services/gcn_service/gcn_service.py
@@ -133,7 +133,7 @@ def poll_events(*args, **kwargs):
                     alert_type = "voevent"
                 except Exception:  # then json
                     payload = json.loads(payload.decode('utf8'))
-                    payload['notice_type'] = topic
+                    payload['notice_type'] = topic.replace("gcn.notices.", "")
                     notice_type = None
                     tags = get_json_tags(payload)
                     alert_type = "json"


### PR DESCRIPTION
This PR strips out the "gcn.notices." part of the topic name.