### PR TITLE
User Profile: show oauth email

### DIFF
--- a/static/js/components/user/UserProfileInfo.jsx
+++ b/static/js/components/user/UserProfileInfo.jsx
@@ -137,8 +137,9 @@ const UserProfileInfo = () => {
             placement="bottom-start"
             title={
               <Typography variant="body2">
-                This is the email address used to log in. If you need to change
-                this, please contact a system administrator.
+                This is the email address used to log in. Unlike the
+                contact_email shown to other users, this cannot be edited. If
+                you wish to change this, please contact a system administrator.
               </Typography>
             }
           >

--- a/static/js/components/user/UserProfileInfo.jsx
+++ b/static/js/components/user/UserProfileInfo.jsx
@@ -4,6 +4,7 @@ import { useSelector } from "react-redux";
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
 import Typography from "@mui/material/Typography";
+import Tooltip from "@mui/material/Tooltip";
 import Box from "@mui/material/Box";
 import PropTypes from "prop-types";
 
@@ -131,6 +132,26 @@ const UserProfileInfo = () => {
             </Box>
           )}
         </Typography>
+        {profile.oauth_uid && (
+          <Tooltip
+            placement="bottom-start"
+            title={
+              <Typography variant="body2">
+                This is the email address used to log in. If you need to change
+                this, please contact a system administrator.
+              </Typography>
+            }
+          >
+            <Typography component="div">
+              <Box pb={1}>
+                <Box fontWeight="fontWeightBold" component="span" mr={1}>
+                  Authentication email:
+                </Box>
+                {profile.oauth_uid}
+              </Box>
+            </Typography>
+          </Tooltip>
+        )}
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
An attempt to help people understand that there is a fixed email used for login, so that they do not think the `email` in the "contact" section is the same thing.