### PR TITLE
Upload Single Photometry: simpler instrument select

### DIFF
--- a/static/js/components/photometry/NewPhotometry.jsx
+++ b/static/js/components/photometry/NewPhotometry.jsx
@@ -5,7 +5,7 @@ import InputLabel from "@mui/material/InputLabel";
 import MenuItem from "@mui/material/MenuItem";
 import { useDispatch, useSelector } from "react-redux";
 import { showNotification } from "baselayer/components/Notifications";
-// eslint-disable-next-line import/no-unresolved
+
 import Form from "@rjsf/mui";
 import validator from "@rjsf/validator-ajv8";
 
@@ -50,7 +50,6 @@ const NewPhotometryForm = ({ obj_id }) => {
   }
 
   const instLookUp = {};
-  // eslint-disable-next-line no-unused-expressions
   instrumentList?.forEach((instrumentObj) => {
     instLookUp[instrumentObj.id] = instrumentObj;
   });
@@ -320,7 +319,7 @@ const NewPhotometryForm = ({ obj_id }) => {
             >
               {instrumentList?.map((instrument) => (
                 <MenuItem value={instrument.id} key={instrument.id}>
-                  {`${instrument.name}: ${instrument.filters}`}
+                  {instrument.name}
                 </MenuItem>
               ))}
             </Select>


### PR DESCRIPTION
Don't show the full list of filters of an instrument in the dropdown menu, which breaks the display when the instrument has more than a few filters, and isn't that useful given that the filters are selectable in a dropdown in the form anyway.