### PR TITLE
Candidate scanning - classification filtering: with OR without

### DIFF
--- a/skyportal/handlers/api/candidate.py
+++ b/skyportal/handlers/api/candidate.py
@@ -415,6 +415,18 @@ class CandidateHandler(BaseHandler):
               Comma-separated string of classification(s) to filter for candidates matching
               that/those classification(s).
           - in: query
+            name: classificationsReject
+            nullable: true
+            schema:
+              type: array
+              items:
+                type: string
+            explode: false
+            style: simple
+            description: |
+                Comma-separated string of classification(s) to filter OUT candidates matching
+                with any of those classification(s).
+          - in: query
             name: minRedshift
             nullable: true
             schema:
@@ -740,6 +752,7 @@ class CandidateHandler(BaseHandler):
         sort_by_origin = self.get_query_argument("sortByAnnotationOrigin", None)
         annotation_filter_list = self.get_query_argument("annotationFilterList", None)
         classifications = self.get_query_argument("classifications", None)
+        classifications_reject = self.get_query_argument("classificationsReject", None)
         min_redshift = self.get_query_argument("minRedshift", None)
         max_redshift = self.get_query_argument("maxRedshift", None)
         list_name = self.get_query_argument('listName', None)
@@ -898,6 +911,36 @@ class CandidateHandler(BaseHandler):
                 q = q.join(Classification).where(
                     Classification.classification.in_(classifications)
                 )
+            if classifications_reject is not None:
+                if (
+                    isinstance(classifications_reject, str)
+                    and "," in classifications_reject
+                ):
+                    classifications_reject = [
+                        c.strip() for c in classifications_reject.split(",")
+                    ]
+                elif isinstance(classifications_reject, str):
+                    classifications_reject = [classifications_reject]
+                else:
+                    return self.error(
+                        "Invalid classificationsReject value -- must provide at least one string value"
+                    )
+                # here we want to keep candidates that:
+                #   1. have no classification
+                #   2. do not have one of the classifications_reject as a classification
+                # first create a subquery to get the classifications we are trying to avoid
+                classifications_reject_subquery = (
+                    Classification.select(
+                        session.user_or_token, columns=[Classification.obj_id]
+                    )
+                    .where(Classification.classification.in_(classifications_reject))
+                    .subquery()
+                )
+                # then left outer join on that subquery
+                q = q.outerjoin(
+                    classifications_reject_subquery,
+                    Obj.id == classifications_reject_subquery.c.obj_id,
+                ).where(classifications_reject_subquery.c.obj_id.is_(None))
             if sort_by_origin is None:
                 # Don't apply the order by just yet. Save it so we can pass it to
                 # the LIMT/OFFSET helper function down the line once other query

--- a/skyportal/tests/frontend/sources_and_observingruns_etc/test_scanning_page.py
+++ b/skyportal/tests/frontend/sources_and_observingruns_etc/test_scanning_page.py
@@ -562,6 +562,9 @@ def test_add_scanning_profile(
     driver.get("/candidates")
     driver.click_xpath('//button[@data-testid="manageScanningProfilesButton"]')
 
+    # click on the + icon on the top right of the table to open the form
+    driver.click_xpath('//button[@name="new_scanning_profile"]')
+
     # let the form initialize, load the groups, etc.
     time.sleep(1)
 
@@ -624,6 +627,9 @@ def test_delete_scanning_profile(driver, user, public_group):
     driver.get("/candidates")
     driver.click_xpath('//button[@data-testid="manageScanningProfilesButton"]')
 
+    # click on the + icon on the top right of the table to open the form
+    driver.click_xpath('//button[@name="new_scanning_profile"]')
+
     # let the form initialize, load the groups, etc.
     time.sleep(1)
 
@@ -644,8 +650,9 @@ def test_delete_scanning_profile(driver, user, public_group):
     # Submit and check it shows up in table of profiles
     driver.click_xpath('//button[@data-testid="saveScanningProfileButton"]')
     driver.wait_for_xpath('//div[text()="123hrs"]')
+
     # Delete and check that it disappears
-    driver.click_xpath('//tr[.//div[text()="123hrs"]]//button[text()="Delete"]')
+    driver.click_xpath('//button[@id="delete_button_0"]')
     driver.wait_for_xpath_to_disappear('//div[text()="123hrs"]')
 
 
@@ -658,6 +665,9 @@ def test_load_scanning_profile(
 
     # Add two scanning profiles with different max redshifts
     driver.click_xpath('//button[@data-testid="manageScanningProfilesButton"]')
+
+    # click on the + icon on the top right of the table to open the form
+    driver.click_xpath('//button[@name="new_scanning_profile"]')
 
     # let the form initialize, load the groups, etc.
     time.sleep(1)
@@ -676,11 +686,20 @@ def test_load_scanning_profile(
     driver.click_xpath('//button[@data-testid="saveScanningProfileButton"]')
     driver.wait_for_xpath('//div[contains(text(), "0.5")]')
 
-    redshift_maximum_input.clear()
+    # click on the + icon on the top right of the table to open the form
+    driver.click_xpath('//button[@name="new_scanning_profile"]')
+
+    redshift_maximum_input = driver.wait_for_xpath(
+        '//div[@data-testid="profile-maximum-redshift"]//input'
+    )
     redshift_maximum_input.send_keys("1.0")
     name_input = driver.wait_for_xpath('//div[@data-testid="profile-name"]//input')
     name_input.clear()
     name_input.send_keys("profile2")
+    driver.click_xpath(
+        f'//span[@data-testid="profileFilteringFormGroupCheckbox-{public_group.id}"]',
+        scroll_parent=True,
+    )
     driver.click_xpath('//button[@data-testid="saveScanningProfileButton"]')
     driver.wait_for_xpath('//div[contains(text(), "1.0")]')
 

--- a/static/js/components/allocation/AllocationTable.jsx
+++ b/static/js/components/allocation/AllocationTable.jsx
@@ -21,7 +21,6 @@ import MUIDataTable from "mui-datatables";
 
 import { showNotification } from "baselayer/components/Notifications";
 import * as allocationActions from "../../ducks/allocation";
-import Button from "../Button";
 import ConfirmDeletionDialog from "../ConfirmDeletionDialog";
 import NewAllocation from "./NewAllocation";
 import ModifyAllocation from "./ModifyAllocation";
@@ -278,22 +277,22 @@ const AllocationTable = ({
     const allocation = allocations[dataIndex];
     return (
       <div className={classes.allocationManage}>
-        <Button
+        <IconButton
           key={`edit_${allocation.id}`}
           id={`edit_button_${allocation.id}`}
           onClick={() => openEditDialog(allocation.id)}
           disabled={!deletePermission}
         >
           <EditIcon />
-        </Button>
-        <Button
+        </IconButton>
+        <IconButton
           key={`delete_${allocation.id}`}
           id={`delete_button_${allocation.id}`}
           onClick={() => openDeleteDialog(allocation.id)}
           disabled={!deletePermission}
         >
           <DeleteIcon />
-        </Button>
+        </IconButton>
       </div>
     );
   };

--- a/static/js/components/candidate/CandidatesPreferences.jsx
+++ b/static/js/components/candidate/CandidatesPreferences.jsx
@@ -20,7 +20,6 @@ import Button from "../Button";
 
 import { allowedClasses } from "../classification/ClassificationForm";
 import ScanningProfilesList from "./ScanningProfilesList";
-import CandidatesPreferencesForm from "./CandidatesPreferencesForm";
 
 dayjs.extend(utc);
 
@@ -29,13 +28,12 @@ const useStyles = makeStyles((theme) => ({
     backgroundColor: theme.palette.background.default,
   },
   header: {
-    justifyContent: "space-between",
+    width: "100%",
+    justifyContent: "flex-end",
   },
 }));
 
-// eslint-disable-next-line react/display-name
 const Transition = React.forwardRef((props, ref) => (
-  // eslint-disable-next-line react/jsx-props-no-spreading
   <Slide direction="up" ref={ref} {...props} />
 ));
 
@@ -94,7 +92,6 @@ const CandidatesPreferences = ({
         aria-describedby="alert-dialog-description"
       >
         <Toolbar className={classes.header}>
-          <Typography variant="h6">Scanning Profiles</Typography>
           <IconButton
             edge="start"
             color="inherit"
@@ -109,28 +106,13 @@ const CandidatesPreferences = ({
           </IconButton>
         </Toolbar>
         <DialogContent className={classes.dialogContent}>
-          <Grid container spacing={2}>
-            <Grid item md={7} sm={12}>
-              <ScanningProfilesList
-                selectedScanningProfile={selectedScanningProfile}
-                setSelectedScanningProfile={setSelectedScanningProfile}
-                userAccessibleGroups={userAccessibleGroups}
-                availableAnnotationsInfo={availableAnnotationsInfo}
-                classifications={classifications}
-              />
-            </Grid>
-            <Grid item md={5} sm={12}>
-              <Paper>
-                <CandidatesPreferencesForm
-                  userAccessibleGroups={userAccessibleGroups}
-                  availableAnnotationsInfo={availableAnnotationsInfo}
-                  classifications={classifications}
-                  addOrEdit="Add"
-                  setSelectedScanningProfile={setSelectedScanningProfile}
-                />
-              </Paper>
-            </Grid>
-          </Grid>
+          <ScanningProfilesList
+            selectedScanningProfile={selectedScanningProfile}
+            setSelectedScanningProfile={setSelectedScanningProfile}
+            userAccessibleGroups={userAccessibleGroups}
+            availableAnnotationsInfo={availableAnnotationsInfo}
+            classifications={classifications}
+          />
         </DialogContent>
       </Dialog>
     </div>

--- a/static/js/components/candidate/CandidatesPreferencesForm.jsx
+++ b/static/js/components/candidate/CandidatesPreferencesForm.jsx
@@ -257,6 +257,7 @@ const CandidatesPreferencesForm = ({
     } else if (addOrEdit === "Add") {
       // New profiles are set to default/loaded immediately
       setSelectedScanningProfile(data);
+      closeDialog();
     }
   };
 

--- a/static/js/components/candidate/CandidatesPreferencesForm.jsx
+++ b/static/js/components/candidate/CandidatesPreferencesForm.jsx
@@ -12,6 +12,7 @@ import TextField from "@mui/material/TextField";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import Checkbox from "@mui/material/Checkbox";
 import SaveIcon from "@mui/icons-material/Save";
+import Switch from "@mui/material/Switch";
 
 import makeStyles from "@mui/styles/makeStyles";
 
@@ -107,6 +108,7 @@ const CandidatesPreferencesForm = ({
 
   const dispatch = useDispatch();
   const [selectedClassifications, setSelectedClassifications] = useState([]);
+  const [classificationsWith, setClassificationsWith] = useState(true);
   const [selectedAnnotationOrigin, setSelectedAnnotationOrigin] = useState();
 
   const {
@@ -149,7 +151,6 @@ const CandidatesPreferencesForm = ({
     );
     // Don't want to reset everytime the component rerenders and
     // the defaultStartDate is updated, so ignore ESLint here
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dispatch]);
 
   let formState = getValues();
@@ -210,6 +211,7 @@ const CandidatesPreferencesForm = ({
     }
     if (selectedClassifications.length > 0) {
       data.classifications = selectedClassifications;
+      data.classificationsWith = classificationsWith;
     }
     if (formData.redshiftMinimum) {
       data.redshiftMinimum = formData.redshiftMinimum;
@@ -277,7 +279,6 @@ const CandidatesPreferencesForm = ({
                 label="Name"
                 data-testid="profile-name"
                 value={value}
-                // eslint-disable-next-line react/jsx-no-duplicate-props
                 InputProps={{ "data-testid": "name" }}
                 InputLabelProps={{
                   shrink: true,
@@ -300,7 +301,6 @@ const CandidatesPreferencesForm = ({
                 type="number"
                 value={value}
                 inputProps={{ step: 1 }}
-                // eslint-disable-next-line react/jsx-no-duplicate-props
                 InputProps={{ "data-testid": "timeRange" }}
                 InputLabelProps={{
                   shrink: true,
@@ -344,6 +344,19 @@ const CandidatesPreferencesForm = ({
             selectedClassifications={selectedClassifications}
             setSelectedClassifications={setSelectedClassifications}
             showShortcuts
+          />
+        </div>
+        <div className={classes.formRow}>
+          {/* select between including candidates with the selected classifications, or without */}
+          <InputLabel id="profile-classifications-with-select-label">
+            {classificationsWith === false ? "without" : "with"} the selected
+            classifications
+          </InputLabel>
+          <Switch
+            checked={classificationsWith}
+            onChange={() => setClassificationsWith(!classificationsWith)}
+            color="primary"
+            inputProps={{ "aria-label": "primary checkbox" }}
           />
         </div>
         <div className={classes.formRow}>
@@ -478,7 +491,6 @@ const CandidatesPreferencesForm = ({
                   data-testid="profileAnnotationSortingKeySelect"
                 >
                   {availableAnnotationsInfo ? (
-                    // eslint-disable-next-line react/prop-types
                     availableAnnotationsInfo[selectedAnnotationOrigin]?.map(
                       (option) => (
                         <MenuItem

--- a/static/js/components/candidate/FilterCandidateList.jsx
+++ b/static/js/components/candidate/FilterCandidateList.jsx
@@ -255,10 +255,14 @@ const FilterCandidateList = ({
     selectedScanningProfile?.classifications || [],
   );
 
+  const [classificationsWith, setClassificationsWith] = useState(
+    selectedScanningProfile?.classificationsWith === false ? false : true,
+  );
+
   const gcnEvents = useSelector((state) => state.gcnEvents);
 
   const gcnEventsLookUp = {};
-  // eslint-disable-next-line no-unused-expressions
+
   gcnEvents?.events.forEach((gcnEvent) => {
     gcnEventsLookUp[gcnEvent.id] = gcnEvent;
   });
@@ -332,6 +336,9 @@ const FilterCandidateList = ({
     }
     setSelectedGcnEventId("");
     setSelectedClassifications(scanningProfile?.classifications || []);
+    setClassificationsWith(
+      scanningProfile?.classificationsWith === false ? false : true,
+    );
     if (availableAnnotationsInfo) {
       const newOptions = scanningProfile?.sortingOrigin
         ? (availableAnnotationsInfo[scanningProfile?.sortingOrigin] || [])
@@ -440,7 +447,11 @@ const FilterCandidateList = ({
       data.endDate = formData.endDate.toISOString();
     }
     if (selectedClassifications.length > 0) {
-      data.classifications = selectedClassifications;
+      if (classificationsWith === false) {
+        data.classificationsReject = selectedClassifications;
+      } else {
+        data.classifications = selectedClassifications;
+      }
     }
     if (formData.redshiftMinimum) {
       data.minRedshift = formData.redshiftMinimum;
@@ -822,19 +833,35 @@ const FilterCandidateList = ({
           </Grid>
           <Grid item xs={12} lg={6}>
             <Paper variant="outlined" className={classes.simplePadding}>
-              <div className={classes.formRow} style={{ marginTop: 0 }}>
-                <Typography
-                  variant="h6"
-                  className={classes.title}
-                  style={{ marginBottom: "0.5rem" }}
-                >
-                  Classification(s)
-                </Typography>
-                <ClassificationSelect
-                  selectedClassifications={selectedClassifications}
-                  setSelectedClassifications={setSelectedClassifications}
-                  showShortcuts
-                />
+              <div className={classes.savedFiltering} style={{ marginTop: 0 }}>
+                <div className={classes.savedStatusSelect}>
+                  <Typography
+                    variant="h6"
+                    className={classes.title}
+                    style={{ marginBottom: "0.5rem" }}
+                  >
+                    Classification(s)
+                  </Typography>
+                  <ClassificationSelect
+                    selectedClassifications={selectedClassifications}
+                    setSelectedClassifications={setSelectedClassifications}
+                    showShortcuts
+                  />
+                </div>
+                <div className={classes.rejectCandidatesSelect}>
+                  <Switch
+                    checked={classificationsWith !== false}
+                    onChange={(event) => {
+                      setClassificationsWith(event.target.checked);
+                    }}
+                    data-testid="classificationsWithSelect"
+                  />
+                  <InputLabel id="classificationsWithLabel">
+                    {classificationsWith !== false
+                      ? "With classification(s)"
+                      : "Without classification(s)"}
+                  </InputLabel>
+                </div>
               </div>
               <div className={classes.formRow}>
                 <Typography variant="h6" className={classes.title}>
@@ -900,7 +927,6 @@ const FilterCandidateList = ({
                           }` || ""
                         }
                         className={classes.select}
-                        // eslint-disable-next-line no-shadow
                         onInputChange={(event, value) => {
                           if (
                             ((event?.type === "change" ||

--- a/static/js/components/candidate/ScanningProfilesList.jsx
+++ b/static/js/components/candidate/ScanningProfilesList.jsx
@@ -288,19 +288,18 @@ const ScanningProfilesList = ({
   };
 
   const renderActions = (dataIndex) => {
-    const profile = profiles[dataIndex];
     return (
       <div className={classes.actionButtons}>
         <IconButton
-          key={`edit_${profile.id}`}
-          id={`edit_button_${profile.id}`}
-          onClick={() => editProfile(profile)}
+          key={`edit_${dataIndex}`}
+          id={`edit_button_${dataIndex}`}
+          onClick={() => editProfile(profiles[dataIndex])}
         >
           <EditIcon />
         </IconButton>
         <IconButton
-          key={`delete_${profile.id}`}
-          id={`delete_button_${profile.id}`}
+          key={`delete_${dataIndex}`}
+          id={`delete_button_${dataIndex}`}
           onClick={() => deleteProfile(dataIndex)}
         >
           <DeleteIcon />

--- a/static/js/components/candidate/ScanningProfilesList.jsx
+++ b/static/js/components/candidate/ScanningProfilesList.jsx
@@ -15,6 +15,10 @@ import {
   ThemeProvider,
   useTheme,
 } from "@mui/material/styles";
+import IconButton from "@mui/material/IconButton";
+import AddIcon from "@mui/icons-material/Add";
+import DeleteIcon from "@mui/icons-material/Delete";
+import EditIcon from "@mui/icons-material/Edit";
 
 import makeStyles from "@mui/styles/makeStyles";
 
@@ -59,11 +63,9 @@ const useStyles = makeStyles((theme) => ({
   },
   actionButtons: {
     display: "flex",
-    flexDirection: "column",
-    justifyContent: "space-evenly",
-    "& > button": {
-      margin: "0.25rem 0",
-    },
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    alignItems: "center",
   },
 }));
 
@@ -111,6 +113,7 @@ const ScanningProfilesList = ({
     (state) => state.profile.preferences.scanningProfiles,
   );
 
+  const [newDialogOpen, setNewDialogOpen] = useState(false);
   const [editDialogOpen, setEditDialogOpen] = useState(false);
   const [profileToEdit, setProfileToEdit] = useState();
 
@@ -200,6 +203,12 @@ const ScanningProfilesList = ({
     const profile = profiles[dataIndex];
     return profile?.classifications ? (
       <div>
+        <p>
+          {" "}
+          {profile?.classificationsWith === false
+            ? "Without any of:"
+            : "With any of:"}{" "}
+        </p>
         {profile.classifications.map((classification) => (
           <Chip
             size="small"
@@ -278,20 +287,27 @@ const ScanningProfilesList = ({
     );
   };
 
-  const renderActions = (dataIndex) => (
-    <div className={classes.actionButtons}>
-      <Button secondary size="small" onClick={() => deleteProfile(dataIndex)}>
-        Delete
-      </Button>
-      <Button
-        secondary
-        size="small"
-        onClick={() => editProfile(profiles[dataIndex])}
-      >
-        Edit
-      </Button>
-    </div>
-  );
+  const renderActions = (dataIndex) => {
+    const profile = profiles[dataIndex];
+    return (
+      <div className={classes.actionButtons}>
+        <IconButton
+          key={`edit_${profile.id}`}
+          id={`edit_button_${profile.id}`}
+          onClick={() => editProfile(profile)}
+        >
+          <EditIcon />
+        </IconButton>
+        <IconButton
+          key={`delete_${profile.id}`}
+          id={`delete_button_${profile.id}`}
+          onClick={() => deleteProfile(dataIndex)}
+        >
+          <DeleteIcon />
+        </IconButton>
+      </div>
+    );
+  };
 
   const columns = [
     {
@@ -362,8 +378,8 @@ const ScanningProfilesList = ({
       },
     },
     {
-      name: "edit",
-      label: "Edit",
+      name: "manage",
+      label: " ",
       options: {
         customBodyRenderLite: renderActions,
       },
@@ -378,6 +394,16 @@ const ScanningProfilesList = ({
     search: false,
     selectableRows: "none",
     elevation: 0,
+    customToolbar: () => (
+      <IconButton
+        name="new_scanning_profile"
+        onClick={() => {
+          setNewDialogOpen(true);
+        }}
+      >
+        <AddIcon />
+      </IconButton>
+    ),
   };
 
   return (
@@ -389,7 +415,7 @@ const ScanningProfilesList = ({
               data={profiles}
               options={options}
               columns={columns}
-              title="Saved Scanning Profiles"
+              title="Scanning Profiles"
             />
           </ThemeProvider>
         </StyledEngineProvider>
@@ -410,6 +436,23 @@ const ScanningProfilesList = ({
             closeDialog={() => setEditDialogOpen(false)}
             selectedScanningProfile={selectedScanningProfile}
             setSelectedScanningProfile={setSelectedScanningProfile}
+          />
+        </DialogContent>
+      </Dialog>
+      <Dialog
+        open={newDialogOpen}
+        onClose={() => {
+          setNewDialogOpen(false);
+        }}
+      >
+        <DialogContent className={classes.dialogContent}>
+          <CandidatesPreferencesForm
+            userAccessibleGroups={userAccessibleGroups}
+            availableAnnotationsInfo={availableAnnotationsInfo}
+            classifications={classifications}
+            addOrEdit="Add"
+            setSelectedScanningProfile={setSelectedScanningProfile}
+            closeDialog={() => setNewDialogOpen(false)}
           />
         </DialogContent>
       </Dialog>


### PR DESCRIPTION
This PR adds the frontend and backend necessary to let users pick if they want to scan for candidates not just WITH but also WITHOUT the classifications of their choice. Previously we could only scan for candidates with the selected classifications, which turned out to not be that useful, as most users want to filter out already classified objects when scanning.

This is a suggestion from Lynne Hillenbrand btw, who scans for large batches of objects every few weeks and wanted to stop seeing the ones she already classified.

Also, we migrate the scanning profiles page to the "new" tables layout, where we use the full width for the table and have the forms to add/edit in a pop up. Creating profiles new profiles also supports that new include vs exclude feature. In the future maybe we want to let users pick both classifications to include and to exclude from the frontend, but that's not a priority for now and being able to pick one or the other is more than enough. 