### PR TITLE
GitHub Action -  Docker build: migrate to docker compose v2

### DIFF
--- a/.github/workflows/test_docker_build.yaml
+++ b/.github/workflows/test_docker_build.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Start containers
         run: |
-          docker-compose up -d
+          docker compose up -d
 
       - name: Test loading demo data
         run: |

--- a/skyportal/handlers/api/source_groups.py
+++ b/skyportal/handlers/api/source_groups.py
@@ -137,7 +137,7 @@ class SourceGroupsHandler(BaseHandler):
                         TNSRobotGroup.auto_report,
                         TNSRobotGroupAutoreporter.group_user_id.in_(
                             sa.select(GroupUser.id).where(
-                                GroupUser.user_id == self.current_user.id,
+                                GroupUser.user_id == self.associated_user_object.id,
                                 GroupUser.group_id == group_id,
                             )
                         ),
@@ -179,13 +179,13 @@ class SourceGroupsHandler(BaseHandler):
                         submission_request = TNSRobotSubmission(
                             obj_id=obj.id,
                             tnsrobot_id=tnsrobot_group_with_autoreporter.tnsrobot_id,
-                            user_id=self.current_user.id,
+                            user_id=self.associated_user_object.id,
                             auto_submission=True,
                         )
                         session.add(submission_request)
                         session.commit()
                         log(
-                            f"Added TNSRobotSubmission request for obj_id {obj.id} saved to group {group_id} with tnsrobot_id {tnsrobot_group_with_autoreporter.tnsrobot_id} for user_id {self.current_user.id}"
+                            f"Added TNSRobotSubmission request for obj_id {obj.id} saved to group {group_id} with tnsrobot_id {tnsrobot_group_with_autoreporter.tnsrobot_id} for user_id {self.associated_user_object.id}"
                         )
                         break
 


### PR DESCRIPTION
Migrate to docker compose v2, where docker-compose is now docker comp…ose (no dash).

Tests are currently failing and that's likely why, as per: https://github.com/orgs/community/discussions/116610