### PR TITLE
Follow-up request: SWIFT ToO mode

### DIFF
--- a/skyportal/facility_apis/swift.py
+++ b/skyportal/facility_apis/swift.py
@@ -35,6 +35,7 @@ modes = {
     '0x9999': '0x9999 - Default (Filter of the day)',
     '0x30ed': '0x30ed - U+B+V+All UV',
     '0x223f': '0x223f - U+B+V+All UV (UV weighted, SN Mode)',
+    '0x0270': '0x0270 - U+B+V+All UV (ToO Upload Mode)',
     '0x209a': '0x209a - U+B+V',
     '0x308f': '0x308f - All UV',
     '0x2019': '0x2019 - White',

--- a/static/js/components/followup_request/FollowupRequestLists.jsx
+++ b/static/js/components/followup_request/FollowupRequestLists.jsx
@@ -138,7 +138,7 @@ const FollowupRequestLists = ({
         dispatch(
           showNotification(
             "Successfully retrieved photometry request, please wait for it to be processed.",
-            "success",
+            "info",
           ),
         );
         setHasRetrieved([...hasRetrieved, id]);


### PR DESCRIPTION
* the notification we show when clicking "retrieve" on a follow-up request had its type set to "success" when it should have been set to "info" to appear green.
* adds the SWIFT ToO mode