### PR TITLE
ZTF Treasuremap filters

### DIFF
--- a/skyportal/handlers/api/observation_plan.py
+++ b/skyportal/handlers/api/observation_plan.py
@@ -157,6 +157,11 @@ for bandpass_name in ALLOWED_BANDPASSES:
     except Exception as e:
         log(f'Error adding bandpass {bandpass_name} to treasuremap filters: {e}')
 
+# overwrite the filters for ZTF, as i-band is will otherwise be matched to TESS by treasuremap
+TREASUREMAP_FILTERS["ztfg"] = "g"
+TREASUREMAP_FILTERS["ztfr"] = "r"
+TREASUREMAP_FILTERS["ztfi"] = "i"
+
 Session = scoped_session(sessionmaker())
 
 observation_plans_microservice_url = (


### PR DESCRIPTION
* force the ztf filters to r,g,i when sending to treasuremap, as otherwise treasuremap matches the central wavelength + bandpass of ztf i-band to TESS.