### PR TITLE
Public page: Add optional title to release panel and tootips

### DIFF
--- a/static/js/components/source/source_publish/SourcePublish.jsx
+++ b/static/js/components/source/source_publish/SourcePublish.jsx
@@ -156,7 +156,7 @@ const SourcePublish = ({ sourceId, isElements }) => {
                 setSourcePublishReleaseOpen(!sourcePublishReleaseOpen)
               }
             >
-              Release
+              Release (optional)
               {sourcePublishReleaseOpen ? <ExpandLess /> : <ExpandMore />}
             </Button>
             {sourcePublishReleaseOpen && (


### PR DESCRIPTION
Improve the user experience of the publish pop-up by adding:
- tool-tips
- (optional) info when its needed

Pop-up to update:
![screen_publish_access](https://github.com/user-attachments/assets/7192b555-64e7-4283-a67c-8e986ae70ffd)
