### PR TITLE
Obj Redshift - use existing z origin

### DIFF
--- a/skyportal/handlers/api/candidate.py
+++ b/skyportal/handlers/api/candidate.py
@@ -99,8 +99,9 @@ def update_redshift_history_if_relevant(request_data, obj, user):
             "uncertainty": request_data.get("redshift_error", None),
         }
 
-        if "redshift_origin" in request_data:
-            history_params["origin"] = request_data["redshift_origin"]
+        origin = request_data.get("redshift_origin", None)
+        if isinstance(origin, str) and len(origin.strip()) > 0:
+            history_params["origin"] = origin
 
         redshift_history.append(history_params)
         obj.redshift_history = redshift_history

--- a/static/js/components/source/SourceRedshiftHistory.jsx
+++ b/static/js/components/source/SourceRedshiftHistory.jsx
@@ -69,6 +69,7 @@ const SourceRedshiftHistory = ({ redshiftHistory }) => {
                 <TableCell>Time (UTC)</TableCell>
                 <TableCell>Value</TableCell>
                 <TableCell>Uncertainty</TableCell>
+                <TableCell>Origin</TableCell>
               </TableRow>
             </TableHead>
             <TableBody>
@@ -82,6 +83,7 @@ const SourceRedshiftHistory = ({ redshiftHistory }) => {
                     <TableCell>{historyItem.set_at_utc}</TableCell>
                     <TableCell>{historyItem.value}</TableCell>
                     <TableCell>{historyItem.uncertainty}</TableCell>
+                    <TableCell>{historyItem?.origin || ""}</TableCell>
                   </TableRow>
                 ))}
             </TableBody>

--- a/static/js/components/source/UpdateSourceRedshift.jsx
+++ b/static/js/components/source/UpdateSourceRedshift.jsx
@@ -33,6 +33,9 @@ const UpdateSourceRedshift = ({ source }) => {
   const [state, setState] = useState({
     redshift: source.redshift ? String(source.redshift) : "",
     redshift_error: source.redshift_error ? String(source.redshift_error) : "",
+    redshift_origin: source.redshift_origin
+      ? String(source.redshift_origin)
+      : "",
   });
 
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -40,14 +43,14 @@ const UpdateSourceRedshift = ({ source }) => {
   const [invalid, setInvalid] = useState(true);
 
   useEffect(() => {
-    setInvalid(
-      // eslint-disable-next-line no-restricted-globals
-      !String(source.redshift) || isNaN(String(source.redshift)),
-    );
+    setInvalid(!String(source.redshift) || isNaN(String(source.redshift)));
     setState({
       redshift: source.redshift ? String(source.redshift) : "",
       redshift_error: source.redshift_error
         ? String(source.redshift_error)
+        : "",
+      redshift_origin: source.redshift_origin
+        ? String(source.redshift_origin)
         : "",
     });
   }, [source, setInvalid]);
@@ -57,7 +60,6 @@ const UpdateSourceRedshift = ({ source }) => {
     newState[e.target.name] = e.target.value;
     const value = String(e.target.value).trim();
     if (e.target.name === "redshift") {
-      // eslint-disable-next-line no-restricted-globals
       setInvalid(!value || isNaN(value));
     }
     setState({
@@ -72,6 +74,9 @@ const UpdateSourceRedshift = ({ source }) => {
     newState.redshift = subState.redshift ? subState.redshift : null;
     newState.redshift_error = subState.redshift_error
       ? subState.redshift_error
+      : null;
+    newState.redshift_origin = subState.redshift_origin
+      ? subState.redshift_origin
       : null;
     const result = await dispatch(
       sourceActions.updateSource(source.id, {
@@ -130,6 +135,18 @@ const UpdateSourceRedshift = ({ source }) => {
               variant="outlined"
             />
           </div>
+          <p />
+          <div>
+            <TextField
+              data-testid="updateRedshiftOriginTextfield"
+              size="small"
+              label="z_origin (optional)"
+              value={state.redshift_origin}
+              name="redshift_origin"
+              onChange={handleChange}
+              variant="outlined"
+            />
+          </div>
           <div className={classes.saveButton}>
             <Button
               secondary
@@ -150,7 +167,11 @@ const UpdateSourceRedshift = ({ source }) => {
                 <Button
                   primary
                   onClick={() => {
-                    handleSubmit({ redshift: null, redshift_error: null });
+                    handleSubmit({
+                      redshift: null,
+                      redshift_error: null,
+                      redshift_origin: null,
+                    });
                   }}
                   endIcon={<ClearIcon />}
                   size="large"
@@ -173,6 +194,7 @@ UpdateSourceRedshift.propTypes = {
     id: PropTypes.string,
     redshift: PropTypes.number,
     redshift_error: PropTypes.number,
+    redshift_origin: PropTypes.string,
   }).isRequired,
 };
 


### PR DESCRIPTION
We already have a concept of redshift origin but we've been ignoring it from the frontend. This PR let's user set it from the frontend if desired, and then shows it on the redshift history table.