### PR TITLE
Followup constraint: ignore_allocation_ids

### DIFF
--- a/skyportal/models/schema.py
+++ b/skyportal/models/schema.py
@@ -1284,6 +1284,16 @@ class FollowupRequestPost(_Schema):
         metadata={'description': "Radius of to use when checking constraints."},
     )
 
+    allocation_deduplication_ids = fields.List(
+        fields.Integer,
+        required=False,
+        metadata={
+            'description': (
+                'If there are any existing requests from the allocations that are pending or completed, the followup request will not be executed.'
+            )
+        },
+    )
+
 
 class ObservationPlanPost(_Schema):
     gcnevent_id = fields.Integer(


### PR DESCRIPTION
add a followup constraint named ignore_allocation_ids, to cancel posting follow-up requests if there are existing submitted/completed requests with any of the allocations specified in that list.

This is to help bots that run on one allocation that want to avoid triggering if there is a request for another allocation already.

There is a PR on Kowalski here: https://github.com/skyportal/kowalski/pull/412