### PR TITLE
get_sources: phot series session.execute fix

### DIFF
--- a/skyportal/handlers/api/sources.py
+++ b/skyportal/handlers/api/sources.py
@@ -2284,7 +2284,7 @@ async def get_sources(
                         WHERE obj_id IN {query_str}
                     """
                     photometric_series_exists = session.execute(
-                        text(stmt).bindparams(bindparam(*bindparams))
+                        text(stmt).bindparams(*bindparams)
                     )
                     photometric_series_exists = [
                         r[0] for r in photometric_series_exists


### PR DESCRIPTION
Fixes a call to session.execute() when fetching photometric series, which we never noticed because it is only called when there is no photometry.