### PR TITLE
Build & Deploy docs GitHub action: auto delete cancelled

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -49,16 +49,15 @@ migration:
 # Add 'needs-migration?' label to any change to models.py without changes to
 # the Alembic versions
 needs-migration?:
-  - any:
-      - changed-files:
-          - any-glob-to-any-file: ["skyportal/models.py", "skyportal/models/*"]
-          - all-globs-to-all-files: "!alembic/versions/*"
+  - all:
       - changed-files:
           - any-glob-to-any-file:
-              ["baselayer/app/models.py", "baselayer/app/models/*"]
-          - all-globs-to-all-files: "!alembic/versions/*"
-      - changed-files:
-          - any-glob-to-any-file: ["requirements.txt"]
+              [
+                "skyportal/models.py",
+                "skyportal/models/*",
+                "baselayer/app/models.py",
+                "baselayer/app/models/*",
+              ]
           - all-globs-to-all-files: "!alembic/versions/*"
 
 # Add 'workflows' label to any changes to GA workflows (.github folder)

--- a/.github/workflows/build-and-deploy-docs.yaml
+++ b/.github/workflows/build-and-deploy-docs.yaml
@@ -14,7 +14,7 @@ jobs:
   delete-cancelled-runs:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "MercuryTechnologies/delete-cancelled-runs@v1.0.0"
+      - uses: "MercuryTechnologies/delete-cancelled-runs@f5c9d322d9c7afbd41f779199818c1ffe381d34b" #v1.0.0
         with:
           workflow-file: "build-and-deploy-docs.yaml"
   build-and-deploy-docs:

--- a/.github/workflows/build-and-deploy-docs.yaml
+++ b/.github/workflows/build-and-deploy-docs.yaml
@@ -14,7 +14,7 @@ jobs:
   delete-cancelled-runs:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "MercuryTechnologies/delete-cancelled-runs@v1"
+      - uses: "MercuryTechnologies/delete-cancelled-runs@v1.0.0"
         with:
           workflow-file: "build-and-deploy-docs.yaml"
   build-and-deploy-docs:

--- a/.github/workflows/build-and-deploy-docs.yaml
+++ b/.github/workflows/build-and-deploy-docs.yaml
@@ -11,12 +11,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  delete-cancelled-runs:
-    runs-on: "ubuntu-latest"
-    steps:
-      - uses: "MercuryTechnologies/delete-cancelled-runs@f5c9d322d9c7afbd41f779199818c1ffe381d34b" #v1.0.0
-        with:
-          workflow-file: "build-and-deploy-docs.yaml"
   build-and-deploy-docs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -40,6 +34,10 @@ jobs:
           --health-retries 5
 
     steps:
+      - uses: "MercuryTechnologies/delete-cancelled-runs@f5c9d322d9c7afbd41f779199818c1ffe381d34b" #v1.0.0
+        with:
+          workflow-file: "build-and-deploy-docs.yaml"
+
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10"

--- a/.github/workflows/build-and-deploy-docs.yaml
+++ b/.github/workflows/build-and-deploy-docs.yaml
@@ -14,7 +14,7 @@ jobs:
   delete-cancelled-runs:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "MercuryTechnologies/delete-cancelled-runs@latest"
+      - uses: "MercuryTechnologies/delete-cancelled-runs@v1"
         with:
           workflow-file: "build-and-deploy-docs.yaml"
   build-and-deploy-docs:

--- a/.github/workflows/build-and-deploy-docs.yaml
+++ b/.github/workflows/build-and-deploy-docs.yaml
@@ -6,7 +6,17 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
+  delete-cancelled-runs:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "MercuryTechnologies/delete-cancelled-runs@latest"
+        with:
+          workflow-file: "build-and-deploy-docs.yaml"
   build-and-deploy-docs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -32,7 +42,7 @@ jobs:
     steps:
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: "3.10"
 
       - uses: actions/setup-node@v3
         with:
@@ -59,14 +69,14 @@ jobs:
 
       - name: Write SkyPortal config
         run: |
-            cat << EOF > config.yaml
-              database:
-                database: skyportal
-                host: localhost
-                port: 5432
-                user: skyportal
-                password: anything
-            EOF
+          cat << EOF > config.yaml
+            database:
+              database: skyportal
+              host: localhost
+              port: 5432
+              user: skyportal
+              password: anything
+          EOF
 
       - name: Install system dependencies
         run: |


### PR DESCRIPTION
Based on a suggestion from @stefanv, this PR is an attempt at using the github action from https://github.com/MercuryTechnologies/delete-cancelled-runs.

The problem we are facing is that the github action we rely on to build&deploy the docs already cancels previous workflows that are still running, except that when workflow are just cancelled they make the overall test suite appear as failed. Deleting cancelled workflows makes a lot of sense here, and prevents the tests from appearing as failed.


Also, I made small changes to the `labeler.yaml` config, because pretty much all of our PRs ended up with this `needs-migrations?` label. I think that it needs merging for that behavior to stop.

