### PR TITLE
pin fiona to 1.9.6 to fix geopandas

### DIFF
--- a/.github/workflows/test_migrations.yaml
+++ b/.github/workflows/test_migrations.yaml
@@ -135,6 +135,7 @@ jobs:
           make dependencies
 
           pip install black
+          pip install fiona==1.9.6 # 1.10.0 breaks geopandas
 
       - name: Save current Alembic head on main
         run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ scipy==1.13.1
 pandas==2.2.0
 dask==2024.5.2
 geopandas==1.0.1
+fiona==1.9.6
 intervals==0.9.2
 joblib==1.4.2
 seaborn==0.13.2


### PR DESCRIPTION
the fiona package (that geopandas uses) released a new version that broke geopandas. Until geopandas makes a new release, we can simply pin fiona its previous version.

This impacts features like the earthquake stuff, which breaks make load_demo_data and the migration CI