### PR TITLE
Localization properties computation: memory usage fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 astroscrappy==1.2.0
-numpy==1.23.4
+numpy>=1.23.4
 scipy==1.13.1
 pandas==2.2.0
 dask==2024.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 astroscrappy==1.2.0
-numpy>=1.23.4
+numpy==1.23.4
 scipy==1.13.1
 pandas==2.2.0
 dask==2024.5.2
@@ -53,7 +53,7 @@ lxml==5.2.2
 suds-py3==1.4.5.0
 vcrpy==6.0.1
 aiosmtpd==1.4.6
-ligo.skymap==2.1.0
+ligo.skymap==2.0.1
 healpy==1.17.1
 pygcn==1.1.2
 pysedm==0.31.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,7 @@ lxml==5.2.2
 suds-py3==1.4.5.0
 vcrpy==6.0.1
 aiosmtpd==1.4.6
-ligo.skymap==2.0.1
+ligo.skymap==2.1.0
 healpy==1.17.1
 pygcn==1.1.2
 pysedm==0.31.1

--- a/skyportal/utils/gcn.py
+++ b/skyportal/utils/gcn.py
@@ -757,7 +757,7 @@ def get_contour(localization):
 
 
 def get_skymap_properties(localization):
-    sky_map = localization.table
+    sky_map = localization.table_2d
 
     properties_dict = {}
     tags_list = []


### PR DESCRIPTION
`ligo.skymap.postprocess` provides a `crossmatch` method that you can use for various things, but we use it to simply compute some statistics that we can use to generate properties like of the probability is in 500 sq. deg, what's that contains 90% of the probability, and a couple of tags that derive from that.

However we don't just send the 2d data (uniq and probdensity) that `ligo.skymap` needs to compute the numbers needed for these stats, but we also send the 3d data (distmu, distsigma, distnorm) that `ligo.skymap` can optionally use to give us some volume-related results.

When the volume is added into the mix, much more memory is required which causes some systems to send a sigkill and stop the program. But, we do not even read these 3d results in the first place, so we can avoid that issue by only sending the 2d data to `ligo.skymap`.

PS: The distance-based properties we might use are directly read from the skymaps, which is why we don't compute anything with distance when ingesting the maps in our system and simply store that info in the DB for whatever feature might use it later on.