### PR TITLE
Reminders: API & Frontend tests: less flaky

### DIFF
--- a/services/reminders/reminders.py
+++ b/services/reminders/reminders.py
@@ -1,6 +1,4 @@
-from datetime import datetime, timedelta
-
-from astropy.time import Time
+from datetime import datetime, timedelta, timezone
 
 from baselayer.log import make_log
 from baselayer.app.models import init_db
@@ -28,7 +26,7 @@ log = make_log('reminders')
 
 
 def send_reminders():
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
     reminders = []
     with DBSession() as session:
         try:
@@ -106,10 +104,7 @@ def send_reminders():
             while True:
                 reminder.number_of_reminders -= 1
                 reminder.next_reminder += timedelta(days=reminder.reminder_delay)
-                if (
-                    reminder.next_reminder > Time(now, format='datetime')
-                    or reminder.number_of_reminders == 0
-                ):
+                if reminder.next_reminder > now or reminder.number_of_reminders == 0:
                     break
             session.add(reminder)
             session.commit()

--- a/skyportal/tests/api/test_reminders.py
+++ b/skyportal/tests/api/test_reminders.py
@@ -7,7 +7,9 @@ from skyportal.tests import api
 
 def post_and_verify_reminder(endpoint, token):
     reminder_text = str(uuid.uuid4())
-    next_reminder = datetime.now(timezone.utc) + timedelta(seconds=2)
+    next_reminder = datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(
+        seconds=2
+    )
     next_reminder = next_reminder.replace(microsecond=0)
     reminder_delay = 1
     number_of_reminders = 1
@@ -41,10 +43,8 @@ def post_and_verify_reminder(endpoint, token):
     assert data[reminder_index]['reminder_delay'] == reminder_delay
     assert data[reminder_index]['number_of_reminders'] <= number_of_reminders
     assert (
-        datetime.strptime(
-            data[reminder_index]['next_reminder'], "%Y-%m-%dT%H:%M:%S"
-        ).timestamp()
-        >= next_reminder.timestamp()
+        datetime.strptime(data[reminder_index]['next_reminder'], "%Y-%m-%dT%H:%M:%S")
+        >= next_reminder
     )
 
     n_retries = 0
@@ -73,10 +73,8 @@ def post_and_verify_reminder(endpoint, token):
     assert data[reminder_index]['reminder_delay'] == reminder_delay
     assert data[reminder_index]['number_of_reminders'] == number_of_reminders - 1
     assert (
-        datetime.strptime(
-            data[reminder_index]['next_reminder'], "%Y-%m-%dT%H:%M:%S"
-        ).timestamp()
-        > next_reminder.timestamp()
+        datetime.strptime(data[reminder_index]['next_reminder'], "%Y-%m-%dT%H:%M:%S")
+        > next_reminder
     )
     return reminder_text
 

--- a/skyportal/tests/api/test_reminders.py
+++ b/skyportal/tests/api/test_reminders.py
@@ -1,13 +1,13 @@
 import time
 import uuid
-from datetime import date, timedelta, datetime
+from datetime import timedelta, datetime, timezone
 
 from skyportal.tests import api
 
 
 def post_and_verify_reminder(endpoint, token):
     reminder_text = str(uuid.uuid4())
-    next_reminder = datetime.utcnow() + timedelta(seconds=1)
+    next_reminder = datetime.now(timezone.utc) + timedelta(seconds=2)
     reminder_delay = 1
     number_of_reminders = 1
     request_data = {
@@ -38,11 +38,14 @@ def post_and_verify_reminder(endpoint, token):
     )
     assert reminder_index != -1
     assert data[reminder_index]['text'] == reminder_text
-    assert data[reminder_index]['next_reminder'] == next_reminder.strftime(
-        "%Y-%m-%dT%H:%M:%S"
-    )
     assert data[reminder_index]['reminder_delay'] == reminder_delay
-    assert data[reminder_index]['number_of_reminders'] == number_of_reminders
+    assert data[reminder_index]['number_of_reminders'] <= number_of_reminders
+    assert (
+        datetime.strptime(
+            data[reminder_index]['next_reminder'], "%Y-%m-%dT%H:%M:%S"
+        ).timestamp()
+        > next_reminder.timestamp()
+    )
 
     n_retries = 0
     while n_retries < 10:
@@ -59,18 +62,21 @@ def post_and_verify_reminder(endpoint, token):
                 for index, reminder in enumerate(data)
                 if reminder['text'] == reminder_text
             )
-            if data[reminder_index]['number_of_reminders'] == number_of_reminders - 1:
+            if data[reminder_index]['number_of_reminders'] < number_of_reminders:
                 break
-        time.sleep(15)
+        time.sleep(2)
         n_retries += 1
     assert n_retries < 10
     assert status == 200
     assert len(data) == 1
     assert data[reminder_index]['text'] == reminder_text
-    assert data[reminder_index]['next_reminder'] == (
-        next_reminder + timedelta(days=reminder_delay)
-    ).strftime("%Y-%m-%dT%H:%M:%S")
     assert data[reminder_index]['reminder_delay'] == reminder_delay
+    assert (
+        datetime.strptime(
+            data[reminder_index]['next_reminder'], "%Y-%m-%dT%H:%M:%S"
+        ).timestamp()
+        > next_reminder.timestamp()
+    )
     assert data[reminder_index]['number_of_reminders'] == number_of_reminders - 1
     return reminder_text
 
@@ -81,8 +87,12 @@ def test_reminder_on_shift(
     super_admin_user,
 ):
     shift_name = str(uuid.uuid4())
-    start_date = (date.today() - timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%S")
-    end_date = (date.today() + timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%S")
+    start_date = (datetime.now(timezone.utc) - timedelta(days=1)).strftime(
+        "%Y-%m-%dT%H:%M:%S"
+    )
+    end_date = (datetime.now(timezone.utc) + timedelta(days=1)).strftime(
+        "%Y-%m-%dT%H:%M:%S"
+    )
     request_data = {
         'name': shift_name,
         'group_id': public_group.id,

--- a/skyportal/tests/frontend/test_profile.py
+++ b/skyportal/tests/frontend/test_profile.py
@@ -121,6 +121,7 @@ def test_add_data_to_user_profile(driver, user):
     )
 
 
+@pytest.mark.flaky(reruns=2)
 def test_insufficient_name_entry_in_profile(driver, user):
     driver.get(f"/become_user/{user.id}")
     driver.get("/profile")

--- a/skyportal/tests/frontend/test_reminders.py
+++ b/skyportal/tests/frontend/test_reminders.py
@@ -40,12 +40,11 @@ def post_and_verify_reminder(endpoint, token):
         if reminder['text'] == reminder_text
     )
     assert reminder_index != -1
-    assert data[reminder_index]['text'] == reminder_text
     assert data[reminder_index]['reminder_delay'] == reminder_delay
     assert data[reminder_index]['number_of_reminders'] <= number_of_reminders
     assert (
         datetime.strptime(data[reminder_index]['next_reminder'], "%Y-%m-%dT%H:%M:%S")
-        > next_reminder
+        >= next_reminder
     )
 
     n_retries = 0
@@ -72,11 +71,11 @@ def post_and_verify_reminder(endpoint, token):
     assert len(data) == 1
     assert data[reminder_index]['text'] == reminder_text
     assert data[reminder_index]['reminder_delay'] == reminder_delay
+    assert data[reminder_index]['number_of_reminders'] == number_of_reminders - 1
     assert (
         datetime.strptime(data[reminder_index]['next_reminder'], "%Y-%m-%dT%H:%M:%S")
         > next_reminder
     )
-    assert data[reminder_index]['number_of_reminders'] == number_of_reminders - 1
     return reminder_text
 
 

--- a/skyportal/tests/frontend/test_reminders.py
+++ b/skyportal/tests/frontend/test_reminders.py
@@ -7,7 +7,10 @@ from datetime import datetime, timedelta, timezone
 
 def post_and_verify_reminder(endpoint, token):
     reminder_text = str(uuid.uuid4())
-    next_reminder = datetime.now(timezone.utc) + timedelta(seconds=2)
+    next_reminder = datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(
+        seconds=2
+    )
+    next_reminder = next_reminder.replace(microsecond=0)
     reminder_delay = 1
     number_of_reminders = 1
     request_data = {
@@ -41,10 +44,8 @@ def post_and_verify_reminder(endpoint, token):
     assert data[reminder_index]['reminder_delay'] == reminder_delay
     assert data[reminder_index]['number_of_reminders'] <= number_of_reminders
     assert (
-        datetime.strptime(
-            data[reminder_index]['next_reminder'], "%Y-%m-%dT%H:%M:%S"
-        ).timestamp()
-        > next_reminder.timestamp()
+        datetime.strptime(data[reminder_index]['next_reminder'], "%Y-%m-%dT%H:%M:%S")
+        > next_reminder
     )
 
     n_retries = 0
@@ -72,10 +73,8 @@ def post_and_verify_reminder(endpoint, token):
     assert data[reminder_index]['text'] == reminder_text
     assert data[reminder_index]['reminder_delay'] == reminder_delay
     assert (
-        datetime.strptime(
-            data[reminder_index]['next_reminder'], "%Y-%m-%dT%H:%M:%S"
-        ).timestamp()
-        > next_reminder.timestamp()
+        datetime.strptime(data[reminder_index]['next_reminder'], "%Y-%m-%dT%H:%M:%S")
+        > next_reminder
     )
     assert data[reminder_index]['number_of_reminders'] == number_of_reminders - 1
     return reminder_text


### PR DESCRIPTION
This is an attempt at making some tests a little less flaky (if not, not flaky at all) by specifying timezones, and being a little more smart about the checks that we run to not be too sensible to the timing of things.