### PR TITLE
Default Observation Plans: auto send - plan properties filter

### DIFF
--- a/services/observation_plan_queue/observation_plan_queue.py
+++ b/services/observation_plan_queue/observation_plan_queue.py
@@ -324,6 +324,7 @@ def service(*args, **kwargs):
                                         plan.observation_plan_request.id,
                                         session=session,
                                         auto_send=True,
+                                        default_obsplan_id=default,
                                     )
                                 for (
                                     default_survey_efficiency
@@ -336,6 +337,7 @@ def service(*args, **kwargs):
                                         asynchronous=False,
                                     )
                     except Exception as e:
+                        traceback.print_exc()
                         log(
                             f"Error occured processing default queue submission or survey efficiency for plan {id}: {e}"
                         )

--- a/skyportal/handlers/api/gcn.py
+++ b/skyportal/handlers/api/gcn.py
@@ -2312,6 +2312,9 @@ def add_observation_plans(localization_id, user_id, parent_session=None):
                 'payload': plan.payload,
                 'default': plan.id,
                 'auto_send': plan.auto_send,
+                'requester_id': user.id
+                if plan.requester_id is None
+                else plan.requester_id,
             }
             gcn_observation_plans.append(gcn_observation_plan)
 
@@ -2346,6 +2349,7 @@ def add_observation_plans(localization_id, user_id, parent_session=None):
                 'allocation_id': allocation.id,
                 'gcnevent_id': event.id,
                 'localization_id': localization_id,
+                'requester_id': gcn_observation_plan['requester_id'],
             }
 
             if isinstance(gcn_observation_plan.get('filters'), dict):
@@ -5430,7 +5434,7 @@ class DefaultGcnTagHandler(BaseHandler):
 
             if default_gcn_tag is None:
                 return self.error(
-                    'Default observation plan with ID {default_observation_plan_id} is not available.'
+                    f'Default GCN tag with ID {default_gcn_tag_id} not found'
                 )
 
             session.delete(default_gcn_tag)

--- a/skyportal/handlers/api/gcn.py
+++ b/skyportal/handlers/api/gcn.py
@@ -2283,7 +2283,11 @@ def add_observation_plans(localization_id, user_id, parent_session=None):
             )
             return
         # sort the notices by date (which is a datetime object)
-        latest_notice = sorted(event.gcn_notices, key=lambda x: x.date)[-1]
+        notices = sorted(event.gcn_notices, key=lambda x: x.date)
+        if localization.notice_id is not None:
+            notices = [n for n in notices if n.id == localization.notice_id]
+        notice = notices[-1]
+
         event_properties = event.properties
         if not isinstance(event_properties, list) or len(event_properties) == 0:
             log(
@@ -2346,24 +2350,29 @@ def add_observation_plans(localization_id, user_id, parent_session=None):
 
             if isinstance(gcn_observation_plan.get('filters'), dict):
                 filters = gcn_observation_plan['filters']
+                # this is a default plan, which we only run on localizations
+                # that have an associated GCN notice
+                if (
+                    localization.notice_id is None
+                    or notice.id != localization.notice_id
+                ):
+                    log(
+                        f"Skipping default observation plan {gcn_observation_plan.id} because it does not match the localization notice"
+                    )
+                    continue
 
                 if (
-                    isinstance(filters.get('gcn_notices'), list)
-                    and len(filters['gcn_notices']) > 0
+                    isinstance(filters.get('notice_types'), list)
+                    and len(filters['notice_types']) > 0
                 ):
-                    gcn_notice_filter = False
-                    if latest_notice.notice_type is not None:
+                    if notice.notice_type is not None:
+                        notice_type = notice.notice_type
                         try:
-                            latest_notice.notice_type = gcn.NoticeType(
-                                latest_notice.notice_type
-                            ).name
+                            notice_type = gcn.NoticeType(int(notice.notice_type)).name
                         except ValueError:
                             pass
-                        if latest_notice.notice_type in filters['gcn_notices']:
-                            gcn_notice_filter = True
-                            break
-                    if not gcn_notice_filter:
-                        continue
+                        if notice_type not in filters['notice_types']:
+                            continue
 
                 if (
                     isinstance(filters.get('gcn_tags'), list)

--- a/skyportal/handlers/api/observation_plan.py
+++ b/skyportal/handlers/api/observation_plan.py
@@ -99,6 +99,7 @@ DEFAULT_OBSPLAN_OPTIONS = [
     'localization_tags',
     'localization_properties',
     'gcn_properties',
+    'plan_properties',
 ]
 
 TREASUREMAP_URL = cfg['app.treasuremap_endpoint']
@@ -671,7 +672,9 @@ def post_observation_plan(
             f'Invalid / missing parameters: {e.normalized_messages()}'
         )
 
-    data["requester_id"] = user.id
+    data["requester_id"] = (
+        user.id if data.get("requester_id") is None else int(data.get("requester_id"))
+    )
     data["last_modified_by_id"] = user.id
     data['allocation_id'] = int(data['allocation_id'])
     data['localization_id'] = int(data['localization_id'])
@@ -3548,6 +3551,10 @@ class DefaultObservationPlanRequestHandler(BaseHandler):
                     )
 
             default_observation_plan_request.target_groups = target_groups
+            if default_observation_plan_request.requester_id is None:
+                default_observation_plan_request.requester_id = (
+                    self.associated_user_object.id
+                )
 
             session.add(default_observation_plan_request)
             session.commit()

--- a/skyportal/handlers/api/observation_plan.py
+++ b/skyportal/handlers/api/observation_plan.py
@@ -307,6 +307,11 @@ def send_observation_plan(plan_id, session, auto_send=False, default_obsplan_id=
                 )
                 return
 
+    # if the observation plan has no observations scheduled, don't send it
+    if not observation_plan_request.observation_plans[0].planned_observations:
+        log(f"No planned observations for observation plan {plan_id}, skipping send.")
+        return
+
     api = observation_plan_request.instrument.api_class_obsplan
     if not api.implements().get('send', False):
         return ValueError('Cannot send observation plans on this instrument.')

--- a/skyportal/handlers/api/observation_plan.py
+++ b/skyportal/handlers/api/observation_plan.py
@@ -2,6 +2,7 @@ import asyncio
 import functools
 import io
 import json
+import operator  # noqa: F401
 import os
 import random
 import re
@@ -162,6 +163,15 @@ TREASUREMAP_FILTERS["ztfg"] = "g"
 TREASUREMAP_FILTERS["ztfr"] = "r"
 TREASUREMAP_FILTERS["ztfi"] = "i"
 
+op_options = [
+    "lt",
+    "le",
+    "eq",
+    "ne",
+    "ge",
+    "gt",
+]
+
 Session = scoped_session(sessionmaker())
 
 observation_plans_microservice_url = (
@@ -171,7 +181,7 @@ observation_plans_microservice_url = (
 MAX_OBSERVATION_PLAN_REQUESTS = 1000
 
 
-def send_observation_plan(plan_id, session, auto_send=False):
+def send_observation_plan(plan_id, session, auto_send=False, default_obsplan_id=None):
     """Send observation plan to queue
 
     Parameters
@@ -206,9 +216,9 @@ def send_observation_plan(plan_id, session, auto_send=False):
         )
         return
 
-    if auto_send:
-        # if we already sent a plan for this event + allocation
-        # in the last 24 hours, we avoid auto-sending again.
+    if auto_send and default_obsplan_id is not None:
+        # if we already sent a plan for this event + allocation,
+        # we avoid auto-sending again.
         existing_obs_plan_requests = session.scalars(
             sa.select(ObservationPlanRequest).where(
                 ObservationPlanRequest.gcnevent_id
@@ -216,8 +226,6 @@ def send_observation_plan(plan_id, session, auto_send=False):
                 ObservationPlanRequest.allocation_id
                 == observation_plan_request.allocation_id,
                 ObservationPlanRequest.status == "submitted to telescope queue",
-                ObservationPlanRequest.modified
-                > datetime.utcnow() - timedelta(hours=24),
             )
         ).first()
         if existing_obs_plan_requests:
@@ -225,6 +233,79 @@ def send_observation_plan(plan_id, session, auto_send=False):
                 f"Skipping auto-send of observation plan {observation_plan_request.id}: plans have already been sent to the instrument in the last 24 hours for event {observation_plan_request.gcnevent_id} and allocation {observation_plan_request.allocation_id}"
             )
             return
+
+        defaultobsplanrequest = session.scalar(
+            sa.select(DefaultObservationPlanRequest).where(
+                DefaultObservationPlanRequest.id == int(default_obsplan_id)
+            )
+        )
+        if defaultobsplanrequest is None:
+            log(
+                f"Cannot find default observation plan request with ID: {default_obsplan_id}, skipping auto send."
+            )
+            return
+
+        filters = defaultobsplanrequest.filters
+        if not filters or not isinstance(filters, dict):
+            log(
+                f"Default observation plan request {default_obsplan_id} has no filters, skipping auto send."
+            )
+            return
+
+        plan_properties = filters.get('plan_properties', [])
+        if len(plan_properties) > 0:
+            try:
+                statistics = (
+                    observation_plan_request.observation_plans[0]
+                    .statistics[0]
+                    .statistics
+                )
+            except Exception as e:
+                log(f"Error getting statistics for observation plan {plan_id}: {e}")
+                return
+
+            properties_pass = True
+            for prop_filt in plan_properties:
+                prop_split = prop_filt.split(":")
+                if not len(prop_split) == 3:
+                    log(
+                        f"Invalid propertiesFilter value -- property filter must have 3 values, cannot auto-send default observation plan {default_obsplan_id}"
+                    )
+                    properties_pass = False
+                    break
+
+                name = prop_split[0].strip()
+                if name not in statistics:
+                    properties_pass = False
+                    break
+
+                value = prop_split[1].strip()
+                try:
+                    value = float(value)
+                except ValueError as e:
+                    log(
+                        f"Invalid propertiesFilter value: {e}, cannot auto-send default observation plan {default_obsplan_id}"
+                    )
+                    properties_pass = False
+                    break
+
+                op = prop_split[2].strip()
+                if op not in op_options:
+                    log(
+                        f"Invalid operator: {op}, skipping default observation plan {default_obsplan_id}"
+                    )
+                    properties_pass = False
+                    break
+                comp_function = getattr(operator, op)
+                if not comp_function(statistics[name], value):
+                    properties_pass = False
+                    break
+
+            if not properties_pass:
+                log(
+                    f"Default observation plan request {default_obsplan_id} failed plan properties/statistics filter, skipping auto send."
+                )
+                return
 
     api = observation_plan_request.instrument.api_class_obsplan
     if not api.implements().get('send', False):
@@ -3453,6 +3534,13 @@ class DefaultObservationPlanRequestHandler(BaseHandler):
                 return self.error(
                     f'Filters must contain at least one of: {DEFAULT_OBSPLAN_OPTIONS}'
                 )
+
+            # verify that the filters are valid, i.e that they are in the allowed options
+            for key in filters.keys():
+                if key not in DEFAULT_OBSPLAN_OPTIONS:
+                    return self.error(
+                        f'Invalid filter key: {key}, must be one of {DEFAULT_OBSPLAN_OPTIONS}'
+                    )
 
             default_observation_plan_request.target_groups = target_groups
 

--- a/skyportal/handlers/api/observation_plan.py
+++ b/skyportal/handlers/api/observation_plan.py
@@ -3544,11 +3544,12 @@ class DefaultObservationPlanRequestHandler(BaseHandler):
                 )
 
             # verify that the filters are valid, i.e that they are in the allowed options
-            for key in filters.keys():
-                if key not in DEFAULT_OBSPLAN_OPTIONS:
-                    return self.error(
-                        f'Invalid filter key: {key}, must be one of {DEFAULT_OBSPLAN_OPTIONS}'
-                    )
+            if isinstance(filters, dict):
+                for key in filters.keys():
+                    if key not in DEFAULT_OBSPLAN_OPTIONS:
+                        return self.error(
+                            f'Invalid filter key: {key}, must be one of {DEFAULT_OBSPLAN_OPTIONS}'
+                        )
 
             default_observation_plan_request.target_groups = target_groups
             if default_observation_plan_request.requester_id is None:

--- a/skyportal/models/schema.py
+++ b/skyportal/models/schema.py
@@ -1332,6 +1332,11 @@ class ObservationPlanPost(_Schema):
         },
     )
 
+    requester_id = fields.Integer(
+        required=False,
+        metadata={'description': "ID of the user making the request."},
+    )
+
 
 class ObservationPlanManualHandlerPost(_Schema):
     gcnevent_id = fields.Integer(

--- a/static/js/components/observation_plan/NewDefaultObservationPlan.jsx
+++ b/static/js/components/observation_plan/NewDefaultObservationPlan.jsx
@@ -16,6 +16,7 @@ import GcnTagsSelect from "../gcn/GcnTagsSelect";
 import GcnPropertiesSelect from "../gcn/GcnPropertiesSelect";
 import LocalizationTagsSelect from "../localization/LocalizationTagsSelect";
 import LocalizationPropertiesSelect from "../localization/LocalizationPropertiesSelect";
+import PlanPropertiesSelect from "./PlanPropertiesSelect";
 
 import * as defaultObservationPlansActions from "../../ducks/default_observation_plans";
 import * as allocationActions from "../../ducks/allocations";
@@ -110,6 +111,7 @@ const NewDefaultObservationPlan = ({ onClose }) => {
   const [selectedLocalizationTags, setSelectedLocalizationTags] = useState([]);
   const [selectedLocalizationProperties, setSelectedLocalizationProperties] =
     useState([]);
+  const [selectedPlanProperties, setSelectedPlanProperties] = useState([]);
 
   const { telescopeList } = useSelector((state) => state.telescopes);
   const { allocationListApiObsplan } = useSelector(
@@ -223,6 +225,7 @@ const NewDefaultObservationPlan = ({ onClose }) => {
       localization_tags: selectedLocalizationTags,
       gcn_properties: selectedGcnProperties,
       localization_properties: selectedLocalizationProperties,
+      plan_properties: selectedPlanProperties,
     };
     const json = {
       allocation_id: selectedAllocationId,
@@ -348,6 +351,18 @@ const NewDefaultObservationPlan = ({ onClose }) => {
             setSelectedLocalizationProperties={
               setSelectedLocalizationProperties
             }
+          />
+        </div>
+      </div>
+      <div className={classes.formGroupDivider} />
+      <div className={classes.form_group}>
+        <Typography className={classes.form_group_title}>
+          Observation Plan Stats Filtering
+        </Typography>
+        <div className={classes.form_subgroup}>
+          <PlanPropertiesSelect
+            selectedPlanProperties={selectedPlanProperties}
+            setSelectedPlanProperties={setSelectedPlanProperties}
           />
         </div>
       </div>

--- a/static/js/components/observation_plan/PlanPropertiesSelect.jsx
+++ b/static/js/components/observation_plan/PlanPropertiesSelect.jsx
@@ -1,0 +1,223 @@
+import React from "react";
+import { useDispatch } from "react-redux";
+import PropTypes from "prop-types";
+import ButtonGroup from "@mui/material/ButtonGroup";
+import TextField from "@mui/material/TextField";
+import makeStyles from "@mui/styles/makeStyles";
+import InputLabel from "@mui/material/InputLabel";
+import Select from "@mui/material/Select";
+import MenuItem from "@mui/material/MenuItem";
+import { Controller, useForm } from "react-hook-form";
+import Button from "../Button";
+import SelectWithChips from "../SelectWithChips";
+
+const comparators = {
+  lt: "<",
+  le: "<=",
+  eq: "=",
+  ne: "!=",
+  ge: ">",
+  gt: ">=",
+};
+
+const useStyles = makeStyles(() => ({
+  root: {
+    display: "flex",
+    flexDirection: "column",
+    width: "100%",
+    gap: "0.5rem",
+    marginBottom: "1rem",
+  },
+  form_group: {
+    display: "flex",
+    flexDirection: "row",
+    justifyContent: "justify-between",
+    alignItems: "top",
+    gap: "0.2rem",
+    width: "100%",
+  },
+  formItem: {
+    width: "100%",
+  },
+  select: {
+    width: "100%",
+    height: "3rem",
+    "& > div": {
+      width: "100%",
+      height: "3rem",
+    },
+  },
+  selectWithMargin: {
+    width: "100%",
+    height: "3rem",
+    "& > div": {
+      width: "100%",
+      height: "3rem",
+    },
+    marginBottom: "0.5rem",
+  },
+  selectItem: {
+    whiteSpace: "break-spaces",
+  },
+}));
+
+const PlanPropertiesSelect = (props) => {
+  const classes = useStyles();
+  const dispatch = useDispatch();
+  const { selectedPlanProperties, setSelectedPlanProperties } = props;
+
+  let planProperties = [
+    "area",
+    "num_observations",
+    "probability",
+    "tot_time_with_overhead",
+    "total_time",
+  ];
+
+  const handleChange = (event) => {
+    setSelectedPlanProperties(event.target.value);
+  };
+
+  const { handleSubmit, register, control, reset, getValues } = useForm();
+
+  const handleSubmitProperties = async () => {
+    const filterData = getValues();
+    const propertiesFilter = `${filterData.property}: ${filterData.propertyComparatorValue}: ${filterData.propertyComparator}`;
+    const selectedPlanPropertiesCopy = [...selectedPlanProperties];
+    selectedPlanPropertiesCopy.push(propertiesFilter);
+    setSelectedPlanProperties(selectedPlanPropertiesCopy);
+  };
+
+  const handleClickReset = () => {
+    reset();
+  };
+
+  return (
+    <div>
+      <form className={classes.root}>
+        <div className={classes.form_group}>
+          <div className={classes.formItem}>
+            <Controller
+              render={({ field: { value } }) => (
+                <>
+                  <InputLabel>Property</InputLabel>
+                  <Select
+                    inputProps={{ MenuProps: { disableScrollLock: true } }}
+                    labelId="PlanPropertySelectLabel"
+                    value={value || ""}
+                    onChange={(event) => {
+                      reset({
+                        ...getValues(),
+                        property:
+                          event.target.value === -1 ? "" : event.target.value,
+                      });
+                    }}
+                    className={classes.select}
+                  >
+                    {planProperties?.map((planProperty) => (
+                      <MenuItem
+                        value={planProperty}
+                        key={planProperty}
+                        className={classes.selectItem}
+                      >
+                        {`${planProperty}`}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </>
+              )}
+              name="property"
+              control={control}
+              defaultValue=""
+            />
+          </div>
+          <div className={classes.formItem}>
+            <Controller
+              render={({ field: { value } }) => (
+                <>
+                  <InputLabel>Comparator</InputLabel>
+                  <Select
+                    inputProps={{ MenuProps: { disableScrollLock: true } }}
+                    labelId="planPropertyComparatorSelectLabel"
+                    value={value || ""}
+                    onChange={(event) => {
+                      reset({
+                        ...getValues(),
+                        propertyComparator:
+                          event.target.value === -1 ? "" : event.target.value,
+                      });
+                    }}
+                    className={classes.select}
+                  >
+                    {Object.keys(comparators)?.map((key) => (
+                      <MenuItem
+                        value={key}
+                        key={key}
+                        className={classes.selectItem}
+                      >
+                        {`${comparators[key]}`}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </>
+              )}
+              name="propertyComparator"
+              control={control}
+              defaultValue="="
+            />
+          </div>
+          <div className={classes.formItem}>
+            <Controller
+              render={({ field: { onChange, value } }) => (
+                <>
+                  <InputLabel>Value</InputLabel>
+                  <TextField
+                    size="small"
+                    name="propertyComparatorValue"
+                    inputRef={register("propertyComparatorValue")}
+                    placeholder="0.0"
+                    onChange={onChange}
+                    value={value}
+                    className={classes.select}
+                  />
+                </>
+              )}
+              name="propertyComparatorValue"
+              control={control}
+            />
+          </div>
+        </div>
+        <div className={classes.form_group}>
+          <ButtonGroup
+            variant="contained"
+            color="primary"
+            aria-label="contained primary button group"
+          >
+            <Button primary onClick={handleSubmit(handleSubmitProperties)}>
+              Add
+            </Button>
+            <Button primary onClick={handleClickReset}>
+              Reset
+            </Button>
+          </ButtonGroup>
+        </div>
+      </form>
+      <div className={classes.selectWithMargin}>
+        <SelectWithChips
+          label="Plan Properties"
+          id="selectPlanProperties"
+          initValue={selectedPlanProperties}
+          onChange={handleChange}
+          options={selectedPlanProperties}
+        />
+      </div>
+    </div>
+  );
+};
+
+PlanPropertiesSelect.propTypes = {
+  selectedPlanProperties: PropTypes.arrayOf(PropTypes.string).isRequired,
+  setSelectedPlanProperties: PropTypes.func.isRequired,
+};
+
+export default PlanPropertiesSelect;


### PR DESCRIPTION
This PR addresses a couple of issues such as:
- associating that localization of the plan to the correct GCN notice
- looking at an incorrect key when filtering on gcn notices

Also, it let's the user - optionally - set a list of plan_properties, that the plan generated by gwemopt needs to meet before we can send a plan to the scheduler (when auto send is turned on).