### PR TITLE
Only run CI on non-draft PRs

### DIFF
--- a/.github/workflows/build-and-deploy-docs.yaml
+++ b/.github/workflows/build-and-deploy-docs.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/build-and-deploy-docs.yaml
+++ b/.github/workflows/build-and-deploy-docs.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
-    if: github.repository_owner == 'skyportal'
+    if: github.repository_owner == 'skyportal' && github.event.pull_request.draft == false
 
     services:
       postgres:

--- a/.github/workflows/test_api_and_frontend.yaml
+++ b/.github/workflows/test_api_and_frontend.yaml
@@ -7,7 +7,8 @@ on:
   pull_request:
 
 jobs:
-  test:
+  test-api-and-frontend:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 120
     services:

--- a/.github/workflows/test_api_and_frontend.yaml
+++ b/.github/workflows/test_api_and_frontend.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
 
 jobs:
   test-api-and-frontend:

--- a/.github/workflows/test_docker_build.yaml
+++ b/.github/workflows/test_docker_build.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   test:
-    if: github.event_name == 'push' || ${{ github.event.label.name == 'docker' }}
+    if: github.event_name == 'push' || github.event.label.name == 'docker'
     name: Test Docker build
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/test_migrations.yaml
+++ b/.github/workflows/test_migrations.yaml
@@ -15,6 +15,7 @@ on:
       - "skyportal/enum_types.py"
       - "skyportal/facility_apis/__init__.py"
       - "requirements.txt"
+    types: [opened, reopened, synchronize, ready_for_review]
 
 jobs:
   test-migrations:

--- a/.github/workflows/test_migrations.yaml
+++ b/.github/workflows/test_migrations.yaml
@@ -17,8 +17,9 @@ on:
       - "requirements.txt"
 
 jobs:
-  test:
+  test-migrations:
     name: Test SkyPortal migrations
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 90
     env:

--- a/.github/workflows/test_models.yaml
+++ b/.github/workflows/test_models.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
 
 jobs:
   test-models:

--- a/.github/workflows/test_models.yaml
+++ b/.github/workflows/test_models.yaml
@@ -7,7 +7,8 @@ on:
   pull_request:
 
 jobs:
-  test:
+  test-models:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 120
 


### PR DESCRIPTION
This should save our CI cycles for when it's necessary. Could also consider adding a label to control `no-ci`.