### PR TITLE
Docs deploy - Fix incorrect GA arguments

### DIFF
--- a/.github/workflows/build-and-deploy-docs.yaml
+++ b/.github/workflows/build-and-deploy-docs.yaml
@@ -140,7 +140,7 @@ jobs:
         if: github.ref == 'refs/heads/main'
         uses: JamesIves/github-pages-deploy-action@v4
         with:
-          FOLDER: doc/_build/html
-          REPOSITORY_NAME: skyportal/docs
-          BRANCH: gh-pages
-          SSH: true
+          folder: doc/_build/html
+          repository-name: skyportal/docs
+          branch: gh-pages
+          ssh-key: true


### PR DESCRIPTION
https://github.com/skyportal/skyportal/pull/4516 upgrades the version of the action responsible of building the docs, but was merged before validating that it still worked. It shows as green anyways, so none of us noticed.