### PR TITLE
OpenAPI spec - security/auth + ACLs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -133,9 +133,9 @@ todo_include_todos = False
 # Per https://github.com/snide/sphinx_rtd_theme: specify theme if not on RTD
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 if not on_rtd:  # only import and set the theme if we're building docs locally
-    import furo  # noqa
+    import sphinx_book_theme  # noqa
 
-    html_theme = 'furo'
+    html_theme = 'sphinx_book_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/doc/openapi.html.template
+++ b/doc/openapi.html.template
@@ -1,14 +1,13 @@
 <!doctype html>
 <html>
   <head>
-    <title>Scalar API Reference</title>
+    <title>SkyPortal API Reference</title>
     <meta charset="utf-8" />
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1" />
   </head>
   <body>
-    <!-- Need a Custom Header? Check out this example https://codepen.io/scalarorg/pen/VwOXqam -->
     <script
         id="api-reference"
         type="application/json">

--- a/doc/openapi.html.template
+++ b/doc/openapi.html.template
@@ -30,6 +30,6 @@
       document.getElementById('api-reference').dataset.configuration =
         JSON.stringify(configuration)
     </script>
-    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.25.10"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.25.24"></script>
   </body>
 </html>

--- a/requirements.docs.txt
+++ b/requirements.docs.txt
@@ -1,5 +1,5 @@
 sphinx
-furo
+sphinx-book-theme
 recommonmark
 numpydoc
 notedown

--- a/skyportal/handlers/api/analysis.py
+++ b/skyportal/handlers/api/analysis.py
@@ -1910,7 +1910,7 @@ class DefaultAnalysisHandler(BaseHandler):
                 )
 
     @auth_or_token
-    def post(self, analysis_service_id, default_analysis_id=None):
+    def post(self, analysis_service_id, *ignored_args):
         """
         ---
         summary: Create a new default analysis

--- a/skyportal/handlers/api/gcn.py
+++ b/skyportal/handlers/api/gcn.py
@@ -914,7 +914,7 @@ class GcnEventAliasesHandler(BaseHandler):
 
 class GcnEventTagsHandler(BaseHandler):
     @auth_or_token
-    async def get(self, dateobs=None, tag=None):
+    async def get(self, *ignored_args):
         """
         ---
         summary: Get all GCN Event tags

--- a/skyportal/handlers/api/internal/log.py
+++ b/skyportal/handlers/api/internal/log.py
@@ -12,7 +12,7 @@ log = make_log('js')
 
 class LogHandler(BaseHandler):
     @tornado.web.authenticated
-    def post(self, file_name=None):
+    def post(self, *ignored_args):
         """Log a frontend error to the server logs, tracking user crash reports."""
         data = self.get_json()
         log(f"{data['error']}{data['stack']}")

--- a/skyportal/handlers/api/invalid.py
+++ b/skyportal/handlers/api/invalid.py
@@ -4,5 +4,5 @@ from ..base import BaseHandler
 
 class InvalidEndpointHandler(BaseHandler):
     @auth_or_token
-    def get(self, group_id=None):
+    def get(self, *ignored_args):
         return self.error('Invalid API endpoint')

--- a/skyportal/handlers/api/reminder.py
+++ b/skyportal/handlers/api/reminder.py
@@ -353,7 +353,7 @@ class ReminderHandler(BaseHandler):
             return self.error(str(e))
 
     @permissions(['Reminder'])
-    def post(self, associated_resource_type, resource_id, reminder_id=None):
+    def post(self, associated_resource_type, resource_id, *ignored_args):
         """
         ---
         summary: Post a reminder

--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -1121,7 +1121,7 @@ class SourceHandler(BaseHandler):
                 application/json:
                   schema: Error
         multiple:
-          summary: Retrieve multiple sources
+          summary: Get multiple sources
           description: Retrieve all sources, given a set of filters
           tags:
             - sources
@@ -1459,6 +1459,14 @@ class SourceHandler(BaseHandler):
               Comma-separated string of "taxonomy: classification" pair(s) to filter for sources NOT matching
               that/those classification(s), i.e. "Sitewide Taxonomy: Type II, Sitewide Taxonomy: AGN"
           - in: query
+            name: classified
+            nullable: true
+            schema:
+              type: boolean
+            description: |
+              Boolean indicating whether to return only sources with classifications.
+              Defaults to false.
+          - in: query
             name: unclassified
             nullable: true
             schema:
@@ -1754,6 +1762,7 @@ class SourceHandler(BaseHandler):
         classifications = self.get_query_argument("classifications", None)
         classifications_simul = self.get_query_argument("classifications_simul", False)
         nonclassifications = self.get_query_argument("nonclassifications", None)
+        classified = self.get_query_argument("classified", False)
         unclassified = self.get_query_argument("unclassified", False)
         annotations_filter = self.get_query_argument("annotationsFilter", None)
         annotations_filter_origin = self.get_query_argument(
@@ -2008,6 +2017,7 @@ class SourceHandler(BaseHandler):
                     classifications=classifications,
                     classifications_simul=classifications_simul,
                     nonclassifications=nonclassifications,
+                    classified=classified,
                     unclassified=unclassified,
                     annotations_filter=annotations_filter,
                     annotations_filter_origin=annotations_filter_origin,

--- a/skyportal/openapi.py
+++ b/skyportal/openapi.py
@@ -127,6 +127,12 @@ def spec_from_handlers(handlers, exclude_internal=True, metadata=None):
             if not getattr(method, '__authenticated__', False):
                 spec['security'] = [{}]
 
+            if getattr(method, '__permissions__', None):
+                spec['description'] = (
+                    f'<b>Permission(s) required:</b> <em>{", ".join(method.__permissions__)} (or System admin)</em><br><br>'
+                    + spec.get('description', '')
+                )
+
             multiple_spec = spec.pop('multiple', {})
             single_spec = spec.pop('single', {})
             other_spec = spec

--- a/skyportal/openapi.py
+++ b/skyportal/openapi.py
@@ -67,6 +67,7 @@ def spec_from_handlers(handlers, exclude_internal=True, metadata=None):
                 'href': 'https://skyportal.io/docs',
             },
         },
+        'security': [{'token': []}],
     }
     if metadata is not None:
         meta.update(metadata)
@@ -122,6 +123,9 @@ def spec_from_handlers(handlers, exclude_internal=True, metadata=None):
 
             if parameters[-1:] == [''] and path_template.endswith('/{}'):
                 path_template = path_template[:-3]
+
+            if not getattr(method, '__authenticated__', False):
+                spec['security'] = [{}]
 
             multiple_spec = spec.pop('multiple', {})
             single_spec = spec.pop('single', {})


### PR DESCRIPTION
This PR requires https://github.com/cesium-ml/baselayer/pull/387 to be merged first, and once that done the new version of baselayer should be pinned on this PR before merging

Essentially it:
- adds the authentication/security (that we already specified in the `components` of the openapi spec) to ALL endpoints by default
- based on what is added in that baselayer PR, is able to figure which endpoints do not use authentication, and makes an exception for those. That way the autogenerated API docs show headers with a token when needed, otherwise do not.
- fixes the endpoint displayed for a few handlers' methods that had unused arguments (often happened on post methods that had the resource_id just to comply with the endpoint's regex, but didn't need them) to avoid confusion for the end user.