### PR TITLE
Python dependencies: loose version requirement for common packages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,31 +1,31 @@
 astroscrappy==1.2.0
-numpy==1.23.4
-scipy==1.13.1
-pandas==2.2.0
-dask==2024.5.2
+numpy>=1.23.4,<2.0.0
+scipy>=1.13.1, <2.0.0
+pandas>=2.2.0, <3.0.0
+dask>=2024.5.2
 geopandas==1.0.1
 fiona==1.9.6
 intervals==0.9.2
-joblib==1.4.2
-seaborn==0.13.2
+joblib>=1.4.2, <2.0.0
+seaborn>=0.13.2, <1.0.0
 pytest-randomly==3.15.0
 factory-boy==3.3.1
 astropy==6.1.0
-distributed==2024.5.2
+distributed>=2024.5.2
 dustmaps==1.0.13
 reproject==0.14.0
 avro-python3==1.10.2
-fastavro==1.9.4
+fastavro>=1.9.4,<2.0.0
 tqdm>=4.27,<4.67
-matplotlib==3.6.2
+matplotlib>=3.6.2, <4.0.0
 astroquery==0.4.7
-apispec==6.3.0
+apispec>=6.3.0, <7.0.0
 marshmallow==3.21.3
 marshmallow-sqlalchemy==1.0.0
 marshmallow-enum==1.5.1
 Pillow>=8.4.0
 pyproj==3.6.1
-pytest==8.3.2
+pytest>=8.3.2, <9.0.0
 sncosmo==2.11.1
 tdtax==0.1.4
 healpix-alchemy==1.1.0
@@ -35,8 +35,8 @@ conesearch-alchemy==1.0.0
 regions==0.9
 jsonschema==4.21.1
 jsonpath_ng==1.6.1
-pytest-rerunfailures==14.0
-tables==3.10.1
+pytest-rerunfailures>=14.0
+tables>=3.10.1,<4.0.0
 timezonefinder==6.5.2
 astroplan==0.10
 email-validator==2.2.0
@@ -48,7 +48,7 @@ requests_toolbelt==0.10.1
 sendgrid==6.11.0
 responses==0.25.3
 twilio==9.2.2
-numba==0.60.0
+numba>=0.59.0
 pyvo==1.5.2
 lxml==5.2.2
 suds-py3==1.4.5.0
@@ -59,11 +59,11 @@ healpy==1.17.1
 pygcn==1.1.2
 pysedm==0.31.1
 xmlschema==3.3.2
-requests==2.32.3
+requests>=2.30.0, <3.0.0
 geojson==3.1.0
 typing-extensions==4.12.2
 swifttools==3.0.22
-pip==24.2
+pip>=24.0.0
 gwemopt==0.3.4
 humanize==4.9.0
 xarray>=21.1
@@ -73,7 +73,7 @@ black==24.4.2
 click==8.1.7
 arviz==0.19.0
 corner==2.2.2
-penquins==2.4.1
+penquins==2.4.2
 selenium==4.8.3
 selenium-requests==2.0.4
 afterglowpy==0.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ reproject==0.14.0
 avro-python3==1.10.2
 fastavro>=1.9.4,<2.0.0
 tqdm>=4.27,<4.67
-matplotlib>=3.6.2, <4.0.0
+matplotlib>=3.6.2, <3.8.0
 astroquery==0.4.7
 apispec>=6.3.0, <7.0.0
 marshmallow==3.21.3


### PR DESCRIPTION
@stefanv mentioned that it wasn't possible to run SkyPortal on Python 3.12 because of the strict requirement we had on a numpy version.

In general, pinning exact versions has proved to make deployment and the CI much nicer and more reliable for us, but it is true that it makes it a little restrictive when trying to just run SkyPortal on whatever environment one has already.

In this PR, I tried to be a bit more flexible version-wise, for a couple of very packages python packages that I expect people to already have installed, or that might have some Python-version requirement.

If the reviewer has python 3.12 on their system, it could be a good idea to give that a go and see if they can run SkyPortal without downgrading to 3.11

PS: I still specific some maximum major version for these packages, just in an effort to minimize our chances of SkyPortal just breaking when one of these dependencies makes a lot of changes.