### PR TITLE
WIP - PR Labels: frontend-only

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -63,3 +63,16 @@ needs-migration?:
 # Add 'workflows' label to any changes to GA workflows (.github folder)
 workflows:
   - any-glob-to-any-file: ".github/**/*"
+
+# Add a 'frontend-only' label to any changes to the frontend code, but none to the backend
+frontend-only:
+  - changed-files:
+      - any-glob-to-any-file:
+          [
+            "static/**/*",
+            "package.json",
+            "webpack.config.js",
+            "baselayer/static/**/*",
+          ]
+      - all-globs-to-all-files:
+          ["!skyportal/**/*", "!requirements.txt", "!baselayer/**/*"]

--- a/.github/workflows/test_models.yaml
+++ b/.github/workflows/test_models.yaml
@@ -5,11 +5,11 @@ on:
     branches:
       - main
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
+    types: [labeled, reopened, synchronize, ready_for_review]
 
 jobs:
   test-models:
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false && !contains( github.event.pull_request.labels.*.name, 'frontend-only')
     runs-on: ubuntu-latest
     timeout-minutes: 120
 


### PR DESCRIPTION
The idea is to label PRs that only edit the frontend, to avoid running all the backend CI that wouldn't be affected by a pure frontend change anyway. This would help speed up these PRs, but also speed-up how quickly we run all of these CI jobs when dependabot does its monthly thing.

This PR is not complete yet, I'm adding a few things incrementally, but can't make it a draft otherwise things won't run