### PR TITLE
followup_request time could be iso or isot

### DIFF
--- a/skyportal/handlers/api/followup_request.py
+++ b/skyportal/handlers/api/followup_request.py
@@ -1587,12 +1587,12 @@ def observation_schedule(
         requester = followup_request.requester
 
         if "start_date" in payload:
-            start_date = Time(payload["start_date"], format='isot')
+            start_date = Time(payload["start_date"])
             if start_date > observation_end:
                 continue
 
         if "end_date" in payload:
-            end_date = Time(payload["end_date"], format='isot')
+            end_date = Time(payload["end_date"])
             if end_date < observation_start:
                 continue
 


### PR DESCRIPTION
This PR does not enforce isot format, as some of our observatories do iso format.