### PR TITLE
Weather: API migration and frontend cache invalidation

### DIFF
--- a/skyportal/handlers/api/weather.py
+++ b/skyportal/handlers/api/weather.py
@@ -113,7 +113,7 @@ class WeatherHandler(BaseHandler):
             message = ""
             if refresh:
                 response = get_url(
-                    "https://api.openweathermap.org/data/2.5/onecall?"
+                    "https://api.openweathermap.org/data/3.0/onecall?"
                     f"lat={telescope.lat}&lon={telescope.lon}&appid={openweather_api_key}"
                 )
                 if response is not None:

--- a/static/js/components/widget/WeatherWidget.jsx
+++ b/static/js/components/widget/WeatherWidget.jsx
@@ -164,15 +164,31 @@ const WeatherWidget = ({ classes }) => {
   const [anchorEl, setAnchorEl] = useState(null);
 
   useEffect(() => {
-    const fetchWeatherData = () => {
-      dispatch(weatherActions.fetchWeather());
-    };
     if (
-      telescopeList.length > 0 &&
-      (weather?.telescope_id !== weatherPrefs?.telescopeID ||
-        weather === undefined)
+      telescopeList === undefined ||
+      telescopeList === null ||
+      telescopeList?.length === 0
     ) {
-      fetchWeatherData();
+      return;
+    }
+    // if we don't have weather info yet, query it
+    if (weather === undefined || weather === null) {
+      dispatch(weatherActions.fetchWeather());
+      return;
+    }
+
+    // if the weather info is stale or for the wrong telescope, query it
+    if (
+      weatherPrefs?.telescopeID !== weather?.telescope_id ||
+      weather?.weather_retrieved_at === undefined ||
+      weather?.weather_retrieved_at === null ||
+      dayjs(new Date(`${weather?.weather_retrieved_at}Z`)).diff(
+        dayjs(),
+        "hour",
+      ) > 1
+    ) {
+      dispatch(weatherActions.fetchWeather());
+      return;
     }
   }, [weatherPrefs, weather, telescopeList, dispatch]);
 


### PR DESCRIPTION
In this PR:
- invalidate the weather data that's in redux if it's older than 1 hour, which is also the default caching time we use in the config (we don't query openweathermap's API more than once every hour).
- migrate openweathermap's `onecall` API from 2.5 (discontinued) to 3.0

Note: Instances that use that feature might want to go to their openweathermap account, and subscribe to the onecall API service. It will ask for credit card info but we get 1000 free API calls a day, and a limit can be added on top of that to make sure the free tier becomes not so free anymore. Also since SkyPortal caches every hour (and per telescope), you would need people to query weather info for >41 distinct facilities (lon/lat coordinates) to get to the paid tier, which is VERY unlikely.