### PR TITLE
Observation Plan Queue & Autosend: safety against old requests

### DIFF
--- a/services/observation_plan_queue/observation_plan_queue.py
+++ b/services/observation_plan_queue/observation_plan_queue.py
@@ -161,15 +161,15 @@ def service(*args, **kwargs):
                             ObservationPlanRequest.created_at
                             > arrow.utcnow().shift(days=-3).datetime,
                         ),
-                        # or plans that have been "running" for more than 30 minutes but less than 24 hours
+                        # or plans that have been "running" for more than 5 minutes but less than 1 hours
                         # this is a way to grab plans that have been stuck in the running state
                         # and have not been processed
                         sa.and_(
                             ObservationPlanRequest.status == "running",
                             ObservationPlanRequest.created_at
-                            < arrow.utcnow().shift(minutes=-30).datetime,
+                            < arrow.utcnow().shift(minutes=-5).datetime,
                             ObservationPlanRequest.created_at
-                            > arrow.utcnow().shift(hours=-24).datetime,
+                            > arrow.utcnow().shift(hours=-1).datetime,
                         ),
                     )
                 )

--- a/services/observation_plan_queue/observation_plan_queue.py
+++ b/services/observation_plan_queue/observation_plan_queue.py
@@ -161,15 +161,15 @@ def service(*args, **kwargs):
                             ObservationPlanRequest.created_at
                             > arrow.utcnow().shift(days=-3).datetime,
                         ),
-                        # or plans that have been "running" for more than 24 hours but less than 72 hours
+                        # or plans that have been "running" for more than 30 minutes but less than 24 hours
                         # this is a way to grab plans that have been stuck in the running state
                         # and have not been processed
                         sa.and_(
                             ObservationPlanRequest.status == "running",
                             ObservationPlanRequest.created_at
-                            < arrow.utcnow().shift(days=-1).datetime,
+                            < arrow.utcnow().shift(minutes=-30).datetime,
                             ObservationPlanRequest.created_at
-                            > arrow.utcnow().shift(days=-3).datetime,
+                            > arrow.utcnow().shift(hours=-24).datetime,
                         ),
                     )
                 )


### PR DESCRIPTION
In this PR we:
- change the obsplan generation retry window from plans that are older than 24 hours but younger than 72 hours, to plans that are older than 5 minutes but younger than 1 hour. This is in an effort to only bother regenerating plans that failed soon after they were created when we care about getting the results and potentially sending them to an instrument.
- when it comes to auto-sending, don't auto-send anything if the plan request is older than an hour (i.e. we took too long to generate that plan).

I'm opening this PR because what happened in prod is that gwemopt kept dying (which is a problem that still needs fixing!) and a plan got generated 3 days after the trigger time, and was sent to the ZTF scheduler. Meaning it appeared as sent though it was sent too late, and anyway ZTF didn't observe because the validity window was in the past. It's pretty confusing that the ZTF API even accepts a plan in the past, but we should just avoid sending that kind of thing.