### PR TITLE
Follow-up requests constraints: not_if_tns_reported

### DIFF
--- a/skyportal/models/schema.py
+++ b/skyportal/models/schema.py
@@ -1269,6 +1269,15 @@ class FollowupRequestPost(_Schema):
         },
     )
 
+    not_if_tns_reported = fields.Float(
+        required=False,
+        metadata={
+            'description': (
+                'If there are any sources within radius with TNS reports, and the source has been discovered within before this many hours from the current time, the followup request will not be executed.'
+            )
+        },
+    )
+
     ignore_source_group_ids = fields.List(
         fields.Integer,
         required=False,


### PR DESCRIPTION
Add an optional `not_if_tns_reported` constraints that can be passed to the API when posting follow-up requests. This parameter is a float/int (in hours). If a source within the specified `radius` parameter (which defaults to 0.5 arcsec) has been reported on TNS more than `not_if_tns_reported` hours before the current time, we can avoid triggering.

Depends on: https://github.com/skyportal/kowalski/pull/444