### PR TITLE
log full traceback when posting autogenerated GCN sources fails

### DIFF
--- a/skyportal/handlers/api/gcn.py
+++ b/skyportal/handlers/api/gcn.py
@@ -460,6 +460,7 @@ def post_skymap_from_notice(
                             post_source(source, user_id, session)
 
         except Exception as e:
+            log(traceback.format_exc())
             log(
                 f"Failed to create source for event {dateobs} with Localization {localization_id} with name {skymap['localization_name']}: {str(e)}."
             )


### PR DESCRIPTION
This PR logs the full traceback when posting autogenerated GCN sources fails

@mcoughlin that's for Icare. The current log message doesn't show us where the error happens, so it's not sufficient for debugging.