### PR TITLE
Analysis Services Page - details mixup bugfix

### DIFF
--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -522,6 +522,8 @@ server:
     google_oauth2_secret:
     google_oauth2_timeout: 15
 
+ports:
+  app: 5000 # This is the internal port
 services:
   dask: False
 

--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -522,8 +522,6 @@ server:
     google_oauth2_secret:
     google_oauth2_timeout: 15
 
-ports:
-  app: 5000 # This is the internal port
 services:
   dask: False
 
@@ -698,6 +696,7 @@ user:
   default_acls: []
 
 ports:
+  app: 5000 # This is the internal port
   facility_queue: 64510
   notification_queue: 64610
   observation_plan_queue: 64710

--- a/skyportal/handlers/api/gcn.py
+++ b/skyportal/handlers/api/gcn.py
@@ -1345,6 +1345,7 @@ class GcnEventHandler(BaseHandler):
               schema:
                 type: string
         multiple:
+          summary: Get multiple GCN Events
           description: Retrieve multiple GCN events
           tags:
             - gcn events

--- a/skyportal/handlers/api/photometric_series.py
+++ b/skyportal/handlers/api/photometric_series.py
@@ -700,7 +700,7 @@ class PhotometricSeriesHandler(BaseHandler):
         responses:
           200:
             content:
-            application/json:
+              application/json:
                 schema:
                   allOf:
                     - $ref: '#/components/schemas/Success'
@@ -782,7 +782,7 @@ class PhotometricSeriesHandler(BaseHandler):
         responses:
           200:
             content:
-            application/json:
+              application/json:
                 schema:
                   allOf:
                     - $ref: '#/components/schemas/Success'

--- a/skyportal/handlers/api/shift.py
+++ b/skyportal/handlers/api/shift.py
@@ -209,6 +209,7 @@ class ShiftHandler(BaseHandler):
                                     "username": gu.user.username,
                                     "first_name": gu.user.first_name,
                                     "last_name": gu.user.last_name,
+                                    "expiration_date": gu.user.expiration_date,
                                 }
                                 for gu in shift.group.group_users
                             ],

--- a/skyportal/handlers/api/user.py
+++ b/skyportal/handlers/api/user.py
@@ -256,6 +256,12 @@ class UserHandler(BaseHandler):
             schema:
               type: string
             description: Get users with access to the stream with name given by this parameter.
+          - in: query
+            name: includeExpired
+            nullable: true
+            schema:
+              type: boolean
+            description: Include users with expired accounts in the results.
           responses:
             200:
               content:

--- a/static/js/components/analysis/AnalysisServicePage.jsx
+++ b/static/js/components/analysis/AnalysisServicePage.jsx
@@ -49,13 +49,6 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const textStyles = makeStyles(() => ({
-  primary: {
-    fontWeight: "bold",
-    fontSize: "110%",
-  },
-}));
-
 export function analysisServiceTitle(analysisService) {
   if (!analysisService?.display_name) {
     return (
@@ -327,7 +320,12 @@ const AnalysisServiceList = ({ analysisServices, deletePermission }) => {
           <DialogTitle>Analysis Service Details</DialogTitle>
           <DialogContent dividers>
             <ReactJson
-              src={analysisServices[analysisServiceToViewDelete] || {}}
+              src={
+                (analysisServices || []).find(
+                  (analysisService) =>
+                    analysisService?.id === analysisServiceToViewDelete,
+                ) || {}
+              }
               name={false}
               displayDataTypes={false}
               displayObjectSize={false}

--- a/static/js/components/shift/ShiftManagement.jsx
+++ b/static/js/components/shift/ShiftManagement.jsx
@@ -171,7 +171,20 @@ const ShiftManagement = ({ currentShift }) => {
 
   const currentShiftGroup = currentShift.group;
 
-  const users = currentShiftGroup?.group_users || [];
+  let users = currentShiftGroup?.group_users || [];
+
+  // remove users from the users list if they are not already in the shift
+  // AND their expiration_date is set AND it is in the past (when compared to the current UTC date)
+  users = users.filter(
+    (user) =>
+      !(
+        !currentShift.shift_users.find(
+          (shiftUser) => shiftUser.user_id === user.id,
+        ) &&
+        user.expiration_date &&
+        new Date(user.expiration_date).getTime() < new Date().getTime()
+      ),
+  );
 
   function MultipleGroupSelectChip() {
     const { selectedUsers } = useSelector((state) => state.shift);

--- a/static/js/components/user/UserManagement.jsx
+++ b/static/js/components/user/UserManagement.jsx
@@ -130,7 +130,9 @@ const UserManagement = () => {
 
   useEffect(() => {
     const fetchData = () => {
-      dispatch(usersActions.fetchUsers(fetchParams));
+      dispatch(
+        usersActions.fetchUsers({ ...fetchParams, includeExpired: true }),
+      );
       dispatch(streamsActions.fetchStreams());
       dispatch(aclsActions.fetchACLs());
       dispatch(rolesActions.fetchRoles());
@@ -201,7 +203,9 @@ const UserManagement = () => {
       );
       reset({ groups: [] });
       setAddUserGroupsDialogOpen(false);
-      dispatch(usersActions.fetchUsers(fetchParams));
+      dispatch(
+        usersActions.fetchUsers({ ...fetchParams, includeExpired: true }),
+      );
       setClickedUser(null);
     }
   };
@@ -223,7 +227,9 @@ const UserManagement = () => {
       );
       reset({ streams: [] });
       setAddUserStreamsDialogOpen(false);
-      dispatch(usersActions.fetchUsers(fetchParams));
+      dispatch(
+        usersActions.fetchUsers({ ...fetchParams, includeExpired: true }),
+      );
       setClickedUser(null);
     }
   };
@@ -239,7 +245,9 @@ const UserManagement = () => {
       dispatch(showNotification("User successfully granted specified ACL(s)."));
       reset({ acls: [] });
       setAddUserACLsDialogOpen(false);
-      dispatch(usersActions.fetchUsers(fetchParams));
+      dispatch(
+        usersActions.fetchUsers({ ...fetchParams, includeExpired: true }),
+      );
       setClickedUser(null);
     }
   };
@@ -251,7 +259,9 @@ const UserManagement = () => {
     if (result.status === "success") {
       dispatch(showNotification("Successfully updated user's affiliations."));
       setAddUserAffiliationsDialogOpen(false);
-      dispatch(usersActions.fetchUsers(fetchParams));
+      dispatch(
+        usersActions.fetchUsers({ ...fetchParams, includeExpired: true }),
+      );
       setClickedUser(null);
     }
   };
@@ -269,7 +279,9 @@ const UserManagement = () => {
       );
       reset({ roles: [] });
       setAddUserRolesDialogOpen(false);
-      dispatch(usersActions.fetchUsers(fetchParams));
+      dispatch(
+        usersActions.fetchUsers({ ...fetchParams, includeExpired: true }),
+      );
       setClickedUser(null);
     }
   };
@@ -282,7 +294,9 @@ const UserManagement = () => {
       dispatch(
         showNotification("User successfully removed from specified group."),
       );
-      dispatch(usersActions.fetchUsers(fetchParams));
+      dispatch(
+        usersActions.fetchUsers({ ...fetchParams, includeExpired: true }),
+      );
     }
   };
 
@@ -292,7 +306,9 @@ const UserManagement = () => {
     );
     if (result.status === "success") {
       dispatch(showNotification("Stream access successfully revoked."));
-      dispatch(usersActions.fetchUsers(fetchParams));
+      dispatch(
+        usersActions.fetchUsers({ ...fetchParams, includeExpired: true }),
+      );
     }
   };
 
@@ -300,7 +316,9 @@ const UserManagement = () => {
     const result = await dispatch(aclsActions.deleteUserACL({ userID, acl }));
     if (result.status === "success") {
       dispatch(showNotification("User ACL successfully removed."));
-      dispatch(usersActions.fetchUsers(fetchParams));
+      dispatch(
+        usersActions.fetchUsers({ ...fetchParams, includeExpired: true }),
+      );
     }
   };
 
@@ -313,7 +331,9 @@ const UserManagement = () => {
     );
     if (result.status === "success") {
       dispatch(showNotification("Successfully deleted user's affiliation."));
-      dispatch(usersActions.fetchUsers(fetchParams));
+      dispatch(
+        usersActions.fetchUsers({ ...fetchParams, includeExpired: true }),
+      );
     }
   };
 
@@ -323,7 +343,9 @@ const UserManagement = () => {
     );
     if (result.status === "success") {
       dispatch(showNotification("User role successfully removed."));
-      dispatch(usersActions.fetchUsers(fetchParams));
+      dispatch(
+        usersActions.fetchUsers({ ...fetchParams, includeExpired: true }),
+      );
     }
   };
 
@@ -346,7 +368,9 @@ const UserManagement = () => {
       dispatch(showNotification("User expiration date successfully updated."));
       reset({ date: null });
       setEditUserExpirationDateDialogOpen(false);
-      dispatch(usersActions.fetchUsers(fetchParams));
+      dispatch(
+        usersActions.fetchUsers({ ...fetchParams, includeExpired: true }),
+      );
       setClickedUser(null);
     }
   };
@@ -644,7 +668,9 @@ const UserManagement = () => {
       ...formData,
     };
     setFetchParams(params);
-    await dispatch(usersActions.fetchUsers(params));
+    await dispatch(
+      usersActions.fetchUsers({ ...params, includeExpired: true }),
+    );
     setQueryInProgress(false);
   };
 
@@ -666,7 +692,9 @@ const UserManagement = () => {
     const params = { ...fetchParams, numPerPage, pageNumber: page + 1 };
     // Save state for future
     setFetchParams(params);
-    await dispatch(usersActions.fetchUsers(params));
+    await dispatch(
+      usersActions.fetchUsers({ ...params, includeExpired: true }),
+    );
     setQueryInProgress(false);
   };
 


### PR DESCRIPTION
This PR:
- fixes an issue on the analysis services page where the popup dialog that shows the details of a service aren't showing the right ones
- fixes the indent of the docstring of a few endpoints (POST & PATCH of the photometric series, GET of the GCN events), which prevented from them appearing on the documentation.
- Hides group users that can be added to a shift, if they are expired
- Show expired users again in the user management page, because otherwise it is impossible to extend their account's expiration date from the frontend.
- document the includeExpired flag of the users endpoint
- fixes the download of executed observations on the GCN page
- adds the `ports` section in the default config, present in baselayer but missing here in Fritz. Both need to be edited to change the port on which the app is running so the fact that it is missing makes it very hard to figure out for folks