### PR TITLE
Docker build action rules - fix

### DIFF
--- a/.github/workflows/test_docker_build.yaml
+++ b/.github/workflows/test_docker_build.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   test:
-    if: github.event_name == 'push' || github.event.label.name == 'docker'
+    if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'docker')
     name: Test Docker build
     runs-on: ubuntu-latest
     timeout-minutes: 30


### PR DESCRIPTION
An attempt at fixing the docker build action which is often not running when it should on PRs.