### PR TITLE
Observation plan auto trigger - end date check bugfix

### DIFF
--- a/skyportal/handlers/api/observation_plan.py
+++ b/skyportal/handlers/api/observation_plan.py
@@ -263,7 +263,10 @@ def send_observation_plan(plan_id, session, auto_send=False, default_obsplan_id=
         # if the plan's end date is in the past (can see that in the payload), we skip the auto-send
         plan_request_end_date = observation_plan_request.payload.get("end_date", None)
         if plan_request_end_date:
-            if arrow.get(plan_request_end_date).datetime < datetime.utcnow():
+            if (
+                arrow.get(plan_request_end_date).timestamp()
+                < datetime.utcnow().timestamp()
+            ):
                 log(
                     f"Default observation plan request {default_obsplan_id} has an end date in the past, skipping auto send."
                 )


### PR DESCRIPTION
Looks like `arrow` creates a timezone aware date in new versions, which break this feature when comparing it to the vanilla `utcnow()` generated `datetime`. This PR is a quick fix, but overall we should migrate to the non `datetime.utcnow()` syntax that newer versions of python are deprecating.

Honestly it's such a stupid choice, everyone uses it and this syntax was perfectly intuitive...