### PR TITLE
Follow-up requests: allocation-wide notifications (by slack & email)

### DIFF
--- a/services/slack/slack.py
+++ b/services/slack/slack.py
@@ -46,13 +46,18 @@ class MainHandler(tornado.web.RequestHandler):
 
         http_client = AsyncHTTPClient()
         try:
-            await http_client.fetch(
+            response = await http_client.fetch(
                 url,
                 raise_error=False,
                 method='POST',
                 body=json.dumps(data),
                 headers={'Content-type': 'application/json'},
             )
+            if response.code != 200:
+                log(
+                    f"Slack POST failed with code {response.code}: {str(response.body)}"
+                )
+                return self.error(response.code, str(response.body))
         except Exception as e:
             log(f"Error posting to Slack: {e}")
 

--- a/skyportal/facility_apis/gemini.py
+++ b/skyportal/facility_apis/gemini.py
@@ -107,12 +107,12 @@ class GeminiRequest:
         if not altdata:
             raise ValueError('No altdata provided')
 
-        email = altdata.get('email')
-        programid = altdata.get('progid')
-        password = altdata.get('password')
+        user_email = altdata.get('user_email')
+        programid = altdata.get('programid')
+        user_password = altdata.get('user_password')
 
-        if email is None or programid is None or password is None:
-            raise ValueError('Email, password, and program id are required')
+        if user_email is None or programid is None or user_password is None:
+            raise ValueError('user_email, user_password, and programid are required')
 
         # create the group str from the allocation's group nickname, PI, and id
         allocation_group_name = (
@@ -210,8 +210,8 @@ class GeminiRequest:
 
         payload = {
             'prog': programid,
-            'email': email,
-            'password': password,
+            'email': user_email,
+            'password': user_password,
             'obsnum': obsnum,
             'target': target,
             'ra': ra,
@@ -249,10 +249,10 @@ class GEMINIAPI(FollowUpAPI):
         if not isinstance(altdata, dict):
             raise ValueError('Invalid altdata format')
 
-        email = str(altdata.get('email')).strip()
-        password = str(altdata.get('password')).strip()
-        progid = str(altdata.get('progid')).strip()
-        if not any([progid.startswith(x) for x in ["GN", "GS"]]):
+        user_email = str(altdata.get('user_email')).strip()
+        user_password = str(altdata.get('user_password')).strip()
+        programid = str(altdata.get('programid')).strip()
+        if not any([programid.startswith(x) for x in ["GN", "GS"]]):
             raise ValueError('Invalid program ID, must start with GN or GS')
 
         instrument = kwargs.get('instrument')
@@ -262,17 +262,17 @@ class GEMINIAPI(FollowUpAPI):
         instrument_name = str(instrument["name"]).lower().strip()
         if any(
             [x in instrument_name for x in ["south", "gs"]]
-        ) and not progid.startswith("GS"):
+        ) and not programid.startswith("GS"):
             raise ValueError('Invalid program ID for Gemini South, must start with GS')
         elif any(
             [x in instrument_name for x in ["north", "gn"]]
-        ) and not progid.startswith("GN"):
+        ) and not programid.startswith("GN"):
             raise ValueError('Invalid program ID for Gemini North, must start with GN')
         elif not any([x in instrument_name for x in ["north", "south", "gn", "gs"]]):
             raise ValueError('Invalid instrument, must be Gemini North or South')
 
-        if not email or not password or not progid:
-            raise ValueError('Email, password, and program ID are required')
+        if not user_email or not user_password or not programid:
+            raise ValueError('user_email, user_password, and programid are required')
 
         template_ids = altdata.get('template_ids')
         if template_ids:
@@ -401,9 +401,9 @@ class GEMINIAPI(FollowUpAPI):
     form_json_schema_altdata = {
         "type": "object",
         "properties": {
-            "email": {"type": "string", "title": "Email"},
-            "password": {"type": "string", "title": "Password"},
-            "progid": {
+            "user_email": {"type": "string", "title": "Email"},
+            "user_password": {"type": "string", "title": "Password"},
+            "programid": {
                 "type": "string",
                 "title": "Program ID",
                 "description": "CAUTION: Gemini North and South have different program IDs, starting with GN or GS respectively. So, make sure to use the correct one for the instrument you've selected.",
@@ -414,7 +414,7 @@ class GEMINIAPI(FollowUpAPI):
                 "description": "List of available templates, comma separated (optional)",
             },
         },
-        "required": ["email", "password", "progid"],
+        "required": ["user_email", "user_password", "programid"],
     }
 
     ui_json_schema = {}

--- a/skyportal/facility_apis/sedm.py
+++ b/skyportal/facility_apis/sedm.py
@@ -102,6 +102,8 @@ def convert_request_to_sedm(request, method_value='new'):
     }
 
     if rtype == "Mix 'n Match":
+        # we make a deepcopy so that the payload's observation_choices
+        # aren't edited when we edit choices
         choices = deepcopy(request.payload['observation_choices'])
         hasspec = 'IFU' in choices
         followup = 'IFU' if hasspec else ''

--- a/skyportal/facility_apis/sedm.py
+++ b/skyportal/facility_apis/sedm.py
@@ -1,6 +1,8 @@
 from datetime import datetime, timedelta
 import json
 import requests
+import traceback
+from copy import deepcopy
 
 from baselayer.app.env import load_env
 from baselayer.log import make_log
@@ -100,7 +102,7 @@ def convert_request_to_sedm(request, method_value='new'):
     }
 
     if rtype == "Mix 'n Match":
-        choices = request.payload['observation_choices']
+        choices = deepcopy(request.payload['observation_choices'])
         hasspec = 'IFU' in choices
         followup = 'IFU' if hasspec else ''
         if hasspec:
@@ -241,6 +243,30 @@ class SEDMAPI(FollowUpAPI):
                 'skyportal/REFRESH_FOLLOWUP_REQUESTS',
             )
 
+        try:
+            notification_type = request.allocation.altdata.get(
+                'notification_type', 'none'
+            )
+            if notification_type == 'slack':
+                from ..utils.notifications import request_notify_by_slack
+
+                request_notify_by_slack(
+                    request,
+                    session,
+                    is_update=False,
+                )
+            elif notification_type == 'email':
+                from ..utils.notifications import request_notify_by_email
+
+                request_notify_by_email(
+                    request,
+                    session,
+                    is_update=False,
+                )
+        except Exception as e:
+            traceback.print_exc()
+            log(f"Error sending notification: {e}")
+
     @staticmethod
     def delete(request, session, **kwargs):
         """Delete a follow-up request from SEDM queue.
@@ -343,6 +369,30 @@ class SEDMAPI(FollowUpAPI):
                 request.last_modified_by_id,
                 "skyportal/REFRESH_FOLLOWUP_REQUESTS",
             )
+
+        try:
+            notification_type = request.allocation.altdata.get(
+                'notification_type', 'none'
+            )
+            if notification_type == 'slack':
+                from ..utils.notifications import request_notify_by_slack
+
+                request_notify_by_slack(
+                    request,
+                    session,
+                    is_update=True,
+                )
+            elif notification_type == 'email':
+                from ..utils.notifications import request_notify_by_email
+
+                request_notify_by_email(
+                    request,
+                    session,
+                    is_update=True,
+                )
+        except Exception as e:
+            traceback.print_exc()
+            log(f"Error sending notification: {e}")
 
     @staticmethod
     def prepare_payload(payload, existing_payload=None):
@@ -466,4 +516,70 @@ class SEDMAPI(FollowUpAPI):
         'end_date': "End Date",
         'priority': "Priority",
         'observation_type': 'Mode',
+    }
+
+    form_json_schema_altdata = {
+        "type": "object",
+        "properties": {
+            "notification_type": {
+                "type": "string",
+                "title": "Notification Type",
+                "enum": ["none", "slack", "email"],
+            },
+        },
+        "dependencies": {
+            "notification_type": {
+                "oneOf": [
+                    {
+                        "properties": {
+                            "notification_type": {"enum": ["none"]},
+                        },
+                    },
+                    {
+                        "properties": {
+                            "notification_type": {"enum": ["slack"]},
+                            "slack_workspace": {
+                                "type": "string",
+                                "title": "Slack Workspace",
+                            },
+                            "slack_channel": {
+                                "type": "string",
+                                "title": "Slack Channel",
+                            },
+                            "slack_token": {
+                                "type": "string",
+                                "title": "Slack Token",
+                            },
+                            "include_comments": {
+                                "type": "boolean",
+                                "title": "Include Comments",
+                                "default": False,
+                            },
+                        },
+                        "required": [
+                            "slack_workspace",
+                            "slack_channel",
+                            "slack_token",
+                        ],
+                    },
+                    {
+                        "properties": {
+                            "notification_type": {"enum": ["email"]},
+                            "email": {
+                                "type": "string",
+                                "title": "Email",
+                            },
+                            "include_comments": {
+                                "type": "boolean",
+                                "title": "Include Comments",
+                                "default": False,
+                            },
+                        },
+                        "required": [
+                            "email",
+                        ],
+                    },
+                ]
+            },
+        },
     }

--- a/skyportal/handlers/api/followup_request.py
+++ b/skyportal/handlers/api/followup_request.py
@@ -1426,6 +1426,7 @@ class FollowupRequestHandler(BaseHandler):
                 )
                 session.commit()
             except Exception as e:
+                traceback.print_exc()
                 return self.error(f'Failed to delete follow-up request: {e}')
             return self.success()
 

--- a/skyportal/handlers/api/sources.py
+++ b/skyportal/handlers/api/sources.py
@@ -31,6 +31,7 @@ from skyportal.models import (
     cosmo,
 )
 from ...utils.cache import Cache, array_to_bytes
+from ...utils.calculations import radec2lb
 
 _, cfg = load_env()
 cache_dir = "cache/sources_queries"
@@ -421,42 +422,6 @@ def get_localization(localization_dateobs, localization_name, session):
     log_verbose(f"get_localization took {endTime - startTime} seconds")
 
     return localization_id, localizationtilescls.__tablename__
-
-
-# Rotation matrix for the conversion : x_galactic = R * x_equatorial (J2000)
-# http://adsabs.harvard.edu/abs/1989A&A...218..325M
-RGE = np.array(
-    [
-        [-0.054875539, -0.873437105, -0.483834992],
-        [+0.494109454, -0.444829594, +0.746982249],
-        [-0.867666136, -0.198076390, +0.455983795],
-    ]
-)
-
-
-def radec2lb(ra, dec):
-    """
-        Convert $R.A.$ and $Decl.$ into Galactic coordinates $l$ and $b$
-    ra [deg]
-    dec [deg]
-
-    return l [deg], b [deg]
-    """
-    ra_rad, dec_rad = np.deg2rad(ra), np.deg2rad(dec)
-    u = np.array(
-        [
-            np.cos(ra_rad) * np.cos(dec_rad),
-            np.sin(ra_rad) * np.cos(dec_rad),
-            np.sin(dec_rad),
-        ]
-    )
-
-    ug = np.dot(RGE, u)
-
-    x, y, z = ug
-    galactic_l = np.arctan2(y, x)
-    galactic_b = np.arctan2(z, (x * x + y * y) ** 0.5)
-    return np.rad2deg(galactic_l), np.rad2deg(galactic_b)
 
 
 def get_luminosity_distance(obj):

--- a/skyportal/utils/notifications.py
+++ b/skyportal/utils/notifications.py
@@ -11,10 +11,33 @@ from baselayer.log import make_log
 from skyportal.app_utils import get_app_base_url
 from skyportal.models import GcnEvent
 from skyportal.models.gcn import SOURCE_RADIUS_THRESHOLD
+from skyportal.utils.calculations import deg2hms, deg2dms, radec2lb
+from skyportal.email_utils import send_email
 
 env, cfg = load_env()
 
 app_url = get_app_base_url()
+
+ALERT_THUMB_TYPES = ["new", "ref", "sub"]
+ARCHIVE_THUMB_TYPES = ["sdss", "ls", "ps1"]
+ALLOWED_THUMBNAIL_TYPES = [
+    *ALERT_THUMB_TYPES,
+    *ARCHIVE_THUMB_TYPES,
+]
+
+SLACK_DIVIDER = {"type": "divider"}
+
+SLACK_BASE_URL = cfg['slack.expected_url_preamble']
+if SLACK_BASE_URL.endswith('/'):
+    SLACK_URL = SLACK_BASE_URL[:-1]
+
+SLACK_URL = f"{SLACK_URL}/services"
+
+SLACK_MICROSERVICE_URL = f'http://127.0.0.1:{cfg["slack.microservice_port"]}'
+
+email_enabled = False
+if cfg.get("email_service") == "sendgrid" or cfg.get("email_service") == "smtp":
+    email_enabled = True
 
 log = make_log('notifications')
 
@@ -463,3 +486,379 @@ def post_notification(request_body, timeout=2):
         return False
     else:
         return True
+
+
+def followup_request_notification_content(target, session):
+    include_comments = False
+    if target.allocation.altdata.get("include_comments", False) in [
+        True,
+        "T",
+        "True",
+        "true",
+        "t",
+        1,
+        "1",
+    ]:
+        include_comments = True
+
+    target_name = target.obj.id
+    ra, dec = target.obj.ra, target.obj.dec
+    ra_hms, ra_dms = deg2hms(ra), deg2dms(dec)
+    if not ra_dms.startswith("-"):
+        ra_dms = "+" + ra_dms
+    l, b = radec2lb(ra, dec)
+
+    allocation = (
+        str(target.allocation.instrument.telescope.nickname)
+        + "/"
+        + str(target.allocation.instrument.name)
+        + " ("
+        + str(target.allocation.pi)
+        + ")"
+    )
+    group = target.allocation.group.name
+    user = (
+        target.requester.username
+        if (
+            target.requester.first_name in ["", None]
+            or target.requester.last_name in ["", None]
+        )
+        else f"{target.requester.first_name} {target.requester.last_name}"
+    ) + (
+        f" ({str(target.requester.affiliations[0]).strip()})"
+        if (
+            isinstance(target.requester.affiliations, list)
+            and len(target.requester.affiliations) > 0
+        )
+        else ""
+    )
+    time = str(Time(target.created_at).isot).split(".")[0] + " UTC"
+
+    # then we want information about the payload itself
+    payload = target.payload
+
+    # we want to loop over the payload, to build a dict like:
+    # key: value as a string
+    payload = {key: str(value) for key, value in payload.items()}
+
+    # check if its a new request, or a request that has been updated
+    # we don't have an easy way to check this since these entries are edited right after they are submitted to the database
+    # so instead we'll define "new" requests where the last_updated is within 1 minute of the created_at
+    new_request = False
+    if (target.modified - target.created_at).seconds < 60:
+        new_request = True
+
+    # last but not least, we want to look for thumbnails
+    # if we find all 3 "alert" types: new, ref, sub, we return these 3
+    # otherwise we return sdss, ls, and ps1 in that order
+    thumbnails = [t for t in target.obj.thumbnails if t.type in ALLOWED_THUMBNAIL_TYPES]
+    # we may have more than one thumbnail of the same type, so we want to de-duplicate
+    # deduplicate by type, keeping the latest one (create_at) for each type
+    # sort by date, most recent first
+    thumbnails = sorted(thumbnails, key=lambda t: t.created_at, reverse=True)
+    thumbnails_by_type = {t: None for t in ALLOWED_THUMBNAIL_TYPES}
+    for thumbnail in thumbnails:
+        if thumbnails_by_type[thumbnail.type] is None:
+            thumbnails_by_type[thumbnail.type] = thumbnail
+
+    # now we check if we have all the alert types
+    # if we do, keep those
+    # otherwise, keep the archive types
+    if all(thumbnails_by_type[t] is not None for t in ALERT_THUMB_TYPES):
+        thumbnails = [thumbnails_by_type[t] for t in ALERT_THUMB_TYPES]
+    else:
+        thumbnails = [
+            thumbnails_by_type[t]
+            for t in ARCHIVE_THUMB_TYPES
+            if thumbnails_by_type.get(t, None) is not None
+        ]
+
+    # make them simple dicts
+    thumbnails = [
+        {
+            "url": app_url + t.public_url
+            if t.type in ALERT_THUMB_TYPES
+            else t.public_url,
+            "type": t.type,
+        }
+        for t in thumbnails
+    ]
+
+    data = {
+        "obj": {
+            "id": target_name,
+            "ra": ra,
+            "dec": dec,
+            "ra_hms": ra_hms,
+            "dec_dms": ra_dms,
+            "l": l,
+            "b": b,
+            "thumbnails": thumbnails,
+        },
+        "request": {
+            "allocation": allocation,
+            "group": group,
+            "user": user,
+            "time": time,
+            "payload": payload,
+            "new": new_request,
+        },
+    }
+
+    if include_comments:
+        comments = []
+        for comment in target.obj.comments:
+            comments.append(
+                (
+                    f"{comment.author.username} ({str(comment.created_at).split('.')[0]}): {comment.text}",
+                    comment.created_at,
+                )
+            )
+
+        # sort by date, most recent first, then remove the date
+        comments = sorted(comments, key=lambda c: c[1], reverse=True)
+        data["comments"] = [c[0] for c in comments]
+
+    return data
+
+
+def followup_request_slack_notification(data):
+    header_section = {
+        "type": "section",
+        "text": {
+            "type": "mrkdwn",
+            "text": f'*<{app_url}/source/{data["obj"]["id"]}|{data["obj"]["id"]}>*\n*{data["obj"]["ra_hms"]} {data["obj"]["dec_dms"]}*\n*'
+            + f'α, δ* = {data["obj"]["ra"]:0.6f}, {data["obj"]["dec"]:0.6f}\n'
+            + f'*l, b* = {data["obj"]["l"]:0.6f}, {data["obj"]["b"]:0.6f}',
+        },
+    }
+    if len(data["obj"]["thumbnails"]) > 0:
+        header_section["accessory"] = {
+            "type": "image",
+            "image_url": data["obj"]["thumbnails"][0]["url"],
+            "alt_text": data["obj"]["thumbnails"][0]["type"],
+        }
+
+    request_section = {
+        "type": "section",
+        "text": {
+            "type": "mrkdwn",
+            "text": f'*{"New" if data["request"]["new"] else "Updated"} Follow-up request:*\n'
+            + f'\t• *Allocation*:  {data["request"]["allocation"]}\n'
+            + f'\t• *Group*:  {data["request"]["group"]}\n'
+            + f'\t• *User:*  {data["request"]["user"]}\n'
+            + f'\t• *Time:*  {data["request"]["time"]}',
+        },
+    }
+    if len(data["obj"]["thumbnails"]) > 1:
+        request_section["accessory"] = {
+            "type": "image",
+            "image_url": data["obj"]["thumbnails"][1]["url"],
+            "alt_text": data["obj"]["thumbnails"][1]["type"],
+        }
+
+    payload_section = {
+        "type": "section",
+        "text": {"type": "mrkdwn", "text": "*Payload:*\n"},
+    }
+
+    for key, value in data["request"]["payload"].items():
+        payload_section["text"][
+            "text"
+        ] += f'\t• *{str(key).lower().capitalize()}*: {value}\n'
+
+    if len(data["obj"]["thumbnails"]) > 2:
+        payload_section["accessory"] = {
+            "type": "image",
+            "image_url": data["obj"]["thumbnails"][2]["url"],
+            "alt_text": data["obj"]["thumbnails"][2]["type"],
+        }
+
+    buttons = {
+        "type": "actions",
+        "elements": [
+            {
+                "type": "button",
+                "text": {"type": "plain_text", "emoji": True, "text": "Observability"},
+                "style": "primary",
+                "url": f"{app_url}/observability/{data['obj']['id']}",
+            },
+            {
+                "type": "button",
+                "text": {"type": "plain_text", "emoji": True, "text": "Finding Chart"},
+                "style": "primary",
+                "url": f"{app_url}/source/{data['obj']['id']}/finder",
+            },
+            {
+                "type": "button",
+                "text": {"type": "plain_text", "emoji": True, "text": "SDSS"},
+                "url": f"https://skyserver.sdss.org/dr18/VisualTools/navi?opt=G&ra={data['obj']['ra']}&dec={data['obj']['dec']}&scale=0.1",
+            },
+            {
+                "type": "button",
+                "text": {"type": "plain_text", "emoji": True, "text": "LS DR9"},
+                "url": f"https://www.legacysurvey.org/viewer?ra={data['obj']['ra']}&dec={data['obj']['dec']}&layer=ls-dr9&photoz-dr9&zoom=16&mark={data['obj']['ra']},{data['obj']['dec']}",
+            },
+            {
+                "type": "button",
+                "text": {"type": "plain_text", "emoji": True, "text": "TNS"},
+                "url": f"https://www.wis-tns.org/search?&ra={data['obj']['ra']}&decl={data['obj']['dec']}&radius=5&coords_unit=arcsec",
+            },
+        ],
+    }
+
+    blocks = [
+        SLACK_DIVIDER,
+        header_section,
+        SLACK_DIVIDER,
+        request_section,
+        SLACK_DIVIDER,
+        payload_section,
+    ]
+
+    if "comments" in data:
+        if len(data["comments"]) > 0:
+            comments_section = {
+                "type": "section",
+                "text": {"type": "mrkdwn", "text": "*Comments:*\n"},
+            }
+            for comment in data["comments"]:
+                comments_section["text"]["text"] += f'\t• {comment}\n'
+            blocks.append(comments_section)
+        else:
+            blocks.append(
+                {
+                    "type": "section",
+                    "text": {"type": "mrkdwn", "text": "*Comments:*\nNo comments yet"},
+                }
+            )
+
+    return blocks + [buttons]
+
+
+def followup_request_email_notification(data):
+    header_text = f"<h3>{'New' if data['request']['new'] else 'Updated'} Follow-up Request: <a href='{app_url}/source/{data['obj']['id']}'>{data['obj']['id']}</a></h3>"
+    subject = f"{cfg['app.title']} - {'New' if data['request']['new'] else 'Updated'} Follow-up Request: {data['obj']['id']}"
+
+    obj_section = (
+        "<div>"
+        f"<p><b>{data['obj']['ra_hms']} {data['obj']['dec_dms']}</b></p>"
+        f"<p>α, δ = {data['obj']['ra']:0.6f}, {data['obj']['dec']:0.6f}</p>"
+        f"<p>l, b = {data['obj']['l']:0.6f}, {data['obj']['b']:0.6f}</p>"
+        "</div>"
+    )
+
+    if len(data['obj']['thumbnails']) > 0:
+        # make one row with all the thumbnails
+        thumbnails_section = "<div style='display: flex; flex-wrap: wrap;'>"
+        for thumbnail in data['obj']['thumbnails']:
+            thumbnails_section += f"<img src='{thumbnail['url']}' style='max-width: 100%; max-height: 100%; margin: 5px;' title='{thumbnail['type']}' />"
+        thumbnails_section += "</div>"
+    else:
+        thumbnails_section = ""
+
+    request_section = (
+        "<div><h4>Request:</h4><ul>"
+        f"<li>Allocation: {data['request']['allocation']}</li>"
+        f"<li>Group: {data['request']['group']}</li>"
+        f"<li>User: {data['request']['user']}</li>"
+        f"<li>Time: {data['request']['time']}</li>"
+        "</ul></div>"
+    )
+
+    payload_section = "<div><h4>Payload:</h4><ul>"
+    for key, value in data["request"]["payload"].items():
+        payload_section += f"<li>{key}: {value}</li>"
+    payload_section += "</ul></div>"
+
+    comments_section = ""
+    if "comments" in data:
+        if len(data["comments"]) > 0:
+            comments_section = "<div><h4>Comments:</h4><ul>"
+            for comment in data["comments"]:
+                comments_section += f"<li>{comment}</li>"
+
+            comments_section += "</ul></div>"
+        else:
+            comments_section = (
+                "<div><h4>Comments:</h4><ul><li>No comments yet</li></ul></div>"
+            )
+
+    buttons = (
+        "<div style='display: flex; gap: 8px;'>"
+        f"<a href='{app_url}/observability/{data['obj']['id']}'><button>Observability</button></a>"
+        f"<a href='{app_url}/source/{data['obj']['id']}/finder'><button>Finding Chart</button></a>"
+        f"<a href='https://skyserver.sdss.org/dr18/VisualTools/navi?opt=G&ra={data['obj']['ra']}&dec={data['obj']['dec']}&scale=0.1'><button>SDSS</button></a>"
+        f"<a href='https://www.legacysurvey.org/viewer?ra={data['obj']['ra']}&dec={data['obj']['dec']}&layer=ls-dr9&photoz-dr9&zoom=16&mark={data['obj']['ra']},{data['obj']['dec']}'><button>LS DR9</button></a>"
+        f"<a href='https://www.wis-tns.org/search?&ra={data['obj']['ra']}&decl={data['obj']['dec']}&radius=5&coords_unit=arcsec'><button>TNS</button></a>"
+        "</div>"
+    )
+
+    return subject, (
+        "<!DOCTYPE html><html><head><style>body {font-family: Arial, Helvetica, sans-serif;}</style></head>"
+        + "<body>"
+        + header_text
+        + obj_section
+        + thumbnails_section
+        + request_section
+        + payload_section
+        + comments_section
+        + buttons
+        + "</body></html>"
+    )
+
+
+def request_notify_by_slack(request, session, is_update=None):
+    altdata = request.allocation.altdata
+
+    if not isinstance(altdata, dict):
+        raise ValueError('No altdata found in allocation.')
+
+    if not all(
+        key in altdata for key in ['slack_workspace', 'slack_channel', 'slack_token']
+    ):
+        raise ValueError('Missing required keys in allocation altdata.')
+
+    content = followup_request_notification_content(request, session)
+    if is_update is not None:  # if we have an explicit is_update, use that
+        content['request']['new'] = not is_update
+    blocks = followup_request_slack_notification(content)
+
+    data = json.dumps(
+        {
+            "url": f"{SLACK_URL}/{altdata['slack_workspace']}/{altdata['slack_channel']}/{altdata['slack_token']}",
+            "text": "test",
+            "blocks": blocks,
+        }
+    )
+
+    r = requests.post(
+        SLACK_MICROSERVICE_URL,
+        data=data,
+        headers={'Content-Type': 'application/json'},
+    )
+    r.raise_for_status()
+
+
+def request_notify_by_email(request, session, is_update=None):
+    # if not email_enabled:
+    #     raise RuntimeError('Email notifications are not enabled.')
+
+    altdata = request.allocation.altdata
+
+    if not isinstance(altdata, dict):
+        raise ValueError('No altdata found in allocation.')
+
+    if 'email' not in altdata:
+        raise ValueError('Missing required key in allocation altdata.')
+
+    content = followup_request_notification_content(request, session)
+    if is_update is not None:  # if we have an explicit is_update, use that
+        content['request']['new'] = not is_update
+    subject, body = followup_request_email_notification(content)
+
+    send_email(
+        recipients=altdata['email'].split(","),
+        subject=subject,
+        body=body,
+    )


### PR DESCRIPTION
This PR:

- refactor Generic API to move the slack & email notification logic into the notification utils, to be important by other facility APIs
- adds optional slack OR email notifications when submitting/updating follow-up requests (for winter, sedm, swift).
- Upgrade the format of Slack and email notifications, to look nicer and be more functional
- change Gemini auth parameter names
- move radec2lb from sources to utils

The idea here is that having every single user that has an allocation set up notifications for it is cumbersome, and often its the same group of user that has access to an allocation that could just easily get notifications sent to a slack channel for everyone to see, or to an email list. This PR enables that.

TODOs (in future PRs):
- when I'll redesign the notification framework (hopefully before the end of the year, otherwise beginning of the next), make use of these new methods to also send nice looking notifications (with this new format added by that PR) with the regular notification (user-specific) system.
- update the follow-up request documentation which is lagging behind the backend features overall, and mention the notification system there too. I'm planning to address that after Thanksgiving, and make a new release then.