### PR TITLE
Obsplan statistics - localization tiles partition selection

### DIFF
--- a/skyportal/utils/observation_plan.py
+++ b/skyportal/utils/observation_plan.py
@@ -187,9 +187,9 @@ def generate_observation_plan_statistics(
         if stats_method == 'python':
             t0 = time.time()
             localization_tiles = session.scalars(
-                sa.select(LocalizationTile)
-                .where(LocalizationTile.localization_id == request.localization_id)
-                .order_by(LocalizationTile.probdensity.desc())
+                sa.select(localizationtilescls)
+                .where(localizationtilescls.localization_id == request.localization_id)
+                .order_by(localizationtilescls.probdensity.desc())
                 .distinct()
             ).all()
             if stats_logging:
@@ -299,13 +299,13 @@ def generate_observation_plan_statistics(
                 log(f'STATS: area= {intarea}. Runtime= {time.time() - t0:.2f}s. ')
 
             prob = sa.func.sum(
-                LocalizationTile.probdensity
-                * (union.columns.healpix * LocalizationTile.healpix).area
+                localizationtilescls.probdensity
+                * (union.columns.healpix * localizationtilescls.healpix).area
             )
 
             query_prob = sa.select(prob).filter(
-                LocalizationTile.localization_id == request.localization_id,
-                union.columns.healpix.overlaps(LocalizationTile.healpix),
+                localizationtilescls.localization_id == request.localization_id,
+                union.columns.healpix.overlaps(localizationtilescls.healpix),
             )
 
             intprob = session.execute(query_prob).scalar_one()


### PR DESCRIPTION
In the `skyportal.utils.observation_plan.py`'s `generate_observation_plan_statistics()` method, we do not make use of the python-based selection of the database partition everywhere

The LocalizationTile table is partitioned, and we can either just query the table and let the DB select the partition, or bypass that and query the partition directly which we do pretty much everywhere already.

In this PR, we make sure that the pre-selected partition is used for all the queries in that method, for consistency but also as it seems to prevent index-selection issues on a production system (Icare) where the postgres migration created issues.