### PR TITLE
TNS API changes

### DIFF
--- a/.github/workflows/build-and-deploy-docs.yaml
+++ b/.github/workflows/build-and-deploy-docs.yaml
@@ -117,7 +117,7 @@ jobs:
           export PATH=${NPM_PACKAGES}/bin:$PATH
           export NODE_PATH="$NPM_PACKAGES/lib/node_modules:$NODE_PATH"
 
-          sudo npm -g install npm@latest
+          npm -g install npm@latest
 
       - name: Checkout branch being tested
         uses: actions/checkout@v4

--- a/.github/workflows/test_api_and_frontend.yaml
+++ b/.github/workflows/test_api_and_frontend.yaml
@@ -150,13 +150,7 @@ jobs:
           export PATH=${NPM_PACKAGES}/bin:$PATH
           export NODE_PATH="$NPM_PACKAGES/lib/node_modules:$NODE_PATH"
 
-          # DEBUG: print the node and npm versions as well as their locations
-          echo node $(node --version)
-          echo npm $(npm --version)
-          echo $(which node)
-          echo $(which npm)
-
-          sudo npm -g install npm@latest
+          npm -g install npm@latest
 
           which python; python --version
           echo npm $(npm --version)

--- a/.github/workflows/test_api_and_frontend.yaml
+++ b/.github/workflows/test_api_and_frontend.yaml
@@ -150,6 +150,12 @@ jobs:
           export PATH=${NPM_PACKAGES}/bin:$PATH
           export NODE_PATH="$NPM_PACKAGES/lib/node_modules:$NODE_PATH"
 
+          # DEBUG: print the node and npm versions as well as their locations
+          echo node $(node --version)
+          echo npm $(npm --version)
+          echo $(which node)
+          echo $(which npm)
+
           sudo npm -g install npm@latest
 
           which python; python --version

--- a/.github/workflows/test_migrations.yaml
+++ b/.github/workflows/test_migrations.yaml
@@ -121,7 +121,7 @@ jobs:
           export PATH=${NPM_PACKAGES}/bin:$PATH
           export NODE_PATH="$NPM_PACKAGES/lib/node_modules:$NODE_PATH"
 
-          sudo npm -g install npm@latest
+          npm -g install npm@latest
 
           which python; python --version
           echo npm $(npm --version)

--- a/.github/workflows/test_models.yaml
+++ b/.github/workflows/test_models.yaml
@@ -129,7 +129,7 @@ jobs:
           export PATH=${NPM_PACKAGES}/bin:$PATH
           export NODE_PATH="$NPM_PACKAGES/lib/node_modules:$NODE_PATH"
 
-          sudo npm -g install npm@latest
+          npm -g install npm@latest
 
           which python; python --version
           echo npm $(npm --version)

--- a/services/tns_retrieval_queue/tns_retrieval_queue.py
+++ b/services/tns_retrieval_queue/tns_retrieval_queue.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import time
+import traceback
 import urllib
 from threading import Thread
 from datetime import datetime, timedelta
@@ -365,7 +366,7 @@ def process_queue(queue):
                     continue
 
                 try:
-                    tns_source_data = r.json().get("data", dict()).get("reply", dict())
+                    tns_source_data = r.json().get("data", dict())
                 except Exception:
                     tns_source_data = None
                 if tns_source_data is None:
@@ -387,7 +388,9 @@ def process_queue(queue):
 
                 tns_prefix = tns_source_data.get("name_prefix", None)
                 if tns_prefix is None:
-                    log(f"Error processing TNS source {tns_name}: obj has no prefix")
+                    log(
+                        f"Error processing TNS source {tns_name}: obj has no prefix ({str(r.json())})"
+                    )
                     continue
 
                 tns_name = f"{tns_prefix} {tns_source}"
@@ -467,6 +470,7 @@ def process_queue(queue):
                             session,
                         )
         except Exception as e:
+            traceback.print_exc()
             log(f"Error processing TNS source {tns_name}: {e}")
             user_id = task.get("user_id", None)
             if user_id is not None:

--- a/services/tns_submission_queue/tns_submission_queue.py
+++ b/services/tns_submission_queue/tns_submission_queue.py
@@ -33,8 +33,8 @@ log = make_log('tns_queue')
 init_db(**cfg['database'])
 
 TNS_URL = cfg['app.tns.endpoint']
-report_url = urljoin(TNS_URL, 'api/bulk-report')
-report_reply_url = urljoin(TNS_URL, 'api/bulk-report-reply')
+report_url = urljoin(TNS_URL, 'api/set/bulk-report')
+report_reply_url = urljoin(TNS_URL, 'api/get/bulk-report-reply')
 search_frontend_url = urljoin(TNS_URL, 'search')
 tns_retrieval_microservice_url = f'http://127.0.0.1:{cfg["ports.tns_retrieval_queue"]}'
 

--- a/skyportal/handlers/api/tns.py
+++ b/skyportal/handlers/api/tns.py
@@ -41,8 +41,8 @@ _, cfg = load_env()
 Session = scoped_session(sessionmaker())
 
 TNS_URL = cfg['app.tns.endpoint']
-upload_url = urllib.parse.urljoin(TNS_URL, 'api/file-upload')
-report_url = urllib.parse.urljoin(TNS_URL, 'api/bulk-report')
+upload_url = urllib.parse.urljoin(TNS_URL, 'api/set/file-upload')
+report_url = urllib.parse.urljoin(TNS_URL, 'api/set/bulk-report')
 
 log = make_log('api/tns')
 

--- a/skyportal/utils/tns.py
+++ b/skyportal/utils/tns.py
@@ -1,5 +1,6 @@
 import json
 import time
+import traceback
 import urllib
 
 import astropy.units as u
@@ -148,8 +149,9 @@ def get_recent_TNS(api_key, headers, public_timestamp, get_data=True):
         return []
     try:
         json_response = json.loads(r.text)
-        reply = json_response['data']['reply']
+        reply = json_response['data']
     except Exception as e:
+        traceback.print_exc()
         log(f'TNS request failed: {str(e)}.')
         return []
 
@@ -194,9 +196,9 @@ def get_recent_TNS(api_key, headers, public_timestamp, get_data=True):
 
             if r.status_code == 200:
                 try:
-                    source_data = r.json().get("data", dict()).get("reply", dict())
+                    source_data = r.json().get("data", dict())
                 except Exception as e:
-                    log(f'Failed to parse TNS response: {str(e)}')
+                    log(f'Failed to parse TNS response: {str(e)} ({str(r.json())})')
                     source_data = None
                 if source_data:
                     sources.append(
@@ -303,9 +305,9 @@ def get_IAUname(
         raise ValueError('TNS request failed: request rate exceeded.')
 
     try:
-        reply = r.json().get("data", dict()).get("reply", [])
+        reply = r.json().get("data", dict())
     except Exception as e:
-        log(f'Failed to parse TNS response: {str(e)}')
+        log(f'Failed to parse TNS response: {str(e)} ({str(r.json())})')
         reply = []
 
     if len(reply) > 0:
@@ -347,7 +349,7 @@ def get_IAUname(
                     continue
 
                 try:
-                    source_data = r.json().get("data", dict()).get("reply", dict())
+                    source_data = r.json().get("data", dict())
                 except Exception:
                     source_data = None
                 if source_data:
@@ -438,7 +440,7 @@ def get_internal_names(api_key, headers, tns_name=None):
     internal_names = []
     try:
         reply = json.loads(r.text)
-        internal_names = reply["data"]["reply"]["internal_names"]
+        internal_names = reply["data"]["internal_names"]
         # comma separated list of internal names, starting with a comma (so we fiter out the first empty string after splitting)
         internal_names = list(filter(None, map(str.strip, internal_names.split(","))))
     except Exception as e:


### PR DESCRIPTION
In this PR we adopt some of the changes recently added to the TNS API, that broke most (if not all!) the scripts that interact with it.

We had to fix a few endpoints, and directly look for the responses' data in `data`, and not `data.reply`.

PS: I already made these changes in production, on Fritz. I already reprocessed all of the failed submissions so we're ok.