### PR TITLE
Unify position calculation (photometry-based) & offset position default source

### DIFF
--- a/skyportal/handlers/api/obj.py
+++ b/skyportal/handlers/api/obj.py
@@ -6,7 +6,7 @@ from sqlalchemy import func
 
 from baselayer.app.access import auth_or_token
 from baselayer.app.env import load_env
-from ..base import BaseHandler
+
 from ...models import (
     Annotation,
     Classification,
@@ -14,11 +14,12 @@ from ...models import (
     Obj,
     PhotometricSeries,
     Photometry,
-    Spectrum,
     SourcesConfirmedInGCN,
+    Spectrum,
 )
-from ...utils.offset import _calculate_best_position_for_offset_stars
 from ...utils.calculations import great_circle_distance
+from ...utils.offset import _calculate_best_position_for_offset_stars
+from ..base import BaseHandler
 
 _, cfg = load_env()
 
@@ -304,6 +305,8 @@ class ObjPositionHandler(BaseHandler):
                         "separation": float(
                             great_circle_distance(ra, dec, obj.ra, obj.dec) * 3600
                         ),
+                        "discovery_ra": obj.ra,
+                        "discovery_dec": obj.dec,
                     }
                 )
             except Exception as e:

--- a/skyportal/utils/offset.py
+++ b/skyportal/utils/offset.py
@@ -1,44 +1,42 @@
-import io
-import os
-import math
 import datetime
+import io
+import math
+import os
+import re
+import time
 import urllib
 import warnings
 from functools import wraps
-import re
-import time
 
-import pandas as pd
-import requests
-from requests.exceptions import HTTPError
 import matplotlib
 import matplotlib.pyplot as plt
-import seaborn as sns
 import numpy as np
 import numpy.ma as ma
-from scipy.ndimage import gaussian_filter
-from joblib import Memory
-
+import pandas as pd
+import pyvo as vo
+import requests
+import seaborn as sns
 from astropy import units as u
 from astropy.coordinates import SkyCoord
-from astroquery.gaia import Gaia
-from astropy.time import Time
+from astropy.io import fits
 from astropy.table import Table
+from astropy.time import Time
 from astropy.utils.exceptions import AstropyWarning
-
-from astropy.wcs.wcs import FITSFixedWarning
+from astropy.visualization import ImageNormalize, ZScaleInterval
 from astropy.wcs import WCS
 from astropy.wcs.utils import pixel_to_skycoord
-from astropy.io import fits
-from astropy.visualization import ImageNormalize, ZScaleInterval
-from reproject import reproject_adaptive
-import pyvo as vo
+from astropy.wcs.wcs import FITSFixedWarning
+from astroquery.gaia import Gaia
+from joblib import Memory
 from pyvo.dal.exceptions import DALQueryError, DALServiceError
+from reproject import reproject_adaptive
+from requests.exceptions import HTTPError
+from scipy.ndimage import gaussian_filter
+
+from baselayer.app.env import load_env
+from baselayer.log import make_log
 
 from .cache import Cache
-
-from baselayer.log import make_log
-from baselayer.app.env import load_env
 
 log = make_log('finder-chart')
 

--- a/static/js/components/FindingChart.jsx
+++ b/static/js/components/FindingChart.jsx
@@ -1,22 +1,22 @@
+import makeStyles from "@mui/styles/makeStyles";
 import React, { Suspense, useRef, useState } from "react";
 import { Link, useParams } from "react-router-dom";
-import makeStyles from "@mui/styles/makeStyles";
 
-import Select from "@mui/material/Select";
-import MenuItem from "@mui/material/MenuItem";
-import InputLabel from "@mui/material/InputLabel";
-import CircularProgress from "@mui/material/CircularProgress";
-import FormControl from "@mui/material/FormControl";
-import Input from "@mui/material/Input";
-import Grid from "@mui/material/Grid";
+import PrintIcon from "@mui/icons-material/Print";
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
+import CircularProgress from "@mui/material/CircularProgress";
+import FormControl from "@mui/material/FormControl";
+import Grid from "@mui/material/Grid";
+import Input from "@mui/material/Input";
+import InputLabel from "@mui/material/InputLabel";
+import MenuItem from "@mui/material/MenuItem";
+import Select from "@mui/material/Select";
 import Typography from "@mui/material/Typography";
-import PrintIcon from "@mui/icons-material/Print";
 
-import TextLoop from "react-text-loop";
-import { useImage } from "react-image";
 import { Controller, useForm } from "react-hook-form";
+import { useImage } from "react-image";
+import TextLoop from "react-text-loop";
 import { useReactToPrint } from "react-to-print";
 import Button from "./Button";
 
@@ -82,7 +82,7 @@ const FindingChart = () => {
   const [params, setParams] = useState({
     imagesource: "ps1",
     facility: "Keck",
-    positionsource: "gaia",
+    positionsource: "ztfref",
     findersize: 4.0,
     numoffset: 3,
   });


### PR DESCRIPTION
The position shown on the source page (calculated on the fly by a dedicated handler) is computed from the photometry's ra/dec, snr^2 weighted. However, the photometry used was different in other handlers (data access sensitive, did not remove the forced photometry, no data quality cut, ...), which confused the users.

Moreover, while a parameter of all of the API endpoints was set to False by default, one page of the web app was setting it to True by default instead, which confused our users even more (`use_ztfref=True` by default in the API, but the webapp's interactive finder chart page was setting it to False instead).

In this PR we make sure that the photometry used for the position calculation is identical in the different handlers, and set the interactive finder chart webpage's default value for `use_ztfref` value to True, just like for the API.