### PR TITLE
Sleep services that repeatedly process queues

### DIFF
--- a/services/recurring_apis/recurring_apis.py
+++ b/services/recurring_apis/recurring_apis.py
@@ -1,5 +1,6 @@
 import json
 from datetime import datetime, timedelta
+import time
 
 from astropy.time import Time
 
@@ -103,6 +104,7 @@ def service(*args, **kwargs):
             perform_api_calls()
         except Exception as e:
             log(e)
+        time.sleep(60)
 
 
 if __name__ == "__main__":

--- a/services/reminders/reminders.py
+++ b/services/reminders/reminders.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta, timezone
+import time
 
 from baselayer.log import make_log
 from baselayer.app.models import init_db
@@ -119,6 +120,7 @@ def service(*args, **kwargs):
             send_reminders()
         except Exception as e:
             log(e)
+        time.sleep(60)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
These two workers currently take up a lot of CPU, and they will flood the database with requests.

I wasn't sure what the longest appropriate wait is here; I'll defer to @mcoughlin.
