### PR TITLE
Fix state update affecting all open tabs

### DIFF
--- a/static/js/ducks/public_pages/public_source_page.js
+++ b/static/js/ducks/public_pages/public_source_page.js
@@ -27,9 +27,12 @@ export const fetchPublicSourcePages = (sourceId) => {
 export const deletePublicSourcePage = (pageId) =>
   API.DELETE(`/api/public_pages/source/${pageId}`, DELETE_PUBLIC_SOURCE_PAGE);
 
-messageHandler.add((actionType, payload, dispatch) => {
+messageHandler.add((actionType, payload, dispatch, getState) => {
   if (actionType === REFRESH_PUBLIC_SOURCE_PAGES) {
-    dispatch(fetchPublicSourcePages(payload.source_id));
+    const { source_id } = payload;
+    if (getState().source.id === source_id) {
+      dispatch(fetchPublicSourcePages(source_id));
+    }
   }
 });
 


### PR DESCRIPTION
This PR resolves a bug where publishing a new public source triggered updates in all open tabs, even for sources that were unrelated.