### PR TITLE
Add source info on public release source list

### DIFF
--- a/static/public_pages/releases/release/release_template.css
+++ b/static/public_pages/releases/release/release_template.css
@@ -43,9 +43,33 @@ header {
         flex-wrap: wrap;
         gap: 0.2rem 1rem;
         align-items: baseline;
-        h2 {
+        .sourceId {
+          position: relative;
+          color: rgb(29, 53, 87);
           margin: 0;
           font-weight: bold;
+
+          &::after {
+            content: " ";
+            position: absolute;
+            bottom: 0;
+            left: 50%;
+            transform: translateX(-50%);
+            height: 3px;
+            width: 0;
+            background-image: linear-gradient(
+              to right,
+              rgb(29, 53, 87),
+              rgb(50, 91, 167)
+            );
+            transition: width 0.3s;
+          }
+
+          &:hover {
+            &::after {
+              width: 100%;
+            }
+          }
         }
         span {
           font-size: 0.9rem;

--- a/static/public_pages/releases/release/release_template.css
+++ b/static/public_pages/releases/release/release_template.css
@@ -5,7 +5,6 @@ header {
   padding: 0 1rem;
   a {
     color: white;
-    font-size: 0.8rem;
     font-weight: bold;
   }
 }

--- a/static/public_pages/releases/release/release_template.html
+++ b/static/public_pages/releases/release/release_template.html
@@ -41,7 +41,11 @@
         <div class="sourceAndVersions" id="{{ source_id }}">
           <div class="source">
             <div class="sourceAndTimeAgo">
-              <h2 class="sourceId">{{ source_id }}</h2>
+              <h2 class="sourceId">
+                <a href="/public/releases/{{release.link_name}}/sources/{{source_id}}/version/{{versions[0].hash}}" target="_blank">
+                  {{ source_id }}
+                </a>
+              </h2>
               {% set time_difference = datetime.datetime.utcnow() - versions[0].created_at %}
               {% set days = time_difference.days %}
               {% set hours = time_difference.seconds // 3600 %}
@@ -58,13 +62,10 @@
                   {{ days }} days and {{ hours }} hours ago
                 {% end %}
               </span>
-              <button type="button" onclick="displayVersions('{{ source_id }}')">
-                view all...
-              </button>
             </div>
-            <a href="/public/releases/{{release.link_name}}/sources/{{source_id}}/version/{{versions[0].hash}}" target="_blank">
-              Link to the latest version
-            </a>
+            <button type="button" onclick="displayVersions('{{ source_id }}')">
+                view all...
+            </button>
           </div>
           <div
             class="versions"

--- a/static/public_pages/releases/release/release_template.html
+++ b/static/public_pages/releases/release/release_template.html
@@ -27,8 +27,8 @@
   </head>
   <body>
     <header>
-      <h1 class="websiteName">Release {{ release.name }}</h1>
-      <a href="/public/releases">Come back to all the releases -></a>
+      <h1 class="websiteName">Release: {{ release.name }}</h1>
+      <a href="/public/releases">All releases -></a>
     </header>
     <div class="releaseTemplate">
       <div class="name">

--- a/static/public_pages/releases/releases_template.css
+++ b/static/public_pages/releases/releases_template.css
@@ -29,6 +29,7 @@
       gap: 0.2rem 1rem;
       align-items: baseline;
       .releaseName {
+        color: rgb(29, 53, 87);
         position: relative;
         margin: 0;
         font-weight: bold;
@@ -38,9 +39,13 @@
           bottom: 0;
           left: 50%;
           transform: translateX(-50%);
-          height: 2px;
+          height: 3px;
           width: 0;
-          background-color: black;
+          background-image: linear-gradient(
+            to right,
+            rgb(29, 53, 87),
+            rgb(75, 132, 211)
+          );
           transition: width 0.3s;
         }
         &:hover {

--- a/static/public_pages/releases/releases_template.css
+++ b/static/public_pages/releases/releases_template.css
@@ -44,7 +44,7 @@
           background-image: linear-gradient(
             to right,
             rgb(29, 53, 87),
-            rgb(75, 132, 211)
+            rgb(50, 91, 167)
           );
           transition: width 0.3s;
         }

--- a/static/public_pages/releases/releases_template.css
+++ b/static/public_pages/releases/releases_template.css
@@ -28,7 +28,7 @@
       flex-wrap: wrap;
       gap: 0.2rem 1rem;
       align-items: baseline;
-      h2 {
+      .releaseName {
         position: relative;
         margin: 0;
         font-weight: bold;

--- a/static/public_pages/sources/sources_template.css
+++ b/static/public_pages/sources/sources_template.css
@@ -31,9 +31,31 @@
         flex-wrap: wrap;
         gap: 0.2rem 1rem;
         align-items: baseline;
-        h2 {
+        .sourceId {
+          position: relative;
+          color: rgb(29, 53, 87);
           margin: 0;
           font-weight: bold;
+          &::after {
+            content: " ";
+            position: absolute;
+            bottom: 0;
+            left: 50%;
+            transform: translateX(-50%);
+            height: 3px;
+            width: 0;
+            background-image: linear-gradient(
+              to right,
+              rgb(29, 53, 87),
+              rgb(50, 91, 167)
+            );
+            transition: width 0.3s;
+          }
+          &:hover {
+            &::after {
+              width: 100%;
+            }
+          }
         }
         span {
           font-size: 0.9rem;

--- a/static/public_pages/sources/sources_template.html
+++ b/static/public_pages/sources/sources_template.html
@@ -42,7 +42,11 @@
       <div class="sourceAndVersions" id="{{ source_id }}">
         <div class="source">
           <div class="sourceAndTimeAgo">
-            <h2 class="sourceId">{{ source_id }}</h2>
+            <h2 class="sourceId">
+              <a href="/public/sources/{{ source_id }}" target="_blank">
+                {{ source_id }}
+              </a>
+            </h2>
             {% set time_difference = datetime.datetime.utcnow() - versions[0].created_at %}
             {% set days = time_difference.days %}
             {% set hours = time_difference.seconds // 3600 %}
@@ -59,13 +63,10 @@
                 {{ days }} days and {{ hours }} hours ago
               {% end %}
             </span>
-            <button type="button" onclick="displayVersions('{{ source_id }}')">
-              view all...
-            </button>
           </div>
-          <a href="/public/sources/{{source_id}}" target="_blank">
-            Link to the latest version
-          </a>
+          <button type="button" onclick="displayVersions('{{ source_id }}')">
+              view all...
+          </button>
         </div>
         <div
           class="versions"


### PR DESCRIPTION
This PR add more source information about each source in the public release page and improve the overall style of the public pages that display sources and releases:

- [ ] Improving the page styling with updates to text colors, hover effects and better naming for links to enhance readability and user experience.

- [ ] Adding more precise source details to the list, including:
        Name, RA, Dec, Peak magnitude in the light curve (with the corresponding filter), T0 (time of first detection), Time when the source was saved to the group(s) of the release (if any).