### PR TITLE
Dockerfile - install rsync

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV SNCOSMO_DATA_DIR=/skyportal/persistentdata/sncosmo
 RUN apt-get update && \
     apt-get install -y curl build-essential software-properties-common ca-certificates gnupg \
     python3 python3-venv python3-dev libpq-dev supervisor libgdal-dev \
-    git postgresql-client vim nano screen htop \
+    git postgresql-client vim nano screen htop rsync \
     libcurl4-gnutls-dev libgnutls28-dev && \
     mkdir -p /etc/apt/keyrings && \
     curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \


### PR DESCRIPTION
I've been asked to make a clone of Fritz on another machine, as a point in time backup for ZTF partners that should not access the live instance anymore, as they should not see any of the new data.

One problem I have is that copying the persistent data & thumbnails to another machine isn't very easy to do on gcp, and having access to `rsync` would make that much easier.

So, this PR adds it to the Docker image