### PR TITLE
Test Migration - caching issue

### DIFF
--- a/.github/workflows/test_migrations.yaml
+++ b/.github/workflows/test_migrations.yaml
@@ -129,11 +129,6 @@ jobs:
           ref: ${{ env.MIGRATION_REFERENCE }}
           submodules: true
 
-      - name: Cache migration reference branch dependencies
-        uses: ./.github/actions/cache-dependencies
-        with:
-          key-prefix: ref
-
       - name: Write SkyPortal configs
         run: |
           cat << EOF > config.yaml
@@ -175,11 +170,6 @@ jobs:
           make run &
           sleep 180 && make load_demo_data
           kill %1
-
-      - name: Save migration reference branch cache
-        uses: ./.github/actions/cache-dependencies-save
-        with:
-          key-prefix: ref
 
       - name: Checkout branch being tested
         uses: actions/checkout@v4

--- a/.github/workflows/test_migrations.yaml
+++ b/.github/workflows/test_migrations.yaml
@@ -15,6 +15,9 @@ on:
       - "skyportal/enum_types.py"
       - "skyportal/facility_apis/__init__.py"
       - "requirements.txt"
+      - ".github/workflows/test_migrations.yaml"
+      - ".github/actions/cache-dependencies/action.yaml"
+      - ".github/actions/cache-dependencies-save/action.yaml"
     types: [opened, reopened, synchronize, ready_for_review]
 
 jobs:


### PR DESCRIPTION
In the migration test, we use the new caching composite action. Issue is we try to cache dependencies after checking out to the reference commit (down migration version of SkyPortal, from which we then try to migrate the db to the latest). However the composite caching does not exist in that down migration, creating a failure.

This PR removes the caching of the dependencies from the reference commit, which while it can help, creates an issue and prevents us from running the GA. We can think about how to reintroduce caching at that step at a later date.