### PR TITLE
Data Sharing - frontend refresh fix

### DIFF
--- a/skyportal/handlers/api/sharing.py
+++ b/skyportal/handlers/api/sharing.py
@@ -113,12 +113,13 @@ class SharingHandler(BaseHandler):
                 for group in groups:
                     spec.groups.append(group)
                 # Grab obj_id for use in websocket message below
-                spec_obj_ids.append(spec.obj_id)
+                spec_obj_ids.append(spec.obj.internal_key)
 
         self.verify_and_commit()
 
-        spec_obj_ids = set(spec_obj_ids)
         phot_obj_ids = set(phot_obj_ids)
+        spec_obj_ids = set(spec_obj_ids)
+
         for obj_id in phot_obj_ids:
             self.push(
                 action="skyportal/REFRESH_SOURCE_PHOTOMETRY", payload={"obj_id": obj_id}
@@ -126,7 +127,8 @@ class SharingHandler(BaseHandler):
 
         for obj_id in spec_obj_ids:
             self.push(
-                action="skyportal/REFRESH_SOURCE_SPECTRA", payload={"obj_id": obj_id}
+                action="skyportal/REFRESH_SOURCE_SPECTRA",
+                payload={"obj_internal_key": obj_id},
             )
 
         return self.success()

--- a/skyportal/handlers/api/sharing.py
+++ b/skyportal/handlers/api/sharing.py
@@ -69,7 +69,7 @@ class SharingHandler(BaseHandler):
         groups = valid_groups
 
         phot_obj_ids = []
-        spec_obj_ids = []
+        spec_obj_internal_keys = []
 
         if phot_ids:
             valid_phot = Photometry.query.filter(Photometry.id.in_(phot_ids))
@@ -113,22 +113,22 @@ class SharingHandler(BaseHandler):
                 for group in groups:
                     spec.groups.append(group)
                 # Grab obj_id for use in websocket message below
-                spec_obj_ids.append(spec.obj.internal_key)
+                spec_obj_internal_keys.append(spec.obj.internal_key)
 
         self.verify_and_commit()
 
         phot_obj_ids = set(phot_obj_ids)
-        spec_obj_ids = set(spec_obj_ids)
+        spec_obj_internal_keys = set(spec_obj_internal_keys)
 
         for obj_id in phot_obj_ids:
             self.push(
                 action="skyportal/REFRESH_SOURCE_PHOTOMETRY", payload={"obj_id": obj_id}
             )
 
-        for obj_id in spec_obj_ids:
+        for obj_internal_key in spec_obj_internal_keys:
             self.push(
                 action="skyportal/REFRESH_SOURCE_SPECTRA",
-                payload={"obj_internal_key": obj_id},
+                payload={"obj_internal_key": obj_internal_key},
             )
 
         return self.success()

--- a/static/js/ducks/spectra.js
+++ b/static/js/ducks/spectra.js
@@ -74,7 +74,10 @@ messageHandler.add((actionType, payload, dispatch, getState) => {
     const state = getState().spectra;
 
     Object.entries(state).forEach(([objID, spectra]) => {
-      if (spectra?.[0]?.obj_internal_key === payload.obj_internal_key) {
+      if (
+        spectra?.[0]?.obj_internal_key === payload.obj_internal_key &&
+        payload?.obj_internal_key !== null
+      ) {
         dispatch(fetchSourceSpectra(objID));
       }
     });


### PR DESCRIPTION
The Sharing handler was sending the obj_id and not the obj_internal_key to the frontend (via websockets) to refresh the data displayed when updating the data access of spectra, which prevented it from being refreshed as expected.

This PR fixes this.