### PR TITLE
Group admission - stream access error message clarification

### DIFF
--- a/skyportal/handlers/api/group_admission_request.py
+++ b/skyportal/handlers/api/group_admission_request.py
@@ -200,7 +200,9 @@ class GroupAdmissionRequestHandler(BaseHandler):
                     if stream not in requesting_user.accessible_streams
                 ]
                 if missing_streams:
-                    stream_names = ", ".join(missing_streams)
+                    stream_names = ", ".join(
+                        [stream.name for stream in missing_streams]
+                    )
                     return self.error(
                         f"User {user_id} does not have access to the following streams: {stream_names},"
                         f"required to be added to group {group_id}."

--- a/skyportal/handlers/api/group_admission_request.py
+++ b/skyportal/handlers/api/group_admission_request.py
@@ -1,13 +1,7 @@
 from baselayer.app.access import auth_or_token, permissions
 from baselayer.app.custom_exceptions import AccessError
 
-from ...models import (
-    Group,
-    GroupAdmissionRequest,
-    GroupUser,
-    User,
-    UserNotification,
-)
+from ...models import Group, GroupAdmissionRequest, GroupUser, User, UserNotification
 from ..base import BaseHandler
 
 
@@ -200,13 +194,16 @@ class GroupAdmissionRequestHandler(BaseHandler):
                 )
             # Ensure user has sufficient stream access for target group
             if group.streams:
-                if not all(
-                    stream in requesting_user.accessible_streams
+                missing_streams = [
+                    stream
                     for stream in group.streams
-                ):
+                    if stream not in requesting_user.accessible_streams
+                ]
+                if missing_streams:
+                    stream_names = ", ".join(missing_streams)
                     return self.error(
-                        f"User {user_id} does not have sufficient stream access "
-                        f"to be added to group {group_id}."
+                        f"User {user_id} does not have access to the following streams: {stream_names},"
+                        f"required to be added to group {group_id}."
                     )
             admission_request = GroupAdmissionRequest(
                 user_id=user_id, group_id=group_id, status="pending"

--- a/skyportal/tests/frontend/test_group_admission_requests.py
+++ b/skyportal/tests/frontend/test_group_admission_requests.py
@@ -44,5 +44,5 @@ def test_group_admission_request_insufficient_stream_access(
     filter_for_value(driver, public_group.name)
     driver.click_xpath(f'//*[@data-testid="requestAdmissionButton{public_group.id}"]')
     driver.wait_for_xpath(
-        f'//*[text()="User {user_no_groups_no_streams.id} does not have sufficient stream access to be added to group {public_group.id}."]'
+        '//*[contains(text(), "does not have access to the following streams")]'
     )


### PR DESCRIPTION
the stream access error triggered when adding a user with insufficient stream access to a group was not clear as we reported IDs rather than actual stream names. This PR hopefully makes that message clearer