### PR TITLE
GCN JSON events - missing tags

### DIFF
--- a/skyportal/handlers/api/gcn.py
+++ b/skyportal/handlers/api/gcn.py
@@ -322,7 +322,7 @@ def post_skymap_from_notice(
         root = json.loads(gcn_notice.content.decode("utf8"))
         notice_type = None
 
-    skymap, url, properties, tags = None, None, None, None
+    skymap, url, properties, tags = None, None, None, []
     try:
         skymap, url, properties, tags = get_skymap(root, notice_type)
     except Exception as e:
@@ -396,10 +396,13 @@ def post_skymap_from_notice(
                     "dec": dec,
                     "origin": None,
                 }
-                tags_formatted = [tag.upper().strip() for tag in tags]
+                try:
+                    tags_formatted = [tag.upper().strip() for tag in tags]
+                except Exception:
+                    tags_formatted = []
                 if "GRB" in tags_formatted:
                     source["name"] = f"GRB-{source_name}"
-                    if "SWIFT" in tags_formatted:
+                    if "SWIFT" in tags_formatted or "GUANO" in tags_formatted:
                         source["origin"] = "Swift"
                     elif "FERMI" in tags_formatted:
                         source["origin"] = "Fermi"

--- a/skyportal/handlers/api/gcn.py
+++ b/skyportal/handlers/api/gcn.py
@@ -322,7 +322,7 @@ def post_skymap_from_notice(
         root = json.loads(gcn_notice.content.decode("utf8"))
         notice_type = None
 
-    skymap, url, properties, tags = None, None, None, []
+    skymap, url, properties, tags = None, None, None, None
     try:
         skymap, url, properties, tags = get_skymap(root, notice_type)
     except Exception as e:
@@ -396,13 +396,15 @@ def post_skymap_from_notice(
                     "dec": dec,
                     "origin": None,
                 }
-                try:
-                    tags_formatted = [tag.upper().strip() for tag in tags]
-                except Exception:
-                    tags_formatted = []
+                event_tags = []
+                if isinstance(root, dict):
+                    event_tags = get_json_tags(root)
+                else:
+                    event_tags = get_tags(root)
+                tags_formatted = [tag.upper().strip() for tag in event_tags]
                 if "GRB" in tags_formatted:
                     source["name"] = f"GRB-{source_name}"
-                    if "SWIFT" in tags_formatted or "GUANO" in tags_formatted:
+                    if "SWIFT" in tags_formatted:
                         source["origin"] = "Swift"
                     elif "FERMI" in tags_formatted:
                         source["origin"] = "Fermi"

--- a/skyportal/utils/gcn.py
+++ b/skyportal/utils/gcn.py
@@ -394,12 +394,6 @@ def get_skymap(root, notice_type, url_timeout=10):
         skymap, properties, tags = from_url(skymap_metadata["url"])
         return skymap, skymap_metadata["url"], properties, tags
     elif status == "cone":
-        tags = []
-        if isinstance(root, dict):
-            try:
-                tags = get_json_tags(root)
-            except Exception as e:
-                print(f"Could not get tags from JSON: {str(e)}")
         return (
             from_cone(
                 ra=skymap_metadata["ra"],
@@ -408,7 +402,7 @@ def get_skymap(root, notice_type, url_timeout=10):
             ),
             None,
             None,
-            tags,
+            [],
         )
     elif status == "healpix_file":
         skymap, properties, tags = from_bytes(skymap_metadata)

--- a/skyportal/utils/gcn.py
+++ b/skyportal/utils/gcn.py
@@ -394,6 +394,12 @@ def get_skymap(root, notice_type, url_timeout=10):
         skymap, properties, tags = from_url(skymap_metadata["url"])
         return skymap, skymap_metadata["url"], properties, tags
     elif status == "cone":
+        tags = []
+        if isinstance(root, dict):
+            try:
+                tags = get_json_tags(root)
+            except Exception as e:
+                print(f"Could not get tags from JSON: {str(e)}")
         return (
             from_cone(
                 ra=skymap_metadata["ra"],
@@ -402,14 +408,14 @@ def get_skymap(root, notice_type, url_timeout=10):
             ),
             None,
             None,
-            None,
+            tags,
         )
     elif status == "healpix_file":
         skymap, properties, tags = from_bytes(skymap_metadata)
         skymap["localization_name"] = "healpix"
         return skymap, None, properties, tags
     else:
-        return None, None, None, None
+        return None, None, None, []
 
 
 def get_properties(root):


### PR DESCRIPTION
I noticed that some - not all - EP events wouldn't get an associated source, and I tracked it as a bug coming from a PR of mine https://github.com/skyportal/skyportal/commit/a2a929b2daccc33db5d8d80650db76a64c4a6270

This PR fixes that