### PR TITLE
Improve follow up information tarot API

### DIFF
--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -30,7 +30,6 @@ app:
   sedm_endpoint: http://minar.caltech.edu/add_fritz
   sedmv2_endpoint:
   trt_endpoint: https://trt.narit.or.th/hub/api
-  tarot_endpoint: http://cador.tarotnet.org/ros
 
   lt_host: 161.72.57.3
   lt_port: 8080
@@ -40,6 +39,12 @@ app:
   lco_port: 443
 
   lco_archive_endpoint: https://archive-api.lco.global
+
+  # Tarot API endpoints
+  tarot_endpoint: http://cador.tarotnet.org/ros
+  calern_endpoint: http://tca4.tarotnet.org/ros
+  chili_endpoint: http://tch4.tarotnet.org/ros
+  reunion_endpoint: http://tre4.tarotnet.org/ros
 
   ztf:
     protocol: https

--- a/services/notification_queue/notification_queue.py
+++ b/services/notification_queue/notification_queue.py
@@ -1068,7 +1068,7 @@ def api(queue):
                                             session.commit()
                                             queue.append(notification.id)
                                 elif is_followup_request:
-                                    if target_data["status"] == "submitted":
+                                    if "submitted" in target_data["status"]:
                                         continue
                                     allocation_id = target_data["allocation_id"]
                                     allocation = session.scalars(

--- a/services/notification_queue/notification_queue.py
+++ b/services/notification_queue/notification_queue.py
@@ -1068,7 +1068,7 @@ def api(queue):
                                             session.commit()
                                             queue.append(notification.id)
                                 elif is_followup_request:
-                                    if "submitted" in target_data["status"]:
+                                    if target_data["status"].startswith("submitted"):
                                         continue
                                     allocation_id = target_data["allocation_id"]
                                     allocation = session.scalars(

--- a/skyportal/facility_apis/tarot.py
+++ b/skyportal/facility_apis/tarot.py
@@ -266,6 +266,7 @@ def login_to_tarot(request, session, altdata):
         f"{cfg['app.tarot_endpoint']}/manage/manage/login.php",
         data=data,
         auth=(altdata["browser_username"], altdata["browser_password"]),
+        timeout=5.0,
     )
 
     if login_response.status_code == 200 and "hashuser" in login_response.text:
@@ -328,6 +329,7 @@ class TAROTAPI(FollowUpAPI):
             f"{cfg['app.tarot_endpoint']}/manage/manage/depot/depot-defaultshort.res.php?hashuser={hash_user}&idreq={altdata['request_id']}",
             data=payload,
             auth=(altdata["browser_username"], altdata["browser_password"]),
+            timeout=5.0,
         )
 
         if "New Scene Inserted" not in response.text:
@@ -393,6 +395,7 @@ class TAROTAPI(FollowUpAPI):
         response = requests.get(
             f"{cfg['app.tarot_endpoint']}/rejected{station_dict[request.payload['station_name']]['url_to_request']}.txt",
             auth=(altdata["browser_username"], altdata["browser_password"]),
+            timeout=5.0,
         )
 
         if response.status_code != 200:
@@ -437,7 +440,7 @@ class TAROTAPI(FollowUpAPI):
                     f"app.{station_dict[request.payload['station_name']]['endpoint']}"
                 ]
 
-                response = requests.get(f"{station_endpoint}/klotz/")
+                response = requests.get(f"{station_endpoint}/klotz/", timeout=5.0)
 
                 if response.status_code != 200:
                     raise ValueError("Error trying to get the observation log")
@@ -542,6 +545,7 @@ class TAROTAPI(FollowUpAPI):
                 f"{cfg['app.tarot_endpoint']}/manage/manage/liste_scene.php?hashuser={hash_user}&idreq={altdata['request_id']}",
                 data=data,
                 auth=(altdata["browser_username"], altdata["browser_password"]),
+                timeout=5.0,
             )
 
             if response.status_code != 200:

--- a/skyportal/facility_apis/tarot.py
+++ b/skyportal/facility_apis/tarot.py
@@ -345,6 +345,7 @@ class TAROTAPI(FollowUpAPI):
         )
 
         session.add(transaction)
+        session.commit()
 
         try:
             flow = Flow()
@@ -422,7 +423,7 @@ class TAROTAPI(FollowUpAPI):
                 match.group(1), "rejected: not planified"
             )
 
-        if "submitted" in request.status:
+        if "rejected" not in request.status:
             # check if the scene has been observed
             station_endpoint = cfg[
                 f"app.{station_dict[request.payload['station_name']]['endpoint']}"

--- a/skyportal/facility_apis/tarot.py
+++ b/skyportal/facility_apis/tarot.py
@@ -338,7 +338,7 @@ class TAROTAPI(FollowUpAPI):
                 )
             request.status = error_response
         else:
-            request.status = "pending"
+            request.status = "submitted: retrieve status..."
 
         transaction = FacilityTransaction(
             request=http.serialize_requests_request(response.request),

--- a/skyportal/facility_apis/tarot.py
+++ b/skyportal/facility_apis/tarot.py
@@ -381,8 +381,8 @@ class TAROTAPI(FollowUpAPI):
         # Each identifier corresponds to a different status, as shown below:
         status_dict = {
             "0": "not planned",
-            "1": "observation ended before range",
-            "2": "observation started after range",
+            "1": "planned for a future night.",
+            "2": "date is before the current/upcoming night.",
             "4": "over quota",
             "5": "planned",
             "6": "planned over",

--- a/skyportal/facility_apis/tarot.py
+++ b/skyportal/facility_apis/tarot.py
@@ -330,10 +330,13 @@ class TAROTAPI(FollowUpAPI):
             auth=(altdata["browser_username"], altdata["browser_password"]),
         )
 
-        if response.status_code != 200 or "New Scene Inserted" not in response.text:
-            request.status = (
-                f"rejected: status code = {response.status_code}\n\r{response.text}"
-            )
+        if "New Scene Inserted" not in response.text:
+            error_response = f"rejected: status code = {response.status_code}. "
+            if response.status_code == 200:
+                error_response += "Scene not Inserted" + (
+                    " - Hashuser not valid" if "secu_erreur" in response.text else ""
+                )
+            request.status = error_response
         else:
             request.status = "pending"
 

--- a/skyportal/facility_apis/tarot.py
+++ b/skyportal/facility_apis/tarot.py
@@ -440,6 +440,18 @@ class TAROTAPI(FollowUpAPI):
                 new_request_status = f"complete"
 
         if new_request_status is None:
+            try:
+                flow = Flow()
+                flow.push(
+                    request.last_modified_by_id,
+                    "baselayer/SHOW_NOTIFICATION",
+                    payload={
+                        "note": "TAROT request status has not changed",
+                        "type": "warning",
+                    },
+                )
+            except Exception as e:
+                log(f"Failed to send notification: {e}")
             return
 
         request.status = new_request_status

--- a/skyportal/facility_apis/tarot.py
+++ b/skyportal/facility_apis/tarot.py
@@ -320,7 +320,7 @@ class TAROTAPI(FollowUpAPI):
                 f"rejected: status code = {response.status_code}\n\r{response.text}"
             )
         else:
-            request.status = "submitted"
+            request.status = "pending"
 
         transaction = FacilityTransaction(
             request=http.serialize_requests_request(response.request),

--- a/skyportal/facility_apis/tarot.py
+++ b/skyportal/facility_apis/tarot.py
@@ -430,7 +430,7 @@ class TAROTAPI(FollowUpAPI):
                 match.group(1), "rejected: not planified"
             )
 
-        if "rejected" not in request.status:
+        if "rejected" not in new_request_status:
             # check if the scene has been observed
             station_endpoint = cfg[
                 f"app.{station_dict[request.payload['station_name']]['endpoint']}"

--- a/skyportal/facility_apis/tarot.py
+++ b/skyportal/facility_apis/tarot.py
@@ -338,7 +338,7 @@ class TAROTAPI(FollowUpAPI):
                 )
             request.status = error_response
         else:
-            request.status = "submitted: retrieve status..."
+            request.status = "submitted: please retrieve status"
 
         transaction = FacilityTransaction(
             request=http.serialize_requests_request(response.request),

--- a/skyportal/facility_apis/tarot.py
+++ b/skyportal/facility_apis/tarot.py
@@ -373,6 +373,8 @@ class TAROTAPI(FollowUpAPI):
         ----------
         request: skyportal.models.FollowupRequest
             The request to get the status for.
+        session: sqlalchemy.Session
+            Database session for this transaction
         """
         from ..models import FacilityTransaction
 

--- a/skyportal/facility_apis/tarot.py
+++ b/skyportal/facility_apis/tarot.py
@@ -363,7 +363,7 @@ class TAROTAPI(FollowUpAPI):
                     request.last_modified_by_id, "skyportal/REFRESH_FOLLOWUP_REQUESTS"
                 )
         except Exception as e:
-            log(f"Failed to send notification: {e}")
+            log(f"Failed to send notification: {str(e)}")
 
     @staticmethod
     def get(request, session, **kwargs):
@@ -454,7 +454,7 @@ class TAROTAPI(FollowUpAPI):
                     },
                 )
             except Exception as e:
-                log(f"Failed to send notification: {e}")
+                log(f"Failed to send notification: {str(e)}")
             return
 
         request.status = new_request_status
@@ -490,7 +490,7 @@ class TAROTAPI(FollowUpAPI):
                     },
                 )
         except Exception as e:
-            log(f"Failed to send notification: {e}")
+            log(f"Failed to send notification: {str(e)}")
 
     @staticmethod
     def delete(request, session, **kwargs):
@@ -578,7 +578,7 @@ class TAROTAPI(FollowUpAPI):
                     "skyportal/REFRESH_FOLLOWUP_REQUESTS",
                 )
         except Exception as e:
-            log(f"Failed to send notification: {e}")
+            log(f"Failed to send notification: {str(e)}")
 
     form_json_schema = {
         "type": "object",

--- a/skyportal/facility_apis/tarot.py
+++ b/skyportal/facility_apis/tarot.py
@@ -392,8 +392,8 @@ class TAROTAPI(FollowUpAPI):
             # To check the request status, an identifier is retrieved from each scene on TAROT manager,
             # Each identifier corresponds to a different status, as shown below:
             status_dict = {
-                "1": "submitted: planned for a future night.",
-                "2": "rejected: date is before the current/upcoming night.",
+                "1": "rejected: date is before the current/upcoming night.",
+                "2": "submitted: planned for a future night.",
                 "4": "rejected: over quota",
                 "5": "submitted: planified",
                 "6": "submitted: planified over",

--- a/skyportal/facility_apis/tarot.py
+++ b/skyportal/facility_apis/tarot.py
@@ -338,7 +338,7 @@ class TAROTAPI(FollowUpAPI):
                 )
             request.status = error_response
         else:
-            request.status = "submitted: please retrieve status"
+            request.status = "submitted: use retrieve to check status"
 
         transaction = FacilityTransaction(
             request=http.serialize_requests_request(response.request),

--- a/skyportal/facility_apis/tarot.py
+++ b/skyportal/facility_apis/tarot.py
@@ -551,7 +551,7 @@ class TAROTAPI(FollowUpAPI):
             request.status = (
                 "deleted"
                 if is_error_on_delete is None
-                else f"rejected: {is_error_on_delete}"
+                else f"rejected: deletion failed - {is_error_on_delete}"
             )
 
             transaction = FacilityTransaction(

--- a/skyportal/facility_apis/tarot.py
+++ b/skyportal/facility_apis/tarot.py
@@ -412,10 +412,10 @@ class TAROTAPI(FollowUpAPI):
         status_dict = {
             "1": "rejected: date is before the current/upcoming night.",
             "2": "submitted: planned for a future night.",
-            "3": "rejected: never visible in the range",
-            "4": "rejected: over quota",
-            "5": "submitted: planified",
-            "6": "submitted: planified over",
+            "3": "rejected: never visible within the specified range.",
+            "4": "rejected: over quota.",
+            "5": "submitted: planified.",
+            "6": "submitted: planified over.",
         }
 
         new_request_status = None

--- a/skyportal/facility_apis/tarot.py
+++ b/skyportal/facility_apis/tarot.py
@@ -430,15 +430,13 @@ class TAROTAPI(FollowUpAPI):
                 match.group(1), "rejected: not planified"
             )
 
-        if "rejected" not in new_request_status:
+        if "rejected" not in (new_request_status or request.status):
             # check if the scene has been observed
-            if (
-                cfg[f"app.{station_dict[request.payload['station_name']]['endpoint']}"]
-                is not None
-            ):
+            try:
                 station_endpoint = cfg[
                     f"app.{station_dict[request.payload['station_name']]['endpoint']}"
                 ]
+
                 response = requests.get(f"{station_endpoint}/klotz/")
 
                 if response.status_code != 200:
@@ -449,13 +447,13 @@ class TAROTAPI(FollowUpAPI):
                 if manager_scene_id in response.text:
                     nb_observation = response.text.count(manager_scene_id)
                     new_request_status = f"complete"
-            else:
+            except:
                 flow = Flow()
                 flow.push(
                     request.last_modified_by_id,
                     "baselayer/SHOW_NOTIFICATION",
                     payload={
-                        "note": f"{request.payload['station_name']} endpoint not configured",
+                        "note": f"{request.payload['station_name']} endpoint not configured to verify observation",
                         "type": "error",
                     },
                 )

--- a/skyportal/facility_apis/tarot.py
+++ b/skyportal/facility_apis/tarot.py
@@ -18,15 +18,18 @@ env, cfg = load_env()
 
 log = make_log("facility_apis/tarot")
 
-url_by_station_and_page = {
+station_dict = {
     "Tarot_Calern": {
-        "request_status": 1,
-        "observation_log": "tca4",
+        "url_to_request": 1,
+        "endpoint": "calern_endpoint",
     },
-    "Tarot_Chili": {"request_status": 2, "observation_log": "tch4"},
+    "Tarot_Chili": {
+        "url_to_request": 2,
+        "endpoint": "chili_endpoint",
+    },
     "Tarot_Reunion": {
-        "request_status": 8,
-        "observation_log": "tre4",
+        "url_to_request": 8,
+        "endpoint": "reunion_endpoint",
     },
 }
 
@@ -382,7 +385,7 @@ class TAROTAPI(FollowUpAPI):
         )
 
         response = requests.get(
-            f"{cfg['app.tarot_endpoint']}/rejected{url_by_station_and_page[request.payload['station_name']]['request_status']}.txt",
+            f"{cfg['app.tarot_endpoint']}/rejected{station_dict[request.payload['station_name']]['url_to_request']}.txt",
             auth=(altdata["browser_username"], altdata["browser_password"]),
         )
 
@@ -421,9 +424,10 @@ class TAROTAPI(FollowUpAPI):
 
         if "submitted" in request.status:
             # check if the scene has been observed
-            response = requests.get(
-                f"{cfg['app.tarot_endpoint']}/rejected{url_by_station_and_page[request.payload['station_name']]['observation_log']}.txt"
-            )
+            station_endpoint = cfg[
+                f"app.{station_dict[request.payload['station_name']]['endpoint']}"
+            ]
+            response = requests.get(f"{station_endpoint}/klotz/")
 
             if response.status_code != 200:
                 raise ValueError("Error trying to get the observation log")

--- a/skyportal/facility_apis/tarot.py
+++ b/skyportal/facility_apis/tarot.py
@@ -412,6 +412,7 @@ class TAROTAPI(FollowUpAPI):
         status_dict = {
             "1": "rejected: date is before the current/upcoming night.",
             "2": "submitted: planned for a future night.",
+            "3": "rejected: never visible in the range",
             "4": "rejected: over quota",
             "5": "submitted: planified",
             "6": "submitted: planified over",
@@ -422,7 +423,8 @@ class TAROTAPI(FollowUpAPI):
         if (
             match is not None
             and match.group(1) is not None
-            and status_dict.get(match.group(1)) not in request.status
+            and status_dict.get(match.group(1), "rejected: not planified")
+            not in request.status
         ):
             new_request_status = status_dict.get(
                 match.group(1), "rejected: not planified"

--- a/skyportal/facility_apis/tarot.py
+++ b/skyportal/facility_apis/tarot.py
@@ -447,18 +447,6 @@ class TAROTAPI(FollowUpAPI):
                 new_request_status = f"complete"
 
         if new_request_status is None:
-            try:
-                flow = Flow()
-                flow.push(
-                    request.last_modified_by_id,
-                    "baselayer/SHOW_NOTIFICATION",
-                    payload={
-                        "note": "TAROT request status has not changed",
-                        "type": "warning",
-                    },
-                )
-            except Exception as e:
-                log(f"Failed to send notification: {str(e)}")
             return
 
         request.status = new_request_status

--- a/skyportal/facility_apis/tarot.py
+++ b/skyportal/facility_apis/tarot.py
@@ -343,18 +343,20 @@ class TAROTAPI(FollowUpAPI):
 
         session.add(transaction)
 
-        if kwargs.get("refresh_source", False):
+        try:
             flow = Flow()
-            flow.push(
-                "*",
-                "skyportal/REFRESH_SOURCE",
-                payload={"obj_key": request.obj.internal_key},
-            )
-        if kwargs.get("refresh_requests", False):
-            flow = Flow()
-            flow.push(
-                request.last_modified_by_id, "skyportal/REFRESH_FOLLOWUP_REQUESTS"
-            )
+            if kwargs.get("refresh_source", False):
+                flow.push(
+                    "*",
+                    "skyportal/REFRESH_SOURCE",
+                    payload={"obj_key": request.obj.internal_key},
+                )
+            if kwargs.get("refresh_requests", False):
+                flow.push(
+                    request.last_modified_by_id, "skyportal/REFRESH_FOLLOWUP_REQUESTS"
+                )
+        except Exception as e:
+            log(f"Failed to send notification: {e}")
 
     @staticmethod
     def get(request, session, **kwargs):
@@ -540,20 +542,23 @@ class TAROTAPI(FollowUpAPI):
             )
 
             session.add(transaction)
+            session.commit()
 
-        if kwargs.get("refresh_source", False):
+        try:
             flow = Flow()
-            flow.push(
-                "*",
-                "skyportal/REFRESH_SOURCE",
-                payload={"obj_key": obj_internal_key},
-            )
-        if kwargs.get("refresh_requests", False):
-            flow = Flow()
-            flow.push(
-                last_modified_by_id,
-                "skyportal/REFRESH_FOLLOWUP_REQUESTS",
-            )
+            if kwargs.get("refresh_source", False):
+                flow.push(
+                    "*",
+                    "skyportal/REFRESH_SOURCE",
+                    payload={"obj_key": obj_internal_key},
+                )
+            if kwargs.get("refresh_requests", False):
+                flow.push(
+                    last_modified_by_id,
+                    "skyportal/REFRESH_FOLLOWUP_REQUESTS",
+                )
+        except Exception as e:
+            log(f"Failed to send notification: {e}")
 
     form_json_schema = {
         "type": "object",

--- a/static/js/components/allocation/AllocationSummary.jsx
+++ b/static/js/components/allocation/AllocationSummary.jsx
@@ -105,9 +105,9 @@ const SimpleMenu = ({ request }) => {
         open={Boolean(anchorEl)}
         onClose={handleClose}
       >
-        {(request.status.includes("submitted") ||
-          request.status === "not observed" ||
-          request.status === "pending") && (
+        {(request.status.startsWith("submitted") ||
+          request.status.startsWith("not observed") ||
+          request.status.startsWith("pending")) && (
           <MenuItem
             onClick={() => updateRequestStatus("complete")}
             variant="contained"
@@ -116,9 +116,9 @@ const SimpleMenu = ({ request }) => {
             Mark Observed
           </MenuItem>
         )}
-        {(request.status.includes("submitted") ||
-          request.status === "complete" ||
-          request.status === "pending") && (
+        {(request.status.startsWith("submitted") ||
+          request.status.startsWith("complete") ||
+          request.status.startsWith("pending")) && (
           <MenuItem
             onClick={() => updateRequestStatus("not observed")}
             variant="contained"

--- a/static/js/components/allocation/AllocationSummary.jsx
+++ b/static/js/components/allocation/AllocationSummary.jsx
@@ -105,7 +105,7 @@ const SimpleMenu = ({ request }) => {
         open={Boolean(anchorEl)}
         onClose={handleClose}
       >
-        {(request.status === "submitted" ||
+        {(request.status.includes("submitted") ||
           request.status === "not observed" ||
           request.status === "pending") && (
           <MenuItem
@@ -116,7 +116,7 @@ const SimpleMenu = ({ request }) => {
             Mark Observed
           </MenuItem>
         )}
-        {(request.status === "submitted" ||
+        {(request.status.includes("submitted") ||
           request.status === "complete" ||
           request.status === "pending") && (
           <MenuItem

--- a/static/js/components/followup_request/FollowupRequestLists.jsx
+++ b/static/js/components/followup_request/FollowupRequestLists.jsx
@@ -332,9 +332,9 @@ const FollowupRequestLists = ({
         const isDone =
           followupRequest.status === "Photometry committed to database";
 
-        const isSubmitted = ["submitted", "pending"].includes(
-          followupRequest.status,
-        );
+        const isSubmitted =
+          followupRequest.status === "pending" ||
+          followupRequest.status.includes("submitted");
 
         const isFailed = followupRequest.status.includes("failed to submit");
 

--- a/static/js/components/followup_request/FollowupRequestLists.jsx
+++ b/static/js/components/followup_request/FollowupRequestLists.jsx
@@ -333,8 +333,8 @@ const FollowupRequestLists = ({
           followupRequest.status === "Photometry committed to database";
 
         const isSubmitted =
-          followupRequest.status === "pending" ||
-          followupRequest.status.includes("submitted");
+          followupRequest.status.startsWith("pending") ||
+          followupRequest.status.startsWith("submitted");
 
         const isFailed = followupRequest.status.includes("failed to submit");
 


### PR DESCRIPTION
- [x] Improve the way the submitted status on the follow request are check to allow adding more information after it.
- [x] Improve the error and the submit message for the tarot API
- [x] Check if the requested scene have been observed on an other page from TAROT.
- [x] Display the "pending" status when no status have been found or requested yet on the TAROT Page.
- [x] Add timeout parameter to requests in TAROT API to manage cases where the server is not accessible.
- [x] Add except to catch when there is not the endpoint URL in the env or when the request is timeout.