### PR TITLE
Dockerfile: add top command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV SNCOSMO_DATA_DIR=/skyportal/persistentdata/sncosmo
 RUN apt-get update && \
     apt-get install -y curl build-essential software-properties-common ca-certificates gnupg \
     python3 python3-venv python3-dev libpq-dev supervisor libgdal-dev \
-    git postgresql-client vim nano screen htop rsync \
+    git postgresql-client vim nano screen htop rsync top \
     libcurl4-gnutls-dev libgnutls28-dev && \
     mkdir -p /etc/apt/keyrings && \
     curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \


### PR DESCRIPTION
This PR adds `top` to the Dockerfile, so we can easily monitor CPU and RAM usage in production