### PR TITLE
Triggering constrain: bugfix + not trigger if assigned

### DIFF
--- a/skyportal/models/schema.py
+++ b/skyportal/models/schema.py
@@ -1277,6 +1277,15 @@ class FollowupRequestPost(_Schema):
         },
     )
 
+    not_if_assignment_exists = fields.Boolean(
+        required=False,
+        metadata={
+            "description": (
+                "If there are any sources within radius that are assigned to an observing run, the followup request will not be executed."
+            )
+        },
+    )
+
     ignore_source_group_ids = fields.List(
         fields.Integer,
         required=False,


### PR DESCRIPTION
This PR fixed the not_if_tns_reported constraint which was ignored, and adds a new "don't report if assigned to an observing run" constraint: not_if_assignment_exists".

This is required for btsbot