### PR TITLE
Bugfixes: Finding chart print & GCN automated source generation

### DIFF
--- a/skyportal/handlers/api/gcn.py
+++ b/skyportal/handlers/api/gcn.py
@@ -403,20 +403,20 @@ def post_skymap_from_notice(
                     event_tags = get_tags(root)
                 tags_formatted = [tag.upper().strip() for tag in event_tags]
                 if "GRB" in tags_formatted:
-                    source["name"] = f"GRB-{source_name}"
+                    source["id"] = f"GRB-{source_name}"
                     if "SWIFT" in tags_formatted:
                         source["origin"] = "Swift"
                     elif "FERMI" in tags_formatted:
                         source["origin"] = "Fermi"
                 elif "GW" in tags_formatted:
-                    source["name"] = f"GW-{source_name}"
+                    source["id"] = f"GW-{source_name}"
                     if "LVC" in tags_formatted:
                         source["origin"] = "LVC"
                 elif "EINSTEIN PROBE" in tags_formatted:
-                    source["name"] = f"EP-{source_name}"
+                    source["id"] = f"EP-{source_name}"
                     source["origin"] = "Einstein Probe"
                 else:
-                    source["name"] = f"GCN-{source_name}"
+                    source["id"] = f"GCN-{source_name}"
 
                 public_group = session.scalar(
                     sa.select(Group).where(Group.name == cfg["misc.public_group_name"])

--- a/static/js/components/FindingChart.jsx
+++ b/static/js/components/FindingChart.jsx
@@ -339,6 +339,7 @@ const FindingChart = () => {
                       className={classes.button}
                       endIcon={<PrintIcon />}
                       onClick={handlePrint}
+                      disabled={!image}
                     >
                       Print
                     </Button>

--- a/static/js/components/FindingChart.jsx
+++ b/static/js/components/FindingChart.jsx
@@ -1,5 +1,5 @@
 import makeStyles from "@mui/styles/makeStyles";
-import React, { Suspense, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 
 import PrintIcon from "@mui/icons-material/Print";
@@ -19,6 +19,14 @@ import { useImage } from "react-image";
 import TextLoop from "react-text-loop";
 import { useReactToPrint } from "react-to-print";
 import Button from "./Button";
+
+const initialFormState = {
+  imagesource: "ps1",
+  facility: "Keck",
+  positionsource: "ztfref",
+  findersize: 4.0,
+  numoffset: 3,
+};
 
 const useStyles = makeStyles((theme) => ({
   media: {
@@ -68,42 +76,9 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const FindingChart = () => {
+const PlaceHolder = () => {
   const classes = useStyles();
-  const {
-    handleSubmit,
-    getValues,
-    control,
-
-    formState: { errors },
-  } = useForm();
-  const { id } = useParams();
-
-  const [params, setParams] = useState({
-    imagesource: "ps1",
-    facility: "Keck",
-    positionsource: "ztfref",
-    findersize: 4.0,
-    numoffset: 3,
-  });
-
-  const componentRef = useRef();
-
-  const initialFormState = {
-    ...params,
-  };
-
-  const url = new URL(`/api/sources/${id}/finder`, window.location.href);
-  url.search = new URLSearchParams({
-    type: "png",
-    image_source: `${params.imagesource}`,
-    use_ztfref: `${params.positionsource === "ztfref"}`,
-    imsize: `${params.findersize}`,
-    num_offset_stars: `${params.numoffset}`,
-    facility: `${params.facility}`,
-  });
-
-  const placeholder = (
+  return (
     <div className={classes.spinner}>
       <TextLoop>
         <span>Downloading image</span>
@@ -115,15 +90,64 @@ const FindingChart = () => {
       <CircularProgress color="primary" />
     </div>
   );
+};
+
+const FindingChart = () => {
+  const classes = useStyles();
+  const {
+    handleSubmit,
+    getValues,
+    control,
+
+    formState: { errors },
+  } = useForm();
+  const { id } = useParams();
+
+  const [params, setParams] = useState({ ...initialFormState });
+
+  const [image, setImage] = useState(null);
+
+  const componentRef = useRef();
+
+  useEffect(() => {
+    const fetchImage = async () => {
+      const url = new URL(`/api/sources/${id}/finder`, window.location.href);
+      url.search = new URLSearchParams({
+        type: "png",
+        image_source: `${params.imagesource}`,
+        use_ztfref: `${params.positionsource === "ztfref"}`,
+        imsize: `${params.findersize}`,
+        num_offset_stars: `${params.numoffset}`,
+        facility: `${params.facility}`,
+      });
+      const response = await fetch(url);
+      if (response.ok) {
+        const blob = await response.blob();
+        const imageUrl = URL.createObjectURL(blob);
+        setImage(imageUrl);
+      } else {
+        console.error("Error fetching image:", response.statusText);
+      }
+    };
+    fetchImage();
+  }, [params]);
 
   function FinderImage() {
     const { src } = useImage({
-      srcList: url,
+      srcList: image,
     });
-    return <img alt={`${id}`} src={src} className={classes.media} />;
+    return (
+      <img
+        alt={`${id}`}
+        src={src}
+        className={classes.media}
+        ref={componentRef}
+      />
+    );
   }
 
   const onSubmit = () => {
+    setImage(null);
     const formData = {
       ...initialFormState,
       ...getValues(),
@@ -134,7 +158,7 @@ const FindingChart = () => {
   const rules = { required: true, min: 2, max: 15, type: "number", step: 0.5 };
 
   const handlePrint = useReactToPrint({
-    content: () => componentRef.current,
+    contentRef: componentRef,
     documentTitle: `finder_${id}.pdf`,
     pageStyle: "@page {size: landscape}",
   });
@@ -159,12 +183,8 @@ const FindingChart = () => {
         >
           <Grid item xs={12} md={10}>
             <Card>
-              <CardContent ref={componentRef}>
-                <div>
-                  <Suspense fallback={placeholder}>
-                    <FinderImage />
-                  </Suspense>
-                </div>
+              <CardContent style={{ textAlign: "center" }}>
+                <div>{image ? <FinderImage /> : <PlaceHolder />}</div>
               </CardContent>
             </Card>
           </Grid>


### PR DESCRIPTION
In this PR we:
- fix the finding chart print button, broken after the update of a dependency. We also refactor some of the code to use the already downloaded & rendered image rather than retrigger a download when hitting "Print"
- fix the GCN sources autogeneration, which was broken - yet again - by a previous PR of mind, where the "id" field was renamed to "name" by error.