### PR TITLE
GCN cone-based localization: avoid zero radius

### DIFF
--- a/skyportal/models/localization.py
+++ b/skyportal/models/localization.py
@@ -16,6 +16,8 @@ import ligo.skymap.moc
 import ligo.skymap.postprocess
 import numpy as np
 import sqlalchemy as sa
+from astropy import units as u
+from astropy.coordinates import SkyCoord
 from astropy.table import Table
 from dateutil.relativedelta import relativedelta
 from dustmaps.config import config
@@ -220,8 +222,18 @@ class Localization(Base):
     def center(self):
         """Get information about the center of the localization."""
 
-        prob = self.flat_2d
-        coord = ligo.skymap.postprocess.posterior_max(prob)
+        # if the localization name is like ra_dec_radius, use the ra, dec,
+        try:
+            ra, dec, _radius = self.localization_name.split("_")
+            ra = float(ra)
+            dec = float(dec)
+            _radius = float(_radius)
+            coord = SkyCoord(
+                ra=ra * u.deg, dec=dec * u.deg, frame="icrs", unit=(u.deg, u.deg)
+            )
+        except ValueError:
+            prob = self.flat_2d
+            coord = ligo.skymap.postprocess.posterior_max(prob)
 
         center_info = {}
         center_info["ra"] = coord.ra.deg

--- a/skyportal/utils/gcn.py
+++ b/skyportal/utils/gcn.py
@@ -355,6 +355,14 @@ def get_skymap_cone(root):
         if mission == "AMON":
             error /= scipy.stats.chi(df=2).ppf(0.95)
 
+    if error < 0:
+        return None, None, None
+
+    if error == 0:
+        # if error is 0, we set it to a small value
+        # around 4 arcseconds
+        error = 0.001  # 4 arcseconds in degrees
+
     return ra, dec, error
 
 


### PR DESCRIPTION
Some notices come with a radius = 0, which of course makes no sense, and would lead to incorrect sky localizations and unpredictable errors (e.g. incorrect localization center, area calculation, ...).

If the radius is 0, in this PR we set it to a very small value instead (4 arcsec) to avoid said errors. We might have to increase that value if still causes issues.

EDIT:
We also now use the localization name as the center we report for a localization, rather than the ligo.skymap calculated ones which gives us weird results for those small maps