### PR TITLE
Default config: GCN JSON notices fix

### DIFF
--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -742,9 +742,9 @@ gcn:
       - gcn.classic.voevent.ICECUBE_ASTROTRACK_BRONZE
       # - gcn.classic.voevent.MAXI_UNKNOWN
     json:
-      - einstein_probe.wxt.alert
-      - swift.bat.guano
-      # - icecube.lvk_nu_track_search
+      - gcn.notices.einstein_probe.wxt.alert
+      - gcn.notices.swift.bat.guano
+      # - gcn.notices.icecube.lvk_nu_track_search
   reject_tags: # reject notices with these tags (optional)
     - MDC
     - ECLAIRs-Catalog


### PR DESCRIPTION
Adds the missing `gcn.notices.` prefix to the JSON notices we currently support.