### PR TITLE
Upload spectra frontend test: fix

### DIFF
--- a/skyportal/tests/frontend/test_upload_spectroscopy.py
+++ b/skyportal/tests/frontend/test_upload_spectroscopy.py
@@ -25,7 +25,11 @@ def test_upload_spectroscopy(
         ),
     )
 
-    driver.wait_for_xpath(f'//*[contains(., "{filename}")]')
+    # some browsers may render the filename as markdown, in which case the _ around the date
+    # will cause it to be italicized. So we check if we can match each part of the filename
+    driver.wait_for_xpath(f'//*[contains(., "ZTF20abucjsa")]')
+    driver.wait_for_xpath(f'//*[contains(., "20200909")]')
+    driver.wait_for_xpath(f'//*[contains(., "LT")]')
 
     mjd_element = driver.wait_for_xpath('//*[@id="root_mjd"]')
     driver.scroll_to_element_and_click(mjd_element)


### PR DESCRIPTION
For some reason this has been flaky for a while, but worked locally just fine.

Turns out, looking at the screenshots from the tests run here on git, we can see that the filename of the selected file is rendered as markdown. By that I mean that the 2 `_` that surround a part of the filename make it render as _italicized_ text!

It doesn't look like that behavior happens locally for me, so it could be due to a new version of firefox, used by the GitHub actions?

Anyways, instead of doing an exact filename match this PR simply splits the filename in it's different alphanumeric parts, and checks for those in the DOM. This allows the test to pass.