### PR TITLE
SVOM GCN properties - handle string types

### DIFF
--- a/skyportal/utils/gcn.py
+++ b/skyportal/utils/gcn.py
@@ -481,7 +481,10 @@ def get_properties(root):
             continue
         value = elem.attrib.get("value", None)
         if value is not None:
-            value = float(value.strip(">="))
+            if property_name in {"Trigger_Type"}:
+                value = str(value)
+            else:
+                value = float(value.strip(">="))
             property_dict[property_name] = value
 
     tags_list = []


### PR DESCRIPTION
This PR fixes a bug introduces recently with the support of additional SVOM GCN notices properties, where some ended up being strings, but we always try to cast to float which creates errors.