### PR TITLE
Dockerfile: pin setuptools version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN bash -c "\
     cp docker.yaml config.yaml && \
     python3 -m venv /skyportal_env && \
     source /skyportal_env/bin/activate && \
-    pip install --upgrade pip wheel packaging setuptools --no-cache && \
+    pip install --upgrade pip wheel packaging 'setuptools<76.1.0' --no-cache && \
     pip install -r baselayer/requirements.txt --no-cache && \
     pip install -r requirements.txt --no-cache && \
     make system_setup && \


### PR DESCRIPTION
pin a max version for setuptools, as the newly released one (76.1.0)  breaks the installer for a number of packages and causes issues with distutils