### PR TITLE
Improve instruments management and hydrate

### DIFF
--- a/static/js/components/allocation/AllocationTable.jsx
+++ b/static/js/components/allocation/AllocationTable.jsx
@@ -80,15 +80,15 @@ const getMuiTheme = (theme) =>
   });
 
 const AllocationTable = ({
-  groups,
+  groups = [],
   allocations,
   telescopes,
   instruments,
-  paginateCallback,
-  totalMatches,
-  numPerPage,
-  sortingCallback,
-  deletePermission,
+  sortingCallback = null,
+  paginateCallback = null,
+  totalMatches = 0,
+  numPerPage = 10,
+  deletePermission = false,
   hideTitle = false,
   telescopeInfo = true,
 }) => {
@@ -298,6 +298,7 @@ const AllocationTable = ({
   };
 
   const handleTableChange = (action, tableState) => {
+    if (!paginateCallback || !sortingCallback) return;
     switch (action) {
       case "changePage":
       case "changeRowsPerPage":
@@ -325,7 +326,6 @@ const AllocationTable = ({
       label: "ID",
       options: {
         filter: true,
-        // sort: true,
         sortThirdClickReset: true,
         customBodyRenderLite: renderAllocationID,
       },
@@ -511,10 +511,10 @@ const AllocationTable = ({
 AllocationTable.propTypes = {
   allocations: PropTypes.arrayOf(PropTypes.any).isRequired,
   instruments: PropTypes.arrayOf(PropTypes.any).isRequired,
-  telescopes: PropTypes.arrayOf(PropTypes.any).isRequired,
+  telescopes: PropTypes.arrayOf(PropTypes.any),
   groups: PropTypes.arrayOf(PropTypes.any),
   deletePermission: PropTypes.bool,
-  paginateCallback: PropTypes.func.isRequired,
+  paginateCallback: PropTypes.func,
   sortingCallback: PropTypes.func,
   totalMatches: PropTypes.number,
   numPerPage: PropTypes.number,
@@ -525,9 +525,10 @@ AllocationTable.propTypes = {
 AllocationTable.defaultProps = {
   groups: [],
   deletePermission: false,
+  paginateCallback: null,
+  sortingCallback: null,
   totalMatches: 0,
   numPerPage: 10,
-  sortingCallback: null,
   hideTitle: false,
   telescopeInfo: true,
 };

--- a/static/js/components/allocation/ModifyAllocation.jsx
+++ b/static/js/components/allocation/ModifyAllocation.jsx
@@ -25,14 +25,6 @@ const useStyles = makeStyles(() => ({
     width: "20rem",
     marginBottom: "0.75rem",
   },
-  usersSelect: {
-    width: "20rem",
-    marginBottom: "0.75rem",
-  },
-  heading: {
-    fontSize: "1.0625rem",
-    fontWeight: 500,
-  },
 }));
 
 const ModifyAllocation = ({ allocation_id, onClose }) => {

--- a/static/js/components/allocation/NewAllocation.jsx
+++ b/static/js/components/allocation/NewAllocation.jsx
@@ -25,14 +25,6 @@ const useStyles = makeStyles(() => ({
     width: "20rem",
     marginBottom: "0.75rem",
   },
-  usersSelect: {
-    width: "20rem",
-    marginBottom: "0.75rem",
-  },
-  heading: {
-    fontSize: "1.0625rem",
-    fontWeight: 500,
-  },
 }));
 
 const basicKeys = [

--- a/static/js/components/followup_request/FollowupRequestForm.jsx
+++ b/static/js/components/followup_request/FollowupRequestForm.jsx
@@ -153,12 +153,7 @@ const FollowupRequestForm = ({
       }
       setSettingFilteredList(false);
     }
-    if (
-      filteredAllocationList.length === 0 &&
-      allocationListApiClassname.length > 0 &&
-      Object.keys(instrumentFormParams).length > 0 &&
-      settingFilteredList === false
-    ) {
+    if (settingFilteredList === false) {
       filterAllocations();
     }
   }, [allocationListApiClassname, instrumentFormParams, settingFilteredList]);

--- a/static/js/components/instrument/InstrumentForm.jsx
+++ b/static/js/components/instrument/InstrumentForm.jsx
@@ -42,7 +42,6 @@ const InstrumentForm = ({ onClose, instrumentID = null }) => {
     );
     if (result.status === "success") {
       dispatch(showNotification("Instrument saved"));
-      dispatch(fetchInstruments());
       onClose();
     }
   };

--- a/static/js/components/instrument/InstrumentPage.jsx
+++ b/static/js/components/instrument/InstrumentPage.jsx
@@ -1,112 +1,11 @@
 import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
-import makeStyles from "@mui/styles/makeStyles";
 import Grid from "@mui/material/Grid";
-import CircularProgress from "@mui/material/CircularProgress";
 
 import InstrumentTable from "./InstrumentTable";
 import * as instrumentsActions from "../../ducks/instruments";
-
-const useStyles = makeStyles((theme) => ({
-  paperDiv: {
-    padding: "1rem",
-    height: "100%",
-  },
-  tableGrid: {
-    width: "100%",
-  },
-  formControl: {
-    margin: theme.spacing(1),
-    minWidth: 120,
-  },
-  paper: {
-    padding: "1rem",
-  },
-  root: {
-    display: "flex",
-    flexWrap: "wrap",
-    "& .MuiTextField-root": {
-      margin: theme.spacing(0.2),
-      width: "10rem",
-    },
-  },
-  blockWrapper: {
-    width: "100%",
-    marginBottom: "0.5rem",
-  },
-  title: {
-    margin: "0.5rem 0rem 0rem 0rem",
-  },
-  instrumentDelete: {
-    cursor: "pointer",
-    fontSize: "2em",
-    position: "absolute",
-    padding: 0,
-    right: 0,
-    top: 0,
-  },
-  instrumentDeleteDisabled: {
-    opacity: 0,
-  },
-}));
-
-export function instrumentTitle(instrument, telescopeList) {
-  const telescope_id = instrument?.telescope_id;
-  const telescope = telescopeList?.filter((t) => t.id === telescope_id)[0];
-
-  if (!(instrument?.name && telescope?.name)) {
-    return (
-      <div>
-        <CircularProgress color="secondary" />
-      </div>
-    );
-  }
-
-  const result = `${instrument?.name}/${telescope?.nickname}`;
-
-  return result;
-}
-
-export function instrumentInfo(instrument, telescopeList) {
-  const telescope_id = instrument?.telescope_id;
-  const telescope = telescopeList?.filter((t) => t.id === telescope_id)[0];
-
-  if (!(instrument?.name && telescope?.name)) {
-    return (
-      <div>
-        <CircularProgress color="secondary" />
-      </div>
-    );
-  }
-
-  let result = "";
-
-  if (
-    instrument?.filters ||
-    instrument?.api_classname ||
-    instrument?.api_classname_obsplan ||
-    instrument?.fields
-  ) {
-    result += "( ";
-    if (instrument?.filters) {
-      const filters_str = instrument.filters.join(", ");
-      result += `filters: ${filters_str}`;
-    }
-    if (instrument?.api_classname) {
-      result += ` / API Classname: ${instrument?.api_classname}`;
-    }
-    if (instrument?.api_classname_obsplan) {
-      result += ` / API Observation Plan Classname: ${instrument?.api_classname_obsplan}`;
-    }
-    if (instrument?.fields && instrument?.fields.length > 0) {
-      result += ` / # of Fields: ${instrument?.fields.length}`;
-    }
-    result += " )";
-  }
-
-  return result;
-}
+import * as telescopeActions from "../../ducks/telescopes";
 
 const InstrumentList = () => {
   const dispatch = useDispatch();
@@ -118,16 +17,13 @@ const InstrumentList = () => {
 
   const currentUser = useSelector((state) => state.profile);
 
-  const post_permission =
-    currentUser.permissions?.includes("Manage instruments") ||
-    currentUser.permissions?.includes("System admin");
-
   const delete_permission =
     currentUser.permissions?.includes("Delete instrument") ||
     currentUser.permissions?.includes("System admin");
 
   useEffect(() => {
     dispatch(instrumentsActions.fetchInstruments());
+    dispatch(telescopeActions.fetchTelescopes());
   }, [dispatch]);
 
   const handleInstrumentTablePagination = (

--- a/static/js/components/instrument/InstrumentTable.jsx
+++ b/static/js/components/instrument/InstrumentTable.jsx
@@ -26,18 +26,10 @@ import ConfirmDeletionDialog from "../ConfirmDeletionDialog";
 import InstrumentForm from "./InstrumentForm";
 import * as instrumentActions from "../../ducks/instrument";
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(() => ({
   container: {
     width: "100%",
     overflow: "scroll",
-  },
-  eventTags: {
-    marginLeft: "0.5rem",
-    "& > div": {
-      margin: "0.25rem",
-      color: "white",
-      background: theme.palette.primary.main,
-    },
   },
   instrumentManage: {
     display: "flex",
@@ -84,10 +76,10 @@ const InstrumentTable = ({
   instruments,
   telescopes,
   deletePermission,
-  paginateCallback,
-  totalMatches,
-  numPerPage,
-  sortingCallback,
+  sortingCallback = null,
+  paginateCallback = null,
+  totalMatches = 0,
+  numPerPage = 10,
   hideTitle = false,
   telescopeInfo = true,
 }) => {
@@ -276,11 +268,13 @@ const InstrumentTable = ({
   };
 
   const handleSearchChange = (searchText) => {
+    if (!paginateCallback) return;
     const data = { name: searchText };
     paginateCallback(1, rowsPerPage, {}, data);
   };
 
   const handleTableChange = (action, tableState) => {
+    if (!paginateCallback || !sortingCallback) return;
     switch (action) {
       case "changePage":
       case "changeRowsPerPage":
@@ -308,7 +302,6 @@ const InstrumentTable = ({
       label: "ID",
       options: {
         filter: true,
-        // sort: true,
         sortThirdClickReset: true,
         customBodyRenderLite: renderInstrumentID,
       },
@@ -318,7 +311,6 @@ const InstrumentTable = ({
       label: "Instrument Name",
       options: {
         filter: true,
-        // sort: true,
         sortThirdClickReset: true,
         customBodyRenderLite: renderInstrumentName,
       },
@@ -521,20 +513,21 @@ const InstrumentTable = ({
 
 InstrumentTable.propTypes = {
   instruments: PropTypes.arrayOf(PropTypes.any).isRequired,
-  telescopes: PropTypes.arrayOf(PropTypes.any).isRequired,
-  paginateCallback: PropTypes.func.isRequired,
+  telescopes: PropTypes.arrayOf(PropTypes.any),
   sortingCallback: PropTypes.func,
+  paginateCallback: PropTypes.func,
   totalMatches: PropTypes.number,
   numPerPage: PropTypes.number,
   hideTitle: PropTypes.bool,
   telescopeInfo: PropTypes.bool,
-  deletePermission: PropTypes.bool.isRequired,
+  deletePermission: PropTypes.bool,
 };
 
 InstrumentTable.defaultProps = {
   totalMatches: 0,
   numPerPage: 10,
   sortingCallback: null,
+  paginateCallback: null,
   hideTitle: false,
   telescopeInfo: true,
 };

--- a/static/js/components/telescope/TelescopePageDesktop.jsx
+++ b/static/js/components/telescope/TelescopePageDesktop.jsx
@@ -1,4 +1,4 @@
-import React, { lazy, Suspense } from "react";
+import React, { lazy, Suspense, useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import Paper from "@mui/material/Paper";
 import Grid from "@mui/material/Grid";
@@ -11,18 +11,12 @@ import NewTelescope from "./NewTelescope";
 import TelescopeInfo from "./TelescopeInfo";
 
 import TelescopeSearchBar from "./TelescopeSearchBar";
+import { fetchTelescopes } from "../../ducks/telescopes";
 
 // lazy import the TelescopeMap component
 const TelescopeMap = lazy(() => import("./TelescopeMap"));
 
-let dispatch;
-const useStyles = makeStyles((theme) => ({
-  root: {
-    width: "100%",
-    backgroundColor: theme.palette.background.paper,
-    maxHeight: "90%",
-    overflowY: "auto",
-  },
+const useStyles = makeStyles(() => ({
   paperContent: {
     padding: "1rem",
   },
@@ -78,42 +72,8 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-export function telescopeTitle(telescope) {
-  if (!telescope?.name) {
-    return (
-      <div>
-        <CircularProgress color="secondary" />
-      </div>
-    );
-  }
-
-  const result = `${telescope?.nickname}`;
-  return result;
-}
-
-export function telescopeInfo(telescope) {
-  if (!telescope?.name) {
-    return (
-      <div>
-        <CircularProgress color="secondary" />
-      </div>
-    );
-  }
-
-  const array = [
-    ...(telescope?.lat ? [`Latitude: ${telescope.lat}`] : []),
-    ...(telescope?.lon ? [`Longitude: ${telescope.lon}`] : []),
-    ...(telescope?.elevation ? [`Elevation: ${telescope.elevation}`] : []),
-  ];
-
-  // eslint-disable-next-line prefer-template
-  const result = "( " + array.join(" / ") + " )";
-
-  return result;
-}
-
 const TelescopePage = () => {
-  dispatch = useDispatch();
+  const dispatch = useDispatch();
   const currentUser = useSelector((state) => state.profile);
   const { telescopeList } = useSelector((state) => state.telescopes);
   const currentTelescopeMenu = useSelector(

--- a/static/js/components/telescope/TelescopeSummary.jsx
+++ b/static/js/components/telescope/TelescopeSummary.jsx
@@ -23,22 +23,8 @@ const useStyles = makeStyles((theme) => ({
   title: {
     fontSize: "0.875rem",
   },
-  chip: {
-    margin: theme.spacing(0.5),
-  },
   displayInlineBlock: {
     display: "inline-block",
-  },
-  center: {
-    margin: "auto",
-    padding: "0.625rem",
-  },
-  columnItem: {
-    marginBottom: theme.spacing(1),
-  },
-  accordionHeading: {
-    fontSize: "1.25rem",
-    fontWeight: theme.typography.fontWeightRegular,
   },
   paper: {
     padding: theme.spacing(2),

--- a/static/js/ducks/allocations.js
+++ b/static/js/ducks/allocations.js
@@ -39,6 +39,8 @@ export function fetchAllocationsApiClassname(params = {}) {
 messageHandler.add((actionType, payload, dispatch) => {
   if (actionType === REFRESH_ALLOCATIONS) {
     dispatch(fetchAllocations());
+    dispatch(fetchAllocationsApiObsplan());
+    dispatch(fetchAllocationsApiClassname());
   }
 });
 

--- a/static/js/ducks/allocations.js
+++ b/static/js/ducks/allocations.js
@@ -17,7 +17,6 @@ const FETCH_ALLOCATIONS_API_CLASSNAME_OK =
 
 const REFRESH_ALLOCATIONS = "skyportal/REFRESH_ALLOCATIONS";
 
-// eslint-disable-next-line import/prefer-default-export
 export const fetchAllocations = () =>
   API.GET("/api/allocation", FETCH_ALLOCATIONS);
 

--- a/static/js/ducks/instruments.js
+++ b/static/js/ducks/instruments.js
@@ -43,6 +43,7 @@ export const fetchInstrumentObsplanForms = () =>
 messageHandler.add((actionType, payload, dispatch) => {
   if (actionType === REFRESH_INSTRUMENTS) {
     dispatch(fetchInstruments());
+    dispatch(fetchInstrumentForms());
   }
 });
 


### PR DESCRIPTION
The main cause of this PR was related to the hydration behavior of different API forms. When an instrument or an allocation was updated or created in a way that should have made it appear or change in the list of possible follow-up request allocations, the update did not take effect. This happened because modifying or adding an instrument or allocation only refreshed the list of instruments or allocations but did not update the list of forms or the allocationListApiClassname, which is used for the follow-up request selection.

With Sarah, we had filtered the allocations and created one for TAROT, but the change did not appear and could not be selected. So I had already noticed this behavior but didn’t know its cause. While working on the TAROT API, I finally understood where the issue was coming from.

Also:
- Delete useless code
- Improve code