### PR TITLE
GCN auto-generated sources - configurable SOURCE_RADIUS_THRESHOLD

### DIFF
--- a/.github/workflows/test_migrations.yaml
+++ b/.github/workflows/test_migrations.yaml
@@ -82,7 +82,7 @@ jobs:
           sudo add-apt-repository ppa:mozillateam/ppa
           printf 'Package: *\nPin: release o=LP-PPA-mozillateam\nPin-Priority: 1001' | sudo tee /etc/apt/preferences.d/mozilla-firefox
 
-          sudo apt install -y wget unzip firefox nginx libcurl4-gnutls-dev libgnutls28-dev
+          sudo apt install -y wget unzip firefox nginx libcurl4-gnutls-dev libgnutls28-dev libkrb5-dev
 
           pip install pip==24.0
           pip install wheel numpy

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && \
     apt-get install -y curl build-essential software-properties-common ca-certificates gnupg \
     python3 python3-venv python3-dev libpq-dev supervisor libgdal-dev \
     git postgresql-client vim nano screen htop rsync procps \
-    libcurl4-gnutls-dev libgnutls28-dev && \
+    libcurl4-gnutls-dev libgnutls28-dev libkrb5-dev && \
     mkdir -p /etc/apt/keyrings && \
     curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
     echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \

--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -766,6 +766,7 @@ gcn:
   summary:
     acknowledgements:
       - The SkyPortal project acknowledges the generous support of The Gordon and Betty Moore Foundation.
+  source_radius_threshold: 8.0 # max skymap cone radius to create an associated source
 
 health_monitor:
   seconds_between_checks: 30.5

--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -766,7 +766,7 @@ gcn:
   summary:
     acknowledgements:
       - The SkyPortal project acknowledges the generous support of The Gordon and Betty Moore Foundation.
-  source_radius_threshold: 8.0 # max skymap cone radius to create an associated source
+  source_radius_threshold: 8.0 # max skymap cone radius to create a source, in arcmin
 
 health_monitor:
   seconds_between_checks: 30.5

--- a/skyportal/models/gcn.py
+++ b/skyportal/models/gcn.py
@@ -66,7 +66,7 @@ cache = Cache(
 # create an associated source. It should be specified in arcminutes
 # in the config's gcn.source_radius_threshold, defaults to 8.0
 # and is then converted in degrees
-SOURCE_RADIUS_THRESHOLD = cfg.get("gcn.source_radius_threshold", 8) / 60.0 
+SOURCE_RADIUS_THRESHOLD = cfg.get("gcn.source_radius_threshold", 8) / 60.0
 
 
 def gcn_update_delete_logic(cls, user_or_token):

--- a/skyportal/models/gcn.py
+++ b/skyportal/models/gcn.py
@@ -62,7 +62,9 @@ cache = Cache(
     max_age=cfg["misc.minutes_to_keep_reports_cache"] * 60,
 )
 
-SOURCE_RADIUS_THRESHOLD = 8 / 60.0  # 8 arcmin in degrees
+# max error radius of a sky localization to automatically
+# create an associated source. Default is 8 arcmin
+SOURCE_RADIUS_THRESHOLD = cfg.get("gcn.source_radius_threshold", 8) / 60.0 
 
 
 def gcn_update_delete_logic(cls, user_or_token):

--- a/skyportal/models/gcn.py
+++ b/skyportal/models/gcn.py
@@ -63,7 +63,9 @@ cache = Cache(
 )
 
 # max error radius of a sky localization to automatically
-# create an associated source. Default is 8 arcmin
+# create an associated source. It should be specified in arcminutes
+# in the config's gcn.source_radius_threshold, defaults to 8.0
+# and is then converted in degrees
 SOURCE_RADIUS_THRESHOLD = cfg.get("gcn.source_radius_threshold", 8) / 60.0 
 
 


### PR DESCRIPTION
No one wants to use the same value for their skyportal and really isn't practical to have to open a PR every time this quantity should change, so instead this PR makes it configurable so it can be customized on a per-instance basis.