### PR TITLE
Small improve on scanning report and MMT api

### DIFF
--- a/skyportal/facility_apis/mmt/binospec.py
+++ b/skyportal/facility_apis/mmt/binospec.py
@@ -65,7 +65,7 @@ def check_request(request):
             raise ValueError("A valid slit width must be provided")
         if payload.get("nb_visits_per_night") not in (0, 1):
             raise ValueError("A valid number of visits per night must be provided")
-        if payload.get("filter") not in ["LP3800", "LP3500"]:
+        if payload.get("filters") not in ["LP3800", "LP3500"]:
             raise ValueError("A valid filter must be provided")
     else:
         if payload.get("maskid") is None:
@@ -74,7 +74,7 @@ def check_request(request):
             raise ValueError("A valid exposure time must be provided")
         if payload.get("nb_visits_per_night") not in (0, 1):
             raise ValueError("A valid number of visits per night must be provided")
-        if payload.get("filter") not in ["g", "r", "i", "z"]:
+        if payload.get("filters") not in ["g", "r", "i", "z"]:
             raise ValueError("A valid filter must be provided")
 
 
@@ -132,7 +132,7 @@ class BINOSPECAPI(FollowUpAPI):
                     "enum": [0, 1],
                     "default": 0,
                 },
-                "filter": {
+                "filters": {
                     "type": "string",
                     "title": "Filter",
                     "enum": ["g", "r", "i", "z"],
@@ -142,7 +142,7 @@ class BINOSPECAPI(FollowUpAPI):
                 "observation_type",
                 "exposure_time",
                 "nb_visits_per_night",
-                "filter",
+                "filters",
             ],
         }
 
@@ -166,7 +166,7 @@ class BINOSPECAPI(FollowUpAPI):
                     "enum": [0, 1],
                     "default": 1,
                 },
-                "filter": {
+                "filters": {
                     "type": "string",
                     "title": "Filter",
                     "enum": ["LP3800", "LP3500"],
@@ -184,7 +184,7 @@ class BINOSPECAPI(FollowUpAPI):
                 "grating",
                 "central_wavelength",
                 "nb_visits_per_night",
-                "filter",
+                "filters",
             ],
             "dependencies": {
                 "grating": {
@@ -290,7 +290,7 @@ class BINOSPECAPI(FollowUpAPI):
                 **mmt_properties,
             },
             "required": [
-                "filter",
+                "filters",
             ]
             + mmt_required,
             "if": {

--- a/skyportal/facility_apis/mmt/mmirs.py
+++ b/skyportal/facility_apis/mmt/mmirs.py
@@ -48,7 +48,7 @@ def check_request(request):
             raise ValueError("A valid slit width property must be provided")
         if payload.get("nb_visits_per_night") not in (0, 1):
             raise ValueError("A valid number of visits per night must be provided")
-        if payload.get("filter") not in ["HK", "zJ"]:
+        if payload.get("filters") not in ["HK", "zJ"]:
             raise ValueError("A valid filter must be provided")
     else:
         if payload.get("dithersize") not in (5, 7, 10, 15, 20, 30, 60, 120, 210):
@@ -61,7 +61,7 @@ def check_request(request):
             raise ValueError("A valid exposure time must be provided")
         if payload.get("nb_visits_per_night") not in (0, 1):
             raise ValueError("A valid number of visits per night must be provided")
-        if payload.get("filter") not in ["J", "H", "K", "Ks"]:
+        if payload.get("filters") not in ["J", "H", "K", "Ks"]:
             raise ValueError("A valid filter must be provided")
 
 
@@ -134,7 +134,7 @@ class MMIRSAPI(FollowUpAPI):
                     "enum": [0, 1],
                     "default": 0,
                 },
-                "filter": {
+                "filters": {
                     "type": "string",
                     "title": "Filter",
                     "enum": ["J", "H", "K", "Ks"],
@@ -146,7 +146,7 @@ class MMIRSAPI(FollowUpAPI):
                 "maskid",
                 "exposure_time",
                 "nb_visits_per_night",
-                "filter",
+                "filters",
             ],
         }
 
@@ -186,7 +186,7 @@ class MMIRSAPI(FollowUpAPI):
                     "enum": [0, 1],
                     "default": 1,
                 },
-                "filter": {
+                "filters": {
                     "type": "string",
                     "title": "Filter",
                     "enum": ["HK", "zJ"],
@@ -199,7 +199,7 @@ class MMIRSAPI(FollowUpAPI):
                 "slitwidth",
                 "slitwidthproperty",
                 "nb_visits_per_night",
-                "filter",
+                "filters",
             ],
         }
 

--- a/skyportal/facility_apis/mmt/mmt_utils.py
+++ b/skyportal/facility_apis/mmt/mmt_utils.py
@@ -103,7 +103,7 @@ def get_mmt_json_payload(obj, altdata, payload):
         "priority": payload.get("priority"),
         "photometric": payload.get("photometric"),
         "targetofopportunity": payload.get("target_of_opportunity"),
-        "filter": payload.get("filter"),
+        "filter": payload.get("filters"),
         "onevisitpernight": payload.get("nb_visits_per_night"),
         "notes": payload.get("notes"),
     }

--- a/static/js/components/candidate/scan_reports/EditReportItemForm.jsx
+++ b/static/js/components/candidate/scan_reports/EditReportItemForm.jsx
@@ -68,6 +68,7 @@ const EditReportItemForm = ({
             display: "flex",
             alignItems: "center",
             justifyContent: "space-between",
+            columnGap: "3rem",
           }}
         >
           <Box>Edit report item</Box>

--- a/static/js/components/candidate/scan_reports/ReportItems.jsx
+++ b/static/js/components/candidate/scan_reports/ReportItems.jsx
@@ -75,7 +75,7 @@ const ReportItem = ({ reportId, isMultiGroup }) => {
             <FieldTitle sx={{ flex: 1 }}>date</FieldTitle>
             <FieldTitle>scanner</FieldTitle>
             {isMultiGroup && <FieldTitle>group</FieldTitle>}
-            <FieldTitle>ZTF Name Fritz link</FieldTitle>
+            <FieldTitle>ZTF Name / Fritz link</FieldTitle>
             <FieldTitle>comment</FieldTitle>
             <FieldTitle>classifications</FieldTitle>
             <FieldTitle sx={{ flex: 1 }}>host redshift</FieldTitle>


### PR DESCRIPTION
- Rename 'filter' to 'filters' in MMT API payload to fit others APIs payloads.
- Add gap between "edit report item" and source name and rename a title to improve clarity.