### PR TITLE
Add troubleshooting docs to deployment

### DIFF
--- a/doc/deploy.md
+++ b/doc/deploy.md
@@ -41,19 +41,18 @@ The key behavior to note when running production mode is that the application wi
 
 To initialize an empty database, run:
 ```
-docker exec skyportal-web-1 bash -c 'source /skyportal_env/bin/activate && FLAGS="--config=config.yaml" make db_create_tables'
+docker compose exec web bash -c 'source /skyportal_env/bin/activate && FLAGS="--config=config.yaml" make db_create_tables'
 ```
 
 To load an example database, run:
 ```
-docker exec skyportal-web-1 bash -c 'source /skyportal_env/bin/activate && FLAGS="--create_tables --config=config.yaml" make load_demo_data'
+docker compose exec web bash -c 'source /skyportal_env/bin/activate && FLAGS="--create_tables --config=config.yaml" make load_demo_data'
 ```
 
 *Notes:*
 
 - This command can take a few minutes to run, depending on your machine's configuration.
 - It should only **run once**.
-- Older versions of docker compose may use a different container name, such as `skyportal_web_1` (with underscores instead of dashes).
 - The `FLAGS` variable is used to pass arguments to the `make` command. In this case, we are passing the `--create_tables` flag to create the database tables and the `--config=config.yaml` flag to specify the configuration file to use. You can pass any other flags you want to the `make` command in the same way.
 - If you are using a different configuration file, please refer to the next section on how to customize the deployment configuration, before you run the `make load_demo_data` command.
 - When running the command above, you might see a few `SAWarning` warnings. These are harmless and can be ignored.
@@ -97,6 +96,28 @@ docker-compose logs db
 ```
 
 (Or, follow the logs with `docker-compose logs -f db`.)
+
+There are additional log files inside the container that might be worth looking at.  Get a shell on the running web container with
+```
+docker compose exec -it web /bin/bash
+```
+and look in `skyportal/log`.  If everything has started up cleaning, then running
+```
+grep 'Listening on' app*log
+```
+should return four lines that end in things like `Listening on 127.0.0.1:65000` (with a different port number for each line).  Right after skyportal startup succesfully completes, these will be the last lines in `app*log`.
+
+### sncosmo bandpass problems
+
+If skyportal is not properly starting up, look in one of the `/skyportal/log/app*log` files.  If you're seeing repeated blocks of exceptions that end with something like:
+```
+ValueError: Could not get bandpass for f460m due to sncosmo error: zero-size array to reduction operation maximum which has no identity
+```
+it may indicate that sncosmo had a glitch downloading some bandpass files, and is not detecting that it needs to redownload them.  When this happens, you may also see high CPU usage as various servies keep trying to restart themselves (run `htop` inside the container).  To address this issue, try finding the directory underneath `/skyportal/persistentdata/sncosmo/bandpasses` that has the failing file; for instance, in the exaple above, you might run:
+```
+find . -name "*460*" -print
+```
+Try deleting the subdirectory under bandpasses where the troublesome file is.  That may break the crash loop, and allow skyportal to finish starting up.  (You can also try deleting the entire `bandpasses` subdirectory to make sncosmo start over on bandpass downloads.)
 
 ## Stopping the deployment
 


### PR DESCRIPTION
Issue #5529

I also made some suggested changes earlier in the file -- you don't need to figure out the actual name that docker sees for the running container, as you can just run `docker compose exec`.