### PR TITLE
Parameterize Dockerfile to allow specification of image name, uid, gid

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,12 @@ RUN apt-get update && \
     curl https://sh.rustup.rs -sSf | sh -s -- -y && \
     apt-get update && \
     apt-get install -y cargo nodejs nginx libnginx-mod-http-brotli-static libnginx-mod-http-brotli-filter && \
-    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
-    useradd --create-home --shell /bin/bash skyportal
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+ARG SKYPORTAL_UID=1000
+ARG SKYPORTAL_GID=1000
+RUN groupadd -g $SKYPORTAL_GID skyportal && \
+    useradd -u $SKYPORTAL_UID -g $SKYPORTAL_GID --create-home --shell /bin/bash skyportal
 
 ADD . /skyportal
 WORKDIR /skyportal

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ NORMAL=\033[0m
 VER := $(shell python -c "import skyportal; print(skyportal.__version__)")
 BANNER := $(shell echo -e "Welcome to $(BOLD)SkyPortal v$(VER)$(NORMAL) (https://skyportal.io)")
 
+SKYPORTAL_UID ?= 1000
+SKYPORTAL_GID ?= 1000
+DOCKER_IMAGENAME ?= skyportal/web
+
 $(info $())
 $(info $(BANNER))
 $(info $())
@@ -30,11 +34,16 @@ docker-images: ## Make and upload docker images
 docker-images: docker-local
 	@# Add --no-cache flag to rebuild from scratch
 	cd baselayer && git submodule update --init --remote
-	docker build -t skyportal/web . && docker push skyportal/web
+	docker build -t $(DOCKER_IMAGENAME) \
+			--build-arg SKYPORTAL_UID=$(SKYPORTAL_UID) \
+			--build-arg SKYPORTAL_GID=$(SKYPORTAL_GID) . && \
+		docker push $(DOCKER_IMAGENAME)
 
 docker-local: ## Build docker images locally
 	cd baselayer && git submodule update --init --remote
-	docker build -t skyportal/web .
+	docker build -t $(DOCKER_IMAGENAME) \
+		--build-arg SKYPORTAL_UID=$(SKYPORTAL_UID) \
+		--build-arg SKYPORTAL_GID=$(SKYPORTAL_GID) .
 
 doc_reqs:
 	pip install -q -r requirements.docs.txt

--- a/doc/deploy.md
+++ b/doc/deploy.md
@@ -20,6 +20,14 @@ After customizing your `docker.yaml` file (the equivalent of `config.yaml`, used
 make docker-local
 ```
 
+### Running with a different UID, GID and Docker image name
+
+If you're building the docker file to deploy somewhere, you may need to have the file and directory ownership inside the container be under a different UID/GID than the default (which is 1000).  In addition, it is convenient to specify the name of the Docker image to be where you need to push it.  You can change any or all of these values by specifying additional arguments to `make docker-local`:
+
+```
+SKYPORTAL_UID=<uid> SKYPORTAL_GID=<gid> DOCKER_IMAGENAME=<imagename> make docker-local
+```
+
 ## Starting containers
 
 Next, we deploy two containers: `web` (the SkyPortal application, which image you just built) and


### PR DESCRIPTION
The uid/gid change is one I had to make to install on my kubernetes cluster to allow me to use bind-mounted directories.  The image name change was just for convenience (allows me to skip a `docker tag` step).

I broke the `useradd` out from the long `RUN` that included `apt-get` because making it a separate line doesn't appreciably affect size, but does allow skipping all the `apt-get` when rebuilding the dockerfile after changing those arguments.