### PR TITLE
Get Sources - sort by altdata

### DIFF
--- a/skyportal/handlers/api/sources.py
+++ b/skyportal/handlers/api/sources.py
@@ -593,6 +593,10 @@ async def get_sources(
                 sort_by = "gcn_status"
             else:
                 sort_by = "saved_at"
+        elif sort_by.startswith("altdata."):
+            sort_by_parts = sort_by.split(".")
+            if not all(sort_by_parts):
+                raise ValueError(f"Invalid sort_by: {sort_by}")
         elif sort_by not in SORT_BY:
             raise ValueError(f"Invalid sort_by: {sort_by}")
 
@@ -1846,6 +1850,16 @@ async def get_sources(
                         statement += f"""ORDER BY bool_and(listings.obj_id IS NULL) {sort_order.upper()}"""
                     elif sort_by in NULL_FIELDS:
                         statement += f"""ORDER BY {SORT_BY[sort_by]} {sort_order.upper()} NULLS LAST"""
+                    elif sort_by.startswith("altdata."):
+                        fields = sort_by.split(".")[1:]
+                        statement += f"""ORDER BY altdata->>:altdata_field_0"""
+                        query_params.append(sa.bindparam("altdata_field_0", fields[0]))
+                        for i, field in fields[1:]:
+                            statement += f"""->>:altdata_field_{i + 1}"""
+                            query_params.append(
+                                sa.bindparam(f"altdata_field_{i + 1}", field)
+                            )
+                        statement += f""" {sort_order.upper()} NULLS LAST"""
                     else:
                         statement += (
                             f"""ORDER BY {SORT_BY[sort_by]} {sort_order.upper()}"""
@@ -1896,6 +1910,16 @@ async def get_sources(
                         statement += f"""ORDER BY bool_and(listings.obj_id IS NULL) {sort_order.upper()}"""
                     elif sort_by in NULL_FIELDS:
                         statement += f"""ORDER BY {SORT_BY[sort_by]} {sort_order.upper()} NULLS LAST"""
+                    elif sort_by.startswith("altdata."):
+                        fields = sort_by.split(".")[1:]
+                        statement += f"""ORDER BY altdata->>:altdata_field_0"""
+                        query_params.append(sa.bindparam("altdata_field_0", fields[0]))
+                        for i, field in fields[1:]:
+                            statement += f"""->>:altdata_field_{i + 1}"""
+                            query_params.append(
+                                sa.bindparam(f"altdata_field_{i + 1}", field)
+                            )
+                        statement += f""" {sort_order.upper()} NULLS LAST"""
                     else:
                         statement += (
                             f"""ORDER BY {SORT_BY[sort_by]} {sort_order.upper()}"""


### PR DESCRIPTION
the `Obj` table has numerous fields, but well that's just never enough for all science cases 😉. Luckily, we've included an `altdata` JSONB column, that basically let's use add arbitrary fields to objects. However, at the moment we:
- don't have a way to display an object's altdata on the frontend's source table
- don't have a way to sort sources we query by the content of the altdata.

In this PR, we focus on the later: allow sorting by altdata fields when calling the SourceHandler to retrieve multiple sources.

Unlike some other fields we do not have an index on the JSONB, and we can't really add any because we'd have to specify - at least that's what I understood while doing some research - specific fields of the JSONB to index on (and their dtype). So, first I'd like to merge this PR as is, to see how performance looks like on non-indexes JSONB. In Fritz we have ~500k objects saved to any groups (which is what we query for with this handler, we don't account for objects not saved to any group) , which I think while much larger than what other instances have, is still low enough to yield decent performance to sort on an unindexes field. However, only testing this in production will tell us if it's valid or not. If not, we can always remove that feature or require some permission to use it for example.

In parallel, I'm working on a new version of the source table that can be customized. I can't decide if it should be customized at the instance level or the user or group level. In a way, I think that at the user and/or group level makes a lot of sense because within the same instance folks do different things. But since this is mostly to use the altdata and 1 individual updating it would overwrite it's content, it feels more like a field that would be edited with certain fields for a given instance of the app rather than a per group thing. That, would rely on annotations. Sorting on annotations should also be added at a later date, but it's much more complex as it require joins, specifying origins somehow, ... So, I suggest starting with the altdata and customization at the config/instance level, and extending on these capabilities to make things more customizable per user/group at a later date.