### PR TITLE
TNS Bot creation: owner group default values bugfix

### DIFF
--- a/skyportal/handlers/api/tns/tns_robot.py
+++ b/skyportal/handlers/api/tns/tns_robot.py
@@ -83,6 +83,7 @@ def create_tns_robot(
             group_id=owner_group_id,
             owner=True,
             auto_report=False,
+            auto_report_allow_bots=False,
         )
         for owner_group_id in owner_group_ids
     ]


### PR DESCRIPTION
For some reason I am getting an error with the preview version of Fritz when adding a tns robot, where it says that a non-nullable field of the `TNSRobotGroup` (an entry is created for the owner group of the bot being created) is null. That field is the `auto_report_allow_bots` which was added to that table after the initial migration, and to make sure existing records got a value for it when running the migration script it has a `server_default="false"` rather than a `default=False`. However it looks like the server for the preview instance isn't picking up on that default, a behavior I can't reproduce locally or in the production instance of Fritz (at least with the current version, as preview is running on a more recent commit).

Whatever the reason may be, a simple fix is to explicitly provide a value (`False`) for that field when creating the `TNSRobotGroup` entry. That said we should look into why that would fail to begin with, but getting that handler up and running again is higher priority.