### PR TITLE
Photometry upload/update: less queries

### DIFF
--- a/skyportal/handlers/api/photometry.py
+++ b/skyportal/handlers/api/photometry.py
@@ -1490,13 +1490,6 @@ class PhotometryHandler(BaseHandler):
                         f"LOCK TABLE {Photometry.__tablename__} IN SHARE ROW EXCLUSIVE MODE"
                     )
                 )
-                new_photometry_query = session.execute(
-                    sa.select(values_table.c.pdidx)
-                    .outerjoin(Photometry, condition)
-                    .filter(Photometry.id.is_(None))
-                )
-
-                new_photometry_df_idxs = [g[0] for g in new_photometry_query]
 
                 duplicated_photometry = (
                     session.execute(
@@ -1508,6 +1501,16 @@ class PhotometryHandler(BaseHandler):
                     .unique()
                     .all()
                 )
+
+                duplicated_photometry_pdidx = {g[0] for g in duplicated_photometry}
+                if len(duplicated_photometry_pdidx) > 0:
+                    new_photometry_df_idxs = [
+                        i
+                        for i in list(df.index)
+                        if i not in duplicated_photometry_pdidx
+                    ]
+                else:
+                    new_photometry_df_idxs = list(df.index)
 
                 id_map = {}
 

--- a/skyportal/handlers/api/photometry.py
+++ b/skyportal/handlers/api/photometry.py
@@ -1121,15 +1121,6 @@ def add_external_photometry(
         )
         if duplicates in ["ignore", "update"]:
             values_table, condition = get_values_table_and_condition(df)
-
-            new_photometry_query = session.execute(
-                sa.select(values_table.c.pdidx)
-                .outerjoin(Photometry, condition)
-                .filter(Photometry.id.is_(None))
-            )
-
-            new_photometry_df_idxs = [g[0] for g in new_photometry_query]
-
             duplicated_photometry = (
                 session.execute(
                     sa.select(values_table.c.pdidx, Photometry)
@@ -1140,6 +1131,13 @@ def add_external_photometry(
                 .unique()
                 .all()
             )
+            duplicated_photometry_pdidx = {g[0] for g in duplicated_photometry}
+            if len(duplicated_photometry_pdidx) > 0:
+                new_photometry_df_idxs = [
+                    i for i in list(df.index) if i not in duplicated_photometry_pdidx
+                ]
+            else:
+                new_photometry_df_idxs = list(df.index)
 
             id_map = {}
             id_map_no_update_needed = {}


### PR DESCRIPTION
Right now in the `add_external_photometry` method which takes a dataframe of photometry rows as input, we run 2 queries:
- the first looks for which rows are new
- the second looks for which rows are duplicates (already exist)

when instead we could just look for which are duplicates, and get the new ones in python just by doing a simple diff between the idx of the duplicates and the new ones in the dataframe, indexes which we get back when we run the query.

I suspect that this can be applied in other places. It does speed things up quite a bit (between 25% and 50%) when it comes to adding the new rows in the DB. This is a simple but really appreciated speed boost when uploading data in bulk