### PR TITLE
Parsing utils: str to bool

### DIFF
--- a/skyportal/handlers/api/followup_request.py
+++ b/skyportal/handlers/api/followup_request.py
@@ -63,7 +63,7 @@ from ...models import (
 )
 from ...models.schema import AssignmentSchema, FollowupRequestPost
 from ...utils.offset import get_formatted_standards_list
-from ...utils.parse import get_list_typed, get_page_and_n_per_page
+from ...utils.parse import get_list_typed, get_page_and_n_per_page, str_to_bool
 from ..base import BaseHandler
 
 log = make_log("api/followup_request")
@@ -1679,7 +1679,7 @@ def observation_schedule(
             exposure_counts = 1
 
         if "too" in payload:
-            too = payload["too"] in ["Y", "Yes", "True", "t", "true", "1", True, 1]
+            too = str_to_bool(payload["too"], default=False)
         else:
             too = False
 

--- a/skyportal/handlers/api/moving_object.py
+++ b/skyportal/handlers/api/moving_object.py
@@ -15,6 +15,7 @@ from ...utils.moving_objects import (
     find_observable_sequence,
     get_ephemeris,
 )
+from ...utils.parse import str_to_bool
 from ..base import BaseHandler
 
 _, cfg = load_env()
@@ -144,7 +145,7 @@ class MovingObjectFollowupHandler(BaseHandler):
         if (end_time - start_time).total_seconds() > 7 * 24 * 3600:
             return self.error("Time window must be less than 7 days")
 
-        if str(references_only).lower() in ["true", "1", "t", "y", "yes"]:
+        if str_to_bool(references_only, default=False):
             references_only = True
         else:
             references_only = False

--- a/skyportal/handlers/api/unsourced_finder.py
+++ b/skyportal/handlers/api/unsourced_finder.py
@@ -17,6 +17,7 @@ from ...utils.offset import (
     get_finding_chart,
     source_image_parameters,
 )
+from ...utils.parse import str_to_bool
 from ..base import BaseHandler
 
 _, cfg = load_env()
@@ -224,7 +225,7 @@ class UnsourcedFinderHandler(BaseHandler):
         image_source = self.get_query_argument("image_source", "ps1")
         use_ztfref = self.get_query_argument("use_ztfref", True)
         if isinstance(use_ztfref, str):
-            use_ztfref = use_ztfref in ["t", "True", "true", "yes", "y"]
+            use_ztfref = str_to_bool(use_ztfref, default=False)
 
         num_offset_stars = self.get_query_argument("num_offset_stars", "3")
         try:

--- a/skyportal/utils/parse.py
+++ b/skyportal/utils/parse.py
@@ -30,10 +30,71 @@ def get_page_and_n_per_page(page_number, n_per_page, n_per_page_max=500):
 def bool_to_int(value):
     """
     Convert a boolean value to an integer
+
+    Parameters
+    ----------
+    value : bool
+        The boolean value to convert.
+
+    Returns
+    -------
+    int
+        1 if the boolean value is True, 0 if it is False.
+
+    Raises
+    -------
+    ValueError
+        If the input value is not a boolean.
     """
-    if isinstance(value, bool):
-        if value is True:
-            return 1
-        else:
-            return 0
-    raise ValueError(f"Invalid boolean value: {value}")
+    if not isinstance(value, bool):
+        raise ValueError(f"Invalid boolean value: {value}")
+
+    if value is True:
+        return 1
+    else:
+        return 0
+
+
+def str_to_bool(value, default=None):
+    """
+    Convert a string to a boolean value
+
+    Accepts various string representations of boolean values.
+    For example:
+        - "yes", "y", "true", "t", "1" -> True
+        - "no", "n", "false", "f", "0" -> False
+    If the string does not match any of these, it raises a ValueError.
+    If default is provided and the string does not match any of the accepted values,
+    it returns the default value instead of raising an error.
+
+    Parameters
+    ----------
+    value : str
+        The string to convert to a boolean.
+    default : bool, optional
+        The default value to return if the string does not match any of the accepted values.
+        If not provided and the string does not match any of the accepted values, a ValueError is raised.
+
+    Returns
+    -------
+    bool
+        The converted boolean value.
+
+    Raises
+    -------
+    ValueError
+        If the string does not match any of the accepted values and no default is provided.
+    """
+    try:
+        value = str(value).strip().lower()
+    except Exception:
+        raise ValueError(f"Invalid string value for boolean conversion: {value}")
+
+    if value in ("yes", "y", "true", "t", "1"):
+        return True
+    elif value in ("no", "n", "false", "f", "0"):
+        return False
+    elif default is not None:
+        return default
+    else:
+        raise ValueError(f"Invalid string value for boolean conversion: {value}")


### PR DESCRIPTION
This PR adds a function to parse a string (or anything that can be converted to string) to a bool. If accepts a variety of string-like representations for True or False, and can be given a `default` (which is set to None if not specified in which case it yields an error if the input does not match a valid True/False value) to return if there is no match to True or False.