### PR TITLE
Instrument field data post/put: delimiter check

### DIFF
--- a/skyportal/handlers/api/instrument.py
+++ b/skyportal/handlers/api/instrument.py
@@ -1056,6 +1056,8 @@ def load_field_data(field_data):
     delimiters = [",", " "]
     loaded = False
     for delimiter in delimiters:
+        if delimiter not in field_data:
+            continue
         try:
             field_data_table = pd.read_table(StringIO(field_data), sep=delimiter)
             if {"ID", "RA", "Dec"}.issubset(field_data_table.columns.tolist()):


### PR DESCRIPTION
when looping over delimiters, don't try loading df with pandas if the delimiter does not even appear in the string. This is required because we try a comma and then a space, but even if there is no comma pandas will successfully read the df and the whole row (regardless of the number of columns) will just be assumed to be one col. 

This PR simply makes sure that we don't even attempt to read it with a certain delimiter if it's char isn't even found in the data string.