### PR TITLE
Joblib update bugfix

### DIFF
--- a/skyportal/utils/offset.py
+++ b/skyportal/utils/offset.py
@@ -273,7 +273,8 @@ starlist_formats = {
 }
 
 JOBLIB_CACHE_SIZE = 100e6  # 100 MB
-offsets_memory = Memory("./cache/offsets/", verbose=0, bytes_limit=JOBLIB_CACHE_SIZE)
+offsets_memory = Memory("./cache/offsets/", verbose=0)
+offsets_memory.reduce_size(JOBLIB_CACHE_SIZE)
 
 
 def memcache(f):


### PR DESCRIPTION
* specifies the bytes limit of the cache size after initiating the Memory() object, since that is now deprecated in joblib v1.5.0 (released on May 3rd 2025)