### PR TITLE
Test Migration bugfix: joblib version

### DIFF
--- a/.github/workflows/test_migrations.yaml
+++ b/.github/workflows/test_migrations.yaml
@@ -188,6 +188,7 @@ jobs:
       - name: Check for migration branching
         run: |
           # First make sure our dependencies are up to date
+          npm i --legacy-peer-deps
           make dependencies
           # Make sure latest revision on main is included in Alembic history
           n_current_head=$( PYTHONPATH=. alembic history | grep -c $CURRENT_HEAD )

--- a/.github/workflows/test_migrations.yaml
+++ b/.github/workflows/test_migrations.yaml
@@ -108,6 +108,7 @@ jobs:
 
           pip install black
           pip install fiona==1.9.6 # 1.10.0 breaks geopandas
+          pip install joblib<1.5.0
 
       - name: Save current Alembic head on main
         run: |

--- a/.github/workflows/test_migrations.yaml
+++ b/.github/workflows/test_migrations.yaml
@@ -108,7 +108,7 @@ jobs:
 
           pip install black
           pip install fiona==1.9.6 # 1.10.0 breaks geopandas
-          pip install joblib<1.5.0
+          pip install 'joblib<1.5.0' # 1.5.0 breaks skyportal/utils/offset.py on reference commit
 
       - name: Save current Alembic head on main
         run: |

--- a/.github/workflows/test_migrations.yaml
+++ b/.github/workflows/test_migrations.yaml
@@ -187,6 +187,8 @@ jobs:
 
       - name: Check for migration branching
         run: |
+          # First make sure our dependencies are up to date
+          make dependencies
           # Make sure latest revision on main is included in Alembic history
           n_current_head=$( PYTHONPATH=. alembic history | grep -c $CURRENT_HEAD )
           if [[ $n_current_head -eq 0 ]]

--- a/.github/workflows/test_migrations.yaml
+++ b/.github/workflows/test_migrations.yaml
@@ -187,7 +187,7 @@ jobs:
 
       - name: Check for migration branching
         run: |
-          # First make sure our dependencies are up to date
+          # First make sure the dependencies are up-to-date
           npm i --legacy-peer-deps
           make dependencies
           # Make sure latest revision on main is included in Alembic history

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ dask>=2024.5.2
 geopandas==1.0.1
 fiona==1.10.1
 intervals==0.9.2
-joblib>=1.4.2, <2.0.0
+joblib>=1.5.0, <2.0.0
 seaborn>=0.13.2, <1.0.0
 pytest-randomly==3.16.0
 factory-boy==3.3.3

--- a/skyportal/utils/offset.py
+++ b/skyportal/utils/offset.py
@@ -274,12 +274,11 @@ starlist_formats = {
 
 JOBLIB_CACHE_SIZE = 100e6  # 100 MB
 offsets_memory = Memory("./cache/offsets/", verbose=0)
-offsets_memory.reduce_size(JOBLIB_CACHE_SIZE)
 
 
 def memcache(f):
     """Ensure that joblib memory cache stays within bytes limit."""
-    offsets_memory.reduce_size()
+    offsets_memory.reduce_size(JOBLIB_CACHE_SIZE)
     return offsets_memory.cache(f)
 
 


### PR DESCRIPTION
* make sure joblib version is less than 1.5.0 in the migration test, as the migration reference commit would otherwise run on joblib latest which yields an error (see #5607)