### PR TITLE
CI: Use PostgreSQL v17

### DIFF
--- a/.github/workflows/build-and-deploy-docs.yaml
+++ b/.github/workflows/build-and-deploy-docs.yaml
@@ -20,7 +20,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:15
+        image: postgres:17
         env:
           POSTGRES_USER: skyportal
           POSTGRES_PASSWORD: anything

--- a/.github/workflows/test_api_and_frontend.yaml
+++ b/.github/workflows/test_api_and_frontend.yaml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 120
     services:
       postgres:
-        image: postgres:15
+        image: postgres:17
         env:
           POSTGRES_USER: skyportal
           POSTGRES_PASSWORD: anything

--- a/.github/workflows/test_migrations.yaml
+++ b/.github/workflows/test_migrations.yaml
@@ -38,7 +38,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:15
+        image: postgres:17
         env:
           POSTGRES_USER: skyportal
           POSTGRES_PASSWORD: anything

--- a/.github/workflows/test_models.yaml
+++ b/.github/workflows/test_models.yaml
@@ -15,7 +15,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:15
+        image: postgres:17
         env:
           POSTGRES_USER: skyportal
           POSTGRES_PASSWORD: anything


### PR DESCRIPTION
This is an attempt at using postgresql version 17 instead of 15 for the CI, so we know if that version is suitable for SkyPortal