### PR TITLE
enh: change default columns in the photometric table

### DIFF
--- a/static/js/components/photometry/PhotometryTable.jsx
+++ b/static/js/components/photometry/PhotometryTable.jsx
@@ -468,7 +468,6 @@ const PhotometryTable = ({ obj_id, open, onClose, magsys, setMagsys }) => {
                 return [
                   x.data[0], // id
                   x.data[1], // mjd
-                  x.data[17], // UTC date
                   x.data[2], // mag
                   x.data[3], // magerr
                   x.data[4], // limiting_mag
@@ -484,6 +483,7 @@ const PhotometryTable = ({ obj_id, open, onClose, magsys, setMagsys }) => {
                   x.data[14], // ra_unc
                   x.data[15], // dec_unc
                   x.data[16], // created_at
+                  x.data[17], // UTC date
                   renderOwnerDownload(x.data[18]),
                   renderStreamsDownload(x.data[19]),
                   x.data[20],

--- a/static/js/components/photometry/PhotometryTable.jsx
+++ b/static/js/components/photometry/PhotometryTable.jsx
@@ -81,7 +81,14 @@ const getMuiTheme = (theme) =>
     },
   });
 
-const defaultHiddenColumns = ["instrument_id", "snr", "magsys", "created_at"];
+const defaultHiddenColumns = [
+  "instrument_id",
+  "ra",
+  "dec",
+  "ra_unc",
+  "dec_unc",
+  "created_at",
+];
 
 const Transition = React.forwardRef(function Transition(props, ref) {
   return <Slide direction="up" ref={ref} {...props} />;
@@ -201,7 +208,8 @@ const PhotometryTable = ({ obj_id, open, onClose, magsys, setMagsys }) => {
           </div>
         );
       };
-      columns.push({
+      const mjdIndex = columns.findIndex((col) => col.name === "mjd");
+      columns.splice(mjdIndex + 1, 0, {
         name: "UTC",
         label: "UTC",
         options: {
@@ -460,6 +468,7 @@ const PhotometryTable = ({ obj_id, open, onClose, magsys, setMagsys }) => {
                 return [
                   x.data[0], // id
                   x.data[1], // mjd
+                  x.data[17], // UTC date
                   x.data[2], // mag
                   x.data[3], // magerr
                   x.data[4], // limiting_mag
@@ -475,7 +484,6 @@ const PhotometryTable = ({ obj_id, open, onClose, magsys, setMagsys }) => {
                   x.data[14], // ra_unc
                   x.data[15], // dec_unc
                   x.data[16], // created_at
-                  x.data[17], // UTC date
                   renderOwnerDownload(x.data[18]),
                   renderStreamsDownload(x.data[19]),
                   x.data[20],


### PR DESCRIPTION
Resolves issue #5622 
Removes the following default columns :
* Ra
* Dec
* Ra_unc
* Dec_unc

Add these columns by default:
* SNR
* Magnitude System (e.g., AB/Vega)

Move UTC column next to MJD column
