### PR TITLE
fix: magsys state is reinitialized after a validation in the photometry table

### DIFF
--- a/skyportal/handlers/api/photometry_validation.py
+++ b/skyportal/handlers/api/photometry_validation.py
@@ -92,6 +92,7 @@ class PhotometryValidationHandler(BaseHandler):
         validated = data.get("validated")
         explanation = data.get("explanation")
         notes = data.get("notes")
+        magsys = data.get("magsys")
 
         validator_instance = Validator()
         params_to_be_validated = {
@@ -161,7 +162,7 @@ class PhotometryValidationHandler(BaseHandler):
 
             self.push_all(
                 action="skyportal/REFRESH_SOURCE_PHOTOMETRY",
-                payload={"obj_id": phot.obj.id},
+                payload={"obj_id": phot.obj.id, "magsys": magsys},
             )
             return self.success(data={"id": photometry_validation.id})
 
@@ -218,6 +219,7 @@ class PhotometryValidationHandler(BaseHandler):
         validated = data.get("validated")
         explanation = data.get("explanation")
         notes = data.get("notes")
+        magsys = data.get("magsys")
 
         validator_instance = Validator()
         params_to_be_validated = {
@@ -258,7 +260,10 @@ class PhotometryValidationHandler(BaseHandler):
 
             self.push_all(
                 action="skyportal/REFRESH_SOURCE_PHOTOMETRY",
-                payload={"obj_id": photometry_validation.photometry.obj.id},
+                payload={
+                    "obj_id": photometry_validation.photometry.obj.id,
+                    "magsys": magsys,
+                },
             )
             return self.success(data={"id": photometry_validation.id})
 

--- a/static/js/components/photometry/PhotometryTable.jsx
+++ b/static/js/components/photometry/PhotometryTable.jsx
@@ -276,7 +276,7 @@ const PhotometryTable = ({ obj_id, open, onClose, magsys, setMagsys }) => {
               name={`${phot.id}_validation_status`}
             >
               {statusIcon}
-              <PhotometryValidation phot={phot} />
+              <PhotometryValidation phot={phot} magsys={magsys} />
             </div>
           );
         };

--- a/static/js/components/photometry/PhotometryValidation.jsx
+++ b/static/js/components/photometry/PhotometryValidation.jsx
@@ -91,7 +91,7 @@ const DialogTitle = withStyles(dialogTitleStyles)(
   ),
 );
 
-const PhotometryValidation = ({ phot }) => {
+const PhotometryValidation = ({ phot, magsys }) => {
   const dispatch = useDispatch();
   const classes = useStyles();
   const { permissions } = useSelector((state) => state.profile);
@@ -140,6 +140,7 @@ const PhotometryValidation = ({ phot }) => {
           validated: true,
           explanation: data.explanation,
           notes: data.notes,
+          magsys: magsys,
         }),
       ).then((response) => {
         if (response.status === "success") {
@@ -152,6 +153,7 @@ const PhotometryValidation = ({ phot }) => {
           validated: true,
           explanation: data.explanation,
           notes: data.notes,
+          magsys: magsys,
         }),
       ).then((response) => {
         if (response.status === "success") {
@@ -169,6 +171,7 @@ const PhotometryValidation = ({ phot }) => {
           validated: false,
           explanation: data.explanation,
           notes: data.notes,
+          magsys: magsys,
         }),
       ).then((response) => {
         if (response.status === "success") {
@@ -181,6 +184,7 @@ const PhotometryValidation = ({ phot }) => {
           validated: false,
           explanation: data.explanation,
           notes: data.notes,
+          magsys: magsys,
         }),
       ).then((response) => {
         if (response.status === "success") {
@@ -198,6 +202,7 @@ const PhotometryValidation = ({ phot }) => {
           validated: null,
           explanation: data.explanation,
           notes: data.notes,
+          magsys: magsys,
         }),
       ).then((response) => {
         if (response.status === "success") {
@@ -210,6 +215,7 @@ const PhotometryValidation = ({ phot }) => {
           validated: null,
           explanation: data.explanation,
           notes: data.notes,
+          magsys: magsys,
         }),
       ).then((response) => {
         if (response.status === "success") {
@@ -220,13 +226,13 @@ const PhotometryValidation = ({ phot }) => {
   };
 
   const handleNotVetted = () => {
-    dispatch(PhotometryValidationAction.deleteValidation(phot.id)).then(
-      (response) => {
-        if (response.status === "success") {
-          handleClose();
-        }
-      },
-    );
+    dispatch(
+      PhotometryValidationAction.deleteValidation(phot.id, { magsys: magsys }),
+    ).then((response) => {
+      if (response.status === "success") {
+        handleClose();
+      }
+    });
   };
 
   return permissions.includes("Manage sources") ? (
@@ -359,6 +365,11 @@ PhotometryValidation.propTypes = {
       }),
     ),
   }).isRequired,
+  magsys: PropTypes.string,
+};
+
+PhotometryValidation.defaultProps = {
+  magsys: "ab",
 };
 
 export default PhotometryValidation;


### PR DESCRIPTION
Resolve issue #5429 

The goal of this PR is to add confidence to the magsys used. 
The magsys was set to "ab" automatically after a validation.
This PR fixes the issue by adding a magsys prop to the PhotometryValidation component.