### PR TITLE
Fix priority handling in scanning report to handle None values

### DIFF
--- a/skyportal/handlers/api/candidate/scan_report_item.py
+++ b/skyportal/handlers/api/candidate/scan_report_item.py
@@ -81,8 +81,10 @@ def create_scan_report_item(session, report, sources_by_obj):
             priority_order = getattr(
                 facility_apis, instrument.api_classname
             ).priorityOrder
-            priority = followup.payload["priority"]
+            priority = followup.payload.get("priority")
             current = followups.get(instrument.name)
+            if current and priority is None:
+                continue  # If the priority is None, keep only the first one
             if (
                 current is None
                 or (priority_order == "desc" and priority < current)

--- a/skyportal/handlers/api/candidate/scan_report_item.py
+++ b/skyportal/handlers/api/candidate/scan_report_item.py
@@ -83,14 +83,18 @@ def create_scan_report_item(session, report, sources_by_obj):
             ).priorityOrder
             priority = followup.payload.get("priority")
             current = followups.get(instrument.name)
-            if current and priority is None:
-                continue  # If the priority is None, keep only the first one
-            if (
-                current is None
-                or (priority_order == "desc" and priority < current)
-                or (priority_order == "asc" and priority > current)
-            ):
-                followups[instrument.name] = priority
+
+            should_update = False
+            if current is None or current == "NA":
+                should_update = True
+            elif priority is not None:
+                if priority_order == "desc" and priority < current:
+                    should_update = True
+                elif priority_order == "asc" and priority > current:
+                    should_update = True
+
+            if should_update:
+                followups[instrument.name] = priority if priority is not None else "NA"
         followups = [
             {"instrument": name, "priority": prio} for name, prio in followups.items()
         ]


### PR DESCRIPTION
Sometimes, follow-up requests may not include a priority value which create an error when creating scanning report. This case should be handled properly when sorting and selecting the follow-up request to display.