### PR TITLE
Fix tarot time calculation

### DIFF
--- a/skyportal/facility_apis/tarot.py
+++ b/skyportal/facility_apis/tarot.py
@@ -398,14 +398,14 @@ class TAROTAPI(FollowUpAPI):
         check_payload(request.payload, specific_config["station_name"])
 
         hash_user = login_to_tarot(request, session, altdata)
-        observing_time = get_observing_time(session, request)
 
         # Add 10 minutes delay to the observing time to avoid issues with the TAROT server
         # This code is a workaround and should be removed after finding a solution
         minimum_observing_time = Time.now() + TimeDelta(600, format="sec")
-        if observing_time < minimum_observing_time:
-            observing_time = minimum_observing_time
+        if request.payload["start_date"] < minimum_observing_time:
+            request.payload["start_date"] = minimum_observing_time
 
+        observing_time = get_observing_time(session, request)
         observation_string = create_request_string(
             request.obj,
             request.payload,
@@ -596,7 +596,7 @@ class TAROTAPI(FollowUpAPI):
                     initiator_id=request.last_modified_by_id,
                 )
                 session.add(transaction)
-                raise ValueError("Error trying to get the observation log")
+                raise ValueError("Observation log currently unavailable on TAROT")
 
             if manager_scene_id in response_observation.text:
                 nb_observation = response_observation.text.count(manager_scene_id)

--- a/skyportal/facility_apis/tarot.py
+++ b/skyportal/facility_apis/tarot.py
@@ -399,7 +399,7 @@ class TAROTAPI(FollowUpAPI):
 
         hash_user = login_to_tarot(request, session, altdata)
 
-        # Add 10 minutes delay to the observing time to avoid issues with the TAROT server
+        # Set the start date to be at least 10 minutes in the future to avoid issues with the TAROT server
         # This code is a workaround and should be removed after finding a solution
         minimum_observing_time = Time.now() + TimeDelta(600, format="sec")
         if request.payload["start_date"] < minimum_observing_time:

--- a/skyportal/utils/calculations.py
+++ b/skyportal/utils/calculations.py
@@ -352,7 +352,7 @@ def get_next_valid_observing_time(
         raise ValueError("Missing some telescope information")
 
     valid_rise_time, valid_set_time = None, None
-    for _ in range(14):
+    for _ in range(14):  # Try 7 days, checking every 12 hours
         # Retrieve the rise and set time of the target within the nighttime observing window
         valid_rise_time, valid_set_time = get_rise_set_time(
             target=target,

--- a/skyportal/utils/calculations.py
+++ b/skyportal/utils/calculations.py
@@ -352,7 +352,7 @@ def get_next_valid_observing_time(
         raise ValueError("Missing some telescope information")
 
     valid_rise_time, valid_set_time = None, None
-    for _ in range(7):
+    for _ in range(14):
         # Retrieve the rise and set time of the target within the nighttime observing window
         valid_rise_time, valid_set_time = get_rise_set_time(
             target=target,
@@ -365,8 +365,8 @@ def get_next_valid_observing_time(
         if valid_rise_time and valid_set_time and observing_time < valid_set_time:
             break
         else:
-            # if the target is not visible, use the next day as the new observing time
-            observing_time += 1 * u.day
+            # if the target is not visible, use the next 12 hours as the new observing time
+            observing_time += 12 * u.hour
             if end_time < observing_time:
                 break
 


### PR DESCRIPTION
- Set the 10 minutes delay before observation time calculation and improve error message.

- Use a 12-hour increment instead of 1 day when the target is not visible, to better avoid wasting all 7 loop attempts, since if T₀ is not visible, T₀ + 1 day likely won't be either.