### PR TITLE
ZTF Executed observations download fix

### DIFF
--- a/skyportal/facility_apis/ztf.py
+++ b/skyportal/facility_apis/ztf.py
@@ -1236,18 +1236,25 @@ def fetch_depot_observations(instrument_id, session, depot_url, jd_start, jd_end
                     continue
 
                 # remove the columns we do not need:
-                obstable = obstable[
-                    [
-                        "jd",
-                        "field",
-                        "fid",
-                        "expid",
-                        "diffmaglim",
-                        "difffwhm",
-                        "exptime",
-                        "subtractionstatus",
+                try:
+                    obstable = obstable[
+                        [
+                            "jd",
+                            "field",
+                            "fid",
+                            "expid",
+                            "diffmaglim",
+                            "difffwhm",
+                            "exptime",
+                            "subtractionstatus",
+                        ]
                     ]
-                ]
+                except KeyError as e:
+                    log(
+                        f"Could not find expected columns in depot file for JD {jd}: {e}"
+                    )
+                    log(f"Depot file head:\n{obstable.head(1)}")
+                    continue
 
                 # move rows with NaN values in any of the columns
                 obstable = obstable.dropna()


### PR DESCRIPTION
Looks like the current version of the code isn't happy when we get an empty/incorrect table from IPAC's depot. This PR should fix that and log what empty/incorrect tables look like, so we can implement a better fix at a latter date if needed.