### PR TITLE
Taxonomy delete: comprehensive error messages

### DIFF
--- a/skyportal/handlers/api/taxonomy.py
+++ b/skyportal/handlers/api/taxonomy.py
@@ -343,7 +343,7 @@ class TaxonomyHandler(BaseHandler):
 
         with self.Session() as session:
             classification = session.scalars(
-                Classification.select(session.user_or_token).where(
+                sa.select(Classification).where(
                     Classification.taxonomy_id == taxonomy_id
                 )
             ).first()

--- a/skyportal/handlers/api/taxonomy.py
+++ b/skyportal/handlers/api/taxonomy.py
@@ -6,7 +6,7 @@ from tdtax import schema, validate
 from baselayer.app.access import auth_or_token, permissions
 from baselayer.app.env import load_env
 
-from ...models import Group, Taxonomy
+from ...models import Classification, Group, Taxonomy
 from ..base import BaseHandler
 
 _, cfg = load_env()
@@ -342,6 +342,16 @@ class TaxonomyHandler(BaseHandler):
         """
 
         with self.Session() as session:
+            classification = session.scalars(
+                Classification.select(session.user_or_token).where(
+                    Classification.taxonomy_id == taxonomy_id
+                )
+            ).first()
+            if classification is not None:
+                return self.error(
+                    f"Cannot delete taxonomy {taxonomy_id} because it has associated classifications."
+                )
+
             taxonomy = session.scalars(
                 Taxonomy.select(session.user_or_token, mode="delete").where(
                     Taxonomy.id == taxonomy_id
@@ -349,7 +359,7 @@ class TaxonomyHandler(BaseHandler):
             ).first()
             if taxonomy is None:
                 return self.error(
-                    "Taxonomy does not exist or is not available to user."
+                    f"Taxonomy {taxonomy_id} does not exist or is not available to user."
                 )
 
             session.delete(taxonomy)


### PR DESCRIPTION
The "delete mode" when querying a taxonomy makes sure that:
- (1) the user does not get the taxonomy to delete if he's not an admin or does not have the delete taxonomy permission.
- (2) the user does not get the taxonomy to delete if there are classifications associated with it.

The problem is that in the handler after running the query and not getting the taxonomy back, we send an error message for (1) but do not mention (2) at all.

This PR makes sure that we check if there are associated classifications first, and return a comprehensive error message if there are any, so the user knows that they can't drop the taxonomy because of that and not because there is some permission issue.

This is based on a comment from @howardisaacson (to clarify if you see this howard, for data integrity reasons we don't want a taxonomy being delete to accidentally cascade into a ton of classifications being deleted, and similarly we do not want classifications to end up without associated taxonomies. So on your skyportal instance, I think you may have some classifications posted on some objects that are associated to the taxonomy you are not able to delete! I suggest just removing those, since you have database access maybe the easiest way is to run `delete from classifications where taxonomy_id = <id_of_the_one_to_delete>`).