### PR TITLE
TAP Services: Gaia implementation

### DIFF
--- a/skyportal/handlers/api/annotation_services.py
+++ b/skyportal/handlers/api/annotation_services.py
@@ -152,7 +152,7 @@ class GaiaQueryHandler(BaseHandler):
                     df = df.to_pandas()
                 except Exception as e:
                     return self.error(
-                        f"Error querying Gaia: {e}. Please try again later."
+                        f"Error querying Gaia annotations for {obj_id}: {e}. Please try again later."
                     )
 
             if df is None:

--- a/skyportal/utils/offset.py
+++ b/skyportal/utils/offset.py
@@ -896,7 +896,11 @@ def get_nearby_offset_stars(
 
     # try to get Gaia sources first
     with gaia as g:
-        r = g.query(query_string)
+        try:
+            r = g.query(query_string)
+        except Exception as e:
+            log(f"Error querying Gaia: {e}. Falling back to ZTFref or empty result.")
+            r = None
 
     # ...otherwise fall back to ZTFref public sources or return
     # a tuple of no offset stars

--- a/skyportal/utils/tap_services/__init__.py
+++ b/skyportal/utils/tap_services/__init__.py
@@ -1,0 +1,1 @@
+from .gaia import GaiaQuery

--- a/skyportal/utils/tap_services/gaia.py
+++ b/skyportal/utils/tap_services/gaia.py
@@ -124,7 +124,7 @@ class GaiaQuery:
         query_string : str
             The TAP query string to execute.
         n_retries : int, optional
-            Number of retries per server in case of failure, by default 1.
+            Number of retries per server in case of failure, by default 0.
 
         Returns
         -------

--- a/skyportal/utils/tap_services/gaia.py
+++ b/skyportal/utils/tap_services/gaia.py
@@ -1,5 +1,4 @@
 import time
-from typing import Union
 
 import numpy as np
 from astropy import units as u
@@ -129,7 +128,7 @@ class GaiaQuery:
 
         Returns
         -------
-        Union[Table, None]
+        Table | None
             The results of the query as an Astropy Table, or None if all servers fail.
         """
         if self.session is None:

--- a/skyportal/utils/tap_services/gaia.py
+++ b/skyportal/utils/tap_services/gaia.py
@@ -149,7 +149,9 @@ class GaiaQuery:
                     HTTPError,
                 ) as e:
                     if retry < n_retries:
-                        wait_time = 1 + 2**retry
+                        wait_time = min(
+                            1 + 2**retry, self.timeout
+                        )  # Exponential backoff, capped at timeout
                         log(
                             f"Query attempt {retry + 1} failed on {server_url}, retrying in {wait_time}s: {e}"
                         )

--- a/skyportal/utils/tap_services/gaia.py
+++ b/skyportal/utils/tap_services/gaia.py
@@ -1,0 +1,182 @@
+import time
+from typing import Union
+
+import numpy as np
+from astropy import units as u
+from astropy.table import Table
+from numpy import ma
+from pyvo.dal import TAPService
+from pyvo.dal.exceptions import DALFormatError, DALQueryError, DALServiceError
+from pyvo.utils.http import create_session
+from requests.adapters import HTTPAdapter
+from requests.exceptions import HTTPError, ReadTimeout
+
+from baselayer.app.env import load_env
+from baselayer.log import make_log
+
+log = make_log("tap/gaia")
+
+_, cfg = load_env()
+
+DEFAULT_TIMEOUT = 10  # seconds
+SERVERS = [
+    # Leibniz-Institute for Astrophysics Potsdam (AIP)
+    "https://gaia.aip.de/tap",
+    # European Space Astronomy Centre (ESAC) of the European Space Agency (ESA)
+    "https://gea.esac.esa.int/tap-server/tap",
+]
+
+
+class TimeoutHTTPAdapter(HTTPAdapter):
+    def __init__(self, *args, **kwargs):
+        self.timeout = DEFAULT_TIMEOUT
+        if "timeout" in kwargs:
+            self.timeout = kwargs["timeout"]
+            del kwargs["timeout"]
+        super().__init__(*args, **kwargs)
+
+    def send(self, request, **kwargs):
+        try:
+            timeout = kwargs.get("timeout")
+            if timeout is None:
+                kwargs["timeout"] = self.timeout
+            return super().send(request, **kwargs)
+        except AttributeError:
+            kwargs["timeout"] = DEFAULT_TIMEOUT
+
+
+class GaiaQuery:
+    db = "gaiadr3"
+
+    # conversion for units in VO tables to astropy units
+    unit_conversion = {
+        "Dimensionless": None,
+        "Angle[deg]": u.deg,
+        "Time[Julian Years]": u.yr,
+        "Magnitude[mag]": u.mag,
+        "Angular Velocity[mas/year]": u.mas / u.yr,
+        "Angle[mas]": u.mas,
+        "yr": u.yr,
+        "mas.yr**-1": u.mas / u.yr,
+        "mas": u.mas,
+        "mag": u.mag,
+        "deg": u.deg,
+        "Angle[rad], Angle[rad]": u.deg,  # this is the `pos` in degrees, incorrectly reported as radians
+    }
+
+    def __init__(self, db="gaiadr3", timeout=DEFAULT_TIMEOUT):
+        self.db = db
+        self.timeout = timeout
+        self.session = None
+        self.connections = {}  # Cache connections by server URL
+        self.server_order = (
+            SERVERS.copy()
+        )  # Dynamic ordering based on last successful server
+        self._initialize_session()
+
+    def _initialize_session(self):
+        """Initialize the HTTP session with timeout adapters."""
+        self.session = create_session()
+        self.session.mount("http://", TimeoutHTTPAdapter(timeout=self.timeout))
+        self.session.mount("https://", TimeoutHTTPAdapter(timeout=self.timeout))
+
+    def _get_connection(self, server_url):
+        """Get or create a connection for a specific server."""
+        if server_url not in self.connections:
+            self.connections[server_url] = TAPService(server_url, session=self.session)
+        return self.connections[server_url]
+
+    def _move_server_to_front(self, successful_server):
+        """Move the successful server to the front of the list for future queries."""
+        if successful_server in self.server_order:
+            self.server_order.remove(successful_server)
+        self.server_order.insert(0, successful_server)
+
+    def _standardize_table(self, tab):
+        new_tab = tab.copy()
+        for col in tab.columns:
+            if tab[col].name == "source_id":
+                new_tab[col] = tab[col].astype(np.int64)
+            if tab[col].unit is not None:
+                colunit = new_tab[col].unit.to_string()
+                new_tab[col].unit = GaiaQuery.unit_conversion.get(colunit)
+            if tab[col].name == "pos":
+                ma.set_fill_value(new_tab[col], 180.0)
+                new_tab[col] = new_tab[col].astype(np.float64)
+                new_tab[col].name = "dist"
+        return new_tab
+
+    def _query_single_server(self, query_string, server_url):
+        """Execute query on a single server."""
+        connection = self._get_connection(server_url)
+        formatted_query = query_string.format(main_db=self.db)
+
+        try:
+            job = connection.search(formatted_query)
+            return self._standardize_table(job.to_table())
+        except Exception as e:
+            raise e
+
+    def query(self, query_string, n_retries=0) -> Table | None:
+        """Execute a Gaia TAP query with automatic failover between servers.
+
+        Parameters
+        ----------
+        query_string : str
+            The TAP query string to execute.
+        n_retries : int, optional
+            Number of retries per server in case of failure, by default 1.
+
+        Returns
+        -------
+        Union[Table, None]
+            The results of the query as an Astropy Table, or None if all servers fail.
+        """
+        if self.session is None:
+            self._initialize_session()
+
+        for server_url in self.server_order:
+            for retry in range(n_retries + 1):
+                try:
+                    result = self._query_single_server(query_string, server_url)
+                    # Success! Move this server to front for future queries
+                    self._move_server_to_front(server_url)
+                    return result
+                except (
+                    DALQueryError,
+                    DALServiceError,
+                    DALFormatError,
+                    ReadTimeout,
+                    HTTPError,
+                ) as e:
+                    if retry < n_retries:
+                        wait_time = 1 + 2**retry
+                        log(
+                            f"Query attempt {retry + 1} failed on {server_url}, retrying in {wait_time}s: {e}"
+                        )
+                        time.sleep(wait_time)
+                    else:
+                        log(f"All {n_retries + 1} attempts failed on {server_url}: {e}")
+                        break  # Move to next server
+
+                except Exception as e:
+                    log(f"Unexpected error on {server_url}: {e}")
+                    break  # Move to next server
+
+        # If we get here, all servers failed
+        log("All servers failed for the query")
+        return None
+
+    # Context manager methods remain the same
+    def __enter__(self):
+        """Initialize session when entering the context."""
+        if self.session is None:
+            self._initialize_session()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Clean up when exiting the context."""
+        if self.session:
+            self.session.close()
+        self.session = None
+        self.connections = {}


### PR DESCRIPTION
Currently, in `skyportal/utils/offset.py` and `skyportal/handlers/api/annotation_services.py` we query the Gaia DR3 `gaia_source` catalog. We first try to use `astroquery`'s implement (class called `Gaia`), then if that fails to connect we then use `pyvo`'s `TapService` to connect to a backup service. However:
- the `astroquery.gaia` import causes a lot of issues, because in their code they instantiate their class which triggers a query. So the imports are slowed down and when servers are unstable/down like they are now, it just **prevents the app from even starting**.
- the `astroquery.gaia` implementation does not let us specify timeouts, so queries that take longer than expected just paralyze us and we can't do anything about it.
- out of these 2 options to query gaia, the query implementations are a little different, which leads to a number of if/else statements
- out of these 2 options to query Gaia (astroquery pointing to the main gaia server or pointing to a backup one using pyvo), we do no cache which one worked last. So if the main server is down, every time we want to query gaia we keep retrying it. When really it would be better to keep track of which server last answered in time and use that thereafter.

So in this PR:
- we completely drop astroquery.gaia in favor of a custom class that only uses `pyvo`'s `TapService` class to query either the main server (ESA's) or the backup one (AIP).
- the new custom class does not query the server at initialization but only at query time. If the query fails for any reason, we switch to the next server and try again. As soon as a server responds, we put that server at the top of our list of servers to try. Effectively caching which one last responded.
- we switch the main and backup servers, as the AIP has proved to be very stable (unlike the main ESA one that has been timing out most of the past 2 weeks).
- implement the `__enter__` and `__exit__` methods so this class can be used as a context manager, which ensures that the `requests` `session`'s attached to the server connections are closed when we are done querying (that's a little overkill and could be dropped).
- we add the new class to a dedicated `skyportal/utils/tap_services` folder, in `gaia.py`. Then we import it everywhere we need to query Gaia.