### PR TITLE
TNS Submissions: include forced photometry + SNR cut

### DIFF
--- a/services/facility_queue/facility_queue.py
+++ b/services/facility_queue/facility_queue.py
@@ -47,6 +47,7 @@ request_session.trust_env = (
 )
 
 WAIT_TIME_BETWEEN_QUERIES = 120  # in seconds
+CUTOFF_TIME_DAYS = 7  # max lookback time for requests to be processed
 
 
 def service():
@@ -54,7 +55,7 @@ def service():
         queue = []
         try:
             with DBSession() as session:
-                cutoff_time = Time.now() - TimeDelta(3 * u.day)
+                cutoff_time = Time.now() - TimeDelta(CUTOFF_TIME_DAYS * u.day)
                 last_query_dt = Time.now() - TimeDelta(WAIT_TIME_BETWEEN_QUERIES * u.s)
                 requests = (
                     session.query(FacilityTransactionRequest)

--- a/services/tns_submission_queue/tns_submission_queue.py
+++ b/services/tns_submission_queue/tns_submission_queue.py
@@ -217,6 +217,11 @@ def apply_existing_tnsreport_rules(tns_headers, tnsrobot, submission_request):
     altdata = tnsrobot.altdata
     obj_id = submission_request.obj_id
 
+    # if the robot is in test mode, we skip the existing TNS report check
+    if tnsrobot.testing:
+        log(f"Skipping existing TNS report check for {obj_id} in test mode.")
+        return
+
     _, existing_tns_name = get_IAUname(
         altdata["api_key"], tns_headers, obj_id=obj_id, closest=True
     )
@@ -967,11 +972,11 @@ def process_submission_request(submission_request, session):
             Photometry.select(user).where(
                 Photometry.obj_id == obj_id,
                 Photometry.instrument_id.in_(instrument_ids),
-                # make sure that the origin does not contain 'fp' (for forced photometry)
-                # as we only want to submit alert-based photometry for surveys
-                # like ZTF that also provide a forced photometry service,
-                # which detections might have lower SNR and be less reliable or not real
-                ~Photometry.origin.ilike("%fp%"),
+                # keep all non-detections, reject detections with SNR < 5
+                sa.or_(
+                    Photometry.flux / Photometry.fluxerr > 5,
+                    Photometry.flux.is_(None),
+                ),
             )
         ).all()
 

--- a/skyportal/handlers/api/candidate/candidate.py
+++ b/skyportal/handlers/api/candidate/candidate.py
@@ -861,12 +861,18 @@ class CandidateHandler(BaseHandler):
                 "null",
                 "undefined",
             }:
-                start_date = arrow.get(start_date).datetime
+                try:
+                    start_date = arrow.get(start_date).datetime
+                except Exception as e:
+                    return self.error(f"Invalid startDate value: {e}")
                 candidate_query = candidate_query.where(
                     Candidate.passed_at >= start_date
                 )
             if end_date and end_date.strip().lower() not in {"", "null", "undefined"}:
-                end_date = arrow.get(end_date).datetime
+                try:
+                    end_date = arrow.get(end_date).datetime
+                except Exception as e:
+                    return self.error(f"Invalid endDate value: {e}")
                 candidate_query = candidate_query.where(Candidate.passed_at <= end_date)
             candidate_subquery = candidate_query.subquery()
             # We'll join in the nested data for Obj (like photometry) later
@@ -1261,7 +1267,10 @@ class CandidateHandler(BaseHandler):
                             f"Localization {localization_dateobs} not found",
                         )
 
-                partition_key = arrow.get(localization.dateobs).datetime
+                try:
+                    partition_key = arrow.get(localization.dateobs).datetime
+                except Exception as e:
+                    return self.error(f"Invalid localization dateobs value: {e}")
                 localizationtile_partition_name = (
                     f"{partition_key.year}_{partition_key.month:02d}"
                 )
@@ -1535,7 +1544,10 @@ class CandidateHandler(BaseHandler):
             passed_at = data.pop("passed_at", None)
             if passed_at is None:
                 return self.error("Missing required parameter: `passed_at`.")
-            passed_at = arrow.get(passed_at).datetime
+            try:
+                passed_at = arrow.get(passed_at).datetime
+            except Exception as e:
+                return self.error(f"Invalid passedAt value: {e}")
             try:
                 filter_ids = data.pop("filter_ids")
             except KeyError:

--- a/skyportal/handlers/api/candidate/candidate_filter.py
+++ b/skyportal/handlers/api/candidate/candidate_filter.py
@@ -149,10 +149,16 @@ class CandidateFilterHandler(BaseHandler):
                 "null",
                 "undefined",
             }:
-                start_date = arrow.get(start_date).datetime
+                try:
+                    start_date = arrow.get(start_date).datetime
+                except Exception as e:
+                    return self.error(f"Invalid startDate value: {e}")
                 stmt = stmt.where(Candidate.passed_at >= start_date)
             if end_date and end_date.strip().lower() not in {"", "null", "undefined"}:
-                end_date = arrow.get(end_date).datetime
+                try:
+                    end_date = arrow.get(end_date).datetime
+                except Exception as e:
+                    return self.error(f"Invalid endDate value: {e}")
                 stmt = stmt.where(Candidate.passed_at <= end_date)
 
             stmt = get_subquery_for_saved_status(


### PR DESCRIPTION
Originally, we made the decision to exclude forced photometry when selecting photometry that can be reported to TNS. But we've seen by now that very often said forced photometry recovers data we do not get from alert streams, and it would be good to report earlier detections to TNS. On the other hand since we lower the SNR cut from 5 to 3 in the FP context, we want to be a bit more conservative when selecting that data (and we might benefit from an SNR cut in general here).

So in this PR, we remove the cut that excludes forced photometry from reports, and replace it by an SNR cut so the newly added FP doesn't yield potentially spurious detections.

PS: This is done based on some issues w/ the alert pipeline of ZTF that resulted in incorrect non detections (from the alert pipeline) to be reported, whereas forced photometry correctly recovered the data.