### PR TITLE
SEDM Allocation based unit tests failures: fix

### DIFF
--- a/skyportal/tests/api/candidates_sources_events/test_followup_requests_api.py
+++ b/skyportal/tests/api/candidates_sources_events/test_followup_requests_api.py
@@ -36,19 +36,22 @@ def test_token_user_post_robotic_followup_request(
 
 
 def test_token_user_delete_owned_followup_request(
-    public_group_sedm_allocation, public_source, upload_data_token
+    public_group_generic_instrument_allocation, public_source, upload_data_token
 ):
     request_data = {
-        "allocation_id": public_group_sedm_allocation.id,
+        "allocation_id": public_group_generic_instrument_allocation.id,
         "obj_id": public_source.id,
         "payload": {
             "priority": 5,
             "start_date": "3020-09-01",
             "end_date": "3022-09-01",
-            "observation_type": "IFU",
+            "observation_choices": public_group_generic_instrument_allocation.instrument.to_dict()[
+                "filters"
+            ],
             "exposure_time": 300,
+            "exposure_counts": 1,
             "maximum_airmass": 2,
-            "maximum_fwhm": 1.2,
+            "minimum_lunar_distance": 30,
         },
     }
 
@@ -116,19 +119,25 @@ def test_token_user_modify_owned_followup_request(
 
 
 def test_regular_user_delete_super_admin_followup_request(
-    public_group_sedm_allocation, public_source, upload_data_token, super_admin_token
+    public_group_generic_instrument_allocation,
+    public_source,
+    upload_data_token,
+    super_admin_token,
 ):
     request_data = {
-        "allocation_id": public_group_sedm_allocation.id,
+        "allocation_id": public_group_generic_instrument_allocation.id,
         "obj_id": public_source.id,
         "payload": {
             "priority": 5,
             "start_date": "3020-09-01",
             "end_date": "3022-09-01",
-            "observation_type": "IFU",
+            "observation_choices": public_group_generic_instrument_allocation.instrument.to_dict()[
+                "filters"
+            ],
             "exposure_time": 300,
+            "exposure_counts": 1,
             "maximum_airmass": 2,
-            "maximum_fwhm": 1.2,
+            "minimum_lunar_distance": 30,
         },
     }
 

--- a/skyportal/tests/api/candidates_sources_events/test_followup_requests_api.py
+++ b/skyportal/tests/api/candidates_sources_events/test_followup_requests_api.py
@@ -36,16 +36,16 @@ def test_token_user_post_robotic_followup_request(
 
 
 def test_token_user_delete_owned_followup_request(
-    public_group_generic_instrument_allocation, public_source, upload_data_token
+    public_group_generic_allocation, public_source, upload_data_token
 ):
     request_data = {
-        "allocation_id": public_group_generic_instrument_allocation.id,
+        "allocation_id": public_group_generic_allocation.id,
         "obj_id": public_source.id,
         "payload": {
             "priority": 5,
             "start_date": "3020-09-01",
             "end_date": "3022-09-01",
-            "observation_choices": public_group_generic_instrument_allocation.instrument.to_dict()[
+            "observation_choices": public_group_generic_allocation.instrument.to_dict()[
                 "filters"
             ],
             "exposure_time": 300,
@@ -119,19 +119,19 @@ def test_token_user_modify_owned_followup_request(
 
 
 def test_regular_user_delete_super_admin_followup_request(
-    public_group_generic_instrument_allocation,
+    public_group_generic_allocation,
     public_source,
     upload_data_token,
     super_admin_token,
 ):
     request_data = {
-        "allocation_id": public_group_generic_instrument_allocation.id,
+        "allocation_id": public_group_generic_allocation.id,
         "obj_id": public_source.id,
         "payload": {
             "priority": 5,
             "start_date": "3020-09-01",
             "end_date": "3022-09-01",
-            "observation_choices": public_group_generic_instrument_allocation.instrument.to_dict()[
+            "observation_choices": public_group_generic_allocation.instrument.to_dict()[
                 "filters"
             ],
             "exposure_time": 300,

--- a/skyportal/tests/api/candidates_sources_events/test_followup_requests_reprioritize.py
+++ b/skyportal/tests/api/candidates_sources_events/test_followup_requests_reprioritize.py
@@ -29,7 +29,6 @@ def test_reprioritize_followup_request(
     status, data = api(
         "POST", "followup_request", data=request_data, token=upload_data_token
     )
-    print(status, data)
     assert status == 200
     assert data["status"] == "success"
     id = data["data"]["id"]

--- a/skyportal/tests/api/candidates_sources_events/test_followup_requests_reprioritize.py
+++ b/skyportal/tests/api/candidates_sources_events/test_followup_requests_reprioritize.py
@@ -2,7 +2,7 @@ from skyportal.tests import api
 
 
 def test_reprioritize_followup_request(
-    public_group_generic_instrument_allocation,
+    public_group_generic_allocation,
     public_source,
     upload_data_token,
     gcn_GW190425,
@@ -10,13 +10,13 @@ def test_reprioritize_followup_request(
     localization_id = gcn_GW190425.localizations[0].id
 
     request_data = {
-        "allocation_id": public_group_generic_instrument_allocation.id,
+        "allocation_id": public_group_generic_allocation.id,
         "obj_id": public_source.id,
         "payload": {
             "priority": 1,
             "start_date": "3020-09-01",
             "end_date": "3022-09-01",
-            "observation_choices": public_group_generic_instrument_allocation.instrument.to_dict()[
+            "observation_choices": public_group_generic_allocation.instrument.to_dict()[
                 "filters"
             ],
             "exposure_time": 300,

--- a/skyportal/tests/api/candidates_sources_events/test_followup_requests_reprioritize.py
+++ b/skyportal/tests/api/candidates_sources_events/test_followup_requests_reprioritize.py
@@ -2,31 +2,34 @@ from skyportal.tests import api
 
 
 def test_reprioritize_followup_request(
-    public_group_sedm_allocation,
+    public_group_generic_instrument_allocation,
     public_source,
     upload_data_token,
-    super_admin_token,
     gcn_GW190425,
 ):
     localization_id = gcn_GW190425.localizations[0].id
 
     request_data = {
-        "allocation_id": public_group_sedm_allocation.id,
+        "allocation_id": public_group_generic_instrument_allocation.id,
         "obj_id": public_source.id,
         "payload": {
             "priority": 1,
             "start_date": "3020-09-01",
             "end_date": "3022-09-01",
-            "observation_type": "IFU",
+            "observation_choices": public_group_generic_instrument_allocation.instrument.to_dict()[
+                "filters"
+            ],
             "exposure_time": 300,
+            "exposure_counts": 1,
             "maximum_airmass": 2,
-            "maximum_fwhm": 1.2,
+            "minimum_lunar_distance": 30,
         },
     }
 
     status, data = api(
         "POST", "followup_request", data=request_data, token=upload_data_token
     )
+    print(status, data)
     assert status == 200
     assert data["status"] == "success"
     id = data["data"]["id"]

--- a/skyportal/tests/conftest.py
+++ b/skyportal/tests/conftest.py
@@ -636,6 +636,20 @@ def sedm(p60_telescope):
 
 
 @pytest.fixture()
+def generic_instrument(p60_telescope):
+    instrument = InstrumentFactory(
+        name=f"GenericInstrument_{uuid.uuid4()}",
+        type="imaging spectrograph",
+        telescope=p60_telescope,
+        band="Optical",
+        filters=["sdssu", "sdssg", "sdssr", "sdssi"],
+        api_classname="GENERICAPI",
+    )
+    yield instrument
+    InstrumentFactory.teardown(instrument)
+
+
+@pytest.fixture()
 def red_transients_run(user):
     run = ObservingRunFactory(owner=user)
     yield run
@@ -1270,6 +1284,19 @@ def public_group2_sedm_allocation(sedm, public_group2):
     allocation = AllocationFactory(
         instrument=sedm,
         group=public_group2,
+        pi=str(uuid.uuid4()),
+        proposal_id=str(uuid.uuid4()),
+        hours_allocated=100,
+    )
+    yield allocation
+    AllocationFactory.teardown(allocation)
+
+
+@pytest.fixture()
+def public_group_generic_instrument_allocation(generic_instrument, public_group):
+    allocation = AllocationFactory(
+        instrument=generic_instrument,
+        group=public_group,
         pi=str(uuid.uuid4()),
         proposal_id=str(uuid.uuid4()),
         hours_allocated=100,

--- a/skyportal/tests/conftest.py
+++ b/skyportal/tests/conftest.py
@@ -1293,7 +1293,7 @@ def public_group2_sedm_allocation(sedm, public_group2):
 
 
 @pytest.fixture()
-def public_group_generic_instrument_allocation(generic_instrument, public_group):
+def public_group_generic_allocation(generic_instrument, public_group):
     allocation = AllocationFactory(
         instrument=generic_instrument,
         group=public_group,


### PR DESCRIPTION
Most follow-up request test rely on the `sedm_allocation` test fixtures, which itself depends on the `sedm` fixture. Naturally, the `sedm` fixture uses the associated SEDMAPI. However for a lot of tests we just want to test more generic follow-up request features and absolutely do not need to do that w/ SEDM's API which points to telescope's server.

In this PR we introduce a `generic_instrument` and `generic_instrument_allocation` test fixtures that we can use in place of the `sedm` one in most tests that aren't SEDM-specific. Then we use said fixture in a handful of tests which have been failing today as the SEDM server seems to be down.

PS: In the future we may consider making that move to an SEDM-less allocation (one that in general does not ping a distant server) for most follow-up request-related tests, for consistency and reliability sake.