### PR TITLE
Add utc time header and shift calendar and fix PDF error

### DIFF
--- a/static/js/components/shift/ShiftCalendar.jsx
+++ b/static/js/components/shift/ShiftCalendar.jsx
@@ -376,6 +376,13 @@ function MyCalendar({ events, currentShift, setShow }) {
             components={{
               event: Event,
             }}
+            formats={{
+              timeGutterFormat: (date) => {
+                const utcHour = date.getUTCHours().toString().padStart(2, "0");
+                const localHour = localizer.format(date, "HH");
+                return `${localHour}h (UTC ${utcHour}h)`;
+              },
+            }}
             startAccessor="start_date"
             endAccessor="end_date"
             titleAccessor="name"

--- a/static/js/components/source/Source.jsx
+++ b/static/js/components/source/Source.jsx
@@ -876,14 +876,14 @@ const SourceContent = ({ source }) => {
                     "aria-labelledby": "basic-button",
                   }}
                 >
-                  <MenuItem onClick={() => setAnchorElFindingChart(null)}>
-                    <a
-                      href={`/api/sources/${source.id}/finder`}
-                      download="finder-chart-pdf"
-                      className={classes.dropdownText}
-                    >
-                      PDF
-                    </a>
+                  <MenuItem
+                    component="a"
+                    href={`/api/sources/${source.id}/finder`}
+                    download="finder-chart"
+                    className={classes.dropdownText}
+                    onClick={() => setAnchorElFindingChart(null)}
+                  >
+                    PDF
                   </MenuItem>
                   <MenuItem onClick={() => setAnchorElFindingChart(null)}>
                     <Link
@@ -927,15 +927,15 @@ const SourceContent = ({ source }) => {
                     "aria-labelledby": "basic-button",
                   }}
                 >
-                  <MenuItem onClick={() => setAnchorElObservability(null)}>
-                    <a
-                      href={`/api/sources/${source.id}/observability`}
-                      download={`observabilityChartRequest-${source.id}`}
-                      data-testid={`observabilityChartRequest_${source.id}`}
-                      className={classes.dropdownText}
-                    >
-                      PDF
-                    </a>
+                  <MenuItem
+                    component="a"
+                    href={`/api/sources/${source.id}/observability`}
+                    download={`observabilityChartRequest-${source.id}`}
+                    data-testid={`observabilityChartRequest_${source.id}`}
+                    className={classes.dropdownText}
+                    onClick={() => setAnchorElObservability(null)}
+                  >
+                    PDF
                   </MenuItem>
                   <MenuItem onClick={() => setAnchorElObservability(null)}>
                     <Link

--- a/static/js/components/templates/HeaderContent.jsx.template
+++ b/static/js/components/templates/HeaderContent.jsx.template
@@ -93,19 +93,22 @@ const HeaderContent = () => {
   }, [isDesktop]);
 
   useEffect(() => {
-    let timeRefresh;
-    if (isDesktop) {
-        setNow(new Date());
-        timeRefresh = setInterval(() => {
-          setNow(new Date());
-        }, 60000);
+    if (!isDesktop) return;
 
-    }
-    return () => {
-        if (timeRefresh) {
-          clearInterval(timeRefresh);
-        }
-    }
+    const updateNow = () => setNow(new Date());
+    const delay = (60 - new Date().getSeconds()) * 1000; // the number of seconds to wait until the next minute
+
+    updateNow();
+    let interval;
+    const timeout = setTimeout(() => {
+      updateNow(); // after the delay, update now
+      interval = setInterval(updateNow, 60000); // then set an interval to update every minute
+    }, delay);
+
+    return () => { // cleanup
+      clearTimeout(timeout);
+      if (interval) clearInterval(interval);
+    };
   }, [isDesktop]);
 
   return (

--- a/static/js/components/templates/HeaderContent.jsx.template
+++ b/static/js/components/templates/HeaderContent.jsx.template
@@ -97,7 +97,7 @@ const HeaderContent = () => {
     let timeRefresh;
     if (isDesktop) {
         setNow(new Date());
-        const timeRefresh = setInterval(() => {
+        timeRefresh = setInterval(() => {
           setNow(new Date());
         }, 60000);
 

--- a/static/js/components/templates/HeaderContent.jsx.template
+++ b/static/js/components/templates/HeaderContent.jsx.template
@@ -65,7 +65,6 @@ const useStyles = makeStyles((theme) => ({
     fontSize: "0.9rem",
     fontWeight: "bold",
     background: alpha(theme.palette.primary.light, 0.4),
-    backgroundOpacity: 0.1,
     padding: "0.3rem 0.6rem",
     borderRadius: "0.5rem",
   },
@@ -124,7 +123,7 @@ const HeaderContent = () => {
         </p>
       </Link>
       <Box className={classes.date} display={{"{{ xs: 'none', lg: 'inline-flex' }}"}}>
-        {now.toLocaleString('us-US', {
+        {now.toLocaleString('en-US', {
           timeZone: 'UTC',
           month: 'short',
           day: '2-digit',

--- a/static/js/components/templates/HeaderContent.jsx.template
+++ b/static/js/components/templates/HeaderContent.jsx.template
@@ -18,6 +18,7 @@ import Notes from "../Notes";
 import hydrate from "../../actions";
 
 import QuickSearchBar from "../QuickSearchBar";
+import {alpha} from "@mui/material";
 
 const useStyles = makeStyles((theme) => ({
   topBannerContent: {
@@ -60,6 +61,14 @@ const useStyles = makeStyles((theme) => ({
       },
     },
   },
+  date: {
+    fontSize: "0.9rem",
+    fontWeight: "bold",
+    background: alpha(theme.palette.primary.light, 0.4),
+    backgroundOpacity: 0.1,
+    padding: "0.3rem 0.6rem",
+    borderRadius: "0.5rem",
+  },
 }));
 
 const HeaderContent = () => {
@@ -70,6 +79,7 @@ const HeaderContent = () => {
 
   const [refreshing, setRefreshing] = useState(false);
   const [openSearch, setOpenSearch] = useState(false);
+  const [now, setNow] = useState(new Date());
 
   const handleRefresh = () => {
     dispatch(hydrate());
@@ -80,6 +90,22 @@ const HeaderContent = () => {
   useEffect(() => {
     if (isDesktop) {
       setOpenSearch(false);
+    }
+  }, [isDesktop]);
+
+  useEffect(() => {
+    let timeRefresh;
+    if (isDesktop) {
+        setNow(new Date());
+        const timeRefresh = setInterval(() => {
+          setNow(new Date());
+        }, 60000);
+
+    }
+    return () => {
+        if (timeRefresh) {
+          clearInterval(timeRefresh);
+        }
     }
   }, [isDesktop]);
 
@@ -97,6 +123,16 @@ const HeaderContent = () => {
           {{ app.title }}
         </p>
       </Link>
+      <Box className={classes.date} display={{"{{ xs: 'none', lg: 'inline-flex' }}"}}>
+        {now.toLocaleString('us-US', {
+          timeZone: 'UTC',
+          month: 'short',
+          day: '2-digit',
+          hour: '2-digit',
+          minute: '2-digit',
+          hour12: false,
+        })} UTC
+      </Box>
       <div style={{"{{ display: openSearch ? 'none' : 'inline-flex', flexDirection: 'row', alignItems: 'center', gap: '1rem', paddingRight: '1rem' }}"}}>
         <Box display={{"{{ xs: 'none', md: 'block' }}"}}>
           <QuickSearchBar />

--- a/static/js/components/templates/HeaderContent.jsx.template
+++ b/static/js/components/templates/HeaderContent.jsx.template
@@ -18,7 +18,7 @@ import Notes from "../Notes";
 import hydrate from "../../actions";
 
 import QuickSearchBar from "../QuickSearchBar";
-import {alpha} from "@mui/material";
+import {alpha} from "@mui/material/styles";
 
 const useStyles = makeStyles((theme) => ({
   topBannerContent: {


### PR DESCRIPTION
- Fixes an issue preventing PDF downloads (observability and finder chart) from working reliably on the source page.
The error occurred most of the time due to the MenuItem's onClick event interfering with the anchor tag's default behavior, preventing the download from triggering properly.

- Add UTC time in the header and refresh time display every minute (My idea on this one, this is something I often need when requesting follow-ups, and I imagine other users might benefit from having both timezones visible as well.
<img width="1504" alt="image" src="https://github.com/user-attachments/assets/ab88ad33-a783-4ed0-9ad1-45b273315769" />

- Add UTC time to shift calendar display. Not the prettiest solution visually, but it's the best I can do with the calendar component. This was requested by Christina and apparently several other users as well.
<img width="962" alt="image" src="https://github.com/user-attachments/assets/b1a5a118-cf56-44d2-b65b-a83d5ef87808" />