### PR TITLE
SourceFinderHandler: handle errors gracefully

### DIFF
--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -2564,8 +2564,10 @@ class SourceOffsetsHandler(BaseHandler):
                     noffsets,
                     used_ztfref,
                 ) = await IOLoop.current().run_in_executor(None, offset_func)
-            except ValueError:
-                return self.error("Error querying for nearby offset stars")
+            except ValueError as e:
+                traceback.print_exc()
+                log(f"Error querying for nearby offset stars: {e}")
+                return self.error(f"Error querying for nearby offset stars: {e}")
 
             starlist_str = "\n".join(
                 [x["str"].replace(" ", "&nbsp;") for x in starlist_info]

--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -2565,8 +2565,8 @@ class SourceOffsetsHandler(BaseHandler):
                     used_ztfref,
                 ) = await IOLoop.current().run_in_executor(None, offset_func)
             except ValueError as e:
-                traceback.print_exc()
                 log(f"Error querying for nearby offset stars: {e}")
+                traceback.print_exc()
                 return self.error(f"Error querying for nearby offset stars: {e}")
 
             starlist_str = "\n".join(


### PR DESCRIPTION
Right now the SourceFinderHandler calls a method that handles errors and returns `ValueError`s, but we do not try/except those and therefore yield the python error instead of gracefully returning it to the user. Also, this means that a missing (or unaccessible source) yields a 400 and not a 404. This PR fixes both of these issues.

PS: Also added some extra full traceback + logging to the SourceOffsetsHandler to make things easier to debug when a starlist fails to generate