### PR TITLE
Pin python-ligo-lw to 1.8.4, as ligo.skymap does not pin a version

### DIFF
--- a/.github/workflows/test_migrations.yaml
+++ b/.github/workflows/test_migrations.yaml
@@ -110,6 +110,7 @@ jobs:
           pip install fiona==1.9.6 # 1.10.0 breaks geopandas
           pip install 'joblib<1.5.0' # 1.5.0 breaks skyportal/utils/offset.py on reference commit
           pip install 'lalsuite<7.26' # 7.26 breaks ligo.skymap
+          pip install 'python-ligo-lw==1.8.4' # 2.0.0 breaks ligo.skymap
 
       - name: Save current Alembic head on main
         run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,6 +55,7 @@ suds-py3==1.4.5.0
 vcrpy==7.0.0
 aiosmtpd==1.4.6
 ligo.skymap==2.0.1
+python-ligo-lw==1.8.4
 lalsuite<7.27
 healpy==1.18.0
 pygcn==1.1.2


### PR DESCRIPTION
It's in the title