### PR TITLE
enh: improved user right management for deletion and update of a tag association to a source

### DIFF
--- a/skyportal/models/tag.py
+++ b/skyportal/models/tag.py
@@ -1,9 +1,20 @@
 import sqlalchemy as sa
 from sqlalchemy.orm import relationship
 
-from baselayer.app.models import Base, join_model
+from baselayer.app.models import Base, CustomUserAccessControl, join_model
 from skyportal.models import User
 from skyportal.models.obj import Obj
+
+
+def objtag_access_logic(cls, user_or_token):
+    query = sa.select(cls)
+
+    if (
+        not user_or_token.is_system_admin
+        or "Manage sources" not in user_or_token.permissions
+    ):
+        query = query.where(cls.author_id == user_or_token.id)
+    return query
 
 
 class ObjTagOption(Base):
@@ -27,3 +38,7 @@ ObjTag.author_id = sa.Column(
 )
 
 ObjTag.author = relationship(User, doc="The associated User")
+
+
+ObjTag.create = ObjTag.read
+ObjTag.update = ObjTag.delete = CustomUserAccessControl(objtag_access_logic)


### PR DESCRIPTION
This PR improved user right management for deletion and update of a tag association to a source.  

Before: use default strategy for the delete mode eg. only admin can delete data.  
Now: Admin, user with "Manage sources" rights and author of the association can remove and update a tag on a source.

fix: https://university-of-minnesota-gz.sentry.io/issues/6714911642/?referrer=slack&notification_uuid=a8953fb5-4830-4e5e-a98b-6ad41dcc3e6c&alert_rule_id=15261568&alert_type=issue 