### PR TITLE
ATLAS FP: filter out detections fainter than associated limiting mag

### DIFF
--- a/skyportal/facility_apis/atlas.py
+++ b/skyportal/facility_apis/atlas.py
@@ -171,9 +171,10 @@ def commit_photometry(
         cyan = df["filter"] == "c"
         orange = df["filter"] == "o"
 
-        # not detection if SNR < 3 or chi/N > 10
+        # not detection if SNR < 3 or chi/N > 10, or mag > limiting_mag
         reject = df["uJy"] / df["duJy"] < 3
         reject |= df["chi/N"] > 10
+        reject |= df["mag"] > df["limiting_mag"]
 
         df.loc[cyan, "filter"] = "atlasc"
         df.loc[orange, "filter"] = "atlaso"


### PR DESCRIPTION
Users pointed out that ATLAS data often comes back with detections (datapoints with a mag and mag error defined) fainter than the associated limiting magnitude. In theory, that should not happen. This PR filters those datapoints out as detections (effectively turning them into non detections).

This was suggested by @robertdstein