### PR TITLE
enh: sort photometry legend alphabetically (filter and instrument)

### DIFF
--- a/static/js/components/plot/PhotometryPlot.jsx
+++ b/static/js/components/plot/PhotometryPlot.jsx
@@ -512,6 +512,7 @@ const PhotometryPlot = ({
     }
     if (plotType === "mag" || plotType === "flux") {
       const newPlotData = Object.keys(groupedPhotometry)
+        .sort()
         .map((key) => {
           const detections = groupedPhotometry[key].filter(
             (point) => point.mag !== null,
@@ -694,6 +695,7 @@ const PhotometryPlot = ({
     }
     if (plotType === "period") {
       const newPlotData = Object.keys(groupedPhotometry)
+        .sort()
         .map((key) => {
           // using the period state variable, calculate the phase of each point
           // and then plot the phase vs mag


### PR DESCRIPTION
This PR sorts the photometry plot legend to improve readability for users.

Before:  
<img width="1041" height="822" alt="image" src="https://github.com/user-attachments/assets/415a2010-d691-40b2-ba24-b6803a0bfa26" />


After:  
<img width="1041" height="822" alt="image" src="https://github.com/user-attachments/assets/b3dd52cc-97be-46df-89aa-e8aea1d317d9" />
