### PR TITLE
fix: Fix mag system conversion with data with the swiftxrt filter

### DIFF
--- a/skyportal/handlers/api/photometry.py
+++ b/skyportal/handlers/api/photometry.py
@@ -328,6 +328,9 @@ def serialize(
 
     filter = phot.filter
 
+    if filter == "swiftxrt":
+        outsys = "ab"
+
     magsys_db = sncosmo.get_magsystem("ab")
     outsys = sncosmo.get_magsystem(outsys)
 

--- a/static/js/components/plot/PhotometryPlot.jsx
+++ b/static/js/components/plot/PhotometryPlot.jsx
@@ -1008,8 +1008,14 @@ const PhotometryPlot = ({
         .map((duplicate) => photometry[duplicate] || [])
         .flat();
 
+      // Filter out SwiftXRT points as they are not relevant for in the vega system
+      const allPhotometry = [...objPhotometry, ...duplicatesPhotometry];
+      const photometryFiltered = allPhotometry.filter(
+        (point) => !(point.filter === "swiftxrt" && magsys === "vega"),
+      );
+
       const [newPhotometry, newPhotStats] = preparePhotometry(
-        [...objPhotometry, ...duplicatesPhotometry],
+        photometryFiltered,
         dm,
       );
       const groupedPhotometry = groupPhotometry(

--- a/static/js/components/plot/VegaPhotometry.jsx
+++ b/static/js/components/plot/VegaPhotometry.jsx
@@ -193,8 +193,13 @@ const VegaPhotometry = (props) => {
           await dispatch(photometryActions.fetchSourcePhotometry(sourceId));
         }
         if (photometry && photometry?.length > 0 && filters.length === 0) {
+          // Filter out SwiftXRT points as they are not relevant for in the vega system
+          const photometryFiltered = photometry.filter(
+            (datum) => datum.filter !== "swiftxrt",
+          );
+
           const newFilters = [
-            ...new Set(photometry.map((datum) => datum.filter)),
+            ...new Set(photometryFiltered.map((datum) => datum.filter)),
           ];
           const newWavelengths = newFilters.map(
             (filter) => filter2color[filter] || [0, 0, 0],
@@ -207,7 +212,7 @@ const VegaPhotometry = (props) => {
           setFilters(newFilters);
           setWavelengths(newWavelengths);
           setHasForcedPhotometry(
-            photometry.some((datum) =>
+            photometryFiltered.some((datum) =>
               ["fp", "alert_fp"].includes(datum.origin),
             ),
           );
@@ -231,8 +236,15 @@ const VegaPhotometry = (props) => {
   }
 
   let photometryFiltered = photometry;
+
+  photometryFiltered = photometryFiltered.filter(
+    (datum) => datum.filter !== "swiftxrt",
+  );
+
   if (!showUpperLimits) {
-    photometryFiltered = photometry.filter((datum) => datum.mag !== null);
+    photometryFiltered = photometryFiltered.filter(
+      (datum) => datum.mag !== null,
+    );
   }
   if (!showForcedPhotometry) {
     photometryFiltered = photometryFiltered.filter(

--- a/static/js/components/plot/VegaPhotometry.jsx
+++ b/static/js/components/plot/VegaPhotometry.jsx
@@ -195,7 +195,8 @@ const VegaPhotometry = (props) => {
         if (photometry && photometry?.length > 0 && filters.length === 0) {
           // Filter out SwiftXRT points as they are not relevant for in the vega system
           const photometryFiltered = photometry.filter(
-            (datum) => datum.filter !== "swiftxrt",
+            (datum) =>
+              !(datum.magsys === "vega" && datum.filter === "swiftxrt"),
           );
 
           const newFilters = [
@@ -238,7 +239,7 @@ const VegaPhotometry = (props) => {
   let photometryFiltered = photometry;
 
   photometryFiltered = photometryFiltered.filter(
-    (datum) => datum.filter !== "swiftxrt",
+    (datum) => !(datum.magsys === "vega" && datum.filter === "swiftxrt"),
   );
 
   if (!showUpperLimits) {


### PR DESCRIPTION
The goal of this PR is to fix the conversion problem when a user is trying to convert to vega system some photometry points that are in the x-ray domain and cannot be converted. Photometry points are also hidden in the plot using vega system to be coherent.

<img width="482" height="118" alt="image" src="https://github.com/user-attachments/assets/1ac1774d-0978-4203-8649-0abde54f9cee" />


The solution is to ignore photometry points with the filter swiftxrt during the conversion :

<img width="1888" height="361" alt="image" src="https://github.com/user-attachments/assets/28557d17-4e11-4d61-9e14-6dadd1032458" />

Note: x-ray data while valid in AB mag system, is not defined / can't be converted in Vega. So this isn't an issue with SkyPortal failing to convert from one system to another, it's just that x-ray data does not exist in Vega to begin with.