### PR TITLE
feat: enable nmma format option in the download form in the Photometry Table

### DIFF
--- a/static/js/components/photometry/PhotometryDownload.jsx
+++ b/static/js/components/photometry/PhotometryDownload.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import { useDispatch } from "react-redux";
 import Dialog from "@mui/material/Dialog";
@@ -19,7 +19,31 @@ import { calculateFluxFromMag } from "../../utils/calculations";
 import { PHOT_ZP } from "../../utils";
 import { getValidationStatus } from "./PhotometryValidation";
 
-const DEFAULT_DOWNLOAD_COLUMNS = [
+const DEFAULT_COLUMN_ORDER = [
+  "id",
+  "mjd",
+  "utc",
+  "mag",
+  "magerr",
+  "limiting_mag",
+  "filter",
+  "snr",
+  "magsys",
+  "instrument_name",
+  "instrument_id",
+  "origin",
+  "flux",
+  "fluxerr",
+  "ra",
+  "dec",
+  "ra_unc",
+  "dec_unc",
+  "created_at",
+  "altdata",
+  "streams",
+];
+
+const DEFAULT_COLUMNS = [
   "id",
   "mjd",
   "mag",
@@ -49,31 +73,30 @@ const PhotometryDownload = ({
 }) => {
   const dispatch = useDispatch();
   const [downloadFormData, setDownloadFormData] = useState({
-    columns: DEFAULT_DOWNLOAD_COLUMNS,
+    columns: [],
     validationFilter: DEFAULT_VALIDATION_FILTER,
   });
   const [downloadMode, setDownloadMode] = useState("default");
 
+  const orderColumns = (columns) => {
+    const orderedColumns = DEFAULT_COLUMN_ORDER.filter((col) =>
+      columns.includes(col),
+    );
+    const remainingColumns = columns.filter(
+      (col) => !DEFAULT_COLUMN_ORDER.includes(col),
+    );
+    return [...orderedColumns, ...remainingColumns];
+  };
+
   let availableDownloadColumns = [];
   if (data && data.length > 0) {
-    const priorityColumns = ["id", "mjd", "mag", "magerr", "filter"];
     const allKeys = [...Object.keys(data[0]), "utc", "flux", "fluxerr"];
-
     const filteredKeys = allKeys.filter(
       (key) => !["groups", "obj_id", "validations"].includes(key),
     );
 
-    // sort columns
-    const priority = filteredKeys
-      .filter((key) => priorityColumns.includes(key))
-      .map((key) => ({ key, label: key }));
-
-    const others = filteredKeys
-      .filter((key) => !priorityColumns.includes(key))
-      .sort()
-      .map((key) => ({ key, label: key }));
-
-    availableDownloadColumns = [...priority, ...others];
+    const orderedKeys = orderColumns(filteredKeys);
+    availableDownloadColumns = orderedKeys.map((key) => ({ key, label: key }));
   }
 
   const downloadSchema = {
@@ -128,6 +151,58 @@ const PhotometryDownload = ({
     }
     return filter;
   };
+
+  const setColumnsForMode = (mode) => {
+    setDownloadMode(mode);
+
+    let selectedColumns;
+    let validationFilter = DEFAULT_VALIDATION_FILTER;
+
+    switch (mode) {
+      case "default":
+        selectedColumns = DEFAULT_COLUMNS.filter((col) =>
+          availableDownloadColumns.some((availCol) => availCol.key === col),
+        );
+        break;
+      case "all":
+        selectedColumns = availableDownloadColumns.map((col) => col.key);
+        validationFilter = {
+          validated: true,
+          rejected: true,
+          ambiguous: true,
+          not_vetted: true,
+        };
+        break;
+      case "nmma":
+        selectedColumns = ["utc", "filter", "mag", "magerr"].filter((col) =>
+          availableDownloadColumns.some((availCol) => availCol.key === col),
+        );
+        break;
+      default:
+        selectedColumns = [];
+    }
+
+    const orderedColumns = orderColumns(selectedColumns);
+
+    setDownloadFormData((prev) => ({
+      ...prev,
+      columns: orderedColumns,
+      ...(usePhotometryValidation && { validationFilter }),
+    }));
+  };
+
+  const handleSetDefaultColumns = () => setColumnsForMode("default");
+  const handleSetAllColumns = () => setColumnsForMode("all");
+  const handleSetNMMAMode = () => setColumnsForMode("nmma");
+
+  useEffect(() => {
+    if (
+      availableDownloadColumns.length > 0 &&
+      downloadFormData.columns.length === 0
+    ) {
+      setColumnsForMode("default");
+    }
+  }, [availableDownloadColumns]);
 
   const performDownload = (buildHead, buildBody, cols, tableData) => {
     const filteredTableData = filterDataByValidation(
@@ -249,48 +324,6 @@ const PhotometryDownload = ({
       downloadParams.tableData,
     );
     onDownload();
-  };
-
-  const handleSetDefaultColumns = () => {
-    setDownloadMode("default");
-    setDownloadFormData((prev) => ({
-      ...prev,
-      columns: DEFAULT_DOWNLOAD_COLUMNS.filter((col) =>
-        availableDownloadColumns.some((availCol) => availCol.key === col),
-      ),
-      ...(usePhotometryValidation && {
-        validationFilter: DEFAULT_VALIDATION_FILTER,
-      }),
-    }));
-  };
-
-  const handleSetAllColumns = () => {
-    setDownloadMode("all");
-    setDownloadFormData((prev) => ({
-      ...prev,
-      columns: availableDownloadColumns.map((col) => col.key),
-      ...(usePhotometryValidation && {
-        validationFilter: {
-          validated: true,
-          rejected: true,
-          ambiguous: true,
-          not_vetted: true,
-        },
-      }),
-    }));
-  };
-
-  const handleSetNMMAMode = () => {
-    setDownloadMode("nmma");
-    setDownloadFormData((prev) => ({
-      ...prev,
-      columns: ["utc", "filter", "mag", "magerr"].filter((col) =>
-        availableDownloadColumns.some((availCol) => availCol.key === col),
-      ),
-      ...(usePhotometryValidation && {
-        validationFilter: DEFAULT_VALIDATION_FILTER,
-      }),
-    }));
   };
 
   return (


### PR DESCRIPTION
The goal of this PR is to enable users to download photometry table in the NMMA format.

This PR also fix the column order to fit user needs.

<img width="615" height="393" alt="image" src="https://github.com/user-attachments/assets/4282603e-dc1e-4ec3-9dbb-dca2a0902fb9" />

Result: .dat file content example  
```
"utc","filter","mag","magerr"
2020-07-27T10:23:50Z,ztfg,12.095780629486423,0.2
2020-07-27T10:23:50Z,ztfg,20.412458499097877,inf
2020-07-27T10:48:47Z,ztfr,20.638849949069094,inf
```
