### PR TITLE
Json file formatting for rubin ToOs

### DIFF
--- a/skyportal/handlers/api/gcn.py
+++ b/skyportal/handlers/api/gcn.py
@@ -31,6 +31,7 @@ from astropy.time import Time
 from marshmallow import Schema, validate
 from marshmallow.exceptions import ValidationError
 from marshmallow.fields import Integer
+from sqlalchemy import Integer as Alchemy_Integer
 from sqlalchemy import String, func
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import joinedload, scoped_session, sessionmaker
@@ -99,6 +100,7 @@ from ...utils.gcn import (
     has_skymap,
 )
 from ...utils.notifications import post_notification
+from ...utils.parse import get_page_and_n_per_page
 from ...utils.UTCTZnaiveDateTime import UTCTZnaiveDateTime
 from ..base import BaseHandler
 from .galaxy import MAX_GALAXIES, get_galaxies, get_galaxies_completeness
@@ -1261,7 +1263,6 @@ class GcnEventCatalogQueryHandler(BaseHandler):
               application/json:
                 schema: ArrayOfCatalogQuerys
         """
-
         try:
             gcnevent_id = int(gcnevent_id)
         except ValueError:
@@ -1271,7 +1272,10 @@ class GcnEventCatalogQueryHandler(BaseHandler):
             queries = session.scalars(
                 CatalogQuery.select(
                     session.user_or_token,
-                ).where(CatalogQuery.payload["gcnevent_id"] == gcnevent_id)
+                ).where(
+                    cast(CatalogQuery.payload["gcnevent_id"].astext, Alchemy_Integer)
+                    == gcnevent_id
+                )
             ).all()
 
             return self.success(data=queries)
@@ -1476,23 +1480,13 @@ class GcnEventHandler(BaseHandler):
             )
 
         page_number = self.get_query_argument("pageNumber", 1)
-        try:
-            page_number = int(page_number)
-        except ValueError as e:
-            return self.error(f"pageNumber fails: {e}")
-
         n_per_page = self.get_query_argument("numPerPage", 10)
-        try:
-            n_per_page = int(n_per_page)
-        except ValueError as e:
-            return self.error(f"numPerPage fails: {e}")
-
-        if n_per_page > MAX_GCNEVENTS:
-            return self.error(f"numPerPage should be no larger than {MAX_GCNEVENTS}.")
+        page_number, n_per_page = get_page_and_n_per_page(
+            page_number, n_per_page, MAX_GCNEVENTS
+        )
 
         sort_by = self.get_query_argument("sortBy", None)
         sort_order = self.get_query_argument("sortOrder", "asc")
-
         start_date = self.get_query_argument("startDate", None)
         end_date = self.get_query_argument("endDate", None)
         gcn_tag_keep = self.get_query_argument("gcnTagKeep", None)

--- a/skyportal/handlers/api/observation_plan.py
+++ b/skyportal/handlers/api/observation_plan.py
@@ -1760,9 +1760,13 @@ class ObservationPlanMovieHandler(BaseHandler):
             )
             observation_plan_request = session.scalars(stmt).first()
 
-            if observation_plan_request is None:
+            if not observation_plan_request:
                 return self.error(
                     f"Could not find observation_plan_request with ID {observation_plan_request_id}"
+                )
+            if not observation_plan_request.observation_plans:
+                return self.error(
+                    f"Observation plan request with ID {observation_plan_request_id} has no observation plans."
                 )
 
             localization = session.scalars(

--- a/static/js/components/gcn/GcnEventPage.jsx
+++ b/static/js/components/gcn/GcnEventPage.jsx
@@ -70,21 +70,6 @@ const useStyles = makeStyles((theme) => ({
     alignItems: "center",
     gap: "1rem",
   },
-  headerLeft: {
-    display: "flex",
-    flexDirection: "row",
-    justifyContent: "flex-start",
-    alignItems: "center",
-    gap: "1rem",
-  },
-  headerRight: {
-    display: "flex",
-    flexDirection: "row",
-    justifyContent: "flex-end",
-    alignItems: "center",
-    alignContent: "center",
-    gap: "1rem",
-  },
   headerName: {
     height: "2rem",
     fontSize: "2rem",
@@ -105,14 +90,6 @@ const useStyles = makeStyles((theme) => ({
     gridTemplateColumns: "repeat(auto-fit, minmax(100px, 1fr))",
     gap: "0.5rem",
   },
-  eventTags: {
-    marginLeft: "1rem",
-    "& > div": {
-      margin: "0.25rem",
-      color: "white",
-      background: theme.palette.primary.main,
-    },
-  },
   accordionHeading: {
     fontSize: "1.25rem",
     fontWeight: theme.typography.fontWeightRegular,
@@ -122,19 +99,8 @@ const useStyles = makeStyles((theme) => ({
     overflow: "hidden",
     flexDirection: "column",
   },
-  comments: {
-    width: "100%",
-  },
   columnItem: {
     marginBottom: theme.spacing(1),
-  },
-  noSources: {
-    padding: theme.spacing(2),
-    display: "flex",
-    flexDirection: "row",
-  },
-  sourceList: {
-    padding: "0",
   },
   noticeListElement: {
     display: "flex",

--- a/static/js/components/gcn/GcnLocalizationsTable.jsx
+++ b/static/js/components/gcn/GcnLocalizationsTable.jsx
@@ -357,7 +357,12 @@ GcnLocalizationsTable.propTypes = {
           data: PropTypes.objectOf(PropTypes.any).isRequired, // eslint-disable-line react/forbid-prop-types,
         }),
       ),
-      tags: PropTypes.arrayOf(PropTypes.string),
+      tags: PropTypes.arrayOf(
+        PropTypes.shape({
+          id: PropTypes.number,
+          text: PropTypes.string.isRequired,
+        }),
+      ),
       center: PropTypes.objectOf(PropTypes.any).isRequired, // eslint-disable-line react/forbid-prop-types,
     }),
   ).isRequired,

--- a/static/js/components/observation_plan/AddRunFromObservationPlanPage.jsx
+++ b/static/js/components/observation_plan/AddRunFromObservationPlanPage.jsx
@@ -5,6 +5,7 @@ import CircularProgress from "@mui/material/CircularProgress";
 import Dialog from "@mui/material/Dialog";
 import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
+import Box from "@mui/material/Box";
 
 import * as Actions from "../../ducks/gcnEvent";
 import GroupShareSelect from "../group/GroupShareSelect";
@@ -46,43 +47,44 @@ const AddRunFromObservationPlanPage = ({ observationplanRequest }) => {
       >
         Create Observing Run
       </Button>
-      <Dialog
-        open={dialogOpen}
-        onClose={closeDialog}
-        style={{ position: "fixed" }}
-      >
+      <Dialog open={dialogOpen} onClose={closeDialog}>
         <DialogTitle>Create Observing Run</DialogTitle>
         <DialogContent>
-          <div>
-            {isCreatingObservingRun === observationplanRequest.id ? (
-              <div>
-                <CircularProgress />
-              </div>
-            ) : (
-              <div>
-                <GroupShareSelect
-                  groupList={allGroups}
-                  setGroupIDs={setSelectedGroupIds}
-                  groupIDs={selectedGroupIds}
-                />
-
-                <Button
-                  secondary
-                  onClick={() => {
-                    handleCreateObservingRun(
-                      observationplanRequest.id,
-                      selectedGroupIds,
-                    );
-                  }}
-                  size="small"
-                  type="submit"
-                  data-testid={`observingRunRequest_${observationplanRequest.id}`}
-                >
-                  Create Observing Run
-                </Button>
-              </div>
-            )}
-          </div>
+          {isCreatingObservingRun === observationplanRequest.id ? (
+            <Box sx={{ textAlign: "center" }}>
+              <CircularProgress />
+            </Box>
+          ) : (
+            <Box
+              sx={{
+                display: "flex",
+                justifyContent: "center",
+                alignItems: "center",
+                flexDirection: "column",
+                gap: 4,
+              }}
+            >
+              <GroupShareSelect
+                groupList={allGroups}
+                setGroupIDs={setSelectedGroupIds}
+                groupIDs={selectedGroupIds}
+              />
+              <Button
+                secondary
+                onClick={() => {
+                  handleCreateObservingRun(
+                    observationplanRequest.id,
+                    selectedGroupIds,
+                  );
+                }}
+                size="small"
+                type="submit"
+                data-testid={`observingRunRequest_${observationplanRequest.id}`}
+              >
+                Create Observing Run
+              </Button>
+            </Box>
+          )}
         </DialogContent>
       </Dialog>
     </>

--- a/static/js/ducks/recentGcnEvents.js
+++ b/static/js/ducks/recentGcnEvents.js
@@ -8,7 +8,6 @@ const REFRESH_RECENT_GCNEVENTS = "skyportal/REFRESH_RECENT_GCNEVENTS";
 const FETCH_RECENT_GCNEVENTS = "skyportal/FETCH_RECENT_GCNEVENTS";
 const FETCH_RECENT_GCNEVENTS_OK = "skyportal/FETCH_RECENT_GCNEVENTS_OK";
 
-// eslint-disable-next-line import/prefer-default-export
 export const fetchRecentGcnEvents = () =>
   API.GET("/api/internal/recent_gcn_events", FETCH_RECENT_GCNEVENTS);
 


### PR DESCRIPTION
For Rubin schedules generated on Fritz/Skyportal, modify the default JSON output file to a format that is compatible with the Rubin block scheduler. In case of a coarsely localized GW event for which Rubin-generated schedules are not optimal, schedules generated using Fritz/Skyportal for Rubin could be ingested manually into the Rubin block scheduler.