### PR TITLE
fix: fix allocation unit test

### DIFF
--- a/skyportal/tests/frontend/test_allocation.py
+++ b/skyportal/tests/frontend/test_allocation.py
@@ -1,5 +1,7 @@
 import pytest
 from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.wait import WebDriverWait
 
 from skyportal.tests import api
 
@@ -36,6 +38,13 @@ def one_request_comment_process(
     driver.find_element(
         By.XPATH, '//button[@data-testid="updateCommentSubmitButton"]'
     ).click()
+
+    WebDriverWait(driver, 10).until(
+        EC.invisibility_of_element_located(
+            (By.XPATH, '//div[@data-testid="updateCommentTextfield"]')
+        )
+    )
+
     assert driver.wait_for_xpath(request_comment_xpath).text == comment_to_put
 
 


### PR DESCRIPTION
The test_allocation_comment_display Selenium test was failing intermittently with an ElementClickInterceptedException:

```
Element <span class=""> is not clickable at point (1898,489) because another element <div class="MuiDialog-container MuiDialog-scrollPaper css-hz1bth-MuiDialog-container"> obscures it
```

Added an explicit wait condition in the one_request_comment_process helper function to ensure the comment edit dialog fully closes to continue