### PR TITLE
Docker build: rspack fix

### DIFF
--- a/rspack.config.js
+++ b/rspack.config.js
@@ -37,7 +37,11 @@ const config = {
       // Enable CSS Modules for Skyportal
       {
         test: /\.css$/,
-        include: [/static\/js/, /node_modules\/react-datepicker\/dist/],
+        include: [
+          /static\/js/,
+          /node_modules\/react-datepicker\/dist/,
+          /node_modules\/@mui\/x-data-grid\/esm/,
+        ],
         use: [
           {
             loader: "style-loader",


### PR DESCRIPTION
Fixes issue introduces by latest @mui/x-data-grid, that added some *.css file that rspack tried to load as a javascript one.