### PR TITLE
WIP - Finding Chart results cache + public cache access

### DIFF
--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -557,13 +557,14 @@ services:
 
 misc:
   days_to_keep_unsaved_candidates: 7
+  days_to_keep_finding_charts_cache: 30
   minutes_to_keep_candidate_query_cache: 60
-  minutes_to_keep_source_query_cache: 360
-  minutes_to_keep_annotations_info_query_cache: 360
-  minutes_to_keep_localization_instrument_query_cache: 1440
+  minutes_to_keep_source_query_cache: 360 # 6 hours
+  minutes_to_keep_annotations_info_query_cache: 360 # 6 hours
+  minutes_to_keep_localization_instrument_query_cache: 1440 # 1 day
   max_items_in_localization_instrument_query_cache: 100
-  minutes_to_keep_public_source_pages_cache: 1440
-  minutes_to_keep_reports_cache: 1440
+  minutes_to_keep_public_source_pages_cache: 1440 # 1 day
+  minutes_to_keep_reports_cache: 1440 # 1 day
   max_seconds_to_sleep_reminders_service: 60
   max_seconds_to_sleep_recurring_apis_service: 60
   public_group_name: "Sitewide Group"

--- a/skyportal/app_server.py
+++ b/skyportal/app_server.py
@@ -222,6 +222,7 @@ from skyportal.handlers.api.internal import (
     TokenHandler,
 )
 from skyportal.handlers.public import (
+    CachedSourceFinderHandler,
     ReleaseHandler,
     ReleaseSourcePageHandler,
     ReportHandler,
@@ -617,6 +618,7 @@ skyportal_handlers = [
     ),
     (r"/public/releases(?:/)?([0-9A-Za-z-_\.\+]+)?", ReleaseHandler),
     (r"/public/reports/(gcn)(/[0-9]+)?(/.*)?", ReportHandler),
+    (r"/public/finding_charts/(.*)", CachedSourceFinderHandler),
     (r"/public/.*", InvalidEndpointHandler),
     # Debug and logout pages.
     (r"/become_user(/.*)?", BecomeUserHandler),

--- a/skyportal/facility_apis/mmt/mmt_utils.py
+++ b/skyportal/facility_apis/mmt/mmt_utils.py
@@ -263,6 +263,7 @@ def submit_mmt_request(
             obj_id=request.obj.id,
             session=session,
             imsize=4.0,
+            use_cache=True,
             facility="Keck",
             image_source=image_source_dict[request.payload["primary_image_source"]],
             use_ztfref=request.payload["offset_position_origin"] == "ZTF Ref",

--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -1,3 +1,4 @@
+import base64
 import datetime
 import functools
 import io
@@ -83,6 +84,7 @@ from ...utils.offset import (
     ALL_NGPS_SNCOSMO_BANDS,
     _calculate_best_position_for_offset_stars,
     facility_parameters,
+    finding_charts_cache,
     get_finding_chart,
     get_nearby_offset_stars,
     source_image_parameters,
@@ -2592,6 +2594,7 @@ def get_finding_chart_callable(
     obj_id,
     session,
     imsize,
+    use_cache,
     facility,
     image_source,
     use_ztfref,
@@ -2608,6 +2611,8 @@ def get_finding_chart_callable(
         The SQLAlchemy session to use for database queries.
     imsize: float
         The size of the image in arcminutes (default is 4.0).
+    use_cache: bool
+        Use caching when generating the finding chart (default is True).
     facility: str
         The facility for which to generate the starlist (e.g., "Keck", "Shane", "P200", "P200-NGPS").
     image_source: str
@@ -2691,6 +2696,7 @@ def get_finding_chart_callable(
         image_source=image_source,
         output_format=output_type,
         imsize=imsize,
+        use_cache=use_cache,
         how_many=num_offset_stars,
         radius_degrees=facility_parameters[facility]["radius_degrees"],
         mag_limit=facility_parameters[facility]["mag_limit"],
@@ -2772,6 +2778,18 @@ class SourceFinderHandler(BaseHandler):
             maximum: 4
           description: |
             output desired number of offset stars [0,5] (default: 3)
+        - in: query
+          name: as_json
+          schema:
+            type: boolean
+          description: |
+            Return a JSON including the finding chart and star_list
+        - in: query
+          name: use_cache
+          schema:
+            type: boolean
+          description: |
+            Use caching when generating finding charts (default: true)
         responses:
           200:
             description: A PDF/PNG finding chart file
@@ -2784,6 +2802,16 @@ class SourceFinderHandler(BaseHandler):
                 schema:
                   type: string
                   format: binary
+              application/json:
+                schema:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                      description: Name of the file
+                    data:
+                      type: string
+                      format: binary
           400:
             content:
               application/json:
@@ -2808,12 +2836,15 @@ class SourceFinderHandler(BaseHandler):
             num_offset_stars = int(num_offset_stars)
         except ValueError:
             return self.error("Invalid argument for `num_offset_stars`")
+        as_json = self.get_query_argument("as_json", False)
+        use_cache = self.get_query_argument("use_cache", True)
 
         with self.Session() as session:
             finder = get_finding_chart_callable(
                 obj_id,
                 session,
                 imsize,
+                use_cache,
                 facility,
                 image_source,
                 use_ztfref,
@@ -2827,6 +2858,21 @@ class SourceFinderHandler(BaseHandler):
             )
             try:
                 rez = await IOLoop.current().run_in_executor(None, finder)
+                if as_json:
+                    data = {
+                        "finding_chart": base64.b64encode(rez["data"]).decode(),
+                        "starlist": rez["starlist"],
+                    }
+                    if "public_url" in rez:
+                        data["public_url"] = rez["public_url"]
+                        if finding_charts_cache._max_age:
+                            data["public_url_expires_at"] = (
+                                datetime.datetime.utcnow()
+                                + datetime.timedelta(
+                                    seconds=finding_charts_cache._max_age
+                                )
+                            )
+                    return self.success(data)
                 filename = rez["name"]
                 data = io.BytesIO(rez["data"])
             except Exception as e:

--- a/skyportal/handlers/public/__init__.py
+++ b/skyportal/handlers/public/__init__.py
@@ -1,3 +1,4 @@
+from .finder import CachedSourceFinderHandler
 from .release import ReleaseHandler
 from .report import ReportHandler
 from .source_page import ReleaseSourcePageHandler, SourcePageHandler

--- a/skyportal/handlers/public/finder.py
+++ b/skyportal/handlers/public/finder.py
@@ -1,0 +1,73 @@
+import io
+import traceback
+
+import numpy as np
+
+from baselayer.app.access import auth_or_token
+from baselayer.app.env import load_env
+from baselayer.log import make_log
+
+from ...utils.offset import finding_charts_cache
+from ..base import BaseHandler
+
+_, cfg = load_env()
+log = make_log("api/source")
+
+
+class CachedSourceFinderHandler(BaseHandler):
+    @auth_or_token
+    async def get(self, cache_key):
+        """
+        ---
+        summary: Retrieve a cached finding chart
+        description: Download a pre-generated PDF/PNG finding chart that has been cached
+        tags:
+          - sources
+          - finding chart
+          - public
+        parameters:
+          - in: path
+            name: cache_key
+            required: true
+            schema:
+              type: string
+        responses:
+          200:
+            description: A PDF/PNG finding chart file
+            content:
+              application/pdf:
+                schema:
+                  type: string
+                  format: binary
+              image/png:
+                schema:
+                  type: string
+                  format: binary
+          400:
+            content:
+              application/json:
+                schema: Error
+        """
+
+        try:
+            value = finding_charts_cache[cache_key]
+            if value is None:
+                return self.error("Finding chart not found in cache", status=404)
+
+            value = np.load(value, allow_pickle=True)
+            value = value.item()
+
+            filename = value["name"]
+            data = io.BytesIO(value["data"])
+            output_type = filename.split(".")[-1].lower()
+        except Exception as e:
+            # if its a value error with text "Source not found", we return a 404
+            if isinstance(e, ValueError) and str(e) == "Source not found":
+                return self.error("Source not found", status=404)
+
+            # otherwise, we log the error and return a 500
+            log(f"Error retrieving cached finding chart: {str(e)}")
+            traceback.print_exc()
+            return self.error(f"Error generating finding chart: {str(e)}")
+
+        await self.send_file(data, filename, output_type=output_type)

--- a/skyportal/utils/offset.py
+++ b/skyportal/utils/offset.py
@@ -4,6 +4,7 @@ import math
 import os
 import re
 import string
+import traceback
 import urllib
 import warnings
 from functools import wraps
@@ -24,19 +25,24 @@ from astropy.visualization import ImageNormalize, ZScaleInterval
 from astropy.wcs import WCS
 from astropy.wcs.utils import pixel_to_skycoord
 from astropy.wcs.wcs import FITSFixedWarning
-from joblib import Memory
+from joblib import Memory, hash
 from reproject import reproject_adaptive
 from scipy.ndimage import gaussian_filter
 
 from baselayer.app.env import load_env
 from baselayer.log import make_log
 
-from .cache import Cache
+from .. import __version__
+from .cache import Cache, dict_to_bytes
 from .tap_services.gaia import GaiaQuery
 
 log = make_log("finder-chart")
 
 _, cfg = load_env()
+
+cache_dir = "cache/finding_charts"
+cache_max_age = cfg.get("misc.days_to_keep_finding_charts_cache", 30) * 24 * 60 * 60
+finding_charts_cache = Cache(cache_dir=cache_dir, max_age=cache_max_age)
 
 PS1_CUTOUT_TIMEOUT = 15  # seconds
 
@@ -1328,6 +1334,48 @@ def fits_image(
     return get_hdu(url)
 
 
+# write a decorator for the get_finding_chart function which takes
+# all the methods inputs (ordered alphabetically, removing those with None or "" values)
+# are converted into a hash, so at the next function we can check if this finding chart was already
+# generated before, and return it
+
+
+def get_finding_chart_cache_key(*args, **kwargs):
+    cache_key_str = (
+        "_".join([str(arg) for arg in args])
+        + "_".join(
+            [
+                f"{key}={value}"
+                for key, value in kwargs.items()
+                if key not in ["obstime"]
+            ]
+        )
+        # also add the version, to invalidate the cache when
+        # the application is upgraded to a new version
+        + "_"
+        + str(__version__)
+        # use the secret key as a salt, so a cache key
+        # can't just be built using function parameters
+        + "_"
+        + str(cfg["app.secret_key"])
+    )
+
+    return hash(cache_key_str)
+
+
+def cache_finding_chart(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        cache_key = get_finding_chart_cache_key(*args, **kwargs)
+        value = finding_charts_cache[cache_key]
+        if value is None:
+            return func(*args, **kwargs)
+
+        return value
+
+    return wrapper
+
+
 @warningfilter(action="ignore", category=FITSFixedWarning)
 def get_finding_chart(
     source_ra,
@@ -1342,6 +1390,7 @@ def get_finding_chart(
     zscale_contrast=0.045,
     zscale_krej=2.5,
     extra_display_string="",
+    use_cache=True,
     **offset_star_kwargs,
 ):
     """Create a finder chart suitable for spectroscopic observations of
@@ -1375,6 +1424,8 @@ def get_finding_chart(
         Krej parameter for the Zscale interval
     extra_display_string :  str, optional
         What else to show for the source itself in the chart (e.g. proper motion)
+    use_cache : bool, optional
+        Cache finding charts to disk. Also provides a public URL to the cached finding chart
     **offset_star_kwargs : dict, optional
         Other parameters passed to `get_nearby_offset_stars`
 
@@ -1391,6 +1442,31 @@ def get_finding_chart(
         reason : str
             If not successful, a reason is returned.
     """
+    if use_cache:
+        cache_key = get_finding_chart_cache_key(
+            source_ra,
+            source_dec,
+            source_name,
+            image_source="ps1",
+            output_format="pdf",
+            imsize=3.0,
+            tick_offset=0.02,
+            tick_length=0.03,
+            fallback_image_source="ps1_cds",
+            zscale_contrast=0.045,
+            zscale_krej=2.5,
+            extra_display_string="",
+            **offset_star_kwargs,
+        )
+        value = finding_charts_cache[cache_key]
+        if value is not None:
+            try:
+                value = np.load(value, allow_pickle=True)
+                value = value.item()
+                return value
+            except Exception as e:
+                log(f"Failed to load cached finding chart: {e}")
+
     if (imsize < 2.0) or (imsize > 15):
         return {
             "success": False,
@@ -1744,9 +1820,22 @@ def get_finding_chart(
     plt.close(fig)
     buf.seek(0)
 
-    return {
+    data = {
         "success": True,
         "name": f"finder_{source_name}.{output_format}",
         "data": buf.read(),
+        "starlist": star_list,
         "reason": "",
     }
+
+    if use_cache:
+        data["public_url"] = urllib.parse.urljoin(
+            HOST, f"/public/finding_charts/{cache_key}"
+        )
+        try:
+            finding_charts_cache[cache_key] = dict_to_bytes(data)
+        except Exception as e:
+            traceback.print_exc()
+            log(f"Failed to cache finding chart: {e}")
+
+    return data

--- a/static/js/components/FindingChart.jsx
+++ b/static/js/components/FindingChart.jsx
@@ -1,6 +1,7 @@
 import makeStyles from "@mui/styles/makeStyles";
 import React, { useEffect, useRef, useState } from "react";
 import { Link, useParams } from "react-router-dom";
+import { useDispatch } from "react-redux";
 
 import PrintIcon from "@mui/icons-material/Print";
 import Card from "@mui/material/Card";
@@ -13,11 +14,13 @@ import InputLabel from "@mui/material/InputLabel";
 import MenuItem from "@mui/material/MenuItem";
 import Select from "@mui/material/Select";
 import Typography from "@mui/material/Typography";
-
 import { Controller, useForm } from "react-hook-form";
 import { useImage } from "react-image";
 import TextLoop from "react-text-loop";
 import { useReactToPrint } from "react-to-print";
+
+import { fetchSourceFinderChart } from "../ducks/source";
+import { showNotification } from "baselayer/components/Notifications";
 import Button from "./Button";
 
 const initialFormState = {
@@ -32,9 +35,6 @@ const useStyles = makeStyles((theme) => ({
   media: {
     maxWidth: "100%",
     width: "95%",
-  },
-  button: {
-    margin: theme.spacing(1),
   },
   paper: {
     width: "100%",
@@ -93,6 +93,7 @@ const PlaceHolder = () => {
 };
 
 const FindingChart = () => {
+  const dispatch = useDispatch();
   const classes = useStyles();
   const {
     handleSubmit,
@@ -106,25 +107,31 @@ const FindingChart = () => {
   const [params, setParams] = useState({ ...initialFormState });
 
   const [image, setImage] = useState(null);
+  const [public_url, setPublicUrl] = useState(null);
 
   const componentRef = useRef();
 
   useEffect(() => {
     const fetchImage = async () => {
-      const url = new URL(`/api/sources/${id}/finder`, window.location.href);
-      url.search = new URLSearchParams({
+      const formData = {
         type: "png",
-        image_source: `${params.imagesource}`,
-        use_ztfref: `${params.positionsource === "ztfref"}`,
-        imsize: `${params.findersize}`,
-        num_offset_stars: `${params.numoffset}`,
-        facility: `${params.facility}`,
-      });
-      const response = await fetch(url);
-      if (response.ok) {
-        const blob = await response.blob();
-        const imageUrl = URL.createObjectURL(blob);
-        setImage(imageUrl);
+        image_source: `${params?.imagesource}`,
+        use_ztfref: `${params?.positionsource === "ztfref"}`,
+        imsize: `${params?.findersize}`,
+        num_offset_stars: `${params?.numoffset}`,
+        facility: `${params?.facility}`,
+        as_json: "true",
+      };
+      const response = await dispatch(fetchSourceFinderChart(id, formData));
+      if (response.status === "success" && response?.data) {
+        const img_data = response?.data?.finding_chart;
+        const url = response?.data?.public_url;
+        if (!img_data) {
+          console.error("No image data returned from server");
+          return;
+        }
+        setImage(`data:image/png;base64,${img_data}`);
+        setPublicUrl(url);
       } else {
         console.error("Error fetching image:", response.statusText);
       }
@@ -342,6 +349,19 @@ const FindingChart = () => {
                       disabled={!image}
                     >
                       Print
+                    </Button>
+                    <Button
+                      secondary
+                      className={classes.button}
+                      onClick={() => {
+                        navigator.clipboard.writeText(public_url);
+                        dispatch(
+                          showNotification("Public link copied to clipboard!"),
+                        );
+                      }}
+                      disabled={!public_url}
+                    >
+                      Share Link
                     </Button>
                   </form>
                 </div>

--- a/static/js/ducks/source.js
+++ b/static/js/ducks/source.js
@@ -120,6 +120,16 @@ const FETCH_LOADED_SOURCE_POSITION_OK =
   "skyportal/FETCH_LOADED_SOURCE_POSITION_OK";
 const REFRESH_SOURCE_POSITION = "skyportal/REFRESH_SOURCE_POSITION";
 
+const FETCH_SOURCE_FINDER_CHART = "skyportal/FETCH_SOURCE_FINDER_CHART";
+
+export function fetchSourceFinderChart(id, formData) {
+  return API.GET(
+    `/api/sources/${id}/finder`,
+    FETCH_SOURCE_FINDER_CHART,
+    formData,
+  );
+}
+
 export function fetchPosition(id) {
   return API.GET(`/api/sources/${id}/position`, FETCH_LOADED_SOURCE_POSITION);
 }


### PR DESCRIPTION
In this PR, we:
- add caching to finding chart results, optional and defaults to True
- add apublic handler (no auth required) to retrieve cached finding charts
- include public url to said handler in the response from the SourceFinderHandler
- add a "share link" button to the finder chart frontend to let users of SkyPortal share a link to the finding chart they just generated to external users. This link is available for as long as the cache is.
- the default cache validity window in the config is set to 30 days

Aside from the obvious benefit of caching finding charts to avoid doing the same work again and again, this lets folks share finding charts to people outside of the app, temporarily. This is very useful when sharing observation details to an observer which does not necessarily have access to the app.

In a following PR, the goal is to use this to send a link to a finding chart to Gemini observers (as part of the request payload), when triggering the instrument.