### PR TITLE
fix: add a try catch to avoid error on the airmass_time calculation

### DIFF
--- a/skyportal/handlers/api/instrument.py
+++ b/skyportal/handlers/api/instrument.py
@@ -414,13 +414,17 @@ class InstrumentHandler(BaseHandler):
             if localization_dateobs is not None:
                 try:
                     airmass_time = Time(arrow.get(localization_dateobs).datetime)
-                except:
-                    pass
+                except Exception as e:
+                    return self.error(
+                        f"Invalid date format for localizationDateobs: '{localization_dateobs}'. Expected ISO 8601 format (YYYY-MM-DDTHH:MM:SS.sss)"
+                    )
         else:
             try:
                 airmass_time = Time(arrow.get(airmass_time).datetime)
-            except:
-                pass
+            except Exception as e:
+                return self.error(
+                    f"Invalid date format for localizationDateobs: '{localization_dateobs}'. Expected ISO 8601 format (YYYY-MM-DDTHH:MM:SS.sss)"
+                )
 
         if includeGeoJSON:
             options = [joinedload(Instrument.fields).undefer(InstrumentField.contour)]

--- a/skyportal/handlers/api/instrument.py
+++ b/skyportal/handlers/api/instrument.py
@@ -412,9 +412,15 @@ class InstrumentHandler(BaseHandler):
 
         if airmass_time is None:
             if localization_dateobs is not None:
-                airmass_time = Time(arrow.get(localization_dateobs).datetime)
+                try:
+                    airmass_time = Time(arrow.get(localization_dateobs).datetime)
+                except:
+                    pass
         else:
-            airmass_time = Time(arrow.get(airmass_time).datetime)
+            try:
+                airmass_time = Time(arrow.get(airmass_time).datetime)
+            except:
+                pass
 
         if includeGeoJSON:
             options = [joinedload(Instrument.fields).undefer(InstrumentField.contour)]


### PR DESCRIPTION
Fixing  the following sentry error : https://university-of-minnesota-gz.sentry.io/issues/6808630071/?alert_rule_id=15261570&alert_type=issue&notification_uuid=151021c4-8127-4a0f-9472-12eabea507ff&project=4507403282546688&referrer=slack