### PR TITLE
dependabot: let packages cool down before installing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     schedule:
       interval: monthly
       time: "06:00"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 10
     ignore:
       - dependency-name: "@date-io/dayjs"


### PR DESCRIPTION
This protects us, to some degree, from npm attacks.