### PR TITLE
Fix mjd key error

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "d3-array": "3.2.4",
     "d3-geo": "3.1.1",
     "d3-geo-projection": "4.0.0",
-    "d3-geo-zoom": "1.5.5",
+    "d3-geo-zoom": "1.4.4",
     "data-uri-to-buffer": "6.0.2",
     "dayjs": "1.11.18",
     "dygraphs": "2.2.1",

--- a/skyportal/models/schema.py
+++ b/skyportal/models/schema.py
@@ -977,6 +977,9 @@ class PhotometryMag(_Schema, PhotBase):
         if not obj:
             raise ValidationError(f"Invalid object ID: {data['obj_id']}")
 
+        if "mjd" not in data or data["mjd"] is None:
+            raise ValidationError("mjd must be provided and non-null.")
+
         if data["filter"] not in instrument.filters:
             raise ValidationError(
                 f"Instrument {instrument.name} has no filter {data['filter']}."


### PR DESCRIPTION
- Fix "KeyError" in PhotometryHandler in sentry-backend.

- Fix `cannot find module 'versor/src/index'` error by downgrading `d3-geo-zoom` to "1.4.4"