### PR TITLE
DNM/WIP - parallelize unit tests

### DIFF
--- a/.github/workflows/test_api_and_frontend.yaml
+++ b/.github/workflows/test_api_and_frontend.yaml
@@ -7,6 +7,9 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
 
+env:
+  PYTEST_N_PROCESSES: 2
+
 jobs:
   test-api-and-frontend:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/test_api_and_frontend.yaml
+++ b/.github/workflows/test_api_and_frontend.yaml
@@ -8,7 +8,7 @@ on:
     types: [opened, reopened, synchronize, ready_for_review]
 
 env:
-  PYTEST_N_PROCESSES: 3
+  PYTEST_N_PROCESSES: 4
 
 jobs:
   test-api-and-frontend:

--- a/.github/workflows/test_api_and_frontend.yaml
+++ b/.github/workflows/test_api_and_frontend.yaml
@@ -8,7 +8,7 @@ on:
     types: [opened, reopened, synchronize, ready_for_review]
 
 env:
-  PYTEST_N_PROCESSES: 4
+  PYTEST_N_PROCESSES: 3
 
 jobs:
   test-api-and-frontend:

--- a/.github/workflows/test_api_and_frontend.yaml
+++ b/.github/workflows/test_api_and_frontend.yaml
@@ -8,7 +8,7 @@ on:
     types: [opened, reopened, synchronize, ready_for_review]
 
 env:
-  PYTEST_N_PROCESSES: 2
+  PYTEST_N_PROCESSES: 4
 
 jobs:
   test-api-and-frontend:

--- a/.github/workflows/test_migrations.yaml
+++ b/.github/workflows/test_migrations.yaml
@@ -111,6 +111,7 @@ jobs:
           pip install 'joblib<1.5.0' # 1.5.0 breaks skyportal/utils/offset.py on reference commit
           pip install 'lalsuite<7.26' # 7.26 breaks ligo.skymap
           pip install 'python-ligo-lw==1.8.4' # 2.0.0 breaks ligo.skymap
+          pip install 'numexpr==2.13.1' # 2.14.0 breaks multiple packages
 
       - name: Save current Alembic head on main
         run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -95,3 +95,4 @@ pydantic==2.11.4
 sentry-sdk==2.34.1
 typing-inspect==0.9.0
 brotli==1.1.0
+numexpr==2.13.1


### PR DESCRIPTION
try multiple processes to run unit tests in parallel instead of sequentially, using pytest-xdist (and 2 processes).

PS: This uses a custom version of baselayer where the changes requires to make this happen live, but also because I can't pin baselayer latest that moved away from npm.

I'll likely make more commit where I increase the number of processes, to see when it stops getting faster or creates more issues. I'm not expecting this to work well anyways, as I'm pretty sure that a lot of tests can't run in parallel because they use the same Sources and things will conflict. Overall, our tests are not as "independent" as they should be, at leat I think...