### PR TITLE
Fix add annotation to invalid source

### DIFF
--- a/skyportal/handlers/api/annotation.py
+++ b/skyportal/handlers/api/annotation.py
@@ -384,9 +384,7 @@ class AnnotationHandler(BaseHandler):
                 session.commit()
             except IntegrityError as e:
                 if 'is not present in table "objs"' in str(e).lower():
-                    return self.error(
-                        f"Could not access object {resource_id}.", status=403
-                    )
+                    return self.error(f"Obj {resource_id} not found", status=404)
                 return self.error(f"Annotation already exists: {str(e)}")
 
             if isinstance(

--- a/skyportal/handlers/api/source_groups.py
+++ b/skyportal/handlers/api/source_groups.py
@@ -66,7 +66,7 @@ class SourceGroupsHandler(BaseHandler):
                 Obj.select(session.user_or_token).where(Obj.id == obj_id)
             )
             if not obj:
-                return self.error(f"Could not access source {obj_id}.", status=403)
+                return self.error(f"Obj {obj_id} not found", status=404)
             save_or_invite_group_ids = data.get("inviteGroupIds", [])
             unsave_group_ids = data.get("unsaveGroupIds", [])
             if not save_or_invite_group_ids and not unsave_group_ids:


### PR DESCRIPTION
Fix a bad error message saying `Annotation already exists` when the targeted source is not found.
Improve code readability.