### PR TITLE
Upon starting container, user will not get added to group if already a member.

### DIFF
--- a/skyportal/model_util.py
+++ b/skyportal/model_util.py
@@ -96,7 +96,9 @@ def add_user(username, roles=[], auth=False, first_name=None, last_name=None):
                 session.add(public_group)
                 session.flush()
 
-        user.groups.append(public_group)
+            # Only add user to group if not already a member
+            if public_group not in user.groups:
+                user.groups.append(public_group)
         session.commit()
 
     return DBSession().query(User).filter(User.username == username).first()


### PR DESCRIPTION
I run Skyportal as a submodule in our instance (called MNTLEAF). 

I am running the most recent Skyportal and baselayer commits. 

When starting the container, I am continually having a problem with the provisional admin user already being in the Statewide group. This SQL duplication error prevents the app from starting. 

This small (3line) change will only add the user if not already in the group.  

If this problem should be handled in a different way (maybe my provisional admin should never be in a group), please me know.