### PR TITLE
enh: add a slider to only show validated points in the photometry plot

### DIFF
--- a/static/js/components/plot/PhotometryPlot.jsx
+++ b/static/js/components/plot/PhotometryPlot.jsx
@@ -462,9 +462,7 @@ const PhotometryPlot = ({
       return newPoint;
     });
 
-    setT0Max(
-      !Number.isNaN(t0Max) ? Math.min(t0Max, stats.mjd.max) : stats.mjd.max,
-    );
+    setT0Max(stats.mjd.max);
     stats.mag.range = [stats.mag.max * 1.02, stats.mag.min * 0.98];
     stats.mjd.range = [
       t0 && displayXAxisSinceT0 ? t0 - 1 : stats.mjd.min - 1,
@@ -1665,6 +1663,7 @@ const PhotometryPlot = ({
                     checked={showOnlyValidated}
                     onChange={() => setShowOnlyValidated(!showOnlyValidated)}
                     inputProps={{ "aria-label": "controlled" }}
+                    size="small"
                   />
                 </div>
               </Tooltip>


### PR DESCRIPTION
The goal of this PR is to add a slider to only show validated points in the photometry plot.  
