### PR TITLE
Fix Datetime has wrong format on lco api

### DIFF
--- a/skyportal/facility_apis/lco.py
+++ b/skyportal/facility_apis/lco.py
@@ -29,7 +29,7 @@ def format_date(date_str: str) -> str:
     """Format date string to LCO API expected format."""
     return (
         arrow.get(date_str, tzinfo=timezone.utc).format("YYYY-MM-DDTHH:mm:ss.SSSSSS")
-        + "+00:00Z"
+        + "+00:00"
     )
 
 


### PR DESCRIPTION
Fix datetime format in LCO API to add only +00:00 and not +00:00Z to avoid `Datetime has wrong format. Use one of these formats instead: YYYY-MM-DDThh:mm[:ss[.uuuuuu]][+HH:MM|-HH:MM|Z]."]` error.