### PR TITLE
Dockerfile: update npm version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,9 @@ RUN apt-get update && \
     curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
     echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
     curl https://sh.rustup.rs -sSf | sh -s -- -y && \
-    npm install -g npm@latest && \
     apt-get update && \
     apt-get install -y cargo nodejs nginx libnginx-mod-http-brotli-static libnginx-mod-http-brotli-filter && \
+    npm install -g npm@latest && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG SKYPORTAL_UID=1000


### PR DESCRIPTION
Looks like we can't build images anymore, some issue with npm not wanting to work now that there is a new version of it... This adds a quick `npm install -g npm@latest` in the Dockerfile, to make sure we use an up-to-date version.