### PR TITLE
fix: errors.tns_source_group_id is undefined when user only create hermes sharing service

### DIFF
--- a/static/js/components/sharing_service/SharingServicesPage.jsx
+++ b/static/js/components/sharing_service/SharingServicesPage.jsx
@@ -812,6 +812,7 @@ const SharingServicesPage = () => {
   const validate = (errors) => {
     const { tns_source_group_id } = sharingServiceToManage;
     if (
+      enablePublishToTNS &&
       tns_source_group_id !== "" &&
       Number.isNaN(Number(tns_source_group_id))
     ) {
@@ -1300,6 +1301,9 @@ const SharingServicesPage = () => {
               },
             }}
             onSubmit={submitSharingService}
+            onError={(errors) =>
+              console.log("Form validation errors: ", errors)
+            }
             validator={validator}
             customValidate={validate}
           />


### PR DESCRIPTION
In local and on Icare, when I want to create a sharing service without TNS and click on the "Submit' button, it does nothing. 
I added some logs and I caught this error : `Uncaught TypeError: can't access property "addError", errors.tns_source_group_id is undefined` and fixed it.