### PR TITLE
User managements: show invitations when there are no streams 

### DIFF
--- a/static/js/components/user/UserInvitations.jsx
+++ b/static/js/components/user/UserInvitations.jsx
@@ -138,7 +138,7 @@ const UserInvitations = () => {
     }
   }, [dataFetched, dispatch]);
 
-  if (!allGroups?.length || !streams?.length) {
+  if (!allGroups?.length || streams === null) {
     return (
       <Box
         display={queryInProgress ? "block" : "none"}


### PR DESCRIPTION
distinguish between streams not fetched yet vs just empty, so we can still render the invitations list and form if the instance has no streams. Right now if you are running a SkyPortal instance with no streams, I think it wouldn't render.