### PR TITLE
Fix ZTF API to use the good field name

### DIFF
--- a/skyportal/facility_apis/ztf.py
+++ b/skyportal/facility_apis/ztf.py
@@ -753,12 +753,10 @@ class ZTFAPI(FollowUpAPI):
             "ipac_http_user": {
                 "type": "string",
                 "title": "IPAC HTTP User",
-                "default": "ztf",
             },
-            "ipac_http_pass": {
+            "ipac_http_password": {
                 "type": "string",
                 "title": "IPAC HTTP Password",
-                "default": "ztf",
             },
             "ipac_email": {
                 "type": "string",


### PR DESCRIPTION
Fix ztf API to use the good field name ( ipac_http_password instead of ipac_http_pass). Remove default value for "ipac_http_user" and "ipac_http_pass" to avoid overriding the good value when editing the allocation.