### PR TITLE
Migration CI: use uv for main branch

### DIFF
--- a/.github/workflows/test_migrations.yaml
+++ b/.github/workflows/test_migrations.yaml
@@ -114,7 +114,7 @@ jobs:
       - name: Save current Alembic head on main
         run: |
           # Get the head line from Alembic history output
-          head=$( PYTHONPATH=. source .venv/bin/python -m alembic history | grep '(head)' )
+          head=$( PYTHONPATH=. .venv/bin/python -m alembic history | grep '(head)' )
 
           # Split by space; index 2 should be latest revision
           tokens=($head)


### PR DESCRIPTION
The migration CI first checks out to main, then to the reference commit. In #6008 that means we still used the usual virtualenv python setup on the main branch and for the reference commit (an older commit we checkout to, in order to test all the migrations since then), then used uv once we checked out to the branch being tested.

But now that PR has been merged, i.e. main needs to use uv. So, here we make that change:
- first use uv for the venv on main
- then create a good old virtualenv+pip environment for the reference commit
- then back to uv for the branch being tested.