### PR TITLE
Add MCP server for AI assistant integration

### DIFF
--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -741,6 +741,7 @@ ports:
   observation_plan_queue: 64710
   tns_retrieval_queue: 64810
   sharing_service_submission_queue: 64812
+  mcp: 8000  # MCP server port; change if 8000 conflicts with another service
 
 gcn:
   server: gcn.nasa.gov

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -109,6 +109,7 @@ User Guide
    extensions
    pages
    thumbnails
+   mcp_server
 
 Contributing
 ------------

--- a/doc/mcp_server.md
+++ b/doc/mcp_server.md
@@ -8,7 +8,7 @@ SkyPortal includes an [MCP (Model Context Protocol)](https://modelcontextprotoco
 
 ### Getting Your API Token
 
-1. Log in to SkyPortal and click your username in the top-right corner to open your profile.
+1. Log in to SkyPortal/Fritz and click your username in the top-right corner to open your profile.
 2. Scroll down to the **API Token** section.
 3. If no token exists, click **Create New Token**, give it a name, and select the permissions you need.
 4. Copy the token — it is a UUID string (e.g. `a1b2c3d4-e5f6-7890-abcd-ef1234567890`).
@@ -25,7 +25,7 @@ The MCP server supports two transport modes:
 
 Choose the setup that matches your use case:
 
-#### Option 1: Remote Production Server (HTTP mode)
+#### Option 1: Remote Server (HTTP mode)
 
 **For Claude Desktop** - edit `~/Library/Application Support/Claude/claude_desktop_config.json`:
 
@@ -92,7 +92,7 @@ Run the MCP server locally as a subprocess - perfect for testing new tools or co
 **For Claude Code** - use the CLI command:
 
 ```bash
-claude mcp add --transport stdio fritz-dev \
+claude mcp add --transport stdio skyportal_mcp \
   -e MCP_TRANSPORT=stdio \
   -e SKYPORTAL_URL=https://fritz.science \
   -e SKYPORTAL_TOKEN=your-api-token-here \
@@ -197,38 +197,29 @@ Generate a comprehensive summary for TNS (Transient Name Server) reports or Astr
 
 #### `analyze_light_curve`
 
-Analyze light curve evolution including rise/fade times, duration, and variability.
+Analyze multi-band light curve evolution including rise/fade times, duration, and variability.
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `source_name` | `str` | Source identifier - SkyPortal obj_id, ZTF name, or TNS name |
-| `filter_name` | `str` | Photometric filter to analyze (default: "ztfr") |
+| `filter_names` | `str` | Comma-separated photometric filters (default: "ztfg,ztfr") |
 | `baseline_threshold` | `float` | Mag difference from peak to consider "baseline" (default: 0.3) |
-| `output_format` | `str` | `"text"` for chat summary or `"notebook"` for interactive plot (default: "text") |
+| `output_format` | `str` | `"notebook"` (default) or `"text"` for chat summary |
 
-**Dual output modes:**
-1. **Text mode** (`output_format="text"`): Returns formatted text summary directly in chat
-2. **Notebook mode** (`output_format="notebook"`): Returns Python code that Claude Code inserts into a notebook cell for the user to run
+**Output modes:**
+1. **Notebook mode** (`output_format="notebook"`, default): Generates CSV + Jupyter notebook
+   - CSV with all bands: `{source}_lightcurve_data.csv` (filter, mjd, mag, magerr)
+   - Jupyter notebook with:
+     - Editable analysis code cells (users can modify baseline threshold, add metrics)
+     - Interactive Plotly plots with all bands overlaid using SkyPortal colors
+     - Per-band metrics table (rise time, fade time, peak, duration)
+2. **Text mode** (`output_format="text"`): Returns per-band metrics summary in chat
 
-**Important:** Claude should ALWAYS prompt the user before calling: *"Would you like the analysis as (1) text summary in chat, or (2) interactive plot in a notebook?"*
-
-**Note:** Claude Code and Claude Desktop cannot display images in chat. When prompting, make this clear:
-- Text mode: Results shown directly in chat
-- Notebook mode: Code inserted into notebook cell for user to run and see plots
-
-**Returns (text mode):** Formatted summary with:
-- Peak magnitude and time
-- Rise time (first detection to peak) and rate (mag/day)
-- Fade time (peak to baseline or current) and rate
-- Total duration (rise + fade if light curve complete)
-- Pre-peak variability metrics and early flare detection
-- Status (still rising, still fading, or complete)
-
-**Returns (notebook mode):** Python code with:
-- Embedded photometry data (mjd, mag, magerr arrays)
-- Interactive matplotlib plot with peak marked
-- Printed analysis results (same as text mode)
-- Ready to run in a notebook cell
+**Multi-band support:**
+- Default pulls both g and r band (`"ztfg,ztfr"`)
+- Supports any comma-separated filter list: `"ztfg,ztfr,ztfi"`
+- Calculates metrics independently for each band
+- Skips filters with insufficient data (<2 points)
 
 **Handles incomplete light curves:**
 - Still rising: Reports time from first detection to current
@@ -237,47 +228,38 @@ Analyze light curve evolution including rise/fade times, duration, and variabili
 
 **Example prompts:**
 - *"Analyze the light curve for ZTF21aaaaaaa"*
-- *"Calculate rise and fade times for AT2024abc"*
+- *"Calculate rise and fade times for AT2024abc in g, r, and i bands"*
 - *"Check for early flares in the r-band light curve"*
-- *"Plot the light curve analysis for this source"*
 
 #### `analyze_color_evolution`
 
-Analyze color evolution and color at peak brightness using matched or interpolated methods.
+Analyze color evolution and color at peak brightness. Calculates BOTH matched and interpolated colors automatically, generating CSV data + Jupyter notebook with overlaid plots.
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `source_name` | `str` | Source identifier - SkyPortal obj_id, ZTF name, or TNS name |
 | `band1` | `str` | First photometric filter (default: "ztfg") |
 | `band2` | `str` | Second photometric filter (default: "ztfr") |
-| `method` | `str` | "matched" (default) or "interpolated" |
 | `max_time_gap` | `float` | Max time difference to pair observations (default: 0.5 days) |
 | `max_data_gap` | `float` | Max gap to avoid spurious colors (default: 3.0 days) |
-| `output_format` | `str` | `"text"` for chat summary or `"notebook"` for interactive plots (default: "text") |
+| `output_format` | `str` | `"notebook"` (default) or `"text"` for chat summary |
 
-**Dual output modes:**
-1. **Text mode** (`output_format="text"`): Returns formatted text summary with CSV table
-2. **Notebook mode** (`output_format="notebook"`): Returns Python code with interactive plots (light curves + color evolution)
+**Default output** (`output_format="notebook"`):
+- **CSV file** (`{source}_color_data.csv`): Contains photometry + both color methods
+- **Jupyter notebook** (`{source}_color_analysis.ipynb`): Interactive plots with:
+  - Top panel: Light curves for both bands
+  - Bottom panel: BOTH color methods overlaid
+    - **Matched** (day-to-day): Darker, more opaque (alpha=0.8)
+    - **Interpolated** (rolling): Lighter, less opaque (alpha=0.4)
+- Files saved to `{source}_color_analysis/` directory
 
-**Important:** Claude should ALWAYS prompt the user TWO questions before calling:
-1. *"Would you like day-to-day colors (matched method) or rolling/continuous colors (interpolated method)?"*
-2. *"Would you like the analysis as text in chat or interactive plot in notebook?"*
+**Text output** (`output_format="text"`):
+- Formatted summary with color at peak, evolution statistics, and measurement table
+- First 20 matched color measurements shown
 
-**Returns (text mode):** Formatted summary with:
-- Color at peak brightness in each band
-- Color evolution statistics (mean, range, trend)
-- CSV table of color measurements with uncertainties
-- Method used and parameters
-
-**Returns (notebook mode):** Python code with:
-- Embedded photometry data for both bands
-- Two-panel interactive plot: light curves (top) + color evolution (bottom)
-- Color at peak and mean color marked on plot
-- Printed analysis results (same as text mode)
-
-**Two calculation methods:**
-1. **Matched** (`method="matched"`): Pairs observations from each band that are close in time, but avoids calculating colors across large gaps in the data. More conservative, respects observing gaps.
-2. **Interpolated** (`method="interpolated"`): Interpolates one band to match the other's observation times, creating continuous color measurements. More measurements but assumes smooth evolution.
+**Color calculation methods** (both computed automatically):
+1. **Matched**: Pairs observations from each band that are close in time, respects observing gaps. More conservative, best for sparse sampling.
+2. **Interpolated**: Interpolates one band to match the other's times, creating continuous color measurements. More measurements, best for well-sampled light curves.
 
 **Example prompts:**
 - *"Calculate g-r color evolution for ZTF21aaaaaaa"*
@@ -315,20 +297,25 @@ When a user asks for bulk analysis, Claude Code will:
 
 #### `generate_bulk_lightcurve_code`
 
-Generate Python code to bulk download ZTF forced photometry using ztfquery.
+Generate a Jupyter notebook to bulk download ZTF **alert photometry** from Fritz.
+
+> **Note:** This downloads alert photometry (detection epochs only), not forced
+> photometry. For forced photometry (including non-detections and upper limits),
+> use the [IRSA ZTF forced photometry service](https://irsa.ipac.caltech.edu/cgi-bin/ZTF/nph_light_curves).
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `sources` | `str` | Comma-separated list of ZTF source names, or JSON array (e.g., `"ZTF24aaaaaaa,ZTF24aaaaaab"` or `'["ZTF24aaaaaaa", "ZTF24aaaaaab"]'`) |
 | `filters` | `str` | Comma-separated filter names (default: `"ztfg,ztfr,ztfi"`) |
-| `include_plots` | `bool` | Generate light curve plots (default: `True`) |
+| `include_plots` | `bool` | Generate interactive Plotly light curve plots (default: `True`) |
 
-**Returns:** Python code that:
-- Creates a `ztf_lightcurves/` directory with results
-- Saves individual light curves as CSV files
+**Requires:** `ztfquery` + Fritz API token (setup instructions included in notebook).
+
+**Returns:** A Jupyter notebook (`.ipynb`) saved to `ztf_lightcurves/` that:
+- Downloads alert photometry from Fritz using `fritz.bulk_download()` (multiprocessed)
+- Saves per-source light curves as CSV files
 - Creates `summary.csv` with statistics
-- Generates plots in `ztf_lightcurves/plots/` if requested
-- Includes progress tracking (tqdm) and error handling
+- Generates interactive Plotly plots (one per source)
 
 **Example prompts:**
 - *"Download photometry for 50 ZTF sources: [list of sources]"*
@@ -524,20 +511,6 @@ Get URLs to browse a sky position across common astronomical surveys (ZTF, Legac
 - *"Where can I look up ZTF21aaaaaaa in other surveys?"*
 - *"Show me PanSTARRS and Legacy Survey images for this source"*
 
-#### `get_ztf_cutout_urls`
-
-Query IRSA for ZTF science and reference image cutout URLs at a given position.
-
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `ra` | `float` | Right ascension in decimal degrees (J2000) |
-| `dec` | `float` | Declination in decimal degrees (J2000) |
-| `size_arcmin` | `float` | Search region size in arcminutes (default: 1.0) |
-
-**Example prompts:**
-- *"Get ZTF images near RA=180.0, Dec=-5.0"*
-- *"Find ZTF reference images for this source's position"*
-
 #### `get_source_observability`
 
 Compute observing windows for a source from specified telescopes. Returns exact time windows (rise/set), transit time, peak altitude, and airmass — in both UTC and the telescope's local time. Accepts either a source ID (auto-resolves coordinates) or explicit RA/Dec.
@@ -633,16 +606,22 @@ Generate MongoDB aggregation pipeline JSON for a watchlist that monitors specifi
 - Ready to copy-paste into Fritz UI's filter creation page
 
 **What this tool CANNOT do:**
-- Create the filter directly via API (requires Fritz UI)
-- MCP cannot automate filter creation — you must paste JSON manually
+- Create the filter directly via API
+- Automate filter creation (manual import required)
 
-**Workflow:**
+**Recommended Workflow (MongoDB Compass):**
+Fritz now recommends using MongoDB Compass for filter development. See the [filter tutorial](https://github.com/fritz-marshal/fritz/blob/main/doc/filter_tutorial.md).
+
+1. Call this tool to generate a MongoDB pipeline template
+2. Install MongoDB Compass and connect to your alert cluster
+3. Import the generated pipeline to Compass for visual testing and refinement
+4. Export the final pipeline from Compass
+5. Import to Fritz
+
+**Alternative Workflow (Direct Import):**
 1. Call this tool with your target coordinates
 2. Copy the generated MongoDB pipeline JSON
-3. Go to Fritz UI → Filters page → Create Filter
-4. Paste the JSON into the "Pipeline" field
-5. Set Group and Stream for the filter
-6. Save to activate monitoring
+3. Import directly to Fritz or use as a starting point in MongoDB Compass
 
 | Parameter | Type | Description |
 |-----------|------|-------------|

--- a/doc/mcp_server.md
+++ b/doc/mcp_server.md
@@ -1,0 +1,819 @@
+# MCP Server
+
+SkyPortal includes an [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server that lets AI assistants like Claude interact with SkyPortal on your behalf. Each user authenticates with their own SkyPortal API token, so data access is fully scoped per user.
+
+---
+
+## For Users
+
+### Getting Your API Token
+
+1. Log in to SkyPortal and click your username in the top-right corner to open your profile.
+2. Scroll down to the **API Token** section.
+3. If no token exists, click **Create New Token**, give it a name, and select the permissions you need.
+4. Copy the token — it is a UUID string (e.g. `a1b2c3d4-e5f6-7890-abcd-ef1234567890`).
+
+Keep your token private. It grants the same data access as your SkyPortal account.
+
+---
+
+### Connecting to the MCP Server
+
+The MCP server supports two transport modes:
+- **HTTP mode** (default): For production deployments - multi-user, runs as a web server
+- **stdio mode**: For local development - single-user, runs as a subprocess
+
+Choose the setup that matches your use case:
+
+#### Option 1: Remote Production Server (HTTP mode)
+
+**For Claude Desktop** - edit `~/Library/Application Support/Claude/claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "skyportal": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote",
+        "https://your-skyportal-host/mcp",
+        "--header",
+        "Authorization:${AUTH_HEADER}"
+      ],
+      "env": {
+        "AUTH_HEADER": "Bearer your-api-token-here"
+      }
+    }
+  }
+}
+```
+
+**For Claude Code:**
+
+```bash
+claude mcp add --transport http skyportal https://your-skyportal-host/mcp \
+  --header "Authorization: Bearer your-api-token-here"
+```
+
+Verify it was added:
+
+```bash
+claude mcp list
+```
+
+Replace `your-skyportal-host` with your instance URL (e.g., `fritz.science`, `localhost:8000`) and `your-api-token-here` with your API token.
+
+**Requires:** Node.js for `npx` (Claude Desktop only). Restart Claude Desktop after config changes.
+
+#### Option 2: Local Development (stdio mode)
+
+Run the MCP server locally as a subprocess - perfect for testing new tools or connecting to a remote SkyPortal API.
+
+**For Claude Desktop** - edit `~/Library/Application Support/Claude/claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "skyportal-dev": {
+      "command": "python",
+      "args": ["-m", "services.mcp_server"],
+      "cwd": "/path/to/skyportal",
+      "env": {
+        "MCP_TRANSPORT": "stdio",
+        "SKYPORTAL_URL": "https://fritz.science",
+        "SKYPORTAL_TOKEN": "your-api-token-here"
+      }
+    }
+  }
+}
+```
+
+**For Claude Code** - use the CLI command:
+
+```bash
+claude mcp add --transport stdio fritz-dev \
+  -e MCP_TRANSPORT=stdio \
+  -e SKYPORTAL_URL=https://fritz.science \
+  -e SKYPORTAL_TOKEN=your-api-token-here \
+  -- /path/to/skyportal/skyportal_env/bin/python -m services.mcp_server
+```
+
+Replace:
+- `/path/to/skyportal` with your local SkyPortal directory (in the Python path)
+- `SKYPORTAL_URL` with the API endpoint (remote: `https://fritz.science`, local: `http://localhost:5001`)
+- `SKYPORTAL_TOKEN` with your API token
+
+Verify it was added:
+
+```bash
+claude mcp list
+```
+
+The CLI command will automatically add the configuration to `~/.claude.json` (local project config)
+
+**Use cases for stdio mode:**
+- Testing new MCP tools before deploying
+- Developing locally against Fritz/production data
+- Running your fork with custom tools
+- No need to deploy a server
+
+**Important:** In stdio mode, the token is hardcoded in your config file. This is fine for local dev, but never commit configs with tokens!
+
+---
+
+### Claude Desktop vs Claude Code
+
+Both clients connect to the same MCP server, but they're suited for different workflows:
+
+| | Claude Desktop | Claude Code |
+|---|---|---|
+| **Best for** | Conversational queries, browsing data, quick lookups | Data analysis, writing code, multi-step workflows |
+| **Interface** | Chat window in the app | Terminal / IDE integration |
+| **Example tasks** | "Show me recent candidates classified as SNe Ia", "When can I observe this source from Keck?", "Get survey links for this position" | "Write a script to compute g-r colors for all sources in group 5", "Fit a light curve model to this source's photometry", "Build a candidate filter for fast-rising blue transients" |
+| **Strengths** | Easy to use, good for exploration and planning | Can read/write files, run code, iterate on analysis |
+
+**Rule of thumb:** Use Desktop for asking questions and getting information. Use Code when you need the AI to write and execute analysis code on your data.
+
+---
+
+### Available Tools
+
+#### `call_skyportal_api`
+
+General-purpose tool for querying the SkyPortal API.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `endpoint` | `str` | API path, e.g. `/api/sources` |
+| `method` | `str` | `GET`, `POST`, `PUT`, or `DELETE` (default: `GET`) |
+| `params` | `dict` | URL query parameters (optional) |
+| `data` | `dict` | Request body for POST/PUT (optional) |
+
+**Example prompts:**
+- *"Show me sources saved in the last 7 days"*
+- *"Get the photometry for source ZTF21aaaaaaa"*
+- *"List all candidates in group 5 classified as SNe Ia"*
+
+**Note:** All source-specific tools accept flexible source identifiers - you can use SkyPortal obj_id, ZTF names, or TNS names interchangeably.
+
+#### `get_tns_summary`
+
+⭐ **USE THIS SINGLE TOOL** when creating TNS reports or AstroNotes - it combines all relevant data in one call.
+
+Generate a comprehensive summary for TNS (Transient Name Server) reports or AstroNote submissions. Includes discovery info, photometry, classification, spectroscopy, and host galaxy data formatted for easy copy-paste.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `source_name` | `str` | Source identifier - SkyPortal obj_id, ZTF name, or TNS name |
+
+**Returns:** Formatted text summary with:
+- Source identification (coordinates in decimal and sexagesimal)
+- Discovery information (first detection date, mag, instrument)
+- Latest photometry and peak magnitude (⚠️ peak = min(mag), not from light curve fit)
+- Classifications and probabilities
+- Spectroscopy and redshift measurements
+- Host galaxy offset
+
+**Example prompts:**
+- *"Generate a TNS summary for ZTF21aaaaaaa"*
+- *"Create an AstroNote summary for AT2024xyz"*
+- *"Give me a report summary for this source"*
+- *"Write a TNS classification report for SN2024abc"*
+
+**After generating the summary, Claude should ask:**
+> "I've generated the TNS summary. What additional information do you need for your report?"
+>
+> Common additions:
+> - **Discovery context:** Was this from a targeted survey? Any non-detections before discovery?
+> - **Follow-up plans:** Are you requesting spectroscopy or additional photometry?
+> - **Comparison:** Similar to any known events? Anything unusual?
+> - **References:** Any papers, ATels, or GCN circulars to cite?
+> - **Notes:** Special observing conditions, calibration issues, or caveats?
+
+---
+
+### Analysis Tools
+
+#### `analyze_light_curve`
+
+Analyze light curve evolution including rise/fade times, duration, and variability.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `source_name` | `str` | Source identifier - SkyPortal obj_id, ZTF name, or TNS name |
+| `filter_name` | `str` | Photometric filter to analyze (default: "ztfr") |
+| `baseline_threshold` | `float` | Mag difference from peak to consider "baseline" (default: 0.3) |
+| `output_format` | `str` | `"text"` for chat summary or `"notebook"` for interactive plot (default: "text") |
+
+**Dual output modes:**
+1. **Text mode** (`output_format="text"`): Returns formatted text summary directly in chat
+2. **Notebook mode** (`output_format="notebook"`): Returns Python code that Claude Code inserts into a notebook cell for the user to run
+
+**Important:** Claude should ALWAYS prompt the user before calling: *"Would you like the analysis as (1) text summary in chat, or (2) interactive plot in a notebook?"*
+
+**Note:** Claude Code and Claude Desktop cannot display images in chat. When prompting, make this clear:
+- Text mode: Results shown directly in chat
+- Notebook mode: Code inserted into notebook cell for user to run and see plots
+
+**Returns (text mode):** Formatted summary with:
+- Peak magnitude and time
+- Rise time (first detection to peak) and rate (mag/day)
+- Fade time (peak to baseline or current) and rate
+- Total duration (rise + fade if light curve complete)
+- Pre-peak variability metrics and early flare detection
+- Status (still rising, still fading, or complete)
+
+**Returns (notebook mode):** Python code with:
+- Embedded photometry data (mjd, mag, magerr arrays)
+- Interactive matplotlib plot with peak marked
+- Printed analysis results (same as text mode)
+- Ready to run in a notebook cell
+
+**Handles incomplete light curves:**
+- Still rising: Reports time from first detection to current
+- Still fading: Reports time from peak to current
+- Returned to baseline: Reports complete rise + fade times
+
+**Example prompts:**
+- *"Analyze the light curve for ZTF21aaaaaaa"*
+- *"Calculate rise and fade times for AT2024abc"*
+- *"Check for early flares in the r-band light curve"*
+- *"Plot the light curve analysis for this source"*
+
+#### `analyze_color_evolution`
+
+Analyze color evolution and color at peak brightness using matched or interpolated methods.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `source_name` | `str` | Source identifier - SkyPortal obj_id, ZTF name, or TNS name |
+| `band1` | `str` | First photometric filter (default: "ztfg") |
+| `band2` | `str` | Second photometric filter (default: "ztfr") |
+| `method` | `str` | "matched" (default) or "interpolated" |
+| `max_time_gap` | `float` | Max time difference to pair observations (default: 0.5 days) |
+| `max_data_gap` | `float` | Max gap to avoid spurious colors (default: 3.0 days) |
+| `output_format` | `str` | `"text"` for chat summary or `"notebook"` for interactive plots (default: "text") |
+
+**Dual output modes:**
+1. **Text mode** (`output_format="text"`): Returns formatted text summary with CSV table
+2. **Notebook mode** (`output_format="notebook"`): Returns Python code with interactive plots (light curves + color evolution)
+
+**Important:** Claude should ALWAYS prompt the user TWO questions before calling:
+1. *"Would you like day-to-day colors (matched method) or rolling/continuous colors (interpolated method)?"*
+2. *"Would you like the analysis as text in chat or interactive plot in notebook?"*
+
+**Returns (text mode):** Formatted summary with:
+- Color at peak brightness in each band
+- Color evolution statistics (mean, range, trend)
+- CSV table of color measurements with uncertainties
+- Method used and parameters
+
+**Returns (notebook mode):** Python code with:
+- Embedded photometry data for both bands
+- Two-panel interactive plot: light curves (top) + color evolution (bottom)
+- Color at peak and mean color marked on plot
+- Printed analysis results (same as text mode)
+
+**Two calculation methods:**
+1. **Matched** (`method="matched"`): Pairs observations from each band that are close in time, but avoids calculating colors across large gaps in the data. More conservative, respects observing gaps.
+2. **Interpolated** (`method="interpolated"`): Interpolates one band to match the other's observation times, creating continuous color measurements. More measurements but assumes smooth evolution.
+
+**Example prompts:**
+- *"Calculate g-r color evolution for ZTF21aaaaaaa"*
+- *"What was the color at peak for this transient?"*
+- *"Show me interpolated color evolution in g and r bands"*
+- *"Plot the color evolution with matched observations"*
+
+---
+
+### Bulk Analysis Tools (ztfquery)
+
+**Important:** These tools generate Python code for users to run locally in Jupyter notebooks. They do NOT execute queries directly. The generated code uses [`ztfquery`](https://github.com/MickaelRigault/ztfquery) for efficient bulk operations.
+
+**Why code generation instead of direct execution?**
+- Bulk queries can be slow - better to run locally where users can monitor progress
+- Users can customize the generated code for their specific needs
+- ztfquery has its own authentication system (IRSA credentials)
+- Provides better performance and flexibility for large-scale data operations
+
+**Prerequisites:**
+1. Install ztfquery: `pip install ztfquery`
+2. Configure IRSA credentials (first time only):
+   ```python
+   from ztfquery import io
+   io.set_account('your_irsa_username', 'your_irsa_password')
+   ```
+3. Get IRSA account at: https://irsa.ipac.caltech.edu/account/signon/login.do
+
+**Output Handling:**
+When a user asks for bulk analysis, Claude Code will:
+1. Call the appropriate bulk tool
+2. Receive Python code as the result
+3. Automatically insert the code into a new notebook cell (or create a new notebook)
+4. User runs the cell to execute the bulk operation locally
+
+#### `generate_bulk_lightcurve_code`
+
+Generate Python code to bulk download ZTF forced photometry using ztfquery.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `sources` | `str` | Comma-separated list of ZTF source names, or JSON array (e.g., `"ZTF24aaaaaaa,ZTF24aaaaaab"` or `'["ZTF24aaaaaaa", "ZTF24aaaaaab"]'`) |
+| `filters` | `str` | Comma-separated filter names (default: `"ztfg,ztfr,ztfi"`) |
+| `include_plots` | `bool` | Generate light curve plots (default: `True`) |
+
+**Returns:** Python code that:
+- Creates a `ztf_lightcurves/` directory with results
+- Saves individual light curves as CSV files
+- Creates `summary.csv` with statistics
+- Generates plots in `ztf_lightcurves/plots/` if requested
+- Includes progress tracking (tqdm) and error handling
+
+**Example prompts:**
+- *"Download photometry for 50 ZTF sources: [list of sources]"*
+- *"I need light curves for all sources in this list"*
+- *"Bulk download g and r band photometry for these transients"*
+
+#### `generate_cone_search_code`
+
+Generate code to perform ZTF cone searches at multiple sky positions.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `coordinates` | `str` | Comma-separated "RA,Dec" pairs or JSON array of [RA, Dec]. RA/Dec in decimal degrees (J2000). Examples: `"150.0,2.5,151.2,3.1"` or `'[[150.0, 2.5], [151.2, 3.1]]'` |
+| `radius_arcsec` | `float` | Search radius in arcseconds (default: 2.0) |
+
+**Returns:** Python code that:
+- Performs cone search at each position
+- Saves all detections to `ztf_cone_search/cone_search_results.csv`
+- Creates summary with detection counts per position
+- Includes query coordinates for cross-reference
+
+**Use case:** Cross-matching catalogs (TNS, Gaia, etc.) with ZTF to find detections near known positions.
+
+**Example prompts:**
+- *"Search for ZTF detections near these coordinates: [list]"*
+- *"I have a catalog of 100 positions - check which have ZTF coverage"*
+- *"Cross-match this TNS list with ZTF"*
+
+#### `generate_fritz_bulk_query_code`
+
+Generate code to bulk query Fritz/SkyPortal for multiple sources using ztfquery's Fritz interface.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `sources` | `str` | Comma-separated source names or JSON array |
+| `include_spectra` | `bool` | Download spectra in addition to photometry (default: `True`) |
+
+**Returns:** Python code that:
+- Queries Fritz API for each source
+- Downloads photometry and (optionally) spectra
+- Saves individual files: `{source}_photometry.csv`, `{source}_spectra.csv`
+- Creates summary with redshifts, classifications, data counts
+- Saves to `fritz_data/` directory
+
+**Note:** Requires Fritz API token. Users should set `FRITZ_TOKEN` environment variable or edit the generated code.
+
+**Example prompts:**
+- *"Download Fritz data for these 20 sources"*
+- *"Bulk query photometry and spectra from Fritz for my source list"*
+
+#### `generate_alert_download_code`
+
+Generate code to download ZTF alert packets for multiple sources.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `sources` | `str` | Comma-separated ZTF source names or JSON array |
+| `with_cutouts` | `bool` | Download cutout images (science, ref, diff) (default: `True`) |
+
+**Returns:** Python code that:
+- Downloads alert packets for each source
+- Saves alerts as JSON files
+- Optionally downloads FITS cutouts
+- Saves to `ztf_alerts/` and `ztf_alerts/cutouts/` directories
+
+**Use case:** When you need complete alert history or alert-level data not available in forced photometry.
+
+**Example prompts:**
+- *"Download all alert packets for these sources"*
+- *"I need the raw ZTF alerts with cutouts for this list"*
+
+#### `generate_field_visualization_code`
+
+Generate code to visualize ZTF field and CCD coverage.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `field_id` | `int` | ZTF field ID (1-1895) |
+| `ccd_id` | `int` or `None` | Optional CCD ID to highlight (1-16) |
+
+**Returns:** Python code that:
+- Creates Mollweide projection sky map
+- Shows field footprint on sky
+- Highlights specific CCD if requested
+- Displays RA/Dec coverage information
+
+**Example prompts:**
+- *"Show me ZTF field 300's sky coverage"*
+- *"Visualize field 450 with CCD 12 highlighted"*
+- *"Map the footprint of this ZTF field"*
+
+---
+
+### Source Data Tools
+
+#### `get_source_photometry`
+
+Retrieve photometry for a source as a CSV table. Returns all photometry points sorted by MJD, ready for analysis or loading into a pandas DataFrame.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `source_id` | `str` | Source/object ID (e.g., `ZTF21aaaaaaa`) |
+| `format` | `str` | `"mag"` (default) or `"flux"` |
+| `magsys` | `str` | Magnitude system: `"ab"` (default), `"vega"`, etc. |
+| `filters` | `str` | Comma-separated filter names to include (optional, e.g., `"ztfg,ztfr"`) |
+
+**Example prompts:**
+- *"Get the light curve for ZTF21aaaaaaa"*
+- *"Show me the g-band and r-band photometry for source ZTF22abcdefg"*
+- *"Save the photometry to a CSV file"* (Claude Code will write the returned data to a file)
+
+#### `get_source_spectra`
+
+Retrieve spectra for a source. Returns all spectra as CSV (one per block) or JSON format.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `source_id` | `str` | Source/object ID (e.g., `ZTF21aaaaaaa`) |
+| `format` | `str` | `"csv"` (default) or `"json"` |
+
+**Example prompts:**
+- *"Get the spectra for ZTF21aaaaaaa"*
+- *"Show me all spectroscopic observations of this source"*
+
+#### `get_source_classifications`
+
+Retrieve classifications for a source. Returns all classifications with type, probability, classifier, and date.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `source_id` | `str` | Source/object ID (e.g., `ZTF21aaaaaaa`) |
+
+**Example prompts:**
+- *"What is ZTF21aaaaaaa classified as?"*
+- *"Show me all classifications for this source"*
+- *"Has anyone classified this as a supernova?"*
+
+#### `get_source_comments_and_annotations`
+
+Retrieve comments and annotations for a source. Returns user comments (text notes) and system annotations (ML scores, cross-match results, etc.).
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `source_id` | `str` | Source/object ID (e.g., `ZTF21aaaaaaa`) |
+
+**Example prompts:**
+- *"What have people said about ZTF21aaaaaaa?"*
+- *"Show me the comments and ML scores for this source"*
+- *"What annotations does this source have?"*
+
+#### `get_source_host_galaxy`
+
+Retrieve host galaxy information for a source. Returns the associated host galaxy from SkyPortal's galaxy catalogs (e.g., GLADE+), including angular separation (offset) and physical distance.
+
+SkyPortal can link sources to host galaxies. If a host association exists, this returns the galaxy's name, position, redshift, distance, stellar mass, magnitudes, and both the angular offset (arcsec) and physical separation (kpc) from the source.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `source_id` | `str` | Source/object ID (e.g., `ZTF21aaaaaaa`) |
+
+**Example prompts:**
+- *"What is the host galaxy of ZTF21aaaaaaa?"*
+- *"Show me the host galaxy information for this source"*
+- *"How far is this source from its host galaxy?"*
+- *"What galaxy is this supernova in?"*
+
+#### `convert_time`
+
+Convert between common astronomical time formats: MJD, JD, ISO datetime, and Unix timestamps.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `value` | `str` | The time value to convert |
+| `from_format` | `str` | `"mjd"`, `"jd"`, `"iso"`, `"unix"`, or `"auto"` (default) |
+| `to_format` | `str` | `"mjd"`, `"jd"`, `"iso"`, `"unix"`, or `"auto"` (returns all) |
+
+**Example prompts:**
+- *"Convert MJD 60400.5 to a date"*
+- *"What's the MJD for 2024-06-15?"*
+
+#### `get_survey_urls`
+
+Get URLs to browse a sky position across common astronomical surveys (ZTF, Legacy Survey, PanSTARRS, SDSS, NED, SIMBAD, VizieR, WISE, and more). Accepts either explicit coordinates or a source ID to auto-resolve coordinates.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `ra` | `float` | Right ascension in decimal degrees (J2000). Not needed if `source_id` provided. |
+| `dec` | `float` | Declination in decimal degrees (J2000). Not needed if `source_id` provided. |
+| `source_id` | `str` | SkyPortal source ID (e.g., `ZTF21aaaaaaa`). RA/Dec resolved automatically. |
+
+**Example prompts:**
+- *"Give me survey links for RA=150.1, Dec=+2.2"*
+- *"Where can I look up ZTF21aaaaaaa in other surveys?"*
+- *"Show me PanSTARRS and Legacy Survey images for this source"*
+
+#### `get_ztf_cutout_urls`
+
+Query IRSA for ZTF science and reference image cutout URLs at a given position.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `ra` | `float` | Right ascension in decimal degrees (J2000) |
+| `dec` | `float` | Declination in decimal degrees (J2000) |
+| `size_arcmin` | `float` | Search region size in arcminutes (default: 1.0) |
+
+**Example prompts:**
+- *"Get ZTF images near RA=180.0, Dec=-5.0"*
+- *"Find ZTF reference images for this source's position"*
+
+#### `get_source_observability`
+
+Compute observing windows for a source from specified telescopes. Returns exact time windows (rise/set), transit time, peak altitude, and airmass — in both UTC and the telescope's local time. Accepts either a source ID (auto-resolves coordinates) or explicit RA/Dec.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `source_id` | `str` | SkyPortal source ID (e.g., `ZTF20abwysqy`). RA/Dec resolved automatically. |
+| `ra` | `float` | Right ascension in decimal degrees (not needed if `source_id` given) |
+| `dec` | `float` | Declination in decimal degrees (not needed if `source_id` given) |
+| `max_airmass` | `float` | Maximum airmass limit (default: 2.0) |
+| `telescopes` | `str` | Comma-separated names (default: `"Keck,Palomar,Gemini-N,Gemini-S,VLT"`). Use `"all"` for all built-in telescopes or `"fritz"` to query your SkyPortal instance. |
+| `date` | `str` | Date in ISO format (default: tonight) |
+
+Built-in telescopes: Keck, Lick, Palomar, APO, CTIO, Gemini-N, Gemini-S, VLT, Subaru, LDT, LCO-COJ, LCO-ELP, LCO-LSC, LCO-OGG, LCO-CPT, LCO-TFN.
+
+**Example prompts:**
+- *"When can I observe ZTF20abwysqy from Keck tonight?"*
+- *"Is this source visible from any Southern hemisphere telescope?"*
+- *"Show me the observability for RA=120, Dec=+45 from all telescopes on June 15"*
+
+#### `get_candidate_filter_reference`
+
+Returns documentation on available query parameters for filtering candidates and sources on Fritz/SkyPortal: annotation-based ML score filters, classification filters, redshift ranges, photometry annotations, and more.
+
+**Important**: This covers **query-time filtering** (searching existing candidates on the scanning page), NOT **alert-time filtering** (MongoDB pipelines that run when alerts arrive). If users want to create permanent alert-time filters, direct them to the Fritz UI Filters page and the filter tutorial.
+
+No parameters — call it to load the reference into context.
+
+**Example prompts:**
+- *"How do I filter for candidates with a real/bogus score above 0.8?"*
+- *"Show me how to search for Type Ia supernovae candidates"*
+- *"What filters can I apply when scanning candidates?"*
+
+**If user asks about creating alert-time filters:**
+Tell them: "Alert-time filters (MongoDB pipelines) must be created in the Fritz UI. See the Filters page and tutorial at https://github.com/fritz-marshal/fritz/blob/main/doc/filter_tutorial.md. The MCP server can only search existing candidates, not create filters that process incoming alerts."
+
+#### `filter_candidates`
+
+Search for candidates matching specific criteria on the scanning page. This performs **query-time filtering** of existing candidates (searching what's already on the scanning page), NOT **alert-time filtering** (creating MongoDB pipelines that process incoming alerts).
+
+**What this tool does:**
+- Searches candidates already on the scanning page
+- Returns CSV table with results
+- Provides filter configuration JSON for saving/reuse
+- Ad-hoc searches (not permanent)
+
+**What this tool CANNOT do:**
+- Create permanent alert-time filters (MongoDB pipelines)
+- Access alert packet history (`prv_candidates` array)
+- Process incoming alerts before they become candidates
+
+**If user wants alert-time filters:** Direct them to the Fritz UI Filters page and tutorial: https://github.com/fritz-marshal/fritz/blob/main/doc/filter_tutorial.md
+
+**Important**: The tool will always ask for user confirmation of filter parameters before executing, and will return the filter configuration JSON at the end.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `group_id` | `int` | Search within specific group ID (optional) |
+| `saved_status` | `str` | Saved status: `"all"` (default), `"savedToAllSelected"`, `"savedToAnySelected"`, `"savedToAnyAccessible"`, `"notSavedToAnyAccessible"`, `"notSavedToAnySelected"`, `"notSavedToAllSelected"` |
+| `classifications` | `str` | Comma-separated classifications to INCLUDE (e.g., `"SN Ia,SN Ib/c"`) |
+| `classifications_reject` | `str` | Comma-separated classifications to EXCLUDE (e.g., `"AGN,varstar"`) |
+| `min_redshift` | `float` | Minimum redshift |
+| `max_redshift` | `float` | Maximum redshift |
+| `annotation_filters` | `str` | JSON array of annotation filters for ML scores. Each filter object contains: `"origin"` (annotation source), `"key"` (score name), and `"min"`/`"max"`/`"value"` for filtering. Examples: `'[{"origin":"braai","key":"braai","min":0.9}]'` for high real/bogus score, `'[{"origin":"kowalski","key":"sgScore","max":0.3}]'` for likely galaxies, `'[{"origin":"Kowalski","key":"ACAI_score","min":0.8}]'` for TDE candidates |
+| `saved_after` | `str` | Only candidates saved after this date (ISO format: `"2024-01-15"`) |
+| `saved_before` | `str` | Only candidates saved before this date |
+| `first_detected_after` | `str` | Only sources first detected after this date |
+| `last_detected_before` | `str` | Only sources last detected before this date |
+| `num_per_page` | `int` | Number of results (default 100, max 500) |
+| `page_number` | `int` | Page number for pagination (default 1) |
+
+**Example prompts:**
+- *"Find SNe Ia with braai score > 0.9 saved in the last week"*
+- *"Search for likely galaxy transients (sgScore < 0.3) with high real/bogus score"*
+- *"Show me TDE candidates with ACAI_score > 0.8"*
+- *"Find unclassified candidates saved to my group"*
+- *"Search for nuclear transients: galaxies with recent detections"*
+
+**Returns**: CSV table with obj_id, position, redshift, latest magnitude, classifications, ML scores, plus the filter configuration JSON for saving.
+
+#### `generate_watchlist_filter`
+
+Generate MongoDB aggregation pipeline JSON for a watchlist that monitors specific sky coordinates. This creates **alert-time filters** that run automatically on every incoming alert from the telescope.
+
+**Important**: This is fundamentally different from `filter_candidates`:
+- **`filter_candidates`**: Query-time tool that searches existing candidates (ad-hoc, runs via API)
+- **`generate_watchlist_filter`**: Alert-time filter generator (permanent, runs on Kowalski backend)
+
+**What this tool does:**
+- Generates MongoDB pipeline JSON for monitoring specific coordinates
+- Implements spherical distance calculation for accurate matching
+- Annotates matching alerts with nearest target name and distance
+- Ready to copy-paste into Fritz UI's filter creation page
+
+**What this tool CANNOT do:**
+- Create the filter directly via API (requires Fritz UI)
+- MCP cannot automate filter creation — you must paste JSON manually
+
+**Workflow:**
+1. Call this tool with your target coordinates
+2. Copy the generated MongoDB pipeline JSON
+3. Go to Fritz UI → Filters page → Create Filter
+4. Paste the JSON into the "Pipeline" field
+5. Set Group and Stream for the filter
+6. Save to activate monitoring
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `targets` | `str` | JSON array of target objects. Each must have `"name"`, `"ra"` (decimal degrees), and `"dec"` (decimal degrees). Example: `'[{"name":"M31","ra":10.6847,"dec":41.2687},{"name":"Crab","ra":83.6333,"dec":22.0145}]'` |
+| `max_distance_arcsec` | `float` | Maximum angular separation for a match (default: 2.0 arcsec, typical for known sources) |
+| `filter_name` | `str` | Name for this watchlist filter (for documentation, default: "Watchlist") |
+
+**Example prompts:**
+- *"Create a watchlist filter for M31 and the Crab Nebula with 2 arcsec radius"*
+- *"Generate a watchlist monitoring NGC1234 at RA=50.0, Dec=+10.0"*
+- *"Make a filter to watch these three positions: [list coordinates]"*
+- *"I want alerts whenever new detections appear near RA=123.456, Dec=-12.345"*
+
+**Returns**: MongoDB aggregation pipeline JSON with instructions, ready to paste into Fritz filter UI. Includes human-readable summary of watched positions and annotations that will be added to matching alerts.
+
+**Technical details**: The pipeline uses spherical trigonometry with `atan2` for accurate angular separation on the celestial sphere, converts to arcseconds, filters by distance threshold, and adds annotations for the closest watchlist target plus a list of all matching targets.
+
+#### `search_sources_near_position`
+
+Search for sources in SkyPortal near a sky position (cone search). Finds all sources within a specified radius. Useful for checking if a source already exists at a location, or finding nearby sources in your SkyPortal instance.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `ra` | `float` | Right ascension in decimal degrees (J2000). Not needed if `source_id` provided. |
+| `dec` | `float` | Declination in decimal degrees (J2000). Not needed if `source_id` provided. |
+| `source_id` | `str` | SkyPortal source ID (e.g., `ZTF21aaaaaaa`). RA/Dec resolved automatically. |
+| `radius_arcsec` | `float` | Search radius in arcseconds (default: 10.0) |
+| `num_per_page` | `int` | Maximum number of sources to return (default: 100) |
+
+**Example prompts:**
+- *"Are there any sources near RA=150.1, Dec=+2.2 within 5 arcsec?"*
+- *"Show me all sources within 30 arcsec of ZTF21aaaaaaa"*
+- *"Check if this position already has a source in SkyPortal"*
+
+---
+
+## For Developers
+
+The server lives in `services/mcp_server/` and is built with [FastMCP](https://gofastmcp.com).
+
+### Transport Modes
+
+The MCP server supports two transport modes, selected via the `MCP_TRANSPORT` environment variable:
+
+#### HTTP Mode (default, for production)
+
+Multi-user authentication with bearer tokens. Clients send a SkyPortal API token as an `Authorization: Bearer <token>` header on every request. FastMCP's auth layer calls `SkyPortalOAuthProvider.load_access_token()`, which validates the token against SkyPortal's `/api/internal/profile` endpoint.
+
+```
+MCP Client                     MCP Server                      SkyPortal
+    |                              |                               |
+    |-- POST /mcp                  |                               |
+    |   Authorization: Bearer ---> |-- GET /api/internal/profile ->|
+    |   load_access_token() called |<- {username, id} -------------|
+    |<- MCP response --------------|                               |
+```
+
+No browser-based OAuth flow is involved. The `OAuthProvider` subclass implements only the `load_access_token()` validation method; the remaining interface methods (client registration, authorize, token exchange) are stubs required by the base class.
+
+#### stdio Mode (for local development)
+
+Single-user mode where the server runs as a subprocess. Authentication uses the `SKYPORTAL_TOKEN` environment variable instead of per-request OAuth. Perfect for:
+- Testing new tools locally
+- Developing against a remote SkyPortal/Fritz instance
+- Running custom forks without deploying
+
+The token is passed via environment variables in the client config (Claude Desktop/Code JSON files).
+
+### Deployment
+
+The MCP server runs as a supervised process on port `ports.mcp` (default 8000) and is proxied through SkyPortal's existing nginx. This means:
+
+- Users connect to `https://your-skyportal-host/mcp` — no separate port to expose
+- HTTPS is handled by nginx, same as the rest of SkyPortal
+- `MCP_BASE_URL` is derived automatically from `server.host`, `server.port`, and `server.ssl` in `config.yaml`
+
+No extra configuration is needed for a standard deployment. If you need to override anything, the environment variables below take precedence over the config-derived defaults.
+
+### Environment Variables
+
+These override the values derived from SkyPortal's `config.yaml` at startup.
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `MCP_TRANSPORT` | Transport mode: `"http"` or `"stdio"` | `"http"` |
+| `SKYPORTAL_URL` | Internal URL for SkyPortal's API | `http://127.0.0.1:{ports.app}` |
+| `SKYPORTAL_TOKEN` | API token for stdio mode (not used in HTTP mode) | None |
+| `MCP_HOST` | Bind host (HTTP mode only) | `127.0.0.1` |
+| `MCP_PORT` | Listen port (HTTP mode only) | `ports.mcp` (default 8000) |
+| `MCP_BASE_URL` | Public URL for OAuth metadata (HTTP mode only) | Derived from `server.host`, `server.port`, `server.ssl` |
+
+### Adding New Tools
+
+Decorate any async function with `@mcp.tool()`. Use `get_skyportal_token()` to retrieve the user's API token (works in both HTTP and stdio modes):
+
+```python
+from ..server import SKYPORTAL_URL, get_skyportal_token, mcp
+import httpx
+
+@mcp.tool()
+async def my_new_tool(source_id: str) -> str:
+    """Describe what this tool does."""
+    token = get_skyportal_token()
+    if not token:
+        return "Not authenticated. Configure SKYPORTAL_TOKEN or send Bearer token."
+
+    async with httpx.AsyncClient(timeout=30) as client:
+        resp = await client.get(
+            f"{SKYPORTAL_URL}/api/sources/{source_id}",
+            headers={"Authorization": f"token {token}"},
+        )
+    resp.raise_for_status()
+    return str(resp.json())
+```
+
+The `get_skyportal_token()` helper automatically handles both transport modes:
+- **HTTP mode**: Retrieves the per-request OAuth token from the Authorization header
+- **stdio mode**: Returns the `SKYPORTAL_TOKEN` environment variable
+
+### Running Locally for Development
+
+#### Option 1: stdio mode (recommended for development)
+
+Run the MCP server as a subprocess - no need to start SkyPortal. Perfect for testing new tools against Fritz or a remote instance.
+
+**For Claude Code:**
+
+```bash
+claude mcp add --transport stdio skyportal-dev \
+  -e MCP_TRANSPORT=stdio \
+  -e SKYPORTAL_URL=https://fritz.science \
+  -e SKYPORTAL_TOKEN=your-api-token \
+  -- /path/to/skyportal/skyportal_env/bin/python -m services.mcp_server
+```
+
+**For Claude Desktop** - edit `~/Library/Application Support/Claude/claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "skyportal-dev": {
+      "command": "python",
+      "args": ["-m", "services.mcp_server"],
+      "cwd": "/path/to/skyportal",
+      "env": {
+        "MCP_TRANSPORT": "stdio",
+        "SKYPORTAL_URL": "https://fritz.science",
+        "SKYPORTAL_TOKEN": "your-api-token"
+      }
+    }
+  }
+}
+```
+
+#### Option 2: HTTP mode (testing full deployment)
+
+Start SkyPortal normally — the MCP server starts automatically via supervisor on `http://localhost:8000/mcp`. Connect with Claude Code:
+
+```bash
+claude mcp add --transport http skyportal http://localhost:8000/mcp \
+  --header "Authorization: Bearer your-api-token-here"
+```
+
+To run the MCP server standalone in HTTP mode (outside supervisor):
+
+```bash
+# Default: HTTP mode on localhost:8000
+python -m services.mcp_server
+
+# Custom port
+MCP_PORT=9000 python -m services.mcp_server
+```
+
+The server reads `SKYPORTAL_URL`, `MCP_PORT`, and `MCP_BASE_URL` from SkyPortal's config automatically.

--- a/services/mcp_server/__init__.py
+++ b/services/mcp_server/__init__.py
@@ -1,0 +1,3 @@
+# Package marker for services.mcp_server.
+# This file makes Python treat the directory as a package, enabling
+# relative imports (e.g., `from ..server import mcp`) in submodules.

--- a/services/mcp_server/__main__.py
+++ b/services/mcp_server/__main__.py
@@ -1,0 +1,20 @@
+"""Allow running as `python -m services.mcp_server`."""
+
+import os
+
+from .server import MCP_HOST, MCP_PORT, logger, mcp
+
+transport = os.getenv("MCP_TRANSPORT", "http")
+if transport == "stdio":
+    logger.info("Starting MCP server in stdio mode")
+    mcp.run(transport="stdio", show_banner=False)
+elif transport == "http":
+    logger.info("Starting MCP server in HTTP mode on %s:%s", MCP_HOST, MCP_PORT)
+    mcp.run(
+        transport="http",
+        host=MCP_HOST,
+        port=MCP_PORT,
+        show_banner=True,
+    )
+else:
+    raise ValueError(f"Unknown transport: {transport}. Use 'stdio' or 'http'.")

--- a/services/mcp_server/resources/api_info.md
+++ b/services/mcp_server/resources/api_info.md
@@ -1,0 +1,399 @@
+# SkyPortal API Info Reference Sheet
+
+> **Note:** For a quick reference of all available MCP tools (recommended high-level interface), see the `tools_reference` resource. This document covers the underlying API endpoints.
+
+## Base URL
+
+`http://localhost:5001` (for local development)
+
+## Authentication
+
+All requests require an API token in the header:
+
+```
+Authorization: token YOUR_TOKEN_HERE
+```
+
+---
+
+## Core Endpoints
+
+### **Sources** (`/api/sources`)
+
+Astronomical objects that have been saved for follow-up
+
+**Common Operations:**
+
+- `GET /api/sources` - List all sources (with filters)
+- `GET /api/sources/{obj_id}` - Get specific source details
+- `POST /api/sources` - Create/save a new source
+- `PATCH /api/sources/{obj_id}` - Update source metadata
+- `DELETE /api/sources/{obj_id}` - Remove source
+
+**Key Query Parameters:**
+
+- `savedAfter`, `savedBefore` - Filter by save date
+- `startDate`, `endDate` - Filter by observation date
+- `group_ids` - Filter by group membership
+- `classifications` - Filter by classification type
+- `ra`, `dec`, `radius` - Spatial cone search
+
+---
+
+### **Candidates** (`/api/candidates`)
+
+Potential sources from alert streams awaiting review
+
+**Common Operations:**
+
+- `GET /api/candidates` - List candidates for scanning
+- `GET /api/candidates/{obj_id}` - Get candidate details
+- `POST /api/candidates` - Save candidate as source
+- `DELETE /api/candidates/{candidate_id}` - Remove candidate
+
+**Key Query Parameters:**
+
+- `savedAfter`, `savedBefore` - Date filters
+- `classifications` - Filter by ML classifications
+- `redshiftMinimum`, `redshiftMaximum` - Redshift range
+- `numPerPage` - Pagination
+
+---
+
+### **Photometry** (`/api/photometry`)
+
+Brightness measurements over time (light curves)
+
+**Common Operations:**
+
+- `GET /api/sources/{obj_id}/photometry` - Get photometry for source
+- `POST /api/photometry` - Upload new photometry
+- `PUT /api/photometry` - Bulk upload photometry
+- `PATCH /api/photometry/{photometry_id}` - Update measurement
+- `DELETE /api/photometry/{photometry_id}` - Delete measurement
+- `GET /api/photometry/range` - Query by time/magnitude range
+
+**Key Fields:**
+
+- `obj_id` - Source identifier
+- `mjd` - Modified Julian Date
+- `mag` or `flux` - Brightness measurement
+- `magerr` or `fluxerr` - Measurement error
+- `filter` - Photometric filter used
+- `instrument_id` - Instrument that made observation
+
+---
+
+### **Spectra** (`/api/spectrum`)
+
+Spectroscopic observations
+
+**Common Operations:**
+
+- `GET /api/sources/{obj_id}/spectra` - Get all spectra for source
+- `GET /api/spectrum/{spectrum_id}` - Get specific spectrum
+- `POST /api/spectrum` - Upload new spectrum
+- `POST /api/spectrum/ascii` - Upload from ASCII file
+- `PUT /api/spectrum/{spectrum_id}` - Update spectrum
+- `DELETE /api/spectrum/{spectrum_id}` - Delete spectrum
+
+**Key Fields:**
+
+- `obj_id` - Source identifier
+- `observed_at` - Observation datetime
+- `wavelengths` - Array of wavelength values
+- `fluxes` - Array of flux values
+- `instrument_id` - Instrument used
+
+---
+
+### **Classifications** (`/api/classification`)
+
+Source type classifications (e.g., SN Ia, AGN, variable star)
+
+**Common Operations:**
+
+- `GET /api/sources/{obj_id}/classifications` - Get all classifications
+- `GET /api/classification/{classification_id}` - Get specific classification
+- `POST /api/classification` - Add new classification
+- `PUT /api/classification/{classification_id}` - Update classification
+- `DELETE /api/classification/{classification_id}` - Remove classification
+
+**Key Fields:**
+
+- `obj_id` - Source identifier
+- `classification` - Type (must be in taxonomy)
+- `taxonomy_id` - Which taxonomy to use
+- `probability` - Confidence (0-1)
+- `group_ids` - Groups that can see this classification
+
+---
+
+### **Comments** (`/api/comment`)
+
+Collaborative notes on sources
+
+**Common Operations:**
+
+- `POST /api/comment` - Add comment to source
+- `GET /api/comment/{comment_id}` - Get specific comment
+- `PUT /api/comment/{comment_id}` - Edit comment
+- `DELETE /api/comment/{comment_id}` - Delete comment
+
+**Key Fields:**
+
+- `obj_id` - Source to comment on
+- `text` - Comment content
+
+---
+
+### **Annotations** (`/api/annotation`)
+
+Structured metadata on sources
+
+**Common Operations:**
+
+- `POST /api/annotation` - Add annotation
+- `GET /api/annotation/{annotation_id}` - Get annotation
+- `PUT /api/annotation/{annotation_id}` - Update annotation
+- `DELETE /api/annotation/{annotation_id}` - Delete annotation
+
+**Key Fields:**
+
+- `obj_id` - Source identifier
+- `origin` - Data source/pipeline name
+- `data` - JSON object with key-value pairs
+
+---
+
+### **Groups** (`/api/groups`)
+
+Collaboration groups with access permissions
+
+**Common Operations:**
+
+- `GET /api/groups` - List all groups user can access
+- `GET /api/groups/{group_id}` - Get group details
+- `POST /api/groups` - Create new group
+- `PUT /api/groups/{group_id}` - Update group
+- `GET /api/sources/{obj_id}/groups` - Get groups that can access source
+
+---
+
+### **Telescopes** (`/api/telescope`)
+
+Telescope facilities
+
+**Common Operations:**
+
+- `GET /api/telescope` - List all telescopes
+- `GET /api/telescope/{telescope_id}` - Get telescope details
+- `POST /api/telescope` - Add new telescope
+
+---
+
+### **Instruments** (`/api/instrument`)
+
+Instruments attached to telescopes
+
+**Common Operations:**
+
+- `GET /api/instrument` - List all instruments
+- `GET /api/instrument/{instrument_id}` - Get instrument details
+- `POST /api/instrument` - Add new instrument
+
+---
+
+### **Follow-up Requests** (`/api/followup_request`)
+
+Observation requests for sources
+
+**Common Operations:**
+
+- `GET /api/followup_request` - List follow-up requests
+- `GET /api/followup_request/{request_id}` - Get request details
+- `POST /api/followup_request` - Submit new request
+- `PUT /api/followup_request/{request_id}` - Update request
+- `DELETE /api/followup_request/{request_id}` - Cancel request
+
+**Key Fields:**
+
+- `obj_id` - Target source
+- `allocation_id` - Time allocation to use
+- `payload` - Request-specific parameters (JSON)
+
+---
+
+### **Observing Runs** (`/api/observing_run`)
+
+Scheduled observing sessions
+
+**Common Operations:**
+
+- `GET /api/observing_run` - List observing runs
+- `GET /api/observing_run/{run_id}` - Get run details with assignments
+- `POST /api/observing_run` - Create new run
+- `PUT /api/observing_run/{run_id}` - Update run
+
+---
+
+### **Taxonomies** (`/api/taxonomy`)
+
+Classification hierarchies
+
+**Common Operations:**
+
+- `GET /api/taxonomy` - List available taxonomies
+- `GET /api/taxonomy/{taxonomy_id}` - Get taxonomy hierarchy
+- `POST /api/taxonomy` - Upload new taxonomy
+
+---
+
+### **System Info** (`/api/sysinfo`)
+
+System information and git version
+
+**Common Operations:**
+
+- `GET /api/sysinfo` - Get version and recent commits
+
+---
+
+## Common Use Cases
+
+### 1. **Find Recent Supernovae**
+
+```
+GET /api/sources?classifications=SN Ia,SN II&savedAfter=2024-01-01
+```
+
+### 2. **Search Sources by Position**
+
+```
+GET /api/sources?ra=150.0&dec=2.5&radius=0.1
+```
+
+(Search within 0.1 degrees of RA=150°, Dec=2.5°)
+
+### 3. **Get Complete Source Information**
+
+```
+GET /api/sources/{obj_id}
+```
+
+Returns source with photometry, spectra, classifications, comments
+
+### 4. **Find Sources in Redshift Range**
+
+```
+GET /api/sources?minRedshift=0.0&maxRedshift=0.1
+```
+
+### 5. **Get Light Curve Data**
+
+```
+GET /api/sources/{obj_id}/photometry
+```
+
+### 6. **Find Candidates from Last Week**
+
+```
+GET /api/candidates?savedAfter=2024-01-25&numPerPage=100
+```
+
+### 7. **Search by Classification and Date**
+
+```
+GET /api/sources?classifications=AGN&startDate=2024-01-01&endDate=2024-12-31
+```
+
+### 8. **Get Sources for a Specific Group**
+
+```
+GET /api/sources?group_ids=5
+```
+
+### 9. **Find Transients with Recent Detections**
+
+```
+GET /api/sources?savedAfter=2024-01-01&hasSpectrum=true
+```
+
+### 10. **Query Photometry by Date Range**
+
+```
+GET /api/photometry/range?startDate=2024-01-01&endDate=2024-12-31&minMag=15&maxMag=20
+```
+
+---
+
+## Response Format
+
+All responses follow this structure:
+
+```json
+{
+  "status": "success" | "error",
+  "data": { ... },
+  "message": "Error message if status is error",
+  "version": "1.4.0"
+}
+```
+
+---
+
+## Pagination
+
+Many endpoints support pagination:
+
+- `numPerPage` - Number of results per page (default: 100)
+- `pageNumber` - Page to retrieve (default: 1)
+
+---
+
+## Use MCP Tools Instead of These Endpoints
+
+> **💡 TIP:** For a complete reference of all MCP tools with usage guidelines and workflows, see the `tools_reference` resource.
+
+Some API endpoints return images or PDFs that cannot be parsed. Use the
+dedicated MCP tools instead:
+
+| Instead of                                          | Use MCP tool                                                       |
+| --------------------------------------------------- | ------------------------------------------------------------------ |
+| **Multiple API calls for TNS report**               | **`get_tns_summary` (ONE call for complete TNS/AstroNote report)** |
+| `GET /api/sources/{id}/observability` (returns PDF) | `get_source_observability` (returns text with exact time windows)  |
+| `GET /api/sources/{id}/photometry`                  | `get_source_photometry` (returns CSV, easier to analyze)           |
+| Manual time conversion                              | `convert_time` (MJD/JD/ISO/Unix)                                   |
+| Looking up survey URLs by hand                      | `get_survey_urls` (returns links for 15+ surveys)                  |
+| Searching IRSA for ZTF images                       | `get_ztf_cutout_urls` (returns FITS download URLs)                 |
+| Reading candidate filter docs                       | `get_candidate_filter_reference` (returns filter parameter guide)  |
+
+### ⭐ TNS/AstroNote Reports
+
+**When user asks to create TNS report, AstroNote, or source summary:**
+
+- Use `get_tns_summary(source_name)` - single tool that combines ALL data
+- DO NOT call `get_source_photometry`, `get_source_spectra`, `get_source_classifications` separately
+- Tool returns formatted report with: coordinates, discovery, photometry, classification, spectra, host
+- After generating summary, ask user what additional context they need (e.g., spectroscopic follow-up plans, comparison to similar events, references)
+
+---
+
+## Tips
+
+1. **Start broad, then filter**: Use `/api/sources` with query parameters rather than trying to get individual sources
+2. **Use date ranges**: Most astronomical queries care about when observations were made
+3. **Spatial searches**: RA/Dec/radius is powerful for finding nearby sources
+4. **Check group access**: Sources are tied to groups for permissions
+5. **Redshift is key**: Many queries filter by redshift range
+6. **Classification filtering**: Use standard taxonomy names (SN Ia, AGN, etc.)
+7. **Prefer MCP tools**: For observability, photometry, and time conversion, use the dedicated MCP tools above rather than raw API calls
+
+---
+
+## Full Documentation
+
+For complete API documentation with all parameters and response schemas:
+
+- Auto-generated docs: https://github.com/skyportal/skyportal_client/tree/master/docs
+- Main SkyPortal docs: https://skyportal.io/docs/api.html

--- a/services/mcp_server/resources/candidate_filter_reference.md
+++ b/services/mcp_server/resources/candidate_filter_reference.md
@@ -1,0 +1,248 @@
+# Candidate & Source Filter Reference
+
+## Two Types of Filtering in Fritz/SkyPortal
+
+### 1. Alert-Time Filters (MongoDB Pipelines) 🚫 Not Available via MCP
+
+**What they do:** Run on Kowalski backend when new alerts arrive from the telescope. These filters determine which alerts become candidates visible on the scanning page.
+
+**How they work:**
+
+- Written as MongoDB aggregation pipelines
+- Access enhanced alert packets with cross-matches, ML scores, photometric history
+- Can iterate through `prv_candidates` array, compute light curve properties, etc.
+- Created and managed in the **Fritz UI** (Filters page)
+- Permanent, automatically process every incoming alert
+
+**⚠️ If you want to create/modify alert-time filters:**
+
+1. Go to the Fritz UI → Filters page
+2. Follow the tutorial: https://github.com/fritz-marshal/fritz/blob/main/doc/filter_tutorial.md
+3. Use MongoDB Compass to test filters: https://docs.fritz.science/user_guide.html#alert-filters-in-fritz
+
+**MCP cannot create these filters** because they require MongoDB pipeline syntax and direct backend access.
+
+---
+
+### 2. Query-Time Filters (API Parameters) ✅ Available via MCP
+
+**What they do:** Search existing candidates that are already on the scanning page. Ad-hoc searches to find candidates matching specific criteria.
+
+**How they work:**
+
+- Use `/api/candidates` API query parameters
+- Filter by classifications, redshift, ML scores, dates, saved status
+- Run on-demand when you query (not permanent)
+- Results returned as JSON/CSV
+
+**✅ Use the `filter_candidates` MCP tool to:**
+
+- Search the scanning page for candidates
+- Filter by any criteria documented below
+- Get results as CSV table
+- Save filter configurations for reuse
+
+**This reference covers query-time filtering only.**
+
+---
+
+### Watchlists (Alert-Time Position Monitoring) ✅ MCP Can Generate
+
+**What they are:** Alert-time filters that monitor specific sky coordinates. When new detections fall within a specified angular distance from watched positions, alerts are flagged and annotated.
+
+**How they work:**
+
+- MongoDB aggregation pipeline with spherical distance calculation
+- Runs automatically on every incoming alert
+- Annotations added: nearest target name, distance in arcseconds, list of all matches
+- Permanent monitoring (unlike ad-hoc query-time searches)
+
+**✅ Use the `generate_watchlist_filter` MCP tool to:**
+
+- Generate the MongoDB pipeline JSON for watchlist filters
+- Specify target coordinates and search radius
+- Get ready-to-paste JSON for Fritz filter UI
+- Monitor multiple positions with a single filter
+
+**Important:** MCP cannot create the filter directly. The workflow is:
+
+1. Generate JSON with `generate_watchlist_filter` tool
+2. Copy the generated MongoDB pipeline
+3. Paste into Fritz UI → Filters page
+4. Set Group/Stream and save
+
+**Use cases:**
+
+- Monitor known sources for new activity (e.g., M31, Crab)
+- Track specific sky positions of interest
+- Get alerted when detections appear near target coordinates
+- Watch multiple objects with a single filter (max distance typically 2 arcsec)
+
+---
+
+## Querying Candidates: GET /api/candidates
+
+### Date & Time Filters
+
+- `startDate` / `endDate` — when the candidate passed the filter (ISO format)
+- `firstDetectionAfter` — only sources first detected after this date
+- `lastDetectionBefore` — only sources last detected before this date
+- `numberDetections` — minimum number of detections required
+- `requireDetections` — boolean (default true)
+- `excludeForcedPhotometry` — boolean, exclude forced photometry from detection counts
+
+### Group & Filter Selection
+
+- `groupIDs` — comma-separated group IDs to search within
+- `filterIDs` — comma-separated filter IDs (alternative to groupIDs)
+
+### Saved Status
+
+- `savedStatus` — one of:
+  - `all` (default), `savedToAllSelected`, `savedToAnySelected`,
+    `savedToAnyAccessible`, `notSavedToAnyAccessible`,
+    `notSavedToAnySelected`, `notSavedToAllSelected`
+
+### Classification Filters
+
+- `classifications` — comma-separated classification names to include
+  (e.g., "SN Ia,SN Ib/c,SN II")
+- `classificationsReject` — exclude candidates with these classifications
+
+### Redshift Filters
+
+- `minRedshift` / `maxRedshift` — redshift range
+
+### User Lists
+
+- `listName` — only show candidates on this user list (e.g., "favorites")
+- `listNameReject` — exclude candidates on this user list (e.g., "rejected_candidates")
+
+---
+
+## Annotation Filters (key for ML scores)
+
+The `annotationFilterList` parameter accepts a JSON-encoded list of filter objects.
+Each object specifies an annotation origin, key, and either a value match or a min/max range.
+
+### Format
+
+**Range filter (for numerical scores):**
+
+```json
+{"origin": "<source>", "key": "<field>", "min": <float>, "max": <float>}
+```
+
+**Exact match filter:**
+
+```json
+{ "origin": "<source>", "key": "<field>", "value": "<value>" }
+```
+
+**Boolean filter:**
+
+```json
+{ "origin": "<source>", "key": "<field>", "value": true }
+```
+
+Multiple filters can be combined (comma-separated in the query string):
+
+```
+annotationFilterList={"origin":"braai","key":"braai","min":0.8,"max":1.0},{"origin":"kowalski","key":"sgScore","min":0.0,"max":0.5}
+```
+
+### Common Annotation Origins and Keys
+
+**Base SkyPortal / ZTF Public:**
+| Origin | Key | Range | Description |
+|--------|-----|-------|-------------|
+| `braai` | `braai` | 0–1 | Real/bogus score (higher = more likely real) |
+| `kowalski` | `drb` | 0–1 | Deep real/bogus score |
+| `kowalski` | `sgScore` | 0–1 | Star/galaxy score (0=galaxy, 1=star) |
+| `Kowalski` | `ACAI_score` | 0–1 | ACAI spectral classifier score |
+
+**Fritz-specific (may not be in base SkyPortal):**
+
+- TDE scores, SN Ia scores, and other classifier outputs
+- Period scores, variability metrics
+- Cross-match results from catalogs
+
+**Note:** Available annotation origins and keys depend on your instance's alert
+processing pipeline. To discover what annotations exist, fetch a source with
+`GET /api/sources/{obj_id}` and inspect the `annotations` field.
+
+### Annotation Sorting
+
+- `sortByAnnotationOrigin` — origin to sort by
+- `sortByAnnotationKey` — key within that annotation
+- `sortByAnnotationOrder` — "asc" or "desc"
+
+---
+
+## Photometry Annotation Filters
+
+These filter on per-detection (per-photometry-point) annotations rather than
+source-level annotations:
+
+- `photometryAnnotationsFilter` — annotation key/value filter
+- `photometryAnnotationsFilterOrigin` — which annotation origin
+- `photometryAnnotationsFilterAfter` / `Before` — date range for detections
+- `photometryAnnotationsFilterMinCount` — minimum number of matching detections (default 1)
+
+---
+
+## Localization (GW/GRB Event) Filters
+
+- `localizationDateobs` — filter by GW/GRB event date
+- `localizationName` — filter by localization name
+- `localizationCumprob` — cumulative probability contour (default 0.95)
+- Requires `firstDetectionAfter` and `lastDetectionBefore` to also be set
+
+---
+
+## Querying Sources: GET /api/sources
+
+Similar to candidates, plus:
+
+- `ra`, `dec`, `radius` — cone search (degrees)
+- `savedAfter` / `savedBefore` — when saved to group
+- `hasSpectrum` — boolean
+- `hasFollowupRequest` — boolean
+- `hasTNSname` — boolean
+
+---
+
+## Managing Filters: /api/filters
+
+Filters determine which alerts from a stream become candidates for a group:
+
+- `POST /api/filters` with `{"name": "...", "stream_id": N, "group_id": N}`
+- `GET /api/filters` — list all accessible filters
+- `PATCH /api/filters/{id}` — update filter name
+- `DELETE /api/filters/{id}` — delete filter
+
+**Important distinction:** Fritz filters operate on the alert stream and determine
+which alerts become candidates. They are NOT the same as query-time parameters
+on `/api/candidates`. To search existing candidates with specific criteria, use
+the query parameters documented above.
+
+---
+
+## What CAN vs CANNOT Be Filtered via API
+
+**Filterable via API parameters (fast, server-side):**
+
+- Classification type, redshift range, date ranges
+- Real/bogus score, star/galaxy score (via annotation filters)
+- Saved status, group membership, user lists
+- Cone search (RA/Dec/radius)
+- Photometry annotation properties
+- Number of detections, first/last detection dates
+
+**Requires fetching data + computation (use dedicated MCP tools):**
+
+- Color cuts (g-r, g-i thresholds) — need photometry per source
+- Rise time or light curve shape — need photometry time series analysis
+- Proximity to galaxy centers — need catalog cross-matching
+- Pre-peak detections — need to identify peak from light curve
+- Combined computed criteria — need multi-step analysis pipeline

--- a/services/mcp_server/resources/tools_reference.md
+++ b/services/mcp_server/resources/tools_reference.md
@@ -12,18 +12,12 @@ Some tools benefit from asking the user for preferences before execution. Below 
 
 1. **`get_tns_summary`** - After generating summary, ask what additional information they need (discovery context, follow-up plans, references, etc.). Display output in markdown text block (```text).
 
-2. **`analyze_light_curve`** and **`analyze_color_evolution`** - ALWAYS prompt before calling:
+2. **`analyze_light_curve`** and **`analyze_color_evolution`** - Generate Jupyter notebooks by default:
 
-   - **For analyze_color_evolution:** Ask TWO questions:
-     1. Method: "Would you like day-to-day colors (matched) or rolling/continuous colors (interpolated)?"
-     2. Output: "Would you like the analysis as text in chat or an interactive plot in a notebook?"
-   - **For analyze_light_curve:** Ask ONE question:
-     - Output: "Would you like the analysis as text in chat or an interactive plot in a notebook?"
-
-   **IMPORTANT:** Claude Code and Claude Desktop cannot display images in chat. Make this clear when prompting:
-
-   - Text mode: Results shown directly in chat
-   - Notebook mode: Python code inserted into notebook cell for user to run and see plots
+   - **analyze_color_evolution:** Generates CSV data + Jupyter notebook with BOTH matched (day-to-day) AND interpolated (rolling) colors overlaid
+   - **analyze_light_curve:** Generates CSV data + Jupyter notebook with light curve analysis
+   - Both support `output_format="text"` for quick summaries in chat
+   - **Default behavior:** Create interactive notebooks - no prompting needed unless user explicitly wants text-only
 
 3. **`get_source_observability`** - If multiple telescopes available and user doesn't specify, ask which telescope they want to use or offer to check all.
 
@@ -55,34 +49,39 @@ Some tools benefit from asking the user for preferences before execution. Below 
 
 ### Light Curve Analysis
 
-- **`analyze_light_curve(source_name, filter_name, baseline_threshold, output_format)`**
-  - Rise time, fade time, duration
+- **`analyze_light_curve(source_name, filter_names, baseline_threshold, output_format)`**
+  - Multi-band analysis: rise time, fade time, duration per filter
   - Rise/fade rates (mag/day)
   - Pre-peak variability and flare detection
   - Handles incomplete light curves (still rising/fading)
-  - Default filter: ztfr
-  - **Dual output modes:**
-    - `output_format="text"` (default): Text summary in chat
-    - `output_format="notebook"`: Python code with interactive plot for Jupyter notebook
-  - **ALWAYS prompt user** for output preference before calling
+  - Default filters: "ztfg,ztfr" (comma-separated, pulls both g and r band)
+  - **Output modes:**
+    - `output_format="notebook"` (default): Generates CSV file + Jupyter notebook
+      - CSV contains all requested bands (filter, mjd, mag, magerr)
+      - Notebook includes editable analysis code cells and interactive Plotly plots
+      - All bands overlaid on one plot with SkyPortal colors
+    - `output_format="text"`: Text summary with per-band metrics
 
 ### Color Analysis
 
-- **`analyze_color_evolution(source_name, band1, band2, method, max_time_gap, max_data_gap, output_format)`**
-  - Color at peak brightness
-  - Color evolution over time
-  - **Two calculation methods:**
-    - `"matched"` (default): Pairs close observations, respects data gaps. Best for sparse sampling.
-    - `"interpolated"`: Continuous/rolling color using interpolation. Best for well-sampled light curves.
-  - **Dual output modes:**
-    - `output_format="text"` (default): Text summary with CSV table in chat
-    - `output_format="notebook"`: Python code with interactive plots (light curves + color) for Jupyter notebook
-  - Default: g-r color using matched method
-  - **ALWAYS prompt user** for method AND output preference before calling
+- **`analyze_color_evolution(source_name, band1, band2, max_time_gap, max_data_gap, output_format)`**
+  - Color at peak brightness and evolution over time
+  - **Calculates BOTH methods automatically:**
+    - **Matched** (day-to-day): Pairs close observations, respects data gaps. Best for sparse sampling.
+    - **Interpolated** (rolling): Continuous color using interpolation. Best for well-sampled light curves.
+  - **Output modes:**
+    - `output_format="notebook"` (default): Generates CSV file + Jupyter notebook with overlaid plots
+      - CSV contains both matched and interpolated colors
+      - Notebook shows both methods overlaid (matched=darker, interpolated=lighter)
+    - `output_format="text"`: Text summary in chat
+  - Default: g-r color with both methods
+  - **Files generated:** `{source}_color_data.csv` and `{source}_color_analysis.ipynb` in `{source}_color_analysis/` directory
 
 ---
 
 ## Candidate Filtering & Scanning
+
+**Note on Alert-Time Filters**: Fritz now recommends using [MongoDB Compass](https://github.com/fritz-marshal/fritz/blob/main/doc/filter_tutorial.md) for developing alert-time filters. The MCP tools below can generate filter templates compatible with this workflow.
 
 ### Filtering Tools
 
@@ -94,9 +93,11 @@ Some tools benefit from asking the user for preferences before execution. Below 
   - See `candidate_filter_reference` resource for all parameters
 
 - **`generate_watchlist_filter(targets, max_distance_arcsec, filter_name)`**
-  - Creates MongoDB filter for TNS position monitoring
-  - Takes CSV of coordinates (name, RA, Dec)
-  - Returns JSON ready for Fritz UI
+  - Creates MongoDB aggregation pipeline for position monitoring
+  - Takes JSON list of coordinates (name, RA, Dec)
+  - Returns MongoDB pipeline compatible with Fritz filters
+  - **Recommended**: Use with [MongoDB Compass workflow](https://github.com/fritz-marshal/fritz/blob/main/doc/filter_tutorial.md)
+  - Can be used as starting point or imported directly
 
 ### Filter Documentation
 
@@ -121,11 +122,15 @@ They do NOT execute queries directly. The generated code uses `ztfquery` for eff
 ### Bulk Photometry
 
 - **`generate_bulk_lightcurve_code(sources, filters, include_plots)`**
-  - Generate code to download ZTF forced photometry for multiple sources
+  - Generates a Jupyter notebook to bulk download ZTF **alert photometry** from Fritz
+  - Uses `ztfquery.fritz.bulk_download()` with multiprocessing
   - Sources: comma-separated or JSON array of ZTF names
   - Filters: ztfg, ztfr, ztfi (comma-separated)
-  - Creates CSV files + optional plots
-  - Example: `sources="ZTF21aaaaaaa,ZTF21aaaaaab"` → downloads g/r/i photometry
+  - Saves per-source CSVs + interactive Plotly plots
+  - Requires: ztfquery + Fritz API token. Setup: `from ztfquery.io import set_account; set_account('fritz', token_based=True)`
+  - **Note:** Downloads alert photometry (detection epochs only).
+    For forced photometry (non-detections/upper limits), use IRSA.
+  - Example: `sources="ZTF21aaaaaaa,ZTF21aaaaaab"` → notebook in `ztf_lightcurves/`
 
 ### Coordinate Searches
 
@@ -141,7 +146,7 @@ They do NOT execute queries directly. The generated code uses `ztfquery` for eff
 - **`generate_fritz_bulk_query_code(sources, include_spectra)`**
   - Generate code to bulk download from Fritz API
   - Downloads photometry, spectra, metadata for multiple sources
-  - Requires Fritz token (set as FRITZ_TOKEN env var)
+  - Requires Fritz token. Setup: `from ztfquery.io import set_account; set_account('fritz', token_based=True)`
   - Faster than individual API calls
 
 ### Alert Packets
@@ -164,22 +169,12 @@ They do NOT execute queries directly. The generated code uses `ztfquery` for eff
 
 ### Target Observability
 
-- **`get_source_observability(source_name, telescope_name)`**
-
-  - Tonight's observable windows
-  - Best observation time
-  - Alt/az at midnight
-  - Handles multiple telescopes
-
-- **`list_available_telescopes()`** - Show configured telescopes
-  - Name, location, elevation
-  - Available for observability queries
-
-### Follow-up Management
-
-- **`list_followup_requests(obj_id, status)`** - View follow-up requests
-- **`get_assigned_sources(run_id)`** - Sources in observing run
-- **`get_observation_plan(run_id)`** - Tonight's observing plan
+- **`get_source_observability(source_id, ra, dec, max_airmass, telescopes, date)`**
+  - Compute observing windows from specified telescopes
+  - Returns rise/set times, transit, peak altitude, airmass
+  - Accepts source_id (auto-resolves coords) or explicit ra/dec
+  - Built-in telescopes: Keck, Lick, Palomar, APO, CTIO, Gemini-N/S, VLT, Subaru, LDT, LCO sites
+  - Can query Fritz for all configured telescopes with `telescopes="fritz"`
 
 ---
 
@@ -187,36 +182,17 @@ They do NOT execute queries directly. The generated code uses `ztfquery` for eff
 
 ### Time Conversion
 
-- **`convert_time(time_value, input_format, output_format)`**
-  - Formats: MJD, JD, ISO, Unix
+- **`convert_time(value, from_format, to_format)`**
+  - Convert between MJD, JD, ISO datetime, and Unix timestamps
+  - Formats: "mjd", "jd", "iso", "unix", or "auto" (detects automatically)
   - Example: MJD → ISO date
-
-### Coordinate Tools
-
-- **`calculate_sky_distance(ra1, dec1, ra2, dec2)`**
-  - Spherical distance between coordinates
-  - Returns arcseconds and degrees
 
 ### External Survey Links
 
 - **`get_survey_urls(ra, dec, obj_id)`**
   - 15+ survey links (SIMBAD, NED, VizieR, etc.)
   - Finding charts, catalogs, archives
-  - TNS, ALeRCE, ATLAS, etc.
-
-### ZTF Image Access
-
-- **`get_ztf_cutout_urls(ra, dec, size, filters, num_days)`**
-  - IRSA cutout service links
-  - Direct FITS download URLs
-  - Science, reference, difference images
-
----
-
-## Group & Permission Management
-
-- **`list_groups()`** - Show groups user can access
-- **`get_user_info()`** - Current user details and permissions
+  - TNS, ALeRCE, ATLAS, ZTF (IRSA), etc.
 
 ---
 
@@ -231,8 +207,6 @@ They do NOT execute queries directly. The generated code uses `ztfquery` for eff
 **Follow-up Planning:**
 
 - `get_source_observability`
-- `list_available_telescopes`
-- `get_observation_plan`
 
 **Candidate Review:**
 
@@ -256,12 +230,11 @@ They do NOT execute queries directly. The generated code uses `ztfquery` for eff
 **Context & Cross-matching:**
 
 - `get_survey_urls`
-- `get_ztf_cutout_urls`
-- `calculate_sky_distance`
+- `search_sources_near_position`
 
 **Bulk Operations (ztfquery code generation):**
 
-- `generate_bulk_lightcurve_code` ⭐ (photometry for many sources)
+- `generate_bulk_lightcurve_code` ⭐ (alert photometry for many sources via Fritz)
 - `generate_cone_search_code` (cross-match coordinates)
 - `generate_fritz_bulk_query_code` (bulk Fritz downloads)
 - `generate_alert_download_code` (alert packets)
@@ -291,17 +264,19 @@ They do NOT execute queries directly. The generated code uses `ztfquery` for eff
 ### 3. Plan Tonight's Observations
 
 ```
-1. list_available_telescopes()
-2. get_source_observability(source_name="ZTF21...", telescope_name="P60")
-3. get_observation_plan(run_id=123)
+1. get_source_observability(source_id="ZTF21...", telescopes="Keck,Palomar")
+2. (Check multiple telescopes for best observing window)
+3. (Use Fritz UI for detailed observing run planning)
 ```
 
 ### 4. Monitor TNS Targets
 
 ```
-1. (Prepare CSV of coordinates from TNS)
-2. generate_watchlist_filter(targets="<CSV>", max_distance_arcsec=2.0)
-3. (Copy JSON into Fritz filter UI)
+1. (Prepare JSON list of coordinates from TNS)
+2. generate_watchlist_filter(targets="<JSON>", max_distance_arcsec=2.0)
+3. (Option A) Import JSON to MongoDB Compass for testing/refinement
+4. (Option B) Import JSON directly to Fritz
+5. See: https://github.com/fritz-marshal/fritz/blob/main/doc/filter_tutorial.md
 ```
 
 ### 5. Analyze Transient Evolution
@@ -316,9 +291,9 @@ They do NOT execute queries directly. The generated code uses `ztfquery` for eff
 
 ```
 1. generate_bulk_lightcurve_code(sources="ZTF21aaa,ZTF21aab,...", filters="ztfg,ztfr")
-2. (Claude inserts code into notebook)
-3. (User runs code locally - faster than individual queries)
-4. (Results saved to ztf_lightcurves/ directory)
+2. (Notebook saved to ztf_lightcurves/bulk_lightcurve_download.ipynb)
+3. (User opens notebook and runs cells — downloads from Fritz via ztfquery)
+4. (Per-source CSVs + interactive Plotly plots saved to ztf_lightcurves/)
 ```
 
 ### 7. Cross-Match Catalog with ZTF

--- a/services/mcp_server/resources/tools_reference.md
+++ b/services/mcp_server/resources/tools_reference.md
@@ -1,0 +1,381 @@
+# SkyPortal MCP Tools Reference
+
+Quick reference for all available MCP tools. For detailed API endpoint documentation, see `api_info` resource.
+
+---
+
+## 📋 User Interaction Guidelines
+
+Some tools benefit from asking the user for preferences before execution. Below are tools that should prompt for user input:
+
+### When to Prompt Users
+
+1. **`get_tns_summary`** - After generating summary, ask what additional information they need (discovery context, follow-up plans, references, etc.). Display output in markdown text block (```text).
+
+2. **`analyze_light_curve`** and **`analyze_color_evolution`** - ALWAYS prompt before calling:
+
+   - **For analyze_color_evolution:** Ask TWO questions:
+     1. Method: "Would you like day-to-day colors (matched) or rolling/continuous colors (interpolated)?"
+     2. Output: "Would you like the analysis as text in chat or an interactive plot in a notebook?"
+   - **For analyze_light_curve:** Ask ONE question:
+     - Output: "Would you like the analysis as text in chat or an interactive plot in a notebook?"
+
+   **IMPORTANT:** Claude Code and Claude Desktop cannot display images in chat. Make this clear when prompting:
+
+   - Text mode: Results shown directly in chat
+   - Notebook mode: Python code inserted into notebook cell for user to run and see plots
+
+3. **`get_source_observability`** - If multiple telescopes available and user doesn't specify, ask which telescope they want to use or offer to check all.
+
+4. **`filter_candidates`** - For broad queries, consider asking if they want to narrow filters (date range, classification, etc.).
+
+---
+
+## ⭐ Most Commonly Used Tools
+
+### TNS/AstroNote Reports
+
+- **`get_tns_summary(source_name)`** - ONE tool for complete TNS reports
+  - Use this instead of calling photometry/spectra/classifications separately
+  - Returns formatted summary ready for TNS submission or AstroNotes
+  - **After calling:** Display output in markdown text block and ask what additional info user needs (discovery context, follow-up plans, comparison to similar events, references, special notes)
+
+### Source Data Retrieval
+
+- **`get_source_photometry(source_name, format, magsys, filters)`** - Light curve data as CSV
+- **`get_source_spectra(source_name, format)`** - Spectroscopic data
+- **`get_source_classifications(source_name)`** - Classification history
+- **`get_source_host_galaxy(source_name)`** - Host galaxy information
+
+**Note:** All source tools accept flexible identifiers (obj_id, ZTF name, or TNS name)
+
+---
+
+## Analysis Tools
+
+### Light Curve Analysis
+
+- **`analyze_light_curve(source_name, filter_name, baseline_threshold, output_format)`**
+  - Rise time, fade time, duration
+  - Rise/fade rates (mag/day)
+  - Pre-peak variability and flare detection
+  - Handles incomplete light curves (still rising/fading)
+  - Default filter: ztfr
+  - **Dual output modes:**
+    - `output_format="text"` (default): Text summary in chat
+    - `output_format="notebook"`: Python code with interactive plot for Jupyter notebook
+  - **ALWAYS prompt user** for output preference before calling
+
+### Color Analysis
+
+- **`analyze_color_evolution(source_name, band1, band2, method, max_time_gap, max_data_gap, output_format)`**
+  - Color at peak brightness
+  - Color evolution over time
+  - **Two calculation methods:**
+    - `"matched"` (default): Pairs close observations, respects data gaps. Best for sparse sampling.
+    - `"interpolated"`: Continuous/rolling color using interpolation. Best for well-sampled light curves.
+  - **Dual output modes:**
+    - `output_format="text"` (default): Text summary with CSV table in chat
+    - `output_format="notebook"`: Python code with interactive plots (light curves + color) for Jupyter notebook
+  - Default: g-r color using matched method
+  - **ALWAYS prompt user** for method AND output preference before calling
+
+---
+
+## Candidate Filtering & Scanning
+
+### Filtering Tools
+
+- **`filter_candidates(...)`** - Query candidates with detailed filters
+
+  - Date ranges, classification, redshift, coordinates
+  - Magnitude, RB score, spatial searches
+  - Returns paginated results
+  - See `candidate_filter_reference` resource for all parameters
+
+- **`generate_watchlist_filter(targets, max_distance_arcsec, filter_name)`**
+  - Creates MongoDB filter for TNS position monitoring
+  - Takes CSV of coordinates (name, RA, Dec)
+  - Returns JSON ready for Fritz UI
+
+### Filter Documentation
+
+- **`get_candidate_filter_reference()`** - Complete parameter guide
+  - All available filter parameters
+  - Watchlist setup instructions
+  - Examples for common queries
+
+---
+
+## Bulk Analysis & ztfquery
+
+**⚠️ Important:** These tools generate Python code for users to run locally in Jupyter notebooks.
+They do NOT execute queries directly. The generated code uses `ztfquery` for efficient bulk operations.
+
+**Setup Required:**
+
+- Install ztfquery: `pip install ztfquery`
+- Configure IRSA credentials (first time): `ztfquery.io.set_account('username', 'password')`
+- Get IRSA account: https://irsa.ipac.caltech.edu/account/signon/login.do
+
+### Bulk Photometry
+
+- **`generate_bulk_lightcurve_code(sources, filters, include_plots)`**
+  - Generate code to download ZTF forced photometry for multiple sources
+  - Sources: comma-separated or JSON array of ZTF names
+  - Filters: ztfg, ztfr, ztfi (comma-separated)
+  - Creates CSV files + optional plots
+  - Example: `sources="ZTF21aaaaaaa,ZTF21aaaaaab"` → downloads g/r/i photometry
+
+### Coordinate Searches
+
+- **`generate_cone_search_code(coordinates, radius_arcsec)`**
+  - Generate code to search ZTF detections near coordinates
+  - Coordinates: "ra1,dec1,ra2,dec2,..." or JSON: [[ra1,dec1], [ra2,dec2]]
+  - RA/Dec in decimal degrees (J2000)
+  - Returns all ZTF detections within radius
+  - Use case: Cross-match catalog with ZTF
+
+### Fritz Bulk Queries
+
+- **`generate_fritz_bulk_query_code(sources, include_spectra)`**
+  - Generate code to bulk download from Fritz API
+  - Downloads photometry, spectra, metadata for multiple sources
+  - Requires Fritz token (set as FRITZ_TOKEN env var)
+  - Faster than individual API calls
+
+### Alert Packets
+
+- **`generate_alert_download_code(sources, with_cutouts)`**
+  - Generate code to download raw ZTF alert packets
+  - Includes full alert history + optional FITS cutouts
+  - Use case: Need alert-level data not in forced photometry
+
+### Field Visualization
+
+- **`generate_field_visualization_code(field_id, ccd_id)`**
+  - Generate code to visualize ZTF field/CCD coverage
+  - Creates Mollweide sky map with footprints
+  - Optional: highlight specific CCD (1-16)
+
+---
+
+## Observability & Planning
+
+### Target Observability
+
+- **`get_source_observability(source_name, telescope_name)`**
+
+  - Tonight's observable windows
+  - Best observation time
+  - Alt/az at midnight
+  - Handles multiple telescopes
+
+- **`list_available_telescopes()`** - Show configured telescopes
+  - Name, location, elevation
+  - Available for observability queries
+
+### Follow-up Management
+
+- **`list_followup_requests(obj_id, status)`** - View follow-up requests
+- **`get_assigned_sources(run_id)`** - Sources in observing run
+- **`get_observation_plan(run_id)`** - Tonight's observing plan
+
+---
+
+## Astronomical Utilities
+
+### Time Conversion
+
+- **`convert_time(time_value, input_format, output_format)`**
+  - Formats: MJD, JD, ISO, Unix
+  - Example: MJD → ISO date
+
+### Coordinate Tools
+
+- **`calculate_sky_distance(ra1, dec1, ra2, dec2)`**
+  - Spherical distance between coordinates
+  - Returns arcseconds and degrees
+
+### External Survey Links
+
+- **`get_survey_urls(ra, dec, obj_id)`**
+  - 15+ survey links (SIMBAD, NED, VizieR, etc.)
+  - Finding charts, catalogs, archives
+  - TNS, ALeRCE, ATLAS, etc.
+
+### ZTF Image Access
+
+- **`get_ztf_cutout_urls(ra, dec, size, filters, num_days)`**
+  - IRSA cutout service links
+  - Direct FITS download URLs
+  - Science, reference, difference images
+
+---
+
+## Group & Permission Management
+
+- **`list_groups()`** - Show groups user can access
+- **`get_user_info()`** - Current user details and permissions
+
+---
+
+## Tool Categories
+
+### By Use Case
+
+**TNS Reporting:**
+
+- `get_tns_summary` ⭐ (use this one!)
+
+**Follow-up Planning:**
+
+- `get_source_observability`
+- `list_available_telescopes`
+- `get_observation_plan`
+
+**Candidate Review:**
+
+- `filter_candidates`
+- `get_candidate_filter_reference`
+- `generate_watchlist_filter`
+
+**Source Investigation:**
+
+- `get_source_photometry`
+- `get_source_spectra`
+- `get_source_classifications`
+- `get_source_host_galaxy`
+- `get_source_comments_and_annotations`
+
+**Scientific Analysis:**
+
+- `analyze_light_curve`
+- `analyze_color_evolution`
+
+**Context & Cross-matching:**
+
+- `get_survey_urls`
+- `get_ztf_cutout_urls`
+- `calculate_sky_distance`
+
+**Bulk Operations (ztfquery code generation):**
+
+- `generate_bulk_lightcurve_code` ⭐ (photometry for many sources)
+- `generate_cone_search_code` (cross-match coordinates)
+- `generate_fritz_bulk_query_code` (bulk Fritz downloads)
+- `generate_alert_download_code` (alert packets)
+- `generate_field_visualization_code` (ZTF field maps)
+
+---
+
+## Common Workflows
+
+### 1. Review and Classify a Candidate
+
+```
+1. filter_candidates(saved_after="2024-01-01", num_per_page=50)
+2. get_source_photometry(source_name="ZTF21...", filters="ztfg,ztfr")
+3. analyze_light_curve(source_name="ZTF21...", filter_name="ztfr")
+4. get_survey_urls(obj_id="ZTF21...")
+5. get_source_spectra(source_name="ZTF21...")
+```
+
+### 2. Prepare TNS Report
+
+```
+1. get_tns_summary(source_name="ZTF21...")  # ONE tool!
+2. (Claude asks for additional context)
+```
+
+### 3. Plan Tonight's Observations
+
+```
+1. list_available_telescopes()
+2. get_source_observability(source_name="ZTF21...", telescope_name="P60")
+3. get_observation_plan(run_id=123)
+```
+
+### 4. Monitor TNS Targets
+
+```
+1. (Prepare CSV of coordinates from TNS)
+2. generate_watchlist_filter(targets="<CSV>", max_distance_arcsec=2.0)
+3. (Copy JSON into Fritz filter UI)
+```
+
+### 5. Analyze Transient Evolution
+
+```
+1. analyze_light_curve(source_name="ZTF21...", filter_name="ztfr")
+2. analyze_color_evolution(source_name="ZTF21...", band1="ztfg", band2="ztfr")
+3. get_source_classifications(source_name="ZTF21...")
+```
+
+### 6. Bulk Download Photometry (>10 sources)
+
+```
+1. generate_bulk_lightcurve_code(sources="ZTF21aaa,ZTF21aab,...", filters="ztfg,ztfr")
+2. (Claude inserts code into notebook)
+3. (User runs code locally - faster than individual queries)
+4. (Results saved to ztf_lightcurves/ directory)
+```
+
+### 7. Cross-Match Catalog with ZTF
+
+```
+1. (User has list of RA/Dec coordinates from catalog/TNS)
+2. generate_cone_search_code(coordinates="150.0,2.5,151.2,3.1,...", radius_arcsec=2.0)
+3. (Claude inserts code into notebook)
+4. (User runs to find all ZTF detections near coordinates)
+```
+
+### 8. Download Complete Alert History
+
+```
+1. generate_alert_download_code(sources="ZTF21aaa,ZTF21aab", with_cutouts=True)
+2. (Claude inserts code into notebook)
+3. (User runs to download alert packets + FITS cutouts)
+4. (Results saved to ztf_alerts/ directory)
+```
+
+---
+
+## Important Notes
+
+### Source Identifiers
+
+All `source_name` parameters accept:
+
+- SkyPortal obj_id (e.g., `"ZTF21aaaaaaa"`)
+- ZTF names (e.g., `"ZTF21aaaaaaa"`)
+- TNS names (e.g., `"AT2021abc"`, `"SN2021xyz"`)
+
+The tools automatically resolve to the correct SkyPortal source.
+
+### Rate Limits & Bulk Operations
+
+- MCP tools respect SkyPortal API rate limits
+- For <5 sources: Use individual tools (get_source_photometry, etc.)
+- For >10 sources: Use bulk analysis tools (generate_bulk_lightcurve_code, etc.)
+- Bulk tools generate ztfquery code that runs locally - much faster than API calls
+
+### Error Handling
+
+- All tools return descriptive error messages
+- Common errors:
+  - Source not found → Check identifier spelling
+  - No photometry → Source may not have data in that filter
+  - Permission denied → Check group access
+
+---
+
+## Resources
+
+In addition to tools, these resources are available:
+
+- **`api_info`** - SkyPortal API endpoint reference
+- **`candidate_filter_reference`** - Candidate filter parameter guide
+- **`tools_reference`** - This document
+
+Use these for understanding the SkyPortal data model and available operations.

--- a/services/mcp_server/server.py
+++ b/services/mcp_server/server.py
@@ -1,0 +1,212 @@
+# pyright: reportMissingTypeStubs=false
+"""SkyPortal MCP server — config, auth, and entrypoint.
+
+Tools are defined in the tools/ package and register themselves on import.
+"""
+
+import logging
+import os
+from pathlib import Path
+
+import httpx
+from fastmcp import FastMCP
+from fastmcp.server.auth import AccessToken, OAuthProvider
+from mcp.server.auth.provider import AuthorizationCode, AuthorizationParams
+from mcp.server.auth.settings import ClientRegistrationOptions
+from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+
+logger = logging.getLogger(__name__)
+
+
+# ─── Configuration ───────────────────────────────────────────────────────────
+
+
+def _load_skyportal_config() -> dict:
+    """Read config.yaml from the SkyPortal root, merging over built-in defaults."""
+    import yaml
+
+    defaults: dict = {
+        "ports": {"app": 5001, "mcp": 8000},
+        "server": {"host": "localhost", "port": None, "ssl": False},
+    }
+    root = Path(__file__).resolve().parent.parent.parent
+    cfg_path = root / "config.yaml"
+    if not cfg_path.exists():
+        return defaults
+    with cfg_path.open() as f:
+        user_cfg = yaml.safe_load(f) or {}
+    for section, values in user_cfg.items():
+        if isinstance(values, dict) and section in defaults:
+            defaults[section].update(values)
+        else:
+            defaults[section] = values
+    return defaults
+
+
+try:
+    _cfg = _load_skyportal_config()
+    _ports = _cfg.get("ports", {})
+    _server = _cfg.get("server", {})
+    _default_skyportal_url = f"http://127.0.0.1:{_ports.get('app', 5001)}"
+    _default_mcp_port = int(_ports.get("mcp", 8000))
+    _ssl = _server.get("ssl", False)
+    _host = _server.get("host", "localhost")
+    _port = _server.get("port")
+    _standard_port = 443 if _ssl else 80
+    _port_str = f":{_port}" if _port and _port != _standard_port else ""
+    _default_mcp_base_url = f"{'https' if _ssl else 'http'}://{_host}{_port_str}"
+except Exception as _e:
+    logging.warning("Could not load SkyPortal config (reason: %s); using defaults", _e)
+    _default_skyportal_url = "http://127.0.0.1:5001"
+    _default_mcp_port = 8000
+    _default_mcp_base_url = None
+
+SKYPORTAL_URL = os.getenv("SKYPORTAL_URL", _default_skyportal_url)
+MCP_PORT = int(os.getenv("MCP_PORT", str(_default_mcp_port)))
+MCP_HOST = os.getenv("MCP_HOST", "127.0.0.1")
+MCP_BASE_URL = os.getenv(
+    "MCP_BASE_URL", _default_mcp_base_url or f"http://localhost:{MCP_PORT}"
+)
+SKYPORTAL_TOKEN = os.getenv("SKYPORTAL_TOKEN")  # For stdio mode
+
+
+# ─── Auth helper for tools ──────────────────────────────────────────────────
+
+
+def get_skyportal_token() -> str | None:
+    """
+    Get SkyPortal API token for the current request.
+
+    In HTTP mode: retrieves token from OAuth provider (per-request auth)
+    In stdio mode: uses SKYPORTAL_TOKEN environment variable
+
+    Returns:
+        API token string, or None if not authenticated
+    """
+    transport = os.getenv("MCP_TRANSPORT", "http")
+
+    if transport == "stdio":
+        # Stdio mode: use env var token
+        return SKYPORTAL_TOKEN
+    else:
+        # HTTP mode: use per-request OAuth token
+        from fastmcp.server.dependencies import get_access_token
+
+        access_token = get_access_token()
+        return access_token.token if access_token else None
+
+
+# ─── OAuth provider ──────────────────────────────────────────────────────────
+
+
+class SkyPortalOAuthProvider(OAuthProvider):
+    """
+    OAuth provider for bearer-token authentication.
+
+    MCP clients send a SkyPortal API token as a Bearer header on every
+    request.  FastMCP's auth layer calls load_access_token() to validate
+    it against SkyPortal's /api/internal/profile endpoint.
+
+    The remaining OAuth methods (client registration, authorize, token
+    exchange) are required by the OAuthProvider interface but are not
+    used in the normal flow — clients pass their token directly.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(
+            base_url=MCP_BASE_URL,
+            client_registration_options=ClientRegistrationOptions(enabled=True),
+        )
+        self._clients: dict[str, OAuthClientInformationFull] = {}
+
+    async def get_client(self, client_id: str) -> OAuthClientInformationFull | None:
+        return self._clients.get(client_id)
+
+    async def register_client(self, client_info: OAuthClientInformationFull) -> None:
+        if client_info.client_id:
+            self._clients[client_info.client_id] = client_info
+
+    async def authorize(
+        self, client: OAuthClientInformationFull, params: AuthorizationParams
+    ) -> str:
+        raise NotImplementedError("Direct bearer-token auth is used instead")
+
+    async def load_authorization_code(
+        self, client: OAuthClientInformationFull, authorization_code: str
+    ) -> AuthorizationCode | None:
+        return None
+
+    async def exchange_authorization_code(
+        self, client: OAuthClientInformationFull, authorization_code: AuthorizationCode
+    ) -> OAuthToken:
+        raise NotImplementedError("Direct bearer-token auth is used instead")
+
+    async def load_refresh_token(
+        self, client: OAuthClientInformationFull, refresh_token: str
+    ):
+        return None
+
+    async def exchange_refresh_token(self, client, refresh_token, scopes):
+        raise NotImplementedError("Refresh tokens are not supported")
+
+    async def load_access_token(self, token: str) -> AccessToken | None:
+        """Validate a SkyPortal token against /api/internal/profile."""
+        try:
+            async with httpx.AsyncClient(timeout=10) as client:
+                resp = await client.get(
+                    f"{SKYPORTAL_URL}/api/internal/profile",
+                    headers={"Authorization": f"token {token}"},
+                )
+            if not resp.is_success:
+                logger.warning(
+                    "Token validation failed: SkyPortal returned %s", resp.status_code
+                )
+                return None
+            data = resp.json().get("data", {})
+            username = data.get("username", "unknown")
+            user_id = data.get("id")
+            logger.info("Token validated for user: %s (id=%s)", username, user_id)
+            return AccessToken(
+                token=token,
+                client_id=username,
+                scopes=[f"user_id:{user_id}"],
+            )
+        except Exception:
+            logger.exception("Token validation error (SKYPORTAL_URL=%s)", SKYPORTAL_URL)
+            return None
+
+    async def revoke_token(self, token) -> None:
+        pass
+
+
+# ─── MCP server instance ────────────────────────────────────────────────────
+
+# For stdio mode, use env var auth; for HTTP mode, use OAuth provider
+_transport = os.getenv("MCP_TRANSPORT", "http")
+if _transport == "stdio":
+    # In stdio mode, no multi-user auth - use SKYPORTAL_TOKEN env var
+    mcp = FastMCP(
+        "SkyPortal",
+        instructions=(
+            "Use the get_api_quick_reference tool to learn about available "
+            "SkyPortal API endpoints and their parameters. Call it once at the "
+            "start of a session or when you need to look up endpoint details."
+        ),
+    )
+else:
+    # In HTTP mode, use OAuth provider for multi-user bearer token auth
+    mcp = FastMCP(
+        "SkyPortal",
+        instructions=(
+            "Use the get_api_quick_reference tool to learn about available "
+            "SkyPortal API endpoints and their parameters. Call it once at the "
+            "start of a session or when you need to look up endpoint details."
+        ),
+        auth=SkyPortalOAuthProvider(),
+    )
+
+# Import tool modules — their @mcp.tool() decorators register on import.
+# This MUST come after mcp is defined.
+from . import tools  # noqa: E402, F401
+
+# Entrypoint: run with `python -m services.mcp_server` (see __main__.py)

--- a/services/mcp_server/supervisor.conf
+++ b/services/mcp_server/supervisor.conf
@@ -1,0 +1,5 @@
+[program:mcp_server]
+command=/usr/bin/env python -m services.mcp_server
+environment=PYTHONPATH=".",PYTHONUNBUFFERED="1",MCP_TRANSPORT="http"
+stdout_logfile=log/mcp_server.log
+redirect_stderr=true

--- a/services/mcp_server/tools/__init__.py
+++ b/services/mcp_server/tools/__init__.py
@@ -1,0 +1,10 @@
+# Import all tool modules so their @mcp.tool() decorators register on import.
+from . import (  # noqa: F401
+    analysis,
+    api,
+    astro_utils,
+    bulk_analysis,
+    filtering,
+    observing,
+    source_products,
+)

--- a/services/mcp_server/tools/analysis.py
+++ b/services/mcp_server/tools/analysis.py
@@ -11,40 +11,39 @@ from .source_products import resolve_source_id
 @mcp.tool()
 async def analyze_light_curve(
     source_name: str,
-    filter_name: str = "ztfr",
+    filter_names: str = "ztfg,ztfr",
     baseline_threshold: float = 0.3,
-    output_format: str = "text",
+    output_format: str = "notebook",
 ) -> str:
-    """Analyze light curve evolution: rise, fade, duration, and variability.
+    """Analyze light curve evolution for multiple photometric bands.
 
     Calculates key temporal properties of a transient's light curve including
-    rise time, fade time, total duration, and pre-peak variability (flares).
+    rise time, fade time, total duration, and pre-peak variability (flares)
+    for each requested photometric band.
 
     Handles incomplete light curves:
     - Still rising: Reports time from first detection to current
     - Still fading: Reports time from peak to current
     - Returned to baseline: Reports complete rise + fade times
 
-    **IMPORTANT - User Preference:**
-    Before calling this tool, ask the user: "Would you like the analysis as
-    (1) text summary in chat, or (2) interactive plot in a notebook?"
-    - If (1): Use output_format="text" (default)
-    - If (2): Use output_format="notebook" and insert returned code into notebook
+    Generates CSV data file + Jupyter notebook with interactive Plotly plots
+    showing all bands overlaid, plus editable analysis code cells.
 
     Args:
         source_name: Source identifier - SkyPortal obj_id, ZTF name, or TNS name
-        filter_name: Photometric filter to analyze (default: "ztfr")
+        filter_names: Comma-separated photometric filters (default: "ztfg,ztfr")
+                     Examples: "ztfg,ztfr", "ztfg,ztfr,ztfi", "sdssr"
         baseline_threshold: Magnitude difference from peak to consider "baseline"
                           (default: 0.3 mag, i.e., source must fade by >0.3 mag
                           from peak to be considered at baseline)
-        output_format: Output format - "text" for chat summary or "notebook" for
-                      Python code to plot in a Jupyter notebook (default: "text")
+        output_format: Output format - "notebook" (default) generates Jupyter notebook + CSV,
+                      "text" returns summary in chat
 
     Returns:
+        - If output_format="notebook": Creates directory with CSV data file (all bands)
+          and Jupyter notebook with interactive Plotly plots and editable analysis code
         - If output_format="text": Formatted text summary with rise/fade times,
-          duration, rates, and variability metrics
-        - If output_format="notebook": Python code that creates an interactive
-          plot with embedded data and prints analysis results
+          duration, rates, and variability metrics for all bands
     """
     token = get_skyportal_token()
     if not token:
@@ -55,7 +54,10 @@ async def analyze_light_curve(
     if not obj_id:
         return f"Error: Could not resolve '{source_name}' to a SkyPortal source."
 
-    # Fetch photometry
+    # Parse filter list
+    filters = [f.strip() for f in filter_names.split(",")]
+
+    # Fetch photometry once for all filters
     try:
         async with httpx.AsyncClient(timeout=30) as client:
             resp = await client.get(
@@ -64,265 +66,489 @@ async def analyze_light_curve(
                 params={"format": "mag", "magsys": "ab"},
             )
         resp.raise_for_status()
-        data = resp.json().get("data", [])
+        all_data = resp.json().get("data", [])
     except Exception as e:
         return f"Error fetching photometry: {e}"
 
-    if not data:
+    if not all_data:
         return f"No photometry found for {obj_id}"
 
-    # Filter by requested band and valid detections
-    phot = [
-        p
-        for p in data
-        if p.get("filter") == filter_name
-        and p.get("mag") is not None
-        and p.get("magerr") is not None
+    # Process each filter and calculate metrics
+    filter_data = {}
+    for filter_name in filters:
+        phot = [
+            p
+            for p in all_data
+            if p.get("filter") == filter_name
+            and p.get("mag") is not None
+            and p.get("magerr") is not None
+        ]
+
+        if len(phot) < 2:
+            continue  # Skip filters with insufficient data
+
+        phot.sort(key=lambda p: p["mjd"])
+
+        mjds = np.array([p["mjd"] for p in phot])
+        mags = np.array([p["mag"] for p in phot])
+        magerrs = np.array([p["magerr"] for p in phot])
+
+        # Find peak (minimum magnitude = brightest)
+        peak_idx = np.argmin(mags)
+        peak_mjd = mjds[peak_idx]
+        peak_mag = mags[peak_idx]
+        peak_magerr = magerrs[peak_idx]
+
+        first_mjd = mjds[0]
+        first_mag = mags[0]
+        last_mjd = mjds[-1]
+        last_mag = mags[-1]
+
+        rise_time = peak_mjd - first_mjd
+        rise_mag = first_mag - peak_mag
+
+        still_rising = peak_idx == len(mjds) - 1
+
+        if still_rising:
+            fade_time = None
+            fade_mag = None
+            fade_rate = None
+            status = "Still rising"
+            duration = None
+        else:
+            post_peak_mags = mags[peak_idx:]
+            faded = post_peak_mags - peak_mag
+            baseline_reached = np.any(faded > baseline_threshold)
+
+            if baseline_reached:
+                baseline_idx = peak_idx + np.where(faded > baseline_threshold)[0][0]
+                fade_time = mjds[baseline_idx] - peak_mjd
+                fade_mag = (
+                    post_peak_mags[np.where(faded > baseline_threshold)[0][0]]
+                    - peak_mag
+                )
+                status = "Complete light curve"
+                duration = rise_time + fade_time
+            else:
+                fade_time = last_mjd - peak_mjd
+                fade_mag = last_mag - peak_mag
+                status = "Still fading"
+                duration = None
+
+            fade_rate = fade_mag / fade_time if fade_time and fade_time > 0 else None
+
+        rise_rate = rise_mag / rise_time if rise_time > 0 else None
+
+        # Pre-peak variability
+        if peak_idx > 1:
+            pre_peak_mags = mags[:peak_idx]
+            mag_diffs = np.diff(pre_peak_mags)
+            brightening_events = int(np.sum(mag_diffs < -0.1))
+            variability_rms = float(np.std(pre_peak_mags))
+        else:
+            brightening_events = 0
+            variability_rms = 0.0
+
+        filter_data[filter_name] = {
+            "mjds": mjds,
+            "mags": mags,
+            "magerrs": magerrs,
+            "peak_mjd": peak_mjd,
+            "peak_mag": peak_mag,
+            "peak_magerr": peak_magerr,
+            "first_mjd": first_mjd,
+            "last_mjd": last_mjd,
+            "rise_time": rise_time,
+            "rise_mag": rise_mag,
+            "rise_rate": rise_rate,
+            "fade_time": fade_time,
+            "fade_mag": fade_mag,
+            "fade_rate": fade_rate,
+            "duration": duration,
+            "status": status,
+            "still_rising": still_rising,
+            "brightening_events": brightening_events,
+            "variability_rms": variability_rms,
+            "n_points": len(mjds),
+        }
+
+    if not filter_data:
+        return f"No sufficient photometry for any requested filters: {filter_names}"
+
+    # Generate output
+    if output_format == "notebook":
+        return _generate_lightcurve_notebook(obj_id, filter_data, baseline_threshold)
+    else:
+        return _generate_lightcurve_text(obj_id, filter_data)
+
+
+def _generate_lightcurve_notebook(obj_id, filter_data, baseline_threshold):
+    """Generate CSV + Jupyter notebook for multi-band light curve analysis."""
+    import csv
+    import json
+    from pathlib import Path
+
+    # SkyPortal filter colors
+    filter_colors = {
+        "ztfg": "#28a745",
+        "ztfr": "#dc3545",
+        "ztfi": "#8b0000",
+        "sdssr": "#dc3545",
+    }
+
+    # Create output directory
+    output_dir = Path(f"{obj_id}_lightcurve_analysis")
+    output_dir.mkdir(exist_ok=True)
+
+    # === Write CSV with all bands ===
+    csv_path = output_dir / f"{obj_id}_lightcurve_data.csv"
+    with open(csv_path, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["filter", "mjd", "mag", "magerr"])
+        for filter_name, data in filter_data.items():
+            for i in range(len(data["mjds"])):
+                writer.writerow(
+                    [
+                        filter_name,
+                        data["mjds"][i],
+                        data["mags"][i],
+                        data["magerrs"][i],
+                    ]
+                )
+
+    # === Generate Jupyter Notebook ===
+    notebook_path = output_dir / f"{obj_id}_lightcurve_analysis.ipynb"
+    filter_list_str = ", ".join(filter_data.keys())
+
+    # Build Plotly trace code for each filter
+    plot_traces = []
+    for filter_name in filter_data:
+        color = filter_colors.get(filter_name, "#1f77b4")
+        plot_traces.append(
+            f"# {filter_name} photometry\n"
+            f"df_filt = df[df['filter'] == '{filter_name}']\n"
+            f"fig.add_trace(\n"
+            f"    go.Scatter(\n"
+            f"        x=df_filt['mjd'],\n"
+            f"        y=df_filt['mag'],\n"
+            f"        error_y=dict(type='data', array=df_filt['magerr'], visible=True, thickness=1.5),\n"
+            f"        mode='markers',\n"
+            f"        marker=dict(\n"
+            f"            size=6,\n"
+            f"            color=hex_to_rgba('{color}', 0.6),\n"
+            f"            line=dict(color='{color}', width=1.5)\n"
+            f"        ),\n"
+            f"        name='{filter_name}',\n"
+            f"        hovertemplate='MJD: %{{x:.2f}}<br>Mag: %{{y:.3f}}<br>Error: %{{error_y.array:.3f}}<extra></extra>'\n"
+            f"    )\n"
+            f")\n"
+        )
+
+    notebook = {
+        "cells": [
+            {
+                "cell_type": "markdown",
+                "metadata": {},
+                "source": [
+                    f"# Light Curve Analysis: {obj_id}\n\n",
+                    f"**Filters**: {filter_list_str}\n\n",
+                    "This notebook contains multi-band light curve analysis with editable code cells.\n",
+                ],
+            },
+            {
+                "cell_type": "code",
+                "execution_count": None,
+                "metadata": {},
+                "source": [
+                    "# Import dependencies\n",
+                    "import pandas as pd\n",
+                    "import numpy as np\n",
+                    "import plotly.graph_objects as go\n",
+                    "from plotly.offline import init_notebook_mode, iplot\n\n",
+                    "# Initialize Plotly offline mode\n",
+                    "init_notebook_mode(connected=True)\n",
+                    "print('✓ Plotly offline mode initialized')\n",
+                ],
+            },
+            {
+                "cell_type": "code",
+                "execution_count": None,
+                "metadata": {},
+                "source": [
+                    f"# Load multi-band light curve data\n",
+                    f"df = pd.read_csv('{obj_id}_lightcurve_data.csv')\n",
+                    f"print(f'Loaded {{len(df)}} total photometry points across {{df[\"filter\"].nunique()}} bands')\n",
+                    "print()\n",
+                    "print(df.groupby('filter').size().to_string())\n",
+                ],
+            },
+            {
+                "cell_type": "markdown",
+                "metadata": {},
+                "source": [
+                    "## Analysis Code\n\n",
+                    "The cells below contain the analysis code used to calculate rise/fade times, peak properties, etc.\n",
+                    "Edit these cells to customize the analysis (e.g., change baseline threshold, add new metrics).\n",
+                ],
+            },
+            {
+                "cell_type": "code",
+                "execution_count": None,
+                "metadata": {},
+                "source": [
+                    "# Analysis parameters (edit as needed)\n",
+                    f"baseline_threshold = {baseline_threshold}  # Magnitude difference from peak to consider baseline\n",
+                ],
+            },
+            {
+                "cell_type": "code",
+                "execution_count": None,
+                "metadata": {},
+                "source": [
+                    "# Function to analyze a single filter\n",
+                    "def analyze_filter(df, filter_name, baseline_threshold=0.3):\n",
+                    '    """Calculate rise/fade metrics for one photometric band."""\n',
+                    "    data = df[df['filter'] == filter_name].sort_values('mjd')\n",
+                    "    if len(data) < 2:\n",
+                    "        return None\n",
+                    "    \n",
+                    "    mjds = data['mjd'].values\n",
+                    "    mags = data['mag'].values\n",
+                    "    magerrs = data['magerr'].values\n",
+                    "    \n",
+                    "    # Find peak (minimum magnitude = brightest)\n",
+                    "    peak_idx = np.argmin(mags)\n",
+                    "    peak_mjd = mjds[peak_idx]\n",
+                    "    peak_mag = mags[peak_idx]\n",
+                    "    \n",
+                    "    # Rise time: first detection to peak\n",
+                    "    first_mjd = mjds[0]\n",
+                    "    rise_time = peak_mjd - first_mjd\n",
+                    "    rise_mag = mags[0] - peak_mag\n",
+                    "    rise_rate = rise_mag / rise_time if rise_time > 0 else None\n",
+                    "    \n",
+                    "    # Check if still rising (peak is last point)\n",
+                    "    still_rising = peak_idx == len(mjds) - 1\n",
+                    "    \n",
+                    "    # Fade analysis\n",
+                    "    if still_rising:\n",
+                    "        status = 'Still rising'\n",
+                    "        fade_time = None\n",
+                    "        fade_rate = None\n",
+                    "        duration = None\n",
+                    "    else:\n",
+                    "        post_peak_mags = mags[peak_idx:]\n",
+                    "        faded = post_peak_mags - peak_mag\n",
+                    "        baseline_reached = np.any(faded > baseline_threshold)\n",
+                    "        \n",
+                    "        if baseline_reached:\n",
+                    "            baseline_idx = peak_idx + np.where(faded > baseline_threshold)[0][0]\n",
+                    "            fade_time = mjds[baseline_idx] - peak_mjd\n",
+                    "            status = 'Complete'\n",
+                    "            duration = rise_time + fade_time\n",
+                    "        else:\n",
+                    "            fade_time = mjds[-1] - peak_mjd\n",
+                    "            status = 'Still fading'\n",
+                    "            duration = None\n",
+                    "        \n",
+                    "        fade_rate = (mags[-1] - peak_mag) / fade_time if fade_time and fade_time > 0 else None\n",
+                    "    \n",
+                    "    # Pre-peak variability\n",
+                    "    if peak_idx > 1:\n",
+                    "        pre_peak_mags = mags[:peak_idx]\n",
+                    "        variability_rms = np.std(pre_peak_mags)\n",
+                    "        brightening_events = int(np.sum(np.diff(pre_peak_mags) < -0.1))\n",
+                    "    else:\n",
+                    "        variability_rms = 0.0\n",
+                    "        brightening_events = 0\n",
+                    "    \n",
+                    "    return {\n",
+                    "        'filter': filter_name,\n",
+                    "        'n_points': len(mjds),\n",
+                    "        'status': status,\n",
+                    "        'peak_mag': f'{peak_mag:.2f}',\n",
+                    "        'peak_mjd': f'{peak_mjd:.2f}',\n",
+                    "        'rise_time': f'{rise_time:.1f}',\n",
+                    "        'rise_rate': f'{rise_rate:.3f}' if rise_rate else 'N/A',\n",
+                    "        'fade_time': f'{fade_time:.1f}' if fade_time else 'N/A',\n",
+                    "        'fade_rate': f'{fade_rate:.3f}' if fade_rate else 'N/A',\n",
+                    "        'duration': f'{duration:.1f}' if duration else 'N/A',\n",
+                    "        'rms': f'{variability_rms:.3f}',\n",
+                    "        'flares': brightening_events,\n",
+                    "    }\n",
+                ],
+            },
+            {
+                "cell_type": "code",
+                "execution_count": None,
+                "metadata": {},
+                "source": [
+                    "# Calculate metrics for all filters\n",
+                    "results = []\n",
+                    "for filt in df['filter'].unique():\n",
+                    "    result = analyze_filter(df, filt, baseline_threshold)\n",
+                    "    if result:\n",
+                    "        results.append(result)\n\n",
+                    "# Display results table\n",
+                    "results_df = pd.DataFrame(results)\n",
+                    "print('=' * 80)\n",
+                    f"print('LIGHT CURVE ANALYSIS: {obj_id}')\n",
+                    "print('=' * 80)\n",
+                    "print()\n",
+                    "print(results_df.to_string(index=False))\n",
+                    "print()\n",
+                    "print('=' * 80)\n",
+                ],
+            },
+            {
+                "cell_type": "markdown",
+                "metadata": {},
+                "source": [
+                    "## Multi-band Light Curve Plot\n",
+                ],
+            },
+            {
+                "cell_type": "code",
+                "execution_count": None,
+                "metadata": {},
+                "source": [
+                    "# Create multi-band interactive plot\n",
+                    "fig = go.Figure()\n\n",
+                    "# Helper function to convert hex to rgba\n",
+                    "def hex_to_rgba(hex_color, alpha):\n",
+                    "    h = hex_color.lstrip('#')\n",
+                    "    rgb = tuple(int(h[i:i+2], 16) for i in (0, 2, 4))\n",
+                    "    return f'rgba({rgb[0]},{rgb[1]},{rgb[2]},{alpha})'\n\n",
+                    "\n".join(plot_traces) + "\n",
+                    "# Update layout\n",
+                    "fig.update_xaxes(title_text='MJD')\n",
+                    "fig.update_yaxes(title_text='AB Magnitude', autorange='reversed')\n",
+                    "fig.update_layout(\n",
+                    f"    title='{obj_id} Multi-band Light Curve',\n",
+                    "    height=600,\n",
+                    "    showlegend=True,\n",
+                    "    hovermode='closest',\n",
+                    "    template='plotly_white'\n",
+                    ")\n\n",
+                    "# Display interactive figure\n",
+                    "iplot(fig)\n",
+                ],
+            },
+        ],
+        "metadata": {
+            "kernelspec": {
+                "display_name": "Python 3",
+                "language": "python",
+                "name": "python3",
+            },
+            "language_info": {"name": "python", "version": "3.9.0"},
+        },
+        "nbformat": 4,
+        "nbformat_minor": 4,
+    }
+
+    with open(notebook_path, "w") as f:
+        json.dump(notebook, f, indent=2)
+
+    # Build summary
+    summary_lines = [
+        "Light curve analysis complete!",
+        "",
+        f"Output files saved to: {output_dir}/",
+        "",
+        "Files created:",
+        f"- {csv_path.name} - Multi-band light curve data",
+        f"- {notebook_path.name} - Interactive Jupyter notebook with analysis code",
+        "",
+        "Summary:",
+        f"- Source: {obj_id}",
+        f"- Filters: {', '.join(filter_data.keys())}",
+        "",
+        "Per-filter metrics:",
     ]
 
-    if len(phot) < 2:
-        return f"Insufficient photometry in {filter_name} band (need at least 2 points)"
-
-    # Sort by time
-    phot.sort(key=lambda p: p["mjd"])
-
-    # Extract arrays
-    mjds = np.array([p["mjd"] for p in phot])
-    mags = np.array([p["mag"] for p in phot])
-    magerrs = np.array([p["magerr"] for p in phot])
-
-    # Find peak (minimum magnitude = brightest)
-    peak_idx = np.argmin(mags)
-    peak_mjd = mjds[peak_idx]
-    peak_mag = mags[peak_idx]
-
-    # First and last detection
-    first_mjd = mjds[0]
-    first_mag = mags[0]
-    last_mjd = mjds[-1]
-    last_mag = mags[-1]
-
-    # Rise time: first detection to peak
-    rise_time = peak_mjd - first_mjd
-    rise_mag = first_mag - peak_mag  # How much it brightened
-
-    # Check if still rising (peak is last point)
-    still_rising = peak_idx == len(mjds) - 1
-
-    # Fade analysis
-    if still_rising:
-        fade_time = None
-        fade_mag = None
-        fade_rate = None
-        status = "Still rising"
-        duration = None
-    else:
-        # Post-peak data
-        post_peak_mjds = mjds[peak_idx:]
-        post_peak_mags = mags[peak_idx:]
-
-        # Check if returned to baseline (faded by > threshold mag)
-        faded = post_peak_mags - peak_mag
-        baseline_reached = np.any(faded > baseline_threshold)
-
-        if baseline_reached:
-            # Find first point where baseline is reached
-            baseline_idx = peak_idx + np.where(faded > baseline_threshold)[0][0]
-            baseline_mjd = mjds[baseline_idx]
-            fade_time = baseline_mjd - peak_mjd
-            fade_mag = (
-                post_peak_mags[np.where(faded > baseline_threshold)[0][0]] - peak_mag
-            )
-            status = "Complete light curve"
-            duration = rise_time + fade_time
-        else:
-            # Still fading
-            fade_time = last_mjd - peak_mjd
-            fade_mag = last_mag - peak_mag
-            status = "Still fading"
-            duration = None
-
-        fade_rate = fade_mag / fade_time if fade_time > 0 else None
-
-    # Rise rate
-    rise_rate = rise_mag / rise_time if rise_time > 0 else None
-
-    # Pre-peak variability analysis (detect flares)
-    if peak_idx > 1:
-        pre_peak_mags = mags[:peak_idx]
-        # Check for magnitude increases before peak (flares)
-        mag_diffs = np.diff(pre_peak_mags)
-        brightening_events = np.sum(mag_diffs < -0.1)  # Brightening by >0.1 mag
-        variability_rms = np.std(pre_peak_mags)
-    else:
-        brightening_events = 0
-        variability_rms = 0.0
-
-    # Generate notebook code if requested
-    if output_format == "notebook":
-        # Convert arrays to Python lists for embedding in code
-        mjd_list = mjds.tolist()
-        mag_list = mags.tolist()
-        magerr_list = magerrs.tolist()
-
-        code = f'''import matplotlib.pyplot as plt
-                import numpy as np
-
-                # Light curve data for {obj_id} ({filter_name} band)
-                mjd = {mjd_list}
-                mag = {mag_list}
-                magerr = {magerr_list}
-
-                # Analysis results
-                peak_mjd = {peak_mjd}
-                peak_mag = {peak_mag}
-                first_mjd = {first_mjd}
-                rise_time = {rise_time}
-                rise_mag = {rise_mag}
-                status = "{status}"
-
-                # Create figure
-                fig, ax = plt.subplots(figsize=(12, 6))
-
-                # Plot photometry
-                ax.errorbar(mjd, mag, yerr=magerr, fmt='o', markersize=6,
-                            capsize=3, label='{filter_name} photometry', alpha=0.7)
-
-                # Mark peak
-                ax.axvline(peak_mjd, color='red', linestyle='--', linewidth=2,
-                        label=f'Peak: MJD {{peak_mjd:.2f}}')
-                ax.plot(peak_mjd, peak_mag, 'r*', markersize=20, label=f'Peak mag: {{peak_mag:.2f}}')
-
-                # Formatting
-                ax.invert_yaxis()  # Brighter = lower magnitude
-                ax.set_xlabel('MJD', fontsize=12)
-                ax.set_ylabel('AB Magnitude', fontsize=12)
-                ax.set_title(f'{obj_id} Light Curve Analysis ({filter_name})', fontsize=14, fontweight='bold')
-                ax.legend(loc='best', fontsize=10)
-                ax.grid(True, alpha=0.3)
-
-                plt.tight_layout()
-                plt.show()
-
-                # Print analysis results
-                print("=" * 60)
-                print(f"LIGHT CURVE ANALYSIS: {obj_id}")
-                print(f"Filter: {filter_name}")
-                print("=" * 60)
-                print()
-                print("## OVERVIEW")
-                print(f"Status:           {{status}}")
-                print(f"Total points:     {{len(mjd)}}")
-                print(f"Time span:        {{min(mjd):.1f}} - {{max(mjd):.1f}} MJD ({{max(mjd) - min(mjd):.1f}} days)")
-                print()
-                print("## PEAK PROPERTIES")
-                print(f"Peak magnitude:   {{peak_mag:.2f}} mag")
-                print(f"Peak time:        MJD {{peak_mjd:.2f}}")
-                print(f"Peak epoch:       Day {{peak_mjd - first_mjd:.1f}} (from first detection)")
-                print()
-                print("## RISE PROPERTIES")
-                print(f"Rise time:        {{rise_time:.1f}} days")
-                print(f"Rise amplitude:   {{rise_mag:.2f}} mag")'''
-
-        if rise_rate:
-            code += f'\nprint(f"Rise rate:        {{{rise_rate:.3f}}} mag/day")'
-        if still_rising:
-            code += '\nprint("Note:             Source is still rising (peak = last detection)")'
-
-        code += '\nprint()\nprint("## FADE PROPERTIES")'
-
-        if fade_time:
-            code += f"""
-print(f"Fade time:        {fade_time:.1f} days")
-print(f"Fade amplitude:   {fade_mag:.2f} mag")"""
-            if fade_rate:
-                code += f"""
-print(f"Fade rate:        {fade_rate:.3f} mag/day")"""
-        else:
-            code += '\nprint("Fade time:        Not yet available (still rising)")'
-
-        if duration:
-            code += f"""
-print(f"Total duration:   {duration:.1f} days (rise + fade)")"""
-        else:
-            code += '\nprint("Total duration:   Not yet determined (light curve incomplete)")'
-
-        code += f"""
-print()
-print("## VARIABILITY")
-print(f"Pre-peak RMS:     {variability_rms:.3f} mag")"""
-
-        if brightening_events > 0:
-            code += f"""
-print(f"Early flares:     {brightening_events} brightening event(s) detected before peak")
-print("                  (magnitude increases >0.1 mag)")"""
-        else:
-            code += '\nprint("Early flares:     None detected")'
-
-        code += '\nprint()\nprint("=" * 60)'
-
-        return code
-
-    # Format text output
-    lines = ["=" * 60]
-    lines.append(f"LIGHT CURVE ANALYSIS: {obj_id}")
-    lines.append(f"Filter: {filter_name}")
-    lines.append("=" * 60)
-    lines.append("")
-
-    lines.append("## OVERVIEW")
-    lines.append(f"Status:           {status}")
-    lines.append(f"Total points:     {len(phot)}")
-    lines.append(
-        f"Time span:        {first_mjd:.1f} - {last_mjd:.1f} MJD ({last_mjd - first_mjd:.1f} days)"
-    )
-    lines.append("")
-
-    lines.append("## PEAK PROPERTIES")
-    lines.append(f"Peak magnitude:   {peak_mag:.2f} ± {magerrs[peak_idx]:.2f} mag")
-    lines.append(f"Peak time:        MJD {peak_mjd:.2f}")
-    lines.append(
-        f"Peak epoch:       Day {peak_mjd - first_mjd:.1f} (from first detection)"
-    )
-    lines.append("")
-
-    lines.append("## RISE PROPERTIES")
-    lines.append(f"Rise time:        {rise_time:.1f} days")
-    lines.append(f"Rise amplitude:   {rise_mag:.2f} mag")
-    if rise_rate:
-        lines.append(f"Rise rate:        {rise_rate:.3f} mag/day")
-    if still_rising:
-        lines.append("Note:             Source is still rising (peak = last detection)")
-    lines.append("")
-
-    lines.append("## FADE PROPERTIES")
-    if fade_time:
-        lines.append(f"Fade time:        {fade_time:.1f} days")
-        lines.append(f"Fade amplitude:   {fade_mag:.2f} mag")
-        if fade_rate:
-            lines.append(f"Fade rate:        {fade_rate:.3f} mag/day")
-    else:
-        lines.append("Fade time:        Not yet available (still rising)")
-
-    if duration:
-        lines.append(f"Total duration:   {duration:.1f} days (rise + fade)")
-    else:
-        lines.append("Total duration:   Not yet determined (light curve incomplete)")
-    lines.append("")
-
-    lines.append("## VARIABILITY")
-    lines.append(f"Pre-peak RMS:     {variability_rms:.3f} mag")
-    if brightening_events > 0:
-        lines.append(
-            f"Early flares:     {brightening_events} brightening event(s) detected before peak"
+    for filter_name, data in filter_data.items():
+        summary_lines.append(f"  {filter_name}:")
+        summary_lines.append(
+            f"    Points: {data['n_points']}, Status: {data['status']}"
         )
-        lines.append("                  (magnitude increases >0.1 mag)")
-    else:
-        lines.append("Early flares:     None detected")
+        summary_lines.append(
+            f"    Peak: {data['peak_mag']:.2f} mag at MJD {data['peak_mjd']:.2f}"
+        )
+        summary_lines.append(f"    Rise: {data['rise_time']:.1f} days")
+        if data["fade_time"]:
+            summary_lines.append(f"    Fade: {data['fade_time']:.1f} days")
+        if data["duration"]:
+            summary_lines.append(f"    Duration: {data['duration']:.1f} days")
+
+    summary_lines.append("")
+    summary_lines.append(
+        "Open the notebook to view interactive plots and customize the analysis!"
+    )
+
+    return "\n".join(summary_lines)
+
+
+def _generate_lightcurve_text(obj_id, filter_data):
+    """Generate text summary for multi-band light curve analysis."""
+    lines = ["=" * 80]
+    lines.append(f"LIGHT CURVE ANALYSIS: {obj_id}")
+    lines.append(f"Filters: {', '.join(filter_data.keys())}")
+    lines.append("=" * 80)
     lines.append("")
 
-    lines.append("=" * 60)
+    for filter_name, data in filter_data.items():
+        lines.append(f"## {filter_name.upper()} BAND")
+        lines.append("")
+        lines.append("OVERVIEW")
+        lines.append(f"  Status:        {data['status']}")
+        lines.append(f"  Total points:  {data['n_points']}")
+        lines.append(
+            f"  Time span:     {data['first_mjd']:.1f} - {data['last_mjd']:.1f} MJD "
+            f"({data['last_mjd'] - data['first_mjd']:.1f} days)"
+        )
+        lines.append("")
 
+        lines.append("PEAK PROPERTIES")
+        lines.append(
+            f"  Peak mag:      {data['peak_mag']:.2f} ± {data['peak_magerr']:.2f} mag"
+        )
+        lines.append(f"  Peak time:     MJD {data['peak_mjd']:.2f}")
+        lines.append("")
+
+        lines.append("RISE PROPERTIES")
+        lines.append(f"  Rise time:     {data['rise_time']:.1f} days")
+        lines.append(f"  Rise mag:      {data['rise_mag']:.2f} mag")
+        if data["rise_rate"]:
+            lines.append(f"  Rise rate:     {data['rise_rate']:.3f} mag/day")
+        if data["still_rising"]:
+            lines.append("  Note:          Still rising")
+        lines.append("")
+
+        lines.append("FADE PROPERTIES")
+        if data["fade_time"]:
+            lines.append(f"  Fade time:     {data['fade_time']:.1f} days")
+            lines.append(f"  Fade mag:      {data['fade_mag']:.2f} mag")
+            if data["fade_rate"]:
+                lines.append(f"  Fade rate:     {data['fade_rate']:.3f} mag/day")
+        else:
+            lines.append("  Fade time:     N/A (still rising)")
+
+        if data["duration"]:
+            lines.append(f"  Total duration: {data['duration']:.1f} days")
+        lines.append("")
+
+        lines.append("VARIABILITY")
+        lines.append(f"  Pre-peak RMS:  {data['variability_rms']:.3f} mag")
+        if data["brightening_events"] > 0:
+            lines.append(f"  Early flares:  {data['brightening_events']} event(s)")
+        else:
+            lines.append("  Early flares:  None detected")
+        lines.append("")
+        lines.append("-" * 80)
+        lines.append("")
+
+    lines.append("=" * 80)
     return "\n".join(lines)
 
 
@@ -331,55 +557,38 @@ async def analyze_color_evolution(
     source_name: str,
     band1: str = "ztfg",
     band2: str = "ztfr",
-    method: str = "matched",
     max_time_gap: float = 0.5,
     max_data_gap: float = 3.0,
-    output_format: str = "text",
+    output_format: str = "notebook",
 ) -> str:
     """Analyze color evolution and color at peak brightness.
 
-    Calculates color curves (band1 - band2) over time using two methods:
+    Calculates color curves (band1 - band2) using BOTH methods:
+    - **Matched**: Day-to-day colors (pairs close observations)
+    - **Interpolated**: Rolling/continuous colors (interpolates for smooth curve)
 
-    1. **Matched observations** (method="matched"): Pairs observations from
-       each band that are close in time, but avoids calculating colors
-       across large gaps in the data.
-
-    2. **Interpolated** (method="interpolated"): Interpolates one band to
-       match the other's observation times, creating a rolling/continuous
-       color measurement. More measurements but assumes smooth evolution.
-
-    **IMPORTANT - User Preferences:**
-    Before calling this tool, ask the user TWO questions:
-    1. "Would you like day-to-day colors (matched method) or rolling/continuous
-       colors (interpolated method)?"
-    2. "Would you like the analysis as text in chat or interactive plot in notebook?"
+    Generates CSV data file + Jupyter notebook with overlaid plots.
 
     Args:
         source_name: Source identifier - SkyPortal obj_id, ZTF name, or TNS name
         band1: First photometric filter (default: "ztfg")
         band2: Second photometric filter (default: "ztfr")
-        method: Calculation method - "matched" or "interpolated" (default: "matched")
         max_time_gap: For matched method - maximum time difference (days) to
                      pair observations (default: 0.5 days)
         max_data_gap: For matched method - if gap between consecutive observations
                      in either band exceeds this, don't calculate colors across
                      the gap (default: 3.0 days). Prevents spurious colors during
                      observing gaps.
-        output_format: Output format - "text" for chat summary or "notebook" for
-                      Python code to plot in a Jupyter notebook (default: "text")
+        output_format: Output format - "notebook" (default) generates Jupyter notebook + CSV,
+                      "text" returns summary in chat
 
     Returns:
-        - If output_format="text": Formatted text summary with color at peak,
-          evolution statistics, and CSV table of measurements
-        - If output_format="notebook": Python code that creates interactive plots
-          (light curves + color evolution) with embedded data and analysis results
+        - If output_format="notebook": Path to generated notebook and CSV files
+        - If output_format="text": Formatted text summary with color measurements
     """
     token = get_skyportal_token()
     if not token:
         return "Not authenticated. Configure SKYPORTAL_TOKEN or send Bearer token."
-
-    if method not in ("matched", "interpolated"):
-        return "Error: method must be 'matched' or 'interpolated'"
 
     # Resolve source name
     obj_id = await resolve_source_id(source_name)
@@ -434,106 +643,100 @@ async def analyze_color_evolution(
     mags2 = np.array([p["mag"] for p in phot2])
     errs2 = np.array([p["magerr"] for p in phot2])
 
-    # Calculate colors based on method
-    colors = []
+    # === Calculate MATCHED colors ===
+    matched_colors = []
+    for i, p1 in enumerate(phot1):
+        mjd1 = p1["mjd"]
+        mag1 = p1["mag"]
+        err1 = p1["magerr"]
 
-    if method == "matched":
-        # Matched observations - pair close observations but respect gaps
-        for i, p1 in enumerate(phot1):
-            mjd1 = p1["mjd"]
-            mag1 = p1["mag"]
-            err1 = p1["magerr"]
+        # Check if this observation is in a large gap
+        if i > 0:
+            prev_gap = mjd1 - phot1[i - 1]["mjd"]
+        else:
+            prev_gap = 0
 
-            # Check if this observation is in a large gap
-            # (if time to prev/next obs > max_data_gap, skip)
-            if i > 0:
-                prev_gap = mjd1 - phot1[i - 1]["mjd"]
+        if i < len(phot1) - 1:
+            next_gap = phot1[i + 1]["mjd"] - mjd1
+        else:
+            next_gap = 0
+
+        in_large_gap = (prev_gap > max_data_gap) or (next_gap > max_data_gap)
+
+        # Find closest observation in band2
+        time_diffs = np.abs(mjds2 - mjd1)
+        closest_idx = np.argmin(time_diffs)
+
+        if time_diffs[closest_idx] <= max_time_gap and not in_large_gap:
+            # Also check if band2 observation is in a large gap
+            if closest_idx > 0:
+                prev_gap2 = mjds2[closest_idx] - mjds2[closest_idx - 1]
             else:
-                prev_gap = 0
+                prev_gap2 = 0
 
-            if i < len(phot1) - 1:
-                next_gap = phot1[i + 1]["mjd"] - mjd1
+            if closest_idx < len(mjds2) - 1:
+                next_gap2 = mjds2[closest_idx + 1] - mjds2[closest_idx]
             else:
-                next_gap = 0
+                next_gap2 = 0
 
-            in_large_gap = (prev_gap > max_data_gap) or (next_gap > max_data_gap)
+            in_large_gap2 = (prev_gap2 > max_data_gap) or (next_gap2 > max_data_gap)
 
-            # Find closest observation in band2
-            time_diffs = np.abs(mjds2 - mjd1)
-            closest_idx = np.argmin(time_diffs)
+            if not in_large_gap2:
+                mag2 = mags2[closest_idx]
+                err2 = errs2[closest_idx]
 
-            if time_diffs[closest_idx] <= max_time_gap and not in_large_gap:
-                # Also check if band2 observation is in a large gap
-                if closest_idx > 0:
-                    prev_gap2 = mjds2[closest_idx] - mjds2[closest_idx - 1]
-                else:
-                    prev_gap2 = 0
+                color = mag1 - mag2
+                color_err = np.sqrt(err1**2 + err2**2)
 
-                if closest_idx < len(mjds2) - 1:
-                    next_gap2 = mjds2[closest_idx + 1] - mjds2[closest_idx]
-                else:
-                    next_gap2 = 0
+                matched_colors.append(
+                    {
+                        "mjd": mjd1,
+                        "color": color,
+                        "color_err": color_err,
+                        "mag1": mag1,
+                        "mag2": mag2,
+                    }
+                )
 
-                in_large_gap2 = (prev_gap2 > max_data_gap) or (next_gap2 > max_data_gap)
+    # === Calculate INTERPOLATED colors ===
+    from scipy.interpolate import interp1d
 
-                if not in_large_gap2:
-                    mag2 = mags2[closest_idx]
-                    err2 = errs2[closest_idx]
+    interpolated_colors = []
+    try:
+        interp_func = interp1d(
+            mjds2, mags2, kind="linear", bounds_error=False, fill_value=np.nan
+        )
+        interp_err_func = interp1d(
+            mjds2, errs2, kind="linear", bounds_error=False, fill_value=np.nan
+        )
 
-                    color = mag1 - mag2
-                    color_err = np.sqrt(err1**2 + err2**2)
+        for i, mjd1 in enumerate(mjds1):
+            mag1 = mags1[i]
+            err1 = errs1[i]
 
-                    colors.append(
-                        {
-                            "mjd": mjd1,
-                            "color": color,
-                            "color_err": color_err,
-                            "mag1": mag1,
-                            "mag2": mag2,
-                        }
-                    )
+            # Interpolate band2
+            mag2_interp = interp_func(mjd1)
+            err2_interp = interp_err_func(mjd1)
 
-    else:  # interpolated
-        # Interpolate band2 to match band1 times
-        # Use linear interpolation
-        from scipy.interpolate import interp1d
+            # Only use if interpolation is valid (within band2 time range)
+            if not np.isnan(mag2_interp):
+                color = mag1 - mag2_interp
+                color_err = np.sqrt(err1**2 + err2_interp**2)
 
-        try:
-            interp_func = interp1d(
-                mjds2, mags2, kind="linear", bounds_error=False, fill_value=np.nan
-            )
-            interp_err_func = interp1d(
-                mjds2, errs2, kind="linear", bounds_error=False, fill_value=np.nan
-            )
+                interpolated_colors.append(
+                    {
+                        "mjd": mjd1,
+                        "color": color,
+                        "color_err": color_err,
+                        "mag1": mag1,
+                        "mag2": mag2_interp,
+                    }
+                )
+    except Exception as e:
+        return f"Error in interpolation: {e}"
 
-            for i, mjd1 in enumerate(mjds1):
-                mag1 = mags1[i]
-                err1 = errs1[i]
-
-                # Interpolate band2
-                mag2_interp = interp_func(mjd1)
-                err2_interp = interp_err_func(mjd1)
-
-                # Only use if interpolation is valid (within band2 time range)
-                if not np.isnan(mag2_interp):
-                    color = mag1 - mag2_interp
-                    # Conservative error: add interpolation uncertainty
-                    color_err = np.sqrt(err1**2 + err2_interp**2)
-
-                    colors.append(
-                        {
-                            "mjd": mjd1,
-                            "color": color,
-                            "color_err": color_err,
-                            "mag1": mag1,
-                            "mag2": mag2_interp,
-                        }
-                    )
-        except Exception as e:
-            return f"Error in interpolation: {e}. Try 'matched' method instead."
-
-    if len(colors) < 2:
-        return f"Insufficient color measurements (got {len(colors)}, need at least 2). Try adjusting max_time_gap or method."
+    if len(matched_colors) < 2 and len(interpolated_colors) < 2:
+        return f"Insufficient color measurements. Try adjusting max_time_gap parameter."
 
     # Find peak in each band
     peak_idx1 = np.argmin(mags1)
@@ -543,161 +746,366 @@ async def analyze_color_evolution(
     peak_mag1 = mags1[peak_idx1]
     peak_mag2 = mags2[peak_idx2]
 
-    # Find color closest to peak time (use average of peak times)
-    peak_mjd_avg = (peak_mjd1 + peak_mjd2) / 2
-    color_mjds = np.array([c["mjd"] for c in colors])
-    peak_color_idx = np.argmin(np.abs(color_mjds - peak_mjd_avg))
-    peak_color = colors[peak_color_idx]
+    # Use matched colors for statistics (more reliable)
+    if len(matched_colors) >= 2:
+        peak_mjd_avg = (peak_mjd1 + peak_mjd2) / 2
+        color_mjds = np.array([c["mjd"] for c in matched_colors])
+        peak_color_idx = np.argmin(np.abs(color_mjds - peak_mjd_avg))
+        peak_color = matched_colors[peak_color_idx]
 
-    # Color evolution statistics
-    color_vals = np.array([c["color"] for c in colors])
-    mean_color = np.mean(color_vals)
-    color_range = np.ptp(color_vals)
-    color_std = np.std(color_vals)
+        color_vals = np.array([c["color"] for c in matched_colors])
+        mean_color = np.mean(color_vals)
+        color_range = np.ptp(color_vals)
+        color_std = np.std(color_vals)
 
-    # Simple linear trend (slope)
-    if len(colors) > 2:
-        color_mjds_centered = color_mjds - color_mjds[0]
-        slope, _ = np.polyfit(color_mjds_centered, color_vals, 1)
-        trend = "bluing" if slope < -0.01 else "reddening" if slope > 0.01 else "stable"
+        if len(matched_colors) > 2:
+            color_mjds_centered = color_mjds - color_mjds[0]
+            slope, _ = np.polyfit(color_mjds_centered, color_vals, 1)
+            trend = (
+                "bluing" if slope < -0.01 else "reddening" if slope > 0.01 else "stable"
+            )
+        else:
+            slope = 0
+            trend = "insufficient data"
     else:
+        peak_color = {"color": np.nan, "color_err": np.nan, "mjd": np.nan}
+        mean_color = np.nan
+        color_range = np.nan
+        color_std = np.nan
         slope = 0
-        trend = "insufficient data"
+        trend = "insufficient matched data"
 
-    # Generate notebook code if requested
+    # Generate output
     if output_format == "notebook":
-        # Convert to lists for embedding
-        mjd1_list = mjds1.tolist()
-        mag1_list = mags1.tolist()
-        err1_list = errs1.tolist()
-        mjd2_list = mjds2.tolist()
-        mag2_list = mags2.tolist()
-        err2_list = errs2.tolist()
-        color_mjd_list = color_mjds.tolist()
-        color_val_list = color_vals.tolist()
-        color_err_list = [c["color_err"] for c in colors]
+        import csv
+        import json
+        from pathlib import Path
 
-        code = f'''import matplotlib.pyplot as plt
-import numpy as np
+        # Create output directory
+        output_dir = Path.cwd() / f"{obj_id}_color_analysis"
+        output_dir.mkdir(exist_ok=True)
 
-# Photometry data for {obj_id}
-mjd_{band1} = {mjd1_list}
-mag_{band1} = {mag1_list}
-err_{band1} = {err1_list}
+        # === Generate CSV file ===
+        csv_path = output_dir / f"{obj_id}_color_data.csv"
+        with open(csv_path, "w", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow(
+                [
+                    "mjd",
+                    f"mag_{band1}",
+                    f"magerr_{band1}",
+                    f"mag_{band2}",
+                    f"magerr_{band2}",
+                    "color_matched",
+                    "color_matched_err",
+                    "color_interpolated",
+                    "color_interpolated_err",
+                ]
+            )
 
-mjd_{band2} = {mjd2_list}
-mag_{band2} = {mag2_list}
-err_{band2} = {err2_list}
+            # Build lookup dicts for colors
+            matched_dict = {
+                c["mjd"]: (c["color"], c["color_err"]) for c in matched_colors
+            }
+            interp_dict = {
+                c["mjd"]: (c["color"], c["color_err"]) for c in interpolated_colors
+            }
 
-# Color measurements ({band1} - {band2})
-color_mjd = {color_mjd_list}
-color = {color_val_list}
-color_err = {color_err_list}
+            # Write all band1 observations with corresponding colors
+            for i in range(len(mjds1)):
+                mjd = mjds1[i]
+                matched_val, matched_err = matched_dict.get(mjd, (None, None))
+                interp_val, interp_err = interp_dict.get(mjd, (None, None))
 
-# Analysis results
-peak_mjd_{band1} = {peak_mjd1}
-peak_mag_{band1} = {peak_mag1}
-peak_mjd_{band2} = {peak_mjd2}
-peak_mag_{band2} = {peak_mag2}
-peak_color = {peak_color["color"]}
-mean_color = {mean_color}
-trend = "{trend}"
+                writer.writerow(
+                    [
+                        mjd,
+                        mags1[i],
+                        errs1[i],
+                        None,
+                        None,
+                        matched_val,
+                        matched_err,
+                        interp_val,
+                        interp_err,
+                    ]
+                )
 
-# Create figure with two subplots
-fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(12, 10), sharex=True)
+            # Write band2-only observations
+            for i in range(len(mjds2)):
+                mjd = mjds2[i]
+                if mjd not in mjds1:
+                    writer.writerow(
+                        [mjd, None, None, mags2[i], errs2[i], None, None, None, None]
+                    )
 
-# Top panel: Light curves
-ax1.errorbar(mjd_{band1}, mag_{band1}, yerr=err_{band1}, fmt='o',
-             label='{band1}', color='blue', alpha=0.7, capsize=3)
-ax1.errorbar(mjd_{band2}, mag_{band2}, yerr=err_{band2}, fmt='s',
-             label='{band2}', color='red', alpha=0.7, capsize=3)
-ax1.axvline(peak_mjd_{band1}, color='blue', linestyle='--', alpha=0.5)
-ax1.axvline(peak_mjd_{band2}, color='red', linestyle='--', alpha=0.5)
-ax1.invert_yaxis()
-ax1.set_ylabel('AB Magnitude', fontsize=12)
-ax1.set_title(f'{obj_id} Multi-band Light Curves', fontsize=14, fontweight='bold')
-ax1.legend(loc='best', fontsize=10)
-ax1.grid(True, alpha=0.3)
+        # === Generate Jupyter Notebook ===
+        notebook_path = output_dir / f"{obj_id}_color_analysis.ipynb"
 
-# Bottom panel: Color evolution
-ax2.errorbar(color_mjd, color, yerr=color_err, fmt='o',
-             color='purple', markersize=6, capsize=3, alpha=0.7)
-ax2.axhline(peak_color, color='red', linestyle='--', linewidth=2,
-            label=f'Color at peak: {{peak_color:.3f}} mag')
-ax2.axhline(mean_color, color='gray', linestyle=':', linewidth=1.5,
-            label=f'Mean color: {{mean_color:.3f}} mag')
-ax2.set_xlabel('MJD', fontsize=12)
-ax2.set_ylabel(f'{{"{band1}"}} - {{"{band2}"}} (mag)', fontsize=12)
-ax2.set_title(f'Color Evolution ({{"{method}"}} method)', fontsize=12)
-ax2.legend(loc='best', fontsize=10)
-ax2.grid(True, alpha=0.3)
+        notebook = {
+            "cells": [
+                {
+                    "cell_type": "markdown",
+                    "metadata": {},
+                    "source": [
+                        f"# Color Evolution Analysis: {obj_id}\n\n",
+                        f"**Color**: {band1} - {band2}\n\n",
+                        f"This notebook shows both **matched** (day-to-day) and **interpolated** (rolling) color measurements overlaid.\n",
+                    ],
+                },
+                {
+                    "cell_type": "markdown",
+                    "metadata": {},
+                    "source": [
+                        "## Dependencies\n\n",
+                        "This notebook requires the following packages:\n",
+                        "```bash\n",
+                        "pip install pandas plotly nbformat\n",
+                        "```\n",
+                    ],
+                },
+                {
+                    "cell_type": "code",
+                    "execution_count": None,
+                    "metadata": {},
+                    "source": [
+                        "# Import dependencies\n",
+                        "import pandas as pd\n",
+                        "import plotly.graph_objects as go\n",
+                        "from plotly.subplots import make_subplots\n",
+                        "from plotly.offline import init_notebook_mode, iplot\n\n",
+                        "# Initialize Plotly offline mode for notebooks\n",
+                        "init_notebook_mode(connected=True)\n",
+                        "print('✓ Plotly offline mode initialized')\n",
+                    ],
+                },
+                {
+                    "cell_type": "code",
+                    "execution_count": None,
+                    "metadata": {},
+                    "source": [
+                        f"# Load data\n",
+                        f"df = pd.read_csv('{obj_id}_color_data.csv')\n",
+                        f"df_band1 = df[df['mag_{band1}'].notna()]\n",
+                        f"df_band2 = df[df['mag_{band2}'].notna()]\n",
+                        f"print(f'Loaded {{len(df)}} rows from {obj_id}_color_data.csv')\n",
+                    ],
+                },
+                {
+                    "cell_type": "code",
+                    "execution_count": None,
+                    "metadata": {},
+                    "source": [
+                        f"# Analysis results\n",
+                        f"peak_mjd_{band1} = {peak_mjd1:.2f}\n",
+                        f"peak_mag_{band1} = {peak_mag1:.2f}\n",
+                        f"peak_mjd_{band2} = {peak_mjd2:.2f}\n",
+                        f"peak_mag_{band2} = {peak_mag2:.2f}\n",
+                        f"peak_color = {peak_color['color']:.3f}\n",
+                        f"mean_color = {mean_color:.3f}\n",
+                        f"trend = '{trend}'\n\n",
+                        f"print(f'Peak in {band1}: {{peak_mag_{band1}:.2f}} mag at MJD {{peak_mjd_{band1}:.2f}}')\n",
+                        f"print(f'Peak in {band2}: {{peak_mag_{band2}:.2f}} mag at MJD {{peak_mjd_{band2}:.2f}}')\n",
+                        f"print(f'Color at peak: {{peak_color:.3f}} mag')\n",
+                        f"print(f'Mean color: {{mean_color:.3f}} mag')\n",
+                        f"print(f'Trend: {{trend}}')\n",
+                    ],
+                },
+                {
+                    "cell_type": "code",
+                    "execution_count": None,
+                    "metadata": {},
+                    "source": [
+                        f"# Create interactive overlay plot with Plotly\n",
+                        f"fig = make_subplots(\n",
+                        f"    rows=2, cols=1,\n",
+                        f"    subplot_titles=('{obj_id}: {band1}-{band2} Multi-band Light Curves',\n",
+                        f"                   'Color Evolution (Both Methods Overlaid)'),\n",
+                        f"    vertical_spacing=0.12,\n",
+                        f"    shared_xaxes=True\n",
+                        f")\n\n",
+                        f"# SkyPortal filter colors\n",
+                        f"filter_colors = {{'ztfg': '#28a745', 'ztfr': '#dc3545', 'ztfi': '#8b0000', 'sdssr': '#dc3545'}}\n",
+                        f"color1 = filter_colors.get('{band1}', '#1f77b4')\n",
+                        f"color2 = filter_colors.get('{band2}', '#ff7f0e')\n\n",
+                        f"# Helper function to convert hex to rgba\n",
+                        f"def hex_to_rgba(hex_color, alpha):\n",
+                        f"    h = hex_color.lstrip('#')\n",
+                        f"    rgb = tuple(int(h[i:i+2], 16) for i in (0, 2, 4))\n",
+                        f"    return f'rgba({{rgb[0]}},{{rgb[1]}},{{rgb[2]}},{{alpha}})'\n\n",
+                        f"# Top panel: Light curves with error bars\n",
+                        f"# {band1} photometry\n",
+                        f"fig.add_trace(\n",
+                        f"    go.Scatter(\n",
+                        f"        x=df_band1['mjd'],\n",
+                        f"        y=df_band1['mag_{band1}'],\n",
+                        f"        error_y=dict(type='data', array=df_band1['magerr_{band1}'], visible=True, thickness=1.5),\n",
+                        f"        mode='markers',\n",
+                        f"        marker=dict(\n",
+                        f"            size=6,\n",
+                        f"            color=hex_to_rgba(color1, 0.6),\n",
+                        f"            line=dict(color=color1, width=1.5)\n",
+                        f"        ),\n",
+                        f"        name='{band1}',\n",
+                        f"        hovertemplate='MJD: %{{x:.2f}}<br>Mag: %{{y:.3f}}<br>Error: %{{error_y.array:.3f}}<extra></extra>'\n",
+                        f"    ),\n",
+                        f"    row=1, col=1\n",
+                        f")\n\n",
+                        f"# {band2} photometry\n",
+                        f"fig.add_trace(\n",
+                        f"    go.Scatter(\n",
+                        f"        x=df_band2['mjd'],\n",
+                        f"        y=df_band2['mag_{band2}'],\n",
+                        f"        error_y=dict(type='data', array=df_band2['magerr_{band2}'], visible=True, thickness=1.5),\n",
+                        f"        mode='markers',\n",
+                        f"        marker=dict(\n",
+                        f"            size=6,\n",
+                        f"            color=hex_to_rgba(color2, 0.6),\n",
+                        f"            line=dict(color=color2, width=1.5)\n",
+                        f"        ),\n",
+                        f"        name='{band2}',\n",
+                        f"        hovertemplate='MJD: %{{x:.2f}}<br>Mag: %{{y:.3f}}<br>Error: %{{error_y.array:.3f}}<extra></extra>'\n",
+                        f"    ),\n",
+                        f"    row=1, col=1\n",
+                        f")\n\n",
+                        f"# Peak vertical lines\n",
+                        f"fig.add_vline(x=peak_mjd_{band1}, line_dash='dash', line_color=color1, opacity=0.5,\n",
+                        f"             annotation_text='Peak {band1}', annotation_position='top',\n",
+                        f"             row=1, col=1)\n",
+                        f"fig.add_vline(x=peak_mjd_{band2}, line_dash='dash', line_color=color2, opacity=0.5,\n",
+                        f"             annotation_text='Peak {band2}', annotation_position='top',\n",
+                        f"             row=1, col=1)\n\n",
+                        f"# Bottom panel: Color evolution (matched in back, interpolated in front)\n",
+                        f"df_matched = df[df['color_matched'].notna()]\n",
+                        f"df_interp = df[df['color_interpolated'].notna()]\n\n",
+                        f"# Matched (grey) - behind with lower opacity\n",
+                        f"fig.add_trace(\n",
+                        f"    go.Scatter(\n",
+                        f"        x=df_matched['mjd'],\n",
+                        f"        y=df_matched['color_matched'],\n",
+                        f"        error_y=dict(type='data', array=df_matched['color_matched_err'], visible=True, thickness=1.5),\n",
+                        f"        mode='markers',\n",
+                        f"        marker=dict(\n",
+                        f"            size=6,\n",
+                        f"            color='rgba(128, 128, 128, 0.5)',\n",
+                        f"            line=dict(color='rgba(128, 128, 128, 1.0)', width=1.5)\n",
+                        f"        ),\n",
+                        f"        name='Matched (day-to-day)',\n",
+                        f"        hovertemplate='MJD: %{{x:.2f}}<br>Color: %{{y:.3f}}<br>Error: %{{error_y.array:.3f}}<extra></extra>'\n",
+                        f"    ),\n",
+                        f"    row=2, col=1\n",
+                        f")\n\n",
+                        f"# Interpolated (black) - in front\n",
+                        f"fig.add_trace(\n",
+                        f"    go.Scatter(\n",
+                        f"        x=df_interp['mjd'],\n",
+                        f"        y=df_interp['color_interpolated'],\n",
+                        f"        error_y=dict(type='data', array=df_interp['color_interpolated_err'], visible=True, thickness=1.5),\n",
+                        f"        mode='markers',\n",
+                        f"        marker=dict(\n",
+                        f"            size=6,\n",
+                        f"            color='rgba(0, 0, 0, 0.6)',\n",
+                        f"            line=dict(color='rgba(0, 0, 0, 1.0)', width=1.5)\n",
+                        f"        ),\n",
+                        f"        name='Interpolated (rolling)',\n",
+                        f"        hovertemplate='MJD: %{{x:.2f}}<br>Color: %{{y:.3f}}<br>Error: %{{error_y.array:.3f}}<extra></extra>'\n",
+                        f"    ),\n",
+                        f"    row=2, col=1\n",
+                        f")\n\n",
+                        f"# Color at peak line\n",
+                        f"fig.add_hline(y=peak_color, line_dash='dash', line_color='red', line_width=2, opacity=0.4,\n",
+                        f"             annotation_text=f'Color at peak: {{peak_color:.3f}} mag',\n",
+                        f"             annotation_position='right',\n",
+                        f"             row=2, col=1)\n\n",
+                        f"# Update layout\n",
+                        f"fig.update_xaxes(title_text='MJD', row=2, col=1)\n",
+                        f"fig.update_yaxes(title_text='AB Magnitude', autorange='reversed', row=1, col=1)\n",
+                        f"fig.update_yaxes(title_text='{band1} - {band2} (mag)', row=2, col=1)\n",
+                        f"fig.update_layout(\n",
+                        f"    height=800,\n",
+                        f"    showlegend=True,\n",
+                        f"    hovermode='closest',\n",
+                        f"    template='plotly_white'\n",
+                        f")\n\n",
+                        f"# Display the interactive figure\n",
+                        f"iplot(fig)\n",
+                    ],
+                },
+            ],
+            "metadata": {
+                "kernelspec": {
+                    "display_name": "Python 3",
+                    "language": "python",
+                    "name": "python3",
+                },
+                "language_info": {"name": "python", "version": "3.9.0"},
+            },
+            "nbformat": 4,
+            "nbformat_minor": 4,
+        }
 
-plt.tight_layout()
-plt.show()
+        with open(notebook_path, "w") as f:
+            json.dump(notebook, f, indent=2)
 
-# Print analysis results
-print("=" * 60)
-print(f"COLOR EVOLUTION ANALYSIS: {obj_id}")
-print(f"Color: {band1} - {band2}")
-print(f"Method: {method}")'''
+        return f"""Analysis complete! Generated files in: {output_dir}
 
-        if method == "matched":
-            code += f"""
-print(f"Max time gap: {max_time_gap} days")
-print(f"Max data gap: {max_data_gap} days")"""
+Files created:
+  • {csv_path.name} - Color data (both methods)
+  • {notebook_path.name} - Jupyter notebook with plots
 
-        code += f"""
-print("=" * 60)
-print()
-print("## PEAK PROPERTIES")
-print(f"Peak in {band1}:     {{peak_mag_{band1}:.2f}} mag at MJD {{peak_mjd_{band1}:.2f}}")
-print(f"Peak in {band2}:     {{peak_mag_{band2}:.2f}} mag at MJD {{peak_mjd_{band2}:.2f}}")
-print(f"Color at peak:       {{peak_color:.3f}} mag")
-print()
-print("## COLOR EVOLUTION")
-print(f"Measurements:        {{len(color)}}")
-print(f"Mean color:          {{mean_color:.3f}} mag")
-print(f"Color range:         {{np.ptp(color):.3f}} mag")
-print(f"Trend:               {{trend}}")
-print()
-print("=" * 60)"""
+Summary:
+  • Matched colors: {len(matched_colors)} measurements
+  • Interpolated colors: {len(interpolated_colors)} measurements
+  • Peak color: {peak_color["color"]:.3f} ± {peak_color["color_err"]:.3f} mag
+  • Trend: {trend}
 
-        return code
+Open the notebook to see interactive plots with both methods overlaid!"""
 
-    # Format text output
-    lines = ["=" * 60]
-    lines.append(f"COLOR EVOLUTION ANALYSIS: {obj_id}")
-    lines.append(f"Color: {band1} - {band2}")
-    lines.append(f"Method: {method}")
-    if method == "matched":
+    else:  # text format
+        lines = ["=" * 60]
+        lines.append(f"COLOR EVOLUTION ANALYSIS: {obj_id}")
+        lines.append(f"Color: {band1} - {band2}")
         lines.append(f"Max time gap: {max_time_gap} days")
         lines.append(f"Max data gap: {max_data_gap} days")
-    lines.append("=" * 60)
-    lines.append("")
+        lines.append("=" * 60)
+        lines.append("")
 
-    lines.append("## PEAK PROPERTIES")
-    lines.append(f"Peak in {band1}:     {peak_mag1:.2f} mag at MJD {peak_mjd1:.2f}")
-    lines.append(f"Peak in {band2}:     {peak_mag2:.2f} mag at MJD {peak_mjd2:.2f}")
-    lines.append(
-        f"Color at peak:       {peak_color['color']:.3f} ± {peak_color['color_err']:.3f} mag"
-    )
-    lines.append(f"                     (measured at MJD {peak_color['mjd']:.2f})")
-    lines.append("")
+        lines.append("## PEAK PROPERTIES")
+        lines.append(f"Peak in {band1}:     {peak_mag1:.2f} mag at MJD {peak_mjd1:.2f}")
+        lines.append(f"Peak in {band2}:     {peak_mag2:.2f} mag at MJD {peak_mjd2:.2f}")
+        if not np.isnan(peak_color["color"]):
+            lines.append(
+                f"Color at peak:       {peak_color['color']:.3f} ± {peak_color['color_err']:.3f} mag"
+            )
+            lines.append(
+                f"                     (measured at MJD {peak_color['mjd']:.2f})"
+            )
+        lines.append("")
 
-    lines.append("## COLOR EVOLUTION")
-    lines.append(f"Measurements:        {len(colors)}")
-    lines.append(f"Mean color:          {mean_color:.3f} ± {color_std:.3f} mag")
-    lines.append(f"Color range:         {color_range:.3f} mag")
-    lines.append(f"Trend:               {trend} ({slope:.4f} mag/day)")
-    lines.append("")
+        lines.append("## COLOR EVOLUTION")
+        lines.append(f"Matched measurements:        {len(matched_colors)}")
+        lines.append(f"Interpolated measurements:   {len(interpolated_colors)}")
+        if not np.isnan(mean_color):
+            lines.append(
+                f"Mean color (matched):        {mean_color:.3f} ± {color_std:.3f} mag"
+            )
+            lines.append(f"Color range:                 {color_range:.3f} mag")
+            lines.append(f"Trend:                       {trend} ({slope:.4f} mag/day)")
+        lines.append("")
 
-    lines.append("## COLOR MEASUREMENTS")
-    lines.append("MJD          Color      Error")
-    lines.append("-" * 35)
-    for c in colors:
-        lines.append(f"{c['mjd']:10.2f}   {c['color']:6.3f}   {c['color_err']:6.3f}")
-    lines.append("")
+        if len(matched_colors) > 0:
+            lines.append("## MATCHED COLOR MEASUREMENTS")
+            lines.append("MJD          Color      Error")
+            lines.append("-" * 35)
+            for c in matched_colors[:20]:  # Limit to first 20
+                lines.append(
+                    f"{c['mjd']:10.2f}   {c['color']:6.3f}   {c['color_err']:6.3f}"
+                )
+            if len(matched_colors) > 20:
+                lines.append(f"... and {len(matched_colors) - 20} more")
+            lines.append("")
 
-    lines.append("=" * 60)
+        lines.append("=" * 60)
+        lines.append("\nTo generate interactive plots, use output_format='notebook'")
 
-    return "\n".join(lines)
+        return "\n".join(lines)

--- a/services/mcp_server/tools/analysis.py
+++ b/services/mcp_server/tools/analysis.py
@@ -1,0 +1,703 @@
+# pyright: reportMissingTypeStubs=false
+"""Light curve and color analysis tools for transients."""
+
+import httpx
+import numpy as np
+
+from ..server import SKYPORTAL_URL, get_skyportal_token, mcp
+from .source_products import resolve_source_id
+
+
+@mcp.tool()
+async def analyze_light_curve(
+    source_name: str,
+    filter_name: str = "ztfr",
+    baseline_threshold: float = 0.3,
+    output_format: str = "text",
+) -> str:
+    """Analyze light curve evolution: rise, fade, duration, and variability.
+
+    Calculates key temporal properties of a transient's light curve including
+    rise time, fade time, total duration, and pre-peak variability (flares).
+
+    Handles incomplete light curves:
+    - Still rising: Reports time from first detection to current
+    - Still fading: Reports time from peak to current
+    - Returned to baseline: Reports complete rise + fade times
+
+    **IMPORTANT - User Preference:**
+    Before calling this tool, ask the user: "Would you like the analysis as
+    (1) text summary in chat, or (2) interactive plot in a notebook?"
+    - If (1): Use output_format="text" (default)
+    - If (2): Use output_format="notebook" and insert returned code into notebook
+
+    Args:
+        source_name: Source identifier - SkyPortal obj_id, ZTF name, or TNS name
+        filter_name: Photometric filter to analyze (default: "ztfr")
+        baseline_threshold: Magnitude difference from peak to consider "baseline"
+                          (default: 0.3 mag, i.e., source must fade by >0.3 mag
+                          from peak to be considered at baseline)
+        output_format: Output format - "text" for chat summary or "notebook" for
+                      Python code to plot in a Jupyter notebook (default: "text")
+
+    Returns:
+        - If output_format="text": Formatted text summary with rise/fade times,
+          duration, rates, and variability metrics
+        - If output_format="notebook": Python code that creates an interactive
+          plot with embedded data and prints analysis results
+    """
+    token = get_skyportal_token()
+    if not token:
+        return "Not authenticated. Configure SKYPORTAL_TOKEN or send Bearer token."
+
+    # Resolve source name
+    obj_id = await resolve_source_id(source_name)
+    if not obj_id:
+        return f"Error: Could not resolve '{source_name}' to a SkyPortal source."
+
+    # Fetch photometry
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            resp = await client.get(
+                f"{SKYPORTAL_URL}/api/sources/{obj_id}/photometry",
+                headers={"Authorization": f"token {token}"},
+                params={"format": "mag", "magsys": "ab"},
+            )
+        resp.raise_for_status()
+        data = resp.json().get("data", [])
+    except Exception as e:
+        return f"Error fetching photometry: {e}"
+
+    if not data:
+        return f"No photometry found for {obj_id}"
+
+    # Filter by requested band and valid detections
+    phot = [
+        p
+        for p in data
+        if p.get("filter") == filter_name
+        and p.get("mag") is not None
+        and p.get("magerr") is not None
+    ]
+
+    if len(phot) < 2:
+        return f"Insufficient photometry in {filter_name} band (need at least 2 points)"
+
+    # Sort by time
+    phot.sort(key=lambda p: p["mjd"])
+
+    # Extract arrays
+    mjds = np.array([p["mjd"] for p in phot])
+    mags = np.array([p["mag"] for p in phot])
+    magerrs = np.array([p["magerr"] for p in phot])
+
+    # Find peak (minimum magnitude = brightest)
+    peak_idx = np.argmin(mags)
+    peak_mjd = mjds[peak_idx]
+    peak_mag = mags[peak_idx]
+
+    # First and last detection
+    first_mjd = mjds[0]
+    first_mag = mags[0]
+    last_mjd = mjds[-1]
+    last_mag = mags[-1]
+
+    # Rise time: first detection to peak
+    rise_time = peak_mjd - first_mjd
+    rise_mag = first_mag - peak_mag  # How much it brightened
+
+    # Check if still rising (peak is last point)
+    still_rising = peak_idx == len(mjds) - 1
+
+    # Fade analysis
+    if still_rising:
+        fade_time = None
+        fade_mag = None
+        fade_rate = None
+        status = "Still rising"
+        duration = None
+    else:
+        # Post-peak data
+        post_peak_mjds = mjds[peak_idx:]
+        post_peak_mags = mags[peak_idx:]
+
+        # Check if returned to baseline (faded by > threshold mag)
+        faded = post_peak_mags - peak_mag
+        baseline_reached = np.any(faded > baseline_threshold)
+
+        if baseline_reached:
+            # Find first point where baseline is reached
+            baseline_idx = peak_idx + np.where(faded > baseline_threshold)[0][0]
+            baseline_mjd = mjds[baseline_idx]
+            fade_time = baseline_mjd - peak_mjd
+            fade_mag = (
+                post_peak_mags[np.where(faded > baseline_threshold)[0][0]] - peak_mag
+            )
+            status = "Complete light curve"
+            duration = rise_time + fade_time
+        else:
+            # Still fading
+            fade_time = last_mjd - peak_mjd
+            fade_mag = last_mag - peak_mag
+            status = "Still fading"
+            duration = None
+
+        fade_rate = fade_mag / fade_time if fade_time > 0 else None
+
+    # Rise rate
+    rise_rate = rise_mag / rise_time if rise_time > 0 else None
+
+    # Pre-peak variability analysis (detect flares)
+    if peak_idx > 1:
+        pre_peak_mags = mags[:peak_idx]
+        # Check for magnitude increases before peak (flares)
+        mag_diffs = np.diff(pre_peak_mags)
+        brightening_events = np.sum(mag_diffs < -0.1)  # Brightening by >0.1 mag
+        variability_rms = np.std(pre_peak_mags)
+    else:
+        brightening_events = 0
+        variability_rms = 0.0
+
+    # Generate notebook code if requested
+    if output_format == "notebook":
+        # Convert arrays to Python lists for embedding in code
+        mjd_list = mjds.tolist()
+        mag_list = mags.tolist()
+        magerr_list = magerrs.tolist()
+
+        code = f'''import matplotlib.pyplot as plt
+                import numpy as np
+
+                # Light curve data for {obj_id} ({filter_name} band)
+                mjd = {mjd_list}
+                mag = {mag_list}
+                magerr = {magerr_list}
+
+                # Analysis results
+                peak_mjd = {peak_mjd}
+                peak_mag = {peak_mag}
+                first_mjd = {first_mjd}
+                rise_time = {rise_time}
+                rise_mag = {rise_mag}
+                status = "{status}"
+
+                # Create figure
+                fig, ax = plt.subplots(figsize=(12, 6))
+
+                # Plot photometry
+                ax.errorbar(mjd, mag, yerr=magerr, fmt='o', markersize=6,
+                            capsize=3, label='{filter_name} photometry', alpha=0.7)
+
+                # Mark peak
+                ax.axvline(peak_mjd, color='red', linestyle='--', linewidth=2,
+                        label=f'Peak: MJD {{peak_mjd:.2f}}')
+                ax.plot(peak_mjd, peak_mag, 'r*', markersize=20, label=f'Peak mag: {{peak_mag:.2f}}')
+
+                # Formatting
+                ax.invert_yaxis()  # Brighter = lower magnitude
+                ax.set_xlabel('MJD', fontsize=12)
+                ax.set_ylabel('AB Magnitude', fontsize=12)
+                ax.set_title(f'{obj_id} Light Curve Analysis ({filter_name})', fontsize=14, fontweight='bold')
+                ax.legend(loc='best', fontsize=10)
+                ax.grid(True, alpha=0.3)
+
+                plt.tight_layout()
+                plt.show()
+
+                # Print analysis results
+                print("=" * 60)
+                print(f"LIGHT CURVE ANALYSIS: {obj_id}")
+                print(f"Filter: {filter_name}")
+                print("=" * 60)
+                print()
+                print("## OVERVIEW")
+                print(f"Status:           {{status}}")
+                print(f"Total points:     {{len(mjd)}}")
+                print(f"Time span:        {{min(mjd):.1f}} - {{max(mjd):.1f}} MJD ({{max(mjd) - min(mjd):.1f}} days)")
+                print()
+                print("## PEAK PROPERTIES")
+                print(f"Peak magnitude:   {{peak_mag:.2f}} mag")
+                print(f"Peak time:        MJD {{peak_mjd:.2f}}")
+                print(f"Peak epoch:       Day {{peak_mjd - first_mjd:.1f}} (from first detection)")
+                print()
+                print("## RISE PROPERTIES")
+                print(f"Rise time:        {{rise_time:.1f}} days")
+                print(f"Rise amplitude:   {{rise_mag:.2f}} mag")'''
+
+        if rise_rate:
+            code += f'\nprint(f"Rise rate:        {{{rise_rate:.3f}}} mag/day")'
+        if still_rising:
+            code += '\nprint("Note:             Source is still rising (peak = last detection)")'
+
+        code += '\nprint()\nprint("## FADE PROPERTIES")'
+
+        if fade_time:
+            code += f"""
+print(f"Fade time:        {fade_time:.1f} days")
+print(f"Fade amplitude:   {fade_mag:.2f} mag")"""
+            if fade_rate:
+                code += f"""
+print(f"Fade rate:        {fade_rate:.3f} mag/day")"""
+        else:
+            code += '\nprint("Fade time:        Not yet available (still rising)")'
+
+        if duration:
+            code += f"""
+print(f"Total duration:   {duration:.1f} days (rise + fade)")"""
+        else:
+            code += '\nprint("Total duration:   Not yet determined (light curve incomplete)")'
+
+        code += f"""
+print()
+print("## VARIABILITY")
+print(f"Pre-peak RMS:     {variability_rms:.3f} mag")"""
+
+        if brightening_events > 0:
+            code += f"""
+print(f"Early flares:     {brightening_events} brightening event(s) detected before peak")
+print("                  (magnitude increases >0.1 mag)")"""
+        else:
+            code += '\nprint("Early flares:     None detected")'
+
+        code += '\nprint()\nprint("=" * 60)'
+
+        return code
+
+    # Format text output
+    lines = ["=" * 60]
+    lines.append(f"LIGHT CURVE ANALYSIS: {obj_id}")
+    lines.append(f"Filter: {filter_name}")
+    lines.append("=" * 60)
+    lines.append("")
+
+    lines.append("## OVERVIEW")
+    lines.append(f"Status:           {status}")
+    lines.append(f"Total points:     {len(phot)}")
+    lines.append(
+        f"Time span:        {first_mjd:.1f} - {last_mjd:.1f} MJD ({last_mjd - first_mjd:.1f} days)"
+    )
+    lines.append("")
+
+    lines.append("## PEAK PROPERTIES")
+    lines.append(f"Peak magnitude:   {peak_mag:.2f} ± {magerrs[peak_idx]:.2f} mag")
+    lines.append(f"Peak time:        MJD {peak_mjd:.2f}")
+    lines.append(
+        f"Peak epoch:       Day {peak_mjd - first_mjd:.1f} (from first detection)"
+    )
+    lines.append("")
+
+    lines.append("## RISE PROPERTIES")
+    lines.append(f"Rise time:        {rise_time:.1f} days")
+    lines.append(f"Rise amplitude:   {rise_mag:.2f} mag")
+    if rise_rate:
+        lines.append(f"Rise rate:        {rise_rate:.3f} mag/day")
+    if still_rising:
+        lines.append("Note:             Source is still rising (peak = last detection)")
+    lines.append("")
+
+    lines.append("## FADE PROPERTIES")
+    if fade_time:
+        lines.append(f"Fade time:        {fade_time:.1f} days")
+        lines.append(f"Fade amplitude:   {fade_mag:.2f} mag")
+        if fade_rate:
+            lines.append(f"Fade rate:        {fade_rate:.3f} mag/day")
+    else:
+        lines.append("Fade time:        Not yet available (still rising)")
+
+    if duration:
+        lines.append(f"Total duration:   {duration:.1f} days (rise + fade)")
+    else:
+        lines.append("Total duration:   Not yet determined (light curve incomplete)")
+    lines.append("")
+
+    lines.append("## VARIABILITY")
+    lines.append(f"Pre-peak RMS:     {variability_rms:.3f} mag")
+    if brightening_events > 0:
+        lines.append(
+            f"Early flares:     {brightening_events} brightening event(s) detected before peak"
+        )
+        lines.append("                  (magnitude increases >0.1 mag)")
+    else:
+        lines.append("Early flares:     None detected")
+    lines.append("")
+
+    lines.append("=" * 60)
+
+    return "\n".join(lines)
+
+
+@mcp.tool()
+async def analyze_color_evolution(
+    source_name: str,
+    band1: str = "ztfg",
+    band2: str = "ztfr",
+    method: str = "matched",
+    max_time_gap: float = 0.5,
+    max_data_gap: float = 3.0,
+    output_format: str = "text",
+) -> str:
+    """Analyze color evolution and color at peak brightness.
+
+    Calculates color curves (band1 - band2) over time using two methods:
+
+    1. **Matched observations** (method="matched"): Pairs observations from
+       each band that are close in time, but avoids calculating colors
+       across large gaps in the data.
+
+    2. **Interpolated** (method="interpolated"): Interpolates one band to
+       match the other's observation times, creating a rolling/continuous
+       color measurement. More measurements but assumes smooth evolution.
+
+    **IMPORTANT - User Preferences:**
+    Before calling this tool, ask the user TWO questions:
+    1. "Would you like day-to-day colors (matched method) or rolling/continuous
+       colors (interpolated method)?"
+    2. "Would you like the analysis as text in chat or interactive plot in notebook?"
+
+    Args:
+        source_name: Source identifier - SkyPortal obj_id, ZTF name, or TNS name
+        band1: First photometric filter (default: "ztfg")
+        band2: Second photometric filter (default: "ztfr")
+        method: Calculation method - "matched" or "interpolated" (default: "matched")
+        max_time_gap: For matched method - maximum time difference (days) to
+                     pair observations (default: 0.5 days)
+        max_data_gap: For matched method - if gap between consecutive observations
+                     in either band exceeds this, don't calculate colors across
+                     the gap (default: 3.0 days). Prevents spurious colors during
+                     observing gaps.
+        output_format: Output format - "text" for chat summary or "notebook" for
+                      Python code to plot in a Jupyter notebook (default: "text")
+
+    Returns:
+        - If output_format="text": Formatted text summary with color at peak,
+          evolution statistics, and CSV table of measurements
+        - If output_format="notebook": Python code that creates interactive plots
+          (light curves + color evolution) with embedded data and analysis results
+    """
+    token = get_skyportal_token()
+    if not token:
+        return "Not authenticated. Configure SKYPORTAL_TOKEN or send Bearer token."
+
+    if method not in ("matched", "interpolated"):
+        return "Error: method must be 'matched' or 'interpolated'"
+
+    # Resolve source name
+    obj_id = await resolve_source_id(source_name)
+    if not obj_id:
+        return f"Error: Could not resolve '{source_name}' to a SkyPortal source."
+
+    # Fetch photometry
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            resp = await client.get(
+                f"{SKYPORTAL_URL}/api/sources/{obj_id}/photometry",
+                headers={"Authorization": f"token {token}"},
+                params={"format": "mag", "magsys": "ab"},
+            )
+        resp.raise_for_status()
+        data = resp.json().get("data", [])
+    except Exception as e:
+        return f"Error fetching photometry: {e}"
+
+    if not data:
+        return f"No photometry found for {obj_id}"
+
+    # Separate by filter
+    phot1 = [
+        p
+        for p in data
+        if p.get("filter") == band1
+        and p.get("mag") is not None
+        and p.get("magerr") is not None
+    ]
+    phot2 = [
+        p
+        for p in data
+        if p.get("filter") == band2
+        and p.get("mag") is not None
+        and p.get("magerr") is not None
+    ]
+
+    if not phot1 or not phot2:
+        return f"Insufficient photometry in {band1} and/or {band2} bands"
+
+    # Sort by time
+    phot1.sort(key=lambda p: p["mjd"])
+    phot2.sort(key=lambda p: p["mjd"])
+
+    # Extract arrays
+    mjds1 = np.array([p["mjd"] for p in phot1])
+    mags1 = np.array([p["mag"] for p in phot1])
+    errs1 = np.array([p["magerr"] for p in phot1])
+
+    mjds2 = np.array([p["mjd"] for p in phot2])
+    mags2 = np.array([p["mag"] for p in phot2])
+    errs2 = np.array([p["magerr"] for p in phot2])
+
+    # Calculate colors based on method
+    colors = []
+
+    if method == "matched":
+        # Matched observations - pair close observations but respect gaps
+        for i, p1 in enumerate(phot1):
+            mjd1 = p1["mjd"]
+            mag1 = p1["mag"]
+            err1 = p1["magerr"]
+
+            # Check if this observation is in a large gap
+            # (if time to prev/next obs > max_data_gap, skip)
+            if i > 0:
+                prev_gap = mjd1 - phot1[i - 1]["mjd"]
+            else:
+                prev_gap = 0
+
+            if i < len(phot1) - 1:
+                next_gap = phot1[i + 1]["mjd"] - mjd1
+            else:
+                next_gap = 0
+
+            in_large_gap = (prev_gap > max_data_gap) or (next_gap > max_data_gap)
+
+            # Find closest observation in band2
+            time_diffs = np.abs(mjds2 - mjd1)
+            closest_idx = np.argmin(time_diffs)
+
+            if time_diffs[closest_idx] <= max_time_gap and not in_large_gap:
+                # Also check if band2 observation is in a large gap
+                if closest_idx > 0:
+                    prev_gap2 = mjds2[closest_idx] - mjds2[closest_idx - 1]
+                else:
+                    prev_gap2 = 0
+
+                if closest_idx < len(mjds2) - 1:
+                    next_gap2 = mjds2[closest_idx + 1] - mjds2[closest_idx]
+                else:
+                    next_gap2 = 0
+
+                in_large_gap2 = (prev_gap2 > max_data_gap) or (next_gap2 > max_data_gap)
+
+                if not in_large_gap2:
+                    mag2 = mags2[closest_idx]
+                    err2 = errs2[closest_idx]
+
+                    color = mag1 - mag2
+                    color_err = np.sqrt(err1**2 + err2**2)
+
+                    colors.append(
+                        {
+                            "mjd": mjd1,
+                            "color": color,
+                            "color_err": color_err,
+                            "mag1": mag1,
+                            "mag2": mag2,
+                        }
+                    )
+
+    else:  # interpolated
+        # Interpolate band2 to match band1 times
+        # Use linear interpolation
+        from scipy.interpolate import interp1d
+
+        try:
+            interp_func = interp1d(
+                mjds2, mags2, kind="linear", bounds_error=False, fill_value=np.nan
+            )
+            interp_err_func = interp1d(
+                mjds2, errs2, kind="linear", bounds_error=False, fill_value=np.nan
+            )
+
+            for i, mjd1 in enumerate(mjds1):
+                mag1 = mags1[i]
+                err1 = errs1[i]
+
+                # Interpolate band2
+                mag2_interp = interp_func(mjd1)
+                err2_interp = interp_err_func(mjd1)
+
+                # Only use if interpolation is valid (within band2 time range)
+                if not np.isnan(mag2_interp):
+                    color = mag1 - mag2_interp
+                    # Conservative error: add interpolation uncertainty
+                    color_err = np.sqrt(err1**2 + err2_interp**2)
+
+                    colors.append(
+                        {
+                            "mjd": mjd1,
+                            "color": color,
+                            "color_err": color_err,
+                            "mag1": mag1,
+                            "mag2": mag2_interp,
+                        }
+                    )
+        except Exception as e:
+            return f"Error in interpolation: {e}. Try 'matched' method instead."
+
+    if len(colors) < 2:
+        return f"Insufficient color measurements (got {len(colors)}, need at least 2). Try adjusting max_time_gap or method."
+
+    # Find peak in each band
+    peak_idx1 = np.argmin(mags1)
+    peak_idx2 = np.argmin(mags2)
+    peak_mjd1 = mjds1[peak_idx1]
+    peak_mjd2 = mjds2[peak_idx2]
+    peak_mag1 = mags1[peak_idx1]
+    peak_mag2 = mags2[peak_idx2]
+
+    # Find color closest to peak time (use average of peak times)
+    peak_mjd_avg = (peak_mjd1 + peak_mjd2) / 2
+    color_mjds = np.array([c["mjd"] for c in colors])
+    peak_color_idx = np.argmin(np.abs(color_mjds - peak_mjd_avg))
+    peak_color = colors[peak_color_idx]
+
+    # Color evolution statistics
+    color_vals = np.array([c["color"] for c in colors])
+    mean_color = np.mean(color_vals)
+    color_range = np.ptp(color_vals)
+    color_std = np.std(color_vals)
+
+    # Simple linear trend (slope)
+    if len(colors) > 2:
+        color_mjds_centered = color_mjds - color_mjds[0]
+        slope, _ = np.polyfit(color_mjds_centered, color_vals, 1)
+        trend = "bluing" if slope < -0.01 else "reddening" if slope > 0.01 else "stable"
+    else:
+        slope = 0
+        trend = "insufficient data"
+
+    # Generate notebook code if requested
+    if output_format == "notebook":
+        # Convert to lists for embedding
+        mjd1_list = mjds1.tolist()
+        mag1_list = mags1.tolist()
+        err1_list = errs1.tolist()
+        mjd2_list = mjds2.tolist()
+        mag2_list = mags2.tolist()
+        err2_list = errs2.tolist()
+        color_mjd_list = color_mjds.tolist()
+        color_val_list = color_vals.tolist()
+        color_err_list = [c["color_err"] for c in colors]
+
+        code = f'''import matplotlib.pyplot as plt
+import numpy as np
+
+# Photometry data for {obj_id}
+mjd_{band1} = {mjd1_list}
+mag_{band1} = {mag1_list}
+err_{band1} = {err1_list}
+
+mjd_{band2} = {mjd2_list}
+mag_{band2} = {mag2_list}
+err_{band2} = {err2_list}
+
+# Color measurements ({band1} - {band2})
+color_mjd = {color_mjd_list}
+color = {color_val_list}
+color_err = {color_err_list}
+
+# Analysis results
+peak_mjd_{band1} = {peak_mjd1}
+peak_mag_{band1} = {peak_mag1}
+peak_mjd_{band2} = {peak_mjd2}
+peak_mag_{band2} = {peak_mag2}
+peak_color = {peak_color["color"]}
+mean_color = {mean_color}
+trend = "{trend}"
+
+# Create figure with two subplots
+fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(12, 10), sharex=True)
+
+# Top panel: Light curves
+ax1.errorbar(mjd_{band1}, mag_{band1}, yerr=err_{band1}, fmt='o',
+             label='{band1}', color='blue', alpha=0.7, capsize=3)
+ax1.errorbar(mjd_{band2}, mag_{band2}, yerr=err_{band2}, fmt='s',
+             label='{band2}', color='red', alpha=0.7, capsize=3)
+ax1.axvline(peak_mjd_{band1}, color='blue', linestyle='--', alpha=0.5)
+ax1.axvline(peak_mjd_{band2}, color='red', linestyle='--', alpha=0.5)
+ax1.invert_yaxis()
+ax1.set_ylabel('AB Magnitude', fontsize=12)
+ax1.set_title(f'{obj_id} Multi-band Light Curves', fontsize=14, fontweight='bold')
+ax1.legend(loc='best', fontsize=10)
+ax1.grid(True, alpha=0.3)
+
+# Bottom panel: Color evolution
+ax2.errorbar(color_mjd, color, yerr=color_err, fmt='o',
+             color='purple', markersize=6, capsize=3, alpha=0.7)
+ax2.axhline(peak_color, color='red', linestyle='--', linewidth=2,
+            label=f'Color at peak: {{peak_color:.3f}} mag')
+ax2.axhline(mean_color, color='gray', linestyle=':', linewidth=1.5,
+            label=f'Mean color: {{mean_color:.3f}} mag')
+ax2.set_xlabel('MJD', fontsize=12)
+ax2.set_ylabel(f'{{"{band1}"}} - {{"{band2}"}} (mag)', fontsize=12)
+ax2.set_title(f'Color Evolution ({{"{method}"}} method)', fontsize=12)
+ax2.legend(loc='best', fontsize=10)
+ax2.grid(True, alpha=0.3)
+
+plt.tight_layout()
+plt.show()
+
+# Print analysis results
+print("=" * 60)
+print(f"COLOR EVOLUTION ANALYSIS: {obj_id}")
+print(f"Color: {band1} - {band2}")
+print(f"Method: {method}")'''
+
+        if method == "matched":
+            code += f"""
+print(f"Max time gap: {max_time_gap} days")
+print(f"Max data gap: {max_data_gap} days")"""
+
+        code += f"""
+print("=" * 60)
+print()
+print("## PEAK PROPERTIES")
+print(f"Peak in {band1}:     {{peak_mag_{band1}:.2f}} mag at MJD {{peak_mjd_{band1}:.2f}}")
+print(f"Peak in {band2}:     {{peak_mag_{band2}:.2f}} mag at MJD {{peak_mjd_{band2}:.2f}}")
+print(f"Color at peak:       {{peak_color:.3f}} mag")
+print()
+print("## COLOR EVOLUTION")
+print(f"Measurements:        {{len(color)}}")
+print(f"Mean color:          {{mean_color:.3f}} mag")
+print(f"Color range:         {{np.ptp(color):.3f}} mag")
+print(f"Trend:               {{trend}}")
+print()
+print("=" * 60)"""
+
+        return code
+
+    # Format text output
+    lines = ["=" * 60]
+    lines.append(f"COLOR EVOLUTION ANALYSIS: {obj_id}")
+    lines.append(f"Color: {band1} - {band2}")
+    lines.append(f"Method: {method}")
+    if method == "matched":
+        lines.append(f"Max time gap: {max_time_gap} days")
+        lines.append(f"Max data gap: {max_data_gap} days")
+    lines.append("=" * 60)
+    lines.append("")
+
+    lines.append("## PEAK PROPERTIES")
+    lines.append(f"Peak in {band1}:     {peak_mag1:.2f} mag at MJD {peak_mjd1:.2f}")
+    lines.append(f"Peak in {band2}:     {peak_mag2:.2f} mag at MJD {peak_mjd2:.2f}")
+    lines.append(
+        f"Color at peak:       {peak_color['color']:.3f} ± {peak_color['color_err']:.3f} mag"
+    )
+    lines.append(f"                     (measured at MJD {peak_color['mjd']:.2f})")
+    lines.append("")
+
+    lines.append("## COLOR EVOLUTION")
+    lines.append(f"Measurements:        {len(colors)}")
+    lines.append(f"Mean color:          {mean_color:.3f} ± {color_std:.3f} mag")
+    lines.append(f"Color range:         {color_range:.3f} mag")
+    lines.append(f"Trend:               {trend} ({slope:.4f} mag/day)")
+    lines.append("")
+
+    lines.append("## COLOR MEASUREMENTS")
+    lines.append("MJD          Color      Error")
+    lines.append("-" * 35)
+    for c in colors:
+        lines.append(f"{c['mjd']:10.2f}   {c['color']:6.3f}   {c['color_err']:6.3f}")
+    lines.append("")
+
+    lines.append("=" * 60)
+
+    return "\n".join(lines)

--- a/services/mcp_server/tools/api.py
+++ b/services/mcp_server/tools/api.py
@@ -1,0 +1,86 @@
+# pyright: reportMissingTypeStubs=false
+"""Core SkyPortal API tools: generic API caller and quick reference."""
+
+import logging
+from pathlib import Path
+
+import httpx
+
+from ..server import SKYPORTAL_URL, get_skyportal_token, mcp
+
+logger = logging.getLogger(__name__)
+
+RESOURCES_DIR = Path(__file__).parent.parent / "resources"
+
+
+@mcp.resource("skyportal://api/quick_reference")
+def get_api_docs() -> str:
+    """Quick reference guide for common SkyPortal API endpoints"""
+    return (RESOURCES_DIR / "api_info.md").read_text()
+
+
+@mcp.resource("skyportal://tools/reference")
+def get_tools_docs() -> str:
+    """Quick reference guide for all available MCP tools"""
+    return (RESOURCES_DIR / "tools_reference.md").read_text()
+
+
+@mcp.tool()
+def get_api_quick_reference() -> str:
+    """Get the SkyPortal API quick reference guide.
+
+    Returns a reference of available API endpoints, required parameters,
+    and usage patterns. Call once to load into context as needed.
+    """
+    return (RESOURCES_DIR / "api_info.md").read_text()
+
+
+@mcp.tool()
+def get_tools_quick_reference() -> str:
+    """Get the MCP tools quick reference guide.
+
+    Returns a comprehensive list of all available MCP tools organized by
+    category, with common workflows and usage examples. Call once to load
+    into context when needed.
+    """
+    return (RESOURCES_DIR / "tools_reference.md").read_text()
+
+
+@mcp.tool()
+async def call_skyportal_api(
+    endpoint: str,
+    method: str = "GET",
+    params: dict | None = None,
+    data: dict | None = None,
+) -> str:
+    """
+    Make an API call to SkyPortal.
+
+    Args:
+        endpoint: API endpoint (e.g., "/api/sources")
+        method: HTTP method (GET, POST, PUT, DELETE)
+        params: Query parameters
+        data: Request body
+    """
+    token = get_skyportal_token()
+    if not token:
+        return "Not authenticated. Configure SKYPORTAL_TOKEN or send Bearer token."
+
+    logger.info("API call → %s %s", method, endpoint)
+    url = f"{SKYPORTAL_URL}{endpoint}"
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            response = await client.request(
+                method=method,
+                url=url,
+                headers={"Authorization": f"token {token}"},
+                params=params,
+                json=data,
+            )
+        response.raise_for_status()
+        return str(response.json())
+    except httpx.HTTPStatusError as e:
+        return f"HTTP Error {e.response.status_code}: {e.response.text}"
+    except Exception as e:
+        logger.exception("API call failed")
+        return f"API Error: {str(e)}"

--- a/services/mcp_server/tools/astro_utils.py
+++ b/services/mcp_server/tools/astro_utils.py
@@ -1,9 +1,7 @@
 # pyright: reportMissingTypeStubs=false, reportUnknownMemberType=false
 # pyright: reportUnknownVariableType=false, reportUnknownArgumentType=false
-"""Astronomical utility tools: time conversion, survey links, ZTF cutouts."""
+"""Astronomical utility tools: time conversion, survey links, cone searches."""
 
-import csv
-import io
 from urllib.parse import quote
 
 import httpx
@@ -196,103 +194,6 @@ async def get_survey_urls(
     return "\n".join(lines)
 
 
-# ─── ZTF cutout URLs ────────────────────────────────────────────────────────
-
-
-@mcp.tool()
-async def get_ztf_cutout_urls(
-    ra: float,
-    dec: float,
-    size_arcmin: float = 1.0,
-) -> str:
-    """Query IRSA for ZTF image cutout URLs at a given position.
-
-    Searches the IRSA ZTF archive for science and reference images covering
-    the position, and returns direct download URLs for the FITS files.
-
-    Args:
-        ra: Right ascension in decimal degrees (J2000)
-        dec: Declination in decimal degrees (J2000)
-        size_arcmin: Search region size in arcminutes (default 1.0)
-    """
-    size_deg = size_arcmin / 60.0
-    base_search = "https://irsa.ipac.caltech.edu/ibe/search/ztf/products"
-    base_data = "https://irsa.ipac.caltech.edu/ibe/data/ztf/products"
-
-    results = []
-
-    # Query for science images
-    sci_url = f"{base_search}/sci?POS={ra:.6f},{dec:.6f}&SIZE={size_deg:.6f}&ct=csv"
-    try:
-        async with httpx.AsyncClient(timeout=30) as client:
-            resp = await client.get(sci_url)
-        if resp.is_success and resp.text.strip():
-            reader = csv.DictReader(io.StringIO(resp.text))
-            rows = list(reader)
-            if rows:
-                results.append(f"Found {len(rows)} science image(s).\n")
-                for i, row in enumerate(rows[:5]):
-                    field = row.get("field", "").zfill(6)
-                    filt = row.get("filtercode", "")
-                    ccdid = row.get("ccdid", "").zfill(2)
-                    qid = row.get("qid", "")
-                    filefracday = row.get("filefracday", "")
-                    imgtypecode = row.get("imgtypecode", "o")
-                    fits_url = (
-                        f"{base_data}/sci/{filefracday[:4]}/{filefracday[4:8]}"
-                        f"/{filefracday}/ztf_{filefracday}_{field}_{filt}"
-                        f"_c{ccdid}_{imgtypecode}_q{qid}_sciimg.fits"
-                    )
-                    results.append(
-                        f"  Science #{i + 1}: filter={filt} field={field} "
-                        f"ccd={ccdid} quad={qid}\n    {fits_url}"
-                    )
-            else:
-                results.append("No science images found at this position.")
-    except Exception as e:
-        results.append(f"Science image search error: {e}")
-
-    # Query for reference images
-    ref_url = f"{base_search}/ref?POS={ra:.6f},{dec:.6f}&SIZE={size_deg:.6f}&ct=csv"
-    try:
-        async with httpx.AsyncClient(timeout=30) as client:
-            resp = await client.get(ref_url)
-        if resp.is_success and resp.text.strip():
-            reader = csv.DictReader(io.StringIO(resp.text))
-            rows = list(reader)
-            if rows:
-                results.append(f"\nFound {len(rows)} reference image(s).\n")
-                for i, row in enumerate(rows[:5]):
-                    field = row.get("field", "").zfill(6)
-                    filt = row.get("filtercode", "")
-                    ccdid = row.get("ccdid", "").zfill(2)
-                    qid = row.get("qid", "")
-                    fits_url = (
-                        f"{base_data}/ref/{field[:3]}/field{field}/{filt}"
-                        f"/ccd{ccdid}/q{qid}"
-                        f"/ztf_{field}_{filt}_c{ccdid}_q{qid}_refimg.fits"
-                    )
-                    results.append(
-                        f"  Reference #{i + 1}: filter={filt} field={field} "
-                        f"ccd={ccdid} quad={qid}\n    {fits_url}"
-                    )
-            else:
-                results.append("\nNo reference images found at this position.")
-    except Exception as e:
-        results.append(f"\nReference image search error: {e}")
-
-    viewer_url = (
-        f"https://irsa.ipac.caltech.edu/applications/ztf/"
-        f"#id=Hydra_ztf_ztf_image_pos&RequestClass=ServerRequest"
-        f"&DoSearch=true&intersect=CENTER&subsize=0.139"
-        f"&mcenter=all&dpLevel=sci,ref,diff"
-        f"&UserTargetWorldPt={ra};{dec};EQ_J2000"
-    )
-    results.append(f"\nInteractive IRSA ZTF viewer: {viewer_url}")
-
-    return "\n".join(results)
-
-
 # ─── SkyPortal cone search ──────────────────────────────────────────────────
 
 
@@ -350,15 +251,22 @@ async def search_sources_near_position(
     if ra is None or dec is None:
         return "Provide either source_id or both ra and dec."
 
-    # Query SkyPortal for all sources (will filter client-side)
-    # Note: SkyPortal's /api/sources doesn't have built-in spatial filtering,
-    # so we fetch sources and compute separations client-side
+    # Convert radius from arcseconds to degrees for API
+    radius_deg = radius_arcsec / 3600.0
+
+    # Query SkyPortal using built-in spatial filtering
     try:
         async with httpx.AsyncClient(timeout=60) as client:
             resp = await client.get(
                 f"{SKYPORTAL_URL}/api/sources",
                 headers={"Authorization": f"token {token}"},
-                params={"numPerPage": num_per_page * 10, "includeComments": False},
+                params={
+                    "ra": ra,
+                    "dec": dec,
+                    "radius": radius_deg,
+                    "numPerPage": num_per_page,
+                    "includeComments": False,
+                },
             )
         resp.raise_for_status()
     except httpx.HTTPStatusError as e:
@@ -368,9 +276,12 @@ async def search_sources_near_position(
 
     sources = resp.json().get("data", {}).get("sources", [])
     if not sources:
-        return "No sources found in SkyPortal (or no access to any groups)."
+        return (
+            f"No sources found within {radius_arcsec:.1f} arcsec of "
+            f"RA={ra:.6f}, Dec={dec:+.6f}"
+        )
 
-    # Compute separations using simple angular distance
+    # Compute separations for sorting
     import math
 
     def angular_separation(ra1: float, dec1: float, ra2: float, dec2: float) -> float:
@@ -390,7 +301,7 @@ async def search_sources_near_position(
         c = 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
         return math.degrees(c) * 3600  # Convert to arcseconds
 
-    # Filter sources by separation
+    # Add separation info to sources
     nearby_sources = []
     for src in sources:
         src_ra = src.get("ra")
@@ -399,22 +310,18 @@ async def search_sources_near_position(
             continue
 
         sep = angular_separation(ra, dec, src_ra, src_dec)
-        if sep <= radius_arcsec:
-            nearby_sources.append(
-                {
-                    "id": src.get("id", ""),
-                    "ra": src_ra,
-                    "dec": src_dec,
-                    "separation_arcsec": sep,
-                    "groups": [g.get("name", "") for g in src.get("groups", [])],
-                }
-            )
+        nearby_sources.append(
+            {
+                "id": src.get("id", ""),
+                "ra": src_ra,
+                "dec": src_dec,
+                "separation_arcsec": sep,
+                "groups": [g.get("name", "") for g in src.get("groups", [])],
+            }
+        )
 
     # Sort by separation
     nearby_sources.sort(key=lambda x: x["separation_arcsec"])
-
-    # Limit to num_per_page
-    nearby_sources = nearby_sources[:num_per_page]
 
     if not nearby_sources:
         return (

--- a/services/mcp_server/tools/astro_utils.py
+++ b/services/mcp_server/tools/astro_utils.py
@@ -1,0 +1,440 @@
+# pyright: reportMissingTypeStubs=false, reportUnknownMemberType=false
+# pyright: reportUnknownVariableType=false, reportUnknownArgumentType=false
+"""Astronomical utility tools: time conversion, survey links, ZTF cutouts."""
+
+import csv
+import io
+from urllib.parse import quote
+
+import httpx
+from astropy.time import Time
+
+from ..server import SKYPORTAL_URL, get_skyportal_token, mcp
+
+# ─── Coordinate formatting helpers ───────────────────────────────────────────
+
+
+def _ra_to_hms(ra_deg: float, sep: str | None = ":") -> str:
+    """Convert RA in decimal degrees to HH:MM:SS string."""
+    from astropy.coordinates import Angle
+
+    a = Angle(ra_deg, unit="deg")
+    kwargs: dict = {"unit": "hour", "precision": 2, "pad": True}
+    if sep is not None:
+        kwargs["sep"] = sep
+    return a.to_string(**kwargs)
+
+
+def _dec_to_dms(dec_deg: float, sep: str | None = ":") -> str:
+    """Convert Dec in decimal degrees to DD:MM:SS string."""
+    from astropy.coordinates import Angle
+
+    a = Angle(dec_deg, unit="deg")
+    kwargs: dict = {"unit": "deg", "precision": 2, "alwayssign": True, "pad": True}
+    if sep is not None:
+        kwargs["sep"] = sep
+    return a.to_string(**kwargs)
+
+
+# ─── Time conversion ────────────────────────────────────────────────────────
+
+
+@mcp.tool()
+def convert_time(
+    value: str,
+    from_format: str = "auto",
+    to_format: str = "auto",
+) -> str:
+    """Convert between MJD, JD, ISO datetime, and Unix timestamps.
+
+    Args:
+        value: The time value to convert (e.g., "60400.5", "2024-03-15T12:00:00",
+               "2024-03-15", "1710504000")
+        from_format: Input format — one of "mjd", "jd", "iso", "unix", or "auto"
+                     to detect automatically
+        to_format: Desired output format — one of "mjd", "jd", "iso", "unix", or
+                   "auto" (returns all formats)
+    """
+    format_map = {"mjd": "mjd", "jd": "jd", "iso": "isot", "unix": "unix"}
+
+    try:
+        if from_format == "auto":
+            try:
+                float_val = float(value)
+                if float_val > 2_400_000:
+                    t = Time(float_val, format="jd")
+                elif float_val > 100_000:
+                    t = Time(float_val, format="mjd")
+                else:
+                    t = Time(float_val, format="mjd")
+            except ValueError:
+                t = Time(value, format="isot")
+        else:
+            fmt = format_map.get(from_format)
+            if fmt is None:
+                return f"Unknown from_format '{from_format}'. Use: mjd, jd, iso, unix, auto"
+            val = float(value) if fmt != "isot" else value
+            t = Time(val, format=fmt)
+
+        if to_format != "auto":
+            fmt = format_map.get(to_format)
+            if fmt is None:
+                return f"Unknown to_format '{to_format}'. Use: mjd, jd, iso, unix, auto"
+            return f"{getattr(t, fmt)}"
+
+        return f"ISO: {t.isot}\nMJD: {t.mjd}\nJD:  {t.jd}\nUnix: {t.unix}"
+    except Exception as e:
+        return f"Conversion error: {e}"
+
+
+# ─── Survey links ───────────────────────────────────────────────────────────
+
+
+@mcp.tool()
+async def get_survey_urls(
+    ra: float | None = None,
+    dec: float | None = None,
+    source_id: str | None = None,
+) -> str:
+    """Get URLs to browse a sky position in common astronomical surveys.
+
+    Provide either ra/dec coordinates or a source_id to auto-resolve
+    coordinates from SkyPortal.
+
+    Args:
+        ra: Right ascension in decimal degrees (J2000). Not needed if
+            source_id is provided.
+        dec: Declination in decimal degrees (J2000). Not needed if
+             source_id is provided.
+        source_id: SkyPortal source ID (e.g., "ZTF21aaaaaaa"). RA/Dec
+                   will be looked up automatically. Requires authentication.
+
+    Returns:
+        Resolved coordinates (RA/Dec in decimal degrees and sexagesimal)
+        followed by clickable links for ZTF, Legacy Survey, PanSTARRS,
+        SDSS, NED, SIMBAD, VizieR, WISE, DSS, ADS, TNS, Aladin, and more.
+        For ZTF (IRSA), the link goes to the search page with instructions
+        to enter the coordinates manually.
+    """
+    # Resolve coordinates from source_id if needed
+    if source_id and (ra is None or dec is None):
+        token = get_skyportal_token()
+        if not token:
+            return "Authentication required to look up source coordinates. Provide ra/dec directly or authenticate."
+        try:
+            async with httpx.AsyncClient(timeout=30) as client:
+                resp = await client.get(
+                    f"{SKYPORTAL_URL}/api/sources/{source_id}",
+                    headers={"Authorization": f"token {token}"},
+                )
+            resp.raise_for_status()
+            src = resp.json().get("data", {})
+            ra = src.get("ra")
+            dec = src.get("dec")
+            if ra is None or dec is None:
+                return f"Could not resolve coordinates for source {source_id}"
+        except Exception as e:
+            return f"Error looking up source {source_id}: {e}"
+
+    if ra is None or dec is None:
+        return "Provide either source_id or both ra and dec."
+
+    ra_hms = _ra_to_hms(ra)
+    dec_dms = _dec_to_dms(dec)
+    ra_hms_space = _ra_to_hms(ra, " ")
+    dec_dms_space = _dec_to_dms(dec, " ")
+
+    sign = "%2B" if dec > 0 else ""
+
+    surveys = {
+        "ZTF (IRSA)": (
+            f"https://irsa.ipac.caltech.edu/applications/ztf/"
+            f"\n    NOTE: Enter coordinates RA={ra:.6f}, Dec={dec:+.6f} in the search box."
+        ),
+        "Legacy Survey": f"https://www.legacysurvey.org/viewer?ra={ra}&dec={dec}&zoom=14",
+        "PanSTARRS": (
+            f"https://ps1images.stsci.edu/cgi-bin/ps1cutouts"
+            f"?pos={ra}+{dec}&filter=color&filter=g&filter=r&filter=i"
+            f"&filter=z&filter=y&filetypes=stack&size=240"
+        ),
+        "SDSS": f"https://skyserver.sdss.org/dr18/VisualTools/navi?opt=G&ra={ra}&dec={dec}&scale=0.1",
+        "NED": f"https://ned.ipac.caltech.edu/cgi-bin/nph-objsearch?lon={ra}d&lat={dec}d&radius=1.0&search_type=Near+Position+Search",
+        "SIMBAD": f"http://simbad.u-strasbg.fr/simbad/sim-coo?protocol=html&NbIdent=30&Radius.unit=arcsec&CooFrame=FK5&CooEpoch=2000&CooEqui=2000&Coord={ra}d+{dec}d",
+        "VizieR": f"https://vizier.cds.unistra.fr/viz-bin/VizieR?-source=&-out.add=_r&-sort=_r&-out.max=20&-c={ra_hms}+{dec_dms}&-c.rs=10",
+        "TNS": f"https://wis-tns.org/search?&ra={ra}&decl={dec}&radius=10&coords_unit=arcsec",
+        "ADS": f"https://ui.adsabs.harvard.edu/search/q=object%22{ra}%20{sign}{dec}%3A0%201%22&sort=date%20desc",
+        "DSS2": f"https://archive.stsci.edu/cgi-bin/dss_search?v=poss2ukstu_red&r={ra}&d={dec}&e=J2000&h=15.0&w=15.0&f=gif",
+        "WISE (IRSA SIA)": (
+            f"https://irsa.ipac.caltech.edu/SIA?COLLECTION=wise_allwise"
+            f"&POS=circle+{ra}+{dec}+0.01&RESPONSEFORMAT=CSV"
+        ),
+        "Gaia DR2 (VizieR)": f"https://vizier.cds.unistra.fr/viz-bin/VizieR?-source=I/345/gaia2&-out.add=_r&-sort=_r&-out.max=20&-c={ra_hms}+{dec_dms}&-c.rs=10",
+        "Aladin": (
+            f"https://aladin.cds.unistra.fr/AladinLite/"
+            f"?target={quote(ra_hms_space)}{sign}{quote(dec_dms_space)}"
+            f"&fov=0.08&survey=P%2FPanSTARRS%2FDR1%2Fcolor-z-zg-g"
+        ),
+        "Extinction (NED)": (
+            f"https://ned.ipac.caltech.edu/extinction_calculator"
+            f"?in_csys=Equatorial&in_equinox=J2000.0&obs_epoch=2000.0"
+            f"&ra={_ra_to_hms(ra, None)}&dec={_dec_to_dms(dec, None)}"
+        ),
+        "HEASARC": (
+            f"https://heasarc.gsfc.nasa.gov/cgi-bin/vo/datascope/jds.pl"
+            f"?position={quote(ra_hms_space)}%2C{quote(dec_dms_space)}&size=0.25"
+        ),
+    }
+
+    header = "Survey links for"
+    if source_id:
+        header += f" {source_id} —"
+    header += f" RA={ra:.6f}, Dec={dec:+.6f} ({ra_hms}, {dec_dms}):\n"
+
+    lines = [header]
+    for name, url in surveys.items():
+        lines.append(f"  {name}: {url}")
+    return "\n".join(lines)
+
+
+# ─── ZTF cutout URLs ────────────────────────────────────────────────────────
+
+
+@mcp.tool()
+async def get_ztf_cutout_urls(
+    ra: float,
+    dec: float,
+    size_arcmin: float = 1.0,
+) -> str:
+    """Query IRSA for ZTF image cutout URLs at a given position.
+
+    Searches the IRSA ZTF archive for science and reference images covering
+    the position, and returns direct download URLs for the FITS files.
+
+    Args:
+        ra: Right ascension in decimal degrees (J2000)
+        dec: Declination in decimal degrees (J2000)
+        size_arcmin: Search region size in arcminutes (default 1.0)
+    """
+    size_deg = size_arcmin / 60.0
+    base_search = "https://irsa.ipac.caltech.edu/ibe/search/ztf/products"
+    base_data = "https://irsa.ipac.caltech.edu/ibe/data/ztf/products"
+
+    results = []
+
+    # Query for science images
+    sci_url = f"{base_search}/sci?POS={ra:.6f},{dec:.6f}&SIZE={size_deg:.6f}&ct=csv"
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            resp = await client.get(sci_url)
+        if resp.is_success and resp.text.strip():
+            reader = csv.DictReader(io.StringIO(resp.text))
+            rows = list(reader)
+            if rows:
+                results.append(f"Found {len(rows)} science image(s).\n")
+                for i, row in enumerate(rows[:5]):
+                    field = row.get("field", "").zfill(6)
+                    filt = row.get("filtercode", "")
+                    ccdid = row.get("ccdid", "").zfill(2)
+                    qid = row.get("qid", "")
+                    filefracday = row.get("filefracday", "")
+                    imgtypecode = row.get("imgtypecode", "o")
+                    fits_url = (
+                        f"{base_data}/sci/{filefracday[:4]}/{filefracday[4:8]}"
+                        f"/{filefracday}/ztf_{filefracday}_{field}_{filt}"
+                        f"_c{ccdid}_{imgtypecode}_q{qid}_sciimg.fits"
+                    )
+                    results.append(
+                        f"  Science #{i + 1}: filter={filt} field={field} "
+                        f"ccd={ccdid} quad={qid}\n    {fits_url}"
+                    )
+            else:
+                results.append("No science images found at this position.")
+    except Exception as e:
+        results.append(f"Science image search error: {e}")
+
+    # Query for reference images
+    ref_url = f"{base_search}/ref?POS={ra:.6f},{dec:.6f}&SIZE={size_deg:.6f}&ct=csv"
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            resp = await client.get(ref_url)
+        if resp.is_success and resp.text.strip():
+            reader = csv.DictReader(io.StringIO(resp.text))
+            rows = list(reader)
+            if rows:
+                results.append(f"\nFound {len(rows)} reference image(s).\n")
+                for i, row in enumerate(rows[:5]):
+                    field = row.get("field", "").zfill(6)
+                    filt = row.get("filtercode", "")
+                    ccdid = row.get("ccdid", "").zfill(2)
+                    qid = row.get("qid", "")
+                    fits_url = (
+                        f"{base_data}/ref/{field[:3]}/field{field}/{filt}"
+                        f"/ccd{ccdid}/q{qid}"
+                        f"/ztf_{field}_{filt}_c{ccdid}_q{qid}_refimg.fits"
+                    )
+                    results.append(
+                        f"  Reference #{i + 1}: filter={filt} field={field} "
+                        f"ccd={ccdid} quad={qid}\n    {fits_url}"
+                    )
+            else:
+                results.append("\nNo reference images found at this position.")
+    except Exception as e:
+        results.append(f"\nReference image search error: {e}")
+
+    viewer_url = (
+        f"https://irsa.ipac.caltech.edu/applications/ztf/"
+        f"#id=Hydra_ztf_ztf_image_pos&RequestClass=ServerRequest"
+        f"&DoSearch=true&intersect=CENTER&subsize=0.139"
+        f"&mcenter=all&dpLevel=sci,ref,diff"
+        f"&UserTargetWorldPt={ra};{dec};EQ_J2000"
+    )
+    results.append(f"\nInteractive IRSA ZTF viewer: {viewer_url}")
+
+    return "\n".join(results)
+
+
+# ─── SkyPortal cone search ──────────────────────────────────────────────────
+
+
+@mcp.tool()
+async def search_sources_near_position(
+    ra: float | None = None,
+    dec: float | None = None,
+    source_id: str | None = None,
+    radius_arcsec: float = 10.0,
+    num_per_page: int = 100,
+) -> str:
+    """Search for sources in SkyPortal near a position (cone search).
+
+    Finds all sources within a specified radius of a sky position. Useful for
+    checking if a source already exists in SkyPortal at a given location, or
+    finding nearby sources.
+
+    Provide either ra/dec coordinates or a source_id to auto-resolve coordinates.
+
+    Args:
+        ra: Right ascension in decimal degrees (J2000). Not needed if
+            source_id is provided.
+        dec: Declination in decimal degrees (J2000). Not needed if
+             source_id is provided.
+        source_id: SkyPortal source ID (e.g., "ZTF21aaaaaaa"). RA/Dec
+                   will be looked up automatically. Requires authentication.
+        radius_arcsec: Search radius in arcseconds (default: 10.0)
+        num_per_page: Maximum number of sources to return (default: 100)
+
+    Returns:
+        List of sources within the radius, sorted by separation. Includes
+        source ID, coordinates, separation, and saved groups.
+    """
+    token = get_skyportal_token()
+    if not token:
+        return "Not authenticated. Configure SKYPORTAL_TOKEN or send Bearer token."
+
+    # Resolve coordinates from source_id if needed
+    if source_id and (ra is None or dec is None):
+        try:
+            async with httpx.AsyncClient(timeout=30) as client:
+                resp = await client.get(
+                    f"{SKYPORTAL_URL}/api/sources/{source_id}",
+                    headers={"Authorization": f"token {token}"},
+                )
+            resp.raise_for_status()
+            src = resp.json().get("data", {})
+            ra = src.get("ra")
+            dec = src.get("dec")
+            if ra is None or dec is None:
+                return f"Could not resolve coordinates for source {source_id}"
+        except Exception as e:
+            return f"Error looking up source {source_id}: {e}"
+
+    if ra is None or dec is None:
+        return "Provide either source_id or both ra and dec."
+
+    # Query SkyPortal for all sources (will filter client-side)
+    # Note: SkyPortal's /api/sources doesn't have built-in spatial filtering,
+    # so we fetch sources and compute separations client-side
+    try:
+        async with httpx.AsyncClient(timeout=60) as client:
+            resp = await client.get(
+                f"{SKYPORTAL_URL}/api/sources",
+                headers={"Authorization": f"token {token}"},
+                params={"numPerPage": num_per_page * 10, "includeComments": False},
+            )
+        resp.raise_for_status()
+    except httpx.HTTPStatusError as e:
+        return f"HTTP Error {e.response.status_code}: {e.response.text}"
+    except Exception as e:
+        return f"Error querying sources: {e}"
+
+    sources = resp.json().get("data", {}).get("sources", [])
+    if not sources:
+        return "No sources found in SkyPortal (or no access to any groups)."
+
+    # Compute separations using simple angular distance
+    import math
+
+    def angular_separation(ra1: float, dec1: float, ra2: float, dec2: float) -> float:
+        """Compute angular separation in arcseconds using haversine formula."""
+        ra1_rad = math.radians(ra1)
+        dec1_rad = math.radians(dec1)
+        ra2_rad = math.radians(ra2)
+        dec2_rad = math.radians(dec2)
+
+        delta_ra = ra2_rad - ra1_rad
+        delta_dec = dec2_rad - dec1_rad
+
+        a = (
+            math.sin(delta_dec / 2) ** 2
+            + math.cos(dec1_rad) * math.cos(dec2_rad) * math.sin(delta_ra / 2) ** 2
+        )
+        c = 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
+        return math.degrees(c) * 3600  # Convert to arcseconds
+
+    # Filter sources by separation
+    nearby_sources = []
+    for src in sources:
+        src_ra = src.get("ra")
+        src_dec = src.get("dec")
+        if src_ra is None or src_dec is None:
+            continue
+
+        sep = angular_separation(ra, dec, src_ra, src_dec)
+        if sep <= radius_arcsec:
+            nearby_sources.append(
+                {
+                    "id": src.get("id", ""),
+                    "ra": src_ra,
+                    "dec": src_dec,
+                    "separation_arcsec": sep,
+                    "groups": [g.get("name", "") for g in src.get("groups", [])],
+                }
+            )
+
+    # Sort by separation
+    nearby_sources.sort(key=lambda x: x["separation_arcsec"])
+
+    # Limit to num_per_page
+    nearby_sources = nearby_sources[:num_per_page]
+
+    if not nearby_sources:
+        return (
+            f"No sources found within {radius_arcsec:.1f} arcsec of "
+            f"RA={ra:.6f}, Dec={dec:+.6f}"
+        )
+
+    # Format output
+    ra_hms = _ra_to_hms(ra)
+    dec_dms = _dec_to_dms(dec)
+    header = f'Sources within {radius_arcsec:.1f}" of RA={ra:.6f}, Dec={dec:+.6f} ({ra_hms}, {dec_dms}):\n'
+    lines = [header]
+
+    for src in nearby_sources:
+        groups_str = ", ".join(src["groups"]) if src["groups"] else "(no groups)"
+        lines.append(
+            f'  • {src["id"]}: {src["separation_arcsec"]:.2f}" away '
+            f"[RA={src['ra']:.6f}, Dec={src['dec']:+.6f}] — {groups_str}"
+        )
+
+    lines.append(f"\nTotal: {len(nearby_sources)} source(s)")
+
+    return "\n".join(lines)

--- a/services/mcp_server/tools/bulk_analysis.py
+++ b/services/mcp_server/tools/bulk_analysis.py
@@ -1,0 +1,249 @@
+# pyright: reportMissingTypeStubs=false
+"""Bulk analysis tools using ztfquery for large-scale data operations."""
+
+import json
+
+from ..server import mcp
+from . import code_templates
+
+
+@mcp.tool()
+async def generate_bulk_lightcurve_code(
+    sources: str,
+    filters: str = "ztfg,ztfr,ztfi",
+    include_plots: bool = True,
+) -> str:
+    """Generate code to bulk download ZTF forced photometry using ztfquery.
+
+    This tool generates ready-to-run Python code for Jupyter notebooks that:
+    - Downloads forced photometry for multiple sources
+    - Saves results to CSV files
+    - Optionally creates light curve plots
+    - Includes progress tracking and error handling
+
+    **Use Case:** When you need photometry for many sources (>5) and want to
+    run the query locally for better performance and control.
+
+    Args:
+        sources: Comma-separated list of ZTF source names, or JSON array.
+                Example: "ZTF24aaaaaaa,ZTF24aaaaaab,ZTF24aaaaaac"
+                Or: '["ZTF24aaaaaaa", "ZTF24aaaaaab"]'
+        filters: Comma-separated filter names (default: "ztfg,ztfr,ztfi")
+        include_plots: Generate light curve plots (default: True)
+
+    Returns:
+        Python code ready to run in a Jupyter notebook. The code will:
+        - Create a 'ztf_lightcurves' directory with results
+        - Save individual light curves as CSV files
+        - Create a summary.csv with statistics
+        - Generate plots in 'ztf_lightcurves/plots/' if requested
+
+    Example:
+        sources = "ZTF21aaaaaaa,ZTF21aaaaaab,ZTF21aaaaaac"
+        filters = "ztfg,ztfr"
+        → Generates code to download g/r photometry for 3 sources
+    """
+    # Parse sources (handle both comma-separated and JSON)
+    if sources.strip().startswith("["):
+        source_list = json.loads(sources)
+    else:
+        source_list = [s.strip() for s in sources.split(",") if s.strip()]
+
+    # Parse filters
+    filter_list = [f.strip() for f in filters.split(",") if f.strip()]
+
+    if not source_list:
+        return "Error: No sources provided"
+
+    if not filter_list:
+        return "Error: No filters provided"
+
+    return code_templates.generate_bulk_lightcurve_query(
+        source_list=source_list,
+        filters=filter_list,
+        include_plots=include_plots,
+    )
+
+
+@mcp.tool()
+async def generate_cone_search_code(
+    coordinates: str,
+    radius_arcsec: float = 2.0,
+) -> str:
+    """Generate code to perform ZTF cone searches at multiple positions.
+
+    This tool generates Python code that searches for ZTF detections within
+    a radius of specified sky coordinates. Useful for cross-matching catalogs
+    or checking if known positions have ZTF coverage.
+
+    **Use Case:** When you have a list of coordinates (e.g., from a catalog,
+    TNS, or previous observations) and want to find all ZTF detections nearby.
+
+    Args:
+        coordinates: Comma-separated "RA,Dec" pairs or JSON array of [RA, Dec].
+                    RA/Dec in decimal degrees (J2000).
+                    Examples:
+                    - "150.0,2.5,151.2,3.1,152.5,2.8"  (3 positions)
+                    - '[[150.0, 2.5], [151.2, 3.1]]'  (JSON format)
+        radius_arcsec: Search radius in arcseconds (default: 2.0)
+
+    Returns:
+        Python code for Jupyter notebook that:
+        - Performs cone search at each position
+        - Saves all detections to 'ztf_cone_search/cone_search_results.csv'
+        - Creates summary with detection counts per position
+        - Includes query coordinates for cross-reference
+
+    Example:
+        coordinates = "150.5,2.3,151.2,3.1"
+        radius_arcsec = 5.0
+        → Searches within 5" of two positions
+    """
+    # Parse coordinates
+    if coordinates.strip().startswith("["):
+        # JSON format: [[ra1, dec1], [ra2, dec2], ...]
+        coord_list = json.loads(coordinates)
+    else:
+        # Comma-separated: ra1,dec1,ra2,dec2,...
+        vals = [float(x.strip()) for x in coordinates.split(",")]
+        if len(vals) % 2 != 0:
+            return "Error: Coordinates must be pairs of (RA, Dec)"
+        coord_list = [(vals[i], vals[i + 1]) for i in range(0, len(vals), 2)]
+
+    if not coord_list:
+        return "Error: No coordinates provided"
+
+    return code_templates.generate_cone_search_query(
+        ra_dec_list=coord_list,
+        radius_arcsec=radius_arcsec,
+    )
+
+
+@mcp.tool()
+async def generate_fritz_bulk_query_code(
+    sources: str,
+    include_spectra: bool = True,
+) -> str:
+    """Generate code to bulk query Fritz/SkyPortal for multiple sources.
+
+    This tool generates code that uses ztfquery's Fritz interface to download
+    photometry, spectra, and metadata for multiple sources from Fritz.
+
+    **Use Case:** When you need to download data products from Fritz for
+    many sources at once (faster than individual API calls).
+
+    **Note:** Requires Fritz API token. Set as FRITZ_TOKEN environment variable
+    or edit the generated code.
+
+    Args:
+        sources: Comma-separated source names or JSON array
+                Example: "ZTF24aaaaaaa,AT2024abc,SN2024xyz"
+        include_spectra: Download spectra in addition to photometry (default: True)
+
+    Returns:
+        Python code for Jupyter notebook that:
+        - Queries Fritz API for each source
+        - Downloads photometry and (optionally) spectra
+        - Saves individual files: {source}_photometry.csv, {source}_spectra.csv
+        - Creates summary with redshifts, classifications, data counts
+        - Saves to 'fritz_data/' directory
+
+    Example:
+        sources = "ZTF21aaaaaaa,AT2021abc"
+        include_spectra = True
+        → Downloads photometry + spectra for both sources
+    """
+    # Parse sources
+    if sources.strip().startswith("["):
+        source_list = json.loads(sources)
+    else:
+        source_list = [s.strip() for s in sources.split(",") if s.strip()]
+
+    if not source_list:
+        return "Error: No sources provided"
+
+    return code_templates.generate_fritz_bulk_query(
+        source_list=source_list,
+        include_spectra=include_spectra,
+    )
+
+
+@mcp.tool()
+async def generate_alert_download_code(
+    sources: str,
+    with_cutouts: bool = True,
+) -> str:
+    """Generate code to download ZTF alert packets for multiple sources.
+
+    This tool generates code that downloads raw ZTF alert packets, which contain
+    the full alert history including candidate info, cutouts, and previous detections.
+
+    **Use Case:** When you need complete alert history or want to access alert-level
+    data that isn't available in forced photometry.
+
+    Args:
+        sources: Comma-separated ZTF source names or JSON array
+                Example: "ZTF24aaaaaaa,ZTF24aaaaaab"
+        with_cutouts: Download cutout images (science, ref, diff) (default: True)
+
+    Returns:
+        Python code for Jupyter notebook that:
+        - Downloads alert packets for each source
+        - Saves alerts as JSON files
+        - Optionally downloads FITS cutouts (science, reference, difference)
+        - Saves to 'ztf_alerts/' and 'ztf_alerts/cutouts/' directories
+        - Creates summary with alert counts
+
+    Example:
+        sources = "ZTF21aaaaaaa,ZTF21aaaaaab"
+        with_cutouts = True
+        → Downloads full alert history + cutouts for both sources
+    """
+    # Parse sources
+    if sources.strip().startswith("["):
+        source_list = json.loads(sources)
+    else:
+        source_list = [s.strip() for s in sources.split(",") if s.strip()]
+
+    if not source_list:
+        return "Error: No sources provided"
+
+    return code_templates.generate_alert_query(
+        source_list=source_list,
+        with_cutouts=with_cutouts,
+    )
+
+
+@mcp.tool()
+async def generate_field_visualization_code(
+    field_id: int,
+    ccd_id: int | None = None,
+) -> str:
+    """Generate code to visualize ZTF field and CCD coverage.
+
+    This tool generates code to create sky maps showing ZTF field footprints
+    and CCD layouts. Useful for understanding coverage and planning observations.
+
+    **Use Case:** When you need to visualize which parts of the sky are covered
+    by specific ZTF fields or CCDs.
+
+    Args:
+        field_id: ZTF field ID (1-1895)
+        ccd_id: Optional CCD ID to highlight (1-16). If None, shows full field.
+
+    Returns:
+        Python code for Jupyter notebook that:
+        - Creates Mollweide projection sky map
+        - Shows field footprint on sky
+        - Highlights specific CCD if requested
+        - Displays RA/Dec coverage information
+
+    Example:
+        field_id = 300
+        ccd_id = 8
+        → Shows field 300 with CCD 8 highlighted
+    """
+    return code_templates.generate_field_visualization(
+        field_id=field_id,
+        ccd_id=ccd_id,
+    )

--- a/services/mcp_server/tools/bulk_analysis.py
+++ b/services/mcp_server/tools/bulk_analysis.py
@@ -13,35 +13,36 @@ async def generate_bulk_lightcurve_code(
     filters: str = "ztfg,ztfr,ztfi",
     include_plots: bool = True,
 ) -> str:
-    """Generate code to bulk download ZTF forced photometry using ztfquery.
+    """Generate a Jupyter notebook to bulk download ZTF light curves from Fritz.
 
-    This tool generates ready-to-run Python code for Jupyter notebooks that:
-    - Downloads forced photometry for multiple sources
-    - Saves results to CSV files
-    - Optionally creates light curve plots
-    - Includes progress tracking and error handling
+    Creates a ready-to-run .ipynb notebook that uses ztfquery's Fritz
+    integration to download **alert photometry** (detection epochs) for
+    multiple sources with multiprocessing, save results to CSV, and create
+    interactive Plotly plots.
 
-    **Use Case:** When you need photometry for many sources (>5) and want to
-    run the query locally for better performance and control.
+    **Note:** This downloads alert photometry, not forced photometry.
+    For forced photometry (including non-detections/upper limits), use the
+    IRSA ZTF forced photometry service.
+
+    **Requires:** ztfquery + Fritz API token.
+    Setup: `from ztfquery.io import set_account; set_account('fritz', token_based=True)`
 
     Args:
         sources: Comma-separated list of ZTF source names, or JSON array.
                 Example: "ZTF24aaaaaaa,ZTF24aaaaaab,ZTF24aaaaaac"
                 Or: '["ZTF24aaaaaaa", "ZTF24aaaaaab"]'
         filters: Comma-separated filter names (default: "ztfg,ztfr,ztfi")
-        include_plots: Generate light curve plots (default: True)
+        include_plots: Generate interactive Plotly light curve plots (default: True)
 
     Returns:
-        Python code ready to run in a Jupyter notebook. The code will:
-        - Create a 'ztf_lightcurves' directory with results
-        - Save individual light curves as CSV files
-        - Create a summary.csv with statistics
-        - Generate plots in 'ztf_lightcurves/plots/' if requested
+        Path to the generated Jupyter notebook in ztf_lightcurves/ directory.
+        The notebook downloads data from Fritz, saves per-source CSVs,
+        and plots interactive light curves with Plotly.
 
     Example:
         sources = "ZTF21aaaaaaa,ZTF21aaaaaab,ZTF21aaaaaac"
         filters = "ztfg,ztfr"
-        → Generates code to download g/r photometry for 3 sources
+        → Generates notebook to download g/r photometry for 3 sources
     """
     # Parse sources (handle both comma-separated and JSON)
     if sources.strip().startswith("["):
@@ -132,8 +133,8 @@ async def generate_fritz_bulk_query_code(
     **Use Case:** When you need to download data products from Fritz for
     many sources at once (faster than individual API calls).
 
-    **Note:** Requires Fritz API token. Set as FRITZ_TOKEN environment variable
-    or edit the generated code.
+    **Note:** Requires Fritz API token.
+    Setup: `from ztfquery.io import set_account; set_account('fritz', token_based=True)`
 
     Args:
         sources: Comma-separated source names or JSON array

--- a/services/mcp_server/tools/code_templates.py
+++ b/services/mcp_server/tools/code_templates.py
@@ -1,0 +1,524 @@
+# pyright: reportMissingTypeStubs=false
+"""Code generation templates for bulk analysis using ztfquery."""
+
+import json
+from typing import Any
+
+
+def generate_ztfquery_setup() -> str:
+    """Generate setup code for ztfquery authentication."""
+    return """# ztfquery Setup and Authentication
+# Run this once to configure IRSA credentials:
+# from ztfquery import io
+# io.set_account('your_irsa_username', 'your_irsa_password')
+# Get IRSA account at: https://irsa.ipac.caltech.edu/account/signon/login.do
+
+import warnings
+warnings.filterwarnings('ignore')
+
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+from tqdm.auto import tqdm
+from pathlib import Path
+"""
+
+
+def generate_bulk_lightcurve_query(
+    source_list: list[str], filters: list[str], include_plots: bool = True
+) -> str:
+    """Generate code to query forced photometry for multiple sources.
+
+    Args:
+        source_list: List of ZTF source names
+        filters: List of filter names (e.g., ['ztfg', 'ztfr', 'ztfi'])
+        include_plots: Include plotting code
+
+    Returns:
+        Python code string for notebook
+    """
+    source_json = json.dumps(source_list, indent=4)
+    filter_json = json.dumps(filters)
+
+    code = generate_ztfquery_setup()
+
+    code += f"""
+from ztfquery import lightcurve
+
+# Configuration
+sources = {source_json}
+
+filters = {filter_json}
+
+# Results storage
+output_dir = Path('ztf_lightcurves')
+output_dir.mkdir(exist_ok=True)
+
+results = {{}}
+errors = []
+
+print(f"Querying forced photometry for {{len(sources)}} sources...")
+print(f"Filters: {{', '.join(filters)}}")
+print()
+
+# Query each source
+for source in tqdm(sources, desc="Downloading light curves"):
+    try:
+        # Download forced photometry
+        lcq = lightcurve.LCQuery.from_name(source)
+
+        # Get data as DataFrame
+        lc_data = lcq.data
+
+        if lc_data is not None and len(lc_data) > 0:
+            # Filter by requested bands
+            lc_filtered = lc_data[lc_data['filter'].isin(filters)]
+
+            # Save to CSV
+            output_file = output_dir / f"{{source}}_lc.csv"
+            lc_filtered.to_csv(output_file, index=False)
+
+            results[source] = {{
+                'data': lc_filtered,
+                'n_points': len(lc_filtered),
+                'filters': lc_filtered['filter'].unique().tolist(),
+                'file': str(output_file)
+            }}
+
+            print(f"✓ {{source}}: {{len(lc_filtered)}} points")
+        else:
+            print(f"✗ {{source}}: No data")
+            errors.append({{'source': source, 'error': 'No data returned'}})
+
+    except Exception as e:
+        print(f"✗ {{source}}: {{str(e)}}")
+        errors.append({{'source': source, 'error': str(e)}})
+
+print()
+print(f"Successfully downloaded: {{len(results)}}/{{len(sources)}}")
+print(f"Failed: {{len(errors)}}")
+
+# Save summary
+summary = pd.DataFrame([
+    {{'source': src, 'n_points': info['n_points'],
+      'filters': ','.join(info['filters']), 'file': info['file']}}
+    for src, info in results.items()
+])
+summary.to_csv(output_dir / 'summary.csv', index=False)
+print(f"\\nSummary saved to: {{output_dir / 'summary.csv'}}")
+
+if errors:
+    error_df = pd.DataFrame(errors)
+    error_df.to_csv(output_dir / 'errors.csv', index=False)
+    print(f"Errors saved to: {{output_dir / 'errors.csv'}}")
+"""
+
+    if include_plots:
+        code += """
+# Plot light curves
+print("\\nGenerating plots...")
+
+fig_dir = output_dir / 'plots'
+fig_dir.mkdir(exist_ok=True)
+
+for source, info in tqdm(results.items(), desc="Creating plots"):
+    lc_data = info['data']
+
+    # Create figure
+    fig, ax = plt.subplots(figsize=(10, 6))
+
+    # Plot each filter
+    colors = {'ztfg': 'green', 'ztfr': 'red', 'ztfi': 'orange'}
+
+    for filt in info['filters']:
+        mask = lc_data['filter'] == filt
+        filt_data = lc_data[mask]
+
+        # Only plot detections (mag is not null)
+        detections = filt_data[filt_data['mag'].notna()]
+
+        if len(detections) > 0:
+            ax.errorbar(
+                detections['mjd'],
+                detections['mag'],
+                yerr=detections['magerr'],
+                fmt='o',
+                label=filt,
+                color=colors.get(filt, 'gray'),
+                alpha=0.7,
+                capsize=3
+            )
+
+    ax.invert_yaxis()
+    ax.set_xlabel('MJD', fontsize=12)
+    ax.set_ylabel('AB Magnitude', fontsize=12)
+    ax.set_title(f'{source} Light Curve', fontsize=14, fontweight='bold')
+    ax.legend()
+    ax.grid(True, alpha=0.3)
+
+    plt.tight_layout()
+    plt.savefig(fig_dir / f'{source}_lc.png', dpi=150, bbox_inches='tight')
+    plt.close()
+
+print(f"Plots saved to: {fig_dir}")
+"""
+
+    return code
+
+
+def generate_cone_search_query(
+    ra_dec_list: list[tuple[float, float]], radius_arcsec: float = 2.0
+) -> str:
+    """Generate code to perform cone search for multiple coordinates.
+
+    Args:
+        ra_dec_list: List of (RA, Dec) tuples in degrees
+        radius_arcsec: Search radius in arcseconds
+
+    Returns:
+        Python code string for notebook
+    """
+    coords_json = json.dumps(ra_dec_list, indent=4)
+
+    code = generate_ztfquery_setup()
+
+    code += f"""
+from ztfquery import query
+from astropy.coordinates import SkyCoord
+from astropy import units as u
+
+# Configuration
+coordinates = {coords_json}  # List of (RA, Dec) in degrees
+
+radius_arcsec = {radius_arcsec}
+
+# Results storage
+output_dir = Path('ztf_cone_search')
+output_dir.mkdir(exist_ok=True)
+
+results = []
+zq = query.ZTFQuery()
+
+print(f"Performing cone search for {{len(coordinates)}} positions...")
+print(f"Search radius: {{radius_arcsec}} arcsec")
+print()
+
+for i, (ra, dec) in enumerate(tqdm(coordinates, desc="Querying positions")):
+    try:
+        # Create coordinate
+        coord = SkyCoord(ra=ra*u.deg, dec=dec*u.deg, frame='icrs')
+
+        # Query ZTF metadata
+        zq.load_metadata(
+            radec=[ra, dec],
+            radius_arcsec=radius_arcsec
+        )
+
+        if zq.metatable is not None and len(zq.metatable) > 0:
+            # Add coordinate info to results
+            meta = zq.metatable.copy()
+            meta['query_ra'] = ra
+            meta['query_dec'] = dec
+            meta['query_id'] = i
+
+            results.append(meta)
+
+            print(f"✓ Position {{i+1}} ({{ra:.6f}}, {{dec:.6f}}): {{len(meta)}} detections")
+        else:
+            print(f"✗ Position {{i+1}} ({{ra:.6f}}, {{dec:.6f}}): No detections")
+
+    except Exception as e:
+        print(f"✗ Position {{i+1}} ({{ra:.6f}}, {{dec:.6f}}): {{str(e)}}")
+
+# Combine results
+if results:
+    combined = pd.concat(results, ignore_index=True)
+
+    # Save results
+    output_file = output_dir / 'cone_search_results.csv'
+    combined.to_csv(output_file, index=False)
+
+    print()
+    print(f"Total detections: {{len(combined)}}")
+    print(f"Results saved to: {{output_file}}")
+
+    # Summary by position
+    summary = combined.groupby('query_id').agg({{
+        'query_ra': 'first',
+        'query_dec': 'first',
+        'obsjd': 'count'
+    }}).rename(columns={{'obsjd': 'n_detections'}})
+
+    print("\\nSummary by position:")
+    print(summary)
+
+    summary.to_csv(output_dir / 'summary.csv')
+else:
+    print("\\nNo detections found for any position.")
+"""
+
+    return code
+
+
+def generate_fritz_bulk_query(
+    source_list: list[str], include_spectra: bool = True
+) -> str:
+    """Generate code to query Fritz/SkyPortal for multiple sources.
+
+    Args:
+        source_list: List of source names
+        include_spectra: Include spectroscopy queries
+
+    Returns:
+        Python code string for notebook
+    """
+    source_json = json.dumps(source_list, indent=4)
+
+    code = generate_ztfquery_setup()
+
+    code += f"""
+from ztfquery import fritz
+import os
+
+# Configuration
+sources = {source_json}
+
+# Fritz API token (set as environment variable or hardcode)
+FRITZ_TOKEN = os.getenv('FRITZ_TOKEN', 'YOUR_TOKEN_HERE')
+
+# Results storage
+output_dir = Path('fritz_data')
+output_dir.mkdir(exist_ok=True)
+
+# Initialize Fritz connection
+fq = fritz.FritzAPI(token=FRITZ_TOKEN)
+
+results = {{}}
+errors = []
+
+print(f"Querying Fritz for {{len(sources)}} sources...")
+print()
+
+# Query each source
+for source in tqdm(sources, desc="Querying sources"):
+    try:
+        # Get source data
+        source_data = fq.get_source(source)
+
+        if source_data:
+            results[source] = {{}}
+
+            # Save basic source info
+            results[source]['info'] = {{
+                'id': source_data.get('id'),
+                'ra': source_data.get('ra'),
+                'dec': source_data.get('dec'),
+                'redshift': source_data.get('redshift'),
+                'classifications': source_data.get('classifications', []),
+            }}
+
+            # Get photometry
+            photometry = source_data.get('photometry', [])
+            if photometry:
+                phot_df = pd.DataFrame(photometry)
+                phot_file = output_dir / f"{{source}}_photometry.csv"
+                phot_df.to_csv(phot_file, index=False)
+                results[source]['photometry_file'] = str(phot_file)
+                results[source]['n_phot'] = len(phot_df)
+"""
+
+    if include_spectra:
+        code += """
+            # Get spectra
+            spectra = source_data.get('spectra', [])
+            if spectra:
+                spec_df = pd.DataFrame(spectra)
+                spec_file = output_dir / f"{source}_spectra.csv"
+                spec_df.to_csv(spec_file, index=False)
+                results[source]['spectra_file'] = str(spec_file)
+                results[source]['n_spectra'] = len(spec_df)
+"""
+
+    code += """
+            print(f"✓ {source}: {results[source].get('n_phot', 0)} phot, "
+                  f"{results[source].get('n_spectra', 0)} spectra")
+        else:
+            print(f"✗ {source}: Not found")
+            errors.append({'source': source, 'error': 'Source not found'})
+
+    except Exception as e:
+        print(f"✗ {source}: {str(e)}")
+        errors.append({'source': source, 'error': str(e)}})
+
+print()
+print(f"Successfully queried: {len(results)}/{len(sources)}")
+
+# Save summary
+summary_data = []
+for src, data in results.items():
+    info = data.get('info', {})
+    summary_data.append({
+        'source': src,
+        'ra': info.get('ra'),
+        'dec': info.get('dec'),
+        'redshift': info.get('redshift'),
+        'n_photometry': data.get('n_phot', 0),
+        'n_spectra': data.get('n_spectra', 0),
+    })
+
+summary = pd.DataFrame(summary_data)
+summary.to_csv(output_dir / 'summary.csv', index=False)
+print(f"\\nSummary saved to: {output_dir / 'summary.csv'}")
+
+if errors:
+    error_df = pd.DataFrame(errors)
+    error_df.to_csv(output_dir / 'errors.csv', index=False)
+"""
+
+    return code
+
+
+def generate_alert_query(source_list: list[str], with_cutouts: bool = True) -> str:
+    """Generate code to download ZTF alert packets.
+
+    Args:
+        source_list: List of ZTF source names
+        with_cutouts: Include cutout image downloads
+
+    Returns:
+        Python code string for notebook
+    """
+    source_json = json.dumps(source_list, indent=4)
+
+    code = generate_ztfquery_setup()
+
+    code += f"""
+from ztfquery import alert
+
+# Configuration
+sources = {source_json}
+
+with_cutouts = {str(with_cutouts)}
+
+# Results storage
+output_dir = Path('ztf_alerts')
+output_dir.mkdir(exist_ok=True)
+
+if with_cutouts:
+    cutout_dir = output_dir / 'cutouts'
+    cutout_dir.mkdir(exist_ok=True)
+
+results = {{}}
+errors = []
+
+print(f"Downloading alert packets for {{len(sources)}} sources...")
+print(f"Include cutouts: {{with_cutouts}}")
+print()
+
+for source in tqdm(sources, desc="Downloading alerts"):
+    try:
+        # Download alerts for this source
+        alertq = alert.AlertQuery.from_name(source)
+
+        if alertq.data is not None and len(alertq.data) > 0:
+            # Save alert data
+            alert_file = output_dir / f"{{source}}_alerts.json"
+            alertq.store(alert_file)
+
+            results[source] = {{
+                'n_alerts': len(alertq.data),
+                'alert_file': str(alert_file),
+            }}
+"""
+
+    if with_cutouts:
+        code += """
+            # Download cutouts if requested
+            if with_cutouts:
+                try:
+                    cutouts = alertq.get_cutouts()
+                    cutout_files = []
+
+                    for i, cutout_dict in enumerate(cutouts):
+                        for cutout_type, cutout_data in cutout_dict.items():
+                            cutout_file = cutout_dir / f"{source}_alert{i}_{cutout_type}.fits"
+                            # Save cutout (this depends on ztfquery version)
+                            # You may need to adjust this based on actual data structure
+                            cutout_files.append(str(cutout_file))
+
+                    results[source]['cutout_files'] = cutout_files
+                    results[source]['n_cutouts'] = len(cutout_files)
+                except Exception as e:
+                    print(f"  Warning: Could not download cutouts for {source}: {e}")
+"""
+
+    code += """
+            print(f"✓ {source}: {results[source]['n_alerts']} alerts")
+        else:
+            print(f"✗ {source}: No alerts found")
+            errors.append({'source': source, 'error': 'No alerts'})
+
+    except Exception as e:
+        print(f"✗ {source}: {str(e)}")
+        errors.append({'source': source, 'error': str(e)}})
+
+print()
+print(f"Successfully downloaded: {len(results)}/{len(sources)}")
+
+# Save summary
+summary = pd.DataFrame([
+    {'source': src, 'n_alerts': info['n_alerts'],
+     'n_cutouts': info.get('n_cutouts', 0)}
+    for src, info in results.items()
+])
+summary.to_csv(output_dir / 'summary.csv', index=False)
+print(f"\\nSummary saved to: {output_dir / 'summary.csv'}")
+
+if errors:
+    error_df = pd.DataFrame(errors)
+    error_df.to_csv(output_dir / 'errors.csv', index=False)
+"""
+
+    return code
+
+
+def generate_field_visualization(field_id: int, ccd_id: int | None = None) -> str:
+    """Generate code to visualize ZTF field/CCD coverage.
+
+    Args:
+        field_id: ZTF field ID
+        ccd_id: Optional CCD ID (1-16)
+
+    Returns:
+        Python code string for notebook
+    """
+    code = generate_ztfquery_setup()
+
+    code += f"""
+from ztfquery import skyvision
+
+# Configuration
+field_id = {field_id}
+ccd_id = {ccd_id if ccd_id else "None"}
+
+# Create field visualizer
+sv = skyvision.SkyVision.from_field(field_id, ccd=ccd_id)
+
+# Plot field coverage
+fig = plt.figure(figsize=(12, 10))
+ax = fig.add_subplot(111, projection='mollweide')
+
+sv.show(ax=ax, show_ccd={str(ccd_id is not None)})
+
+plt.title(f'ZTF Field {{field_id}}' + (f' CCD {{ccd_id}}' if ccd_id else ''),
+          fontsize=14, fontweight='bold')
+plt.tight_layout()
+plt.show()
+
+# Get field information
+print(f"Field {{field_id}} coverage:")
+print(f"  RA range: {{sv.ra_range}}")
+print(f"  Dec range: {{sv.dec_range}}")
+"""
+
+    return code

--- a/services/mcp_server/tools/code_templates.py
+++ b/services/mcp_server/tools/code_templates.py
@@ -2,18 +2,31 @@
 """Code generation templates for bulk analysis using ztfquery."""
 
 import json
-from typing import Any
 
 
-def generate_ztfquery_setup() -> str:
-    """Generate setup code for ztfquery authentication."""
-    return """# ztfquery Setup and Authentication
-# Run this once to configure IRSA credentials:
-# from ztfquery import io
-# io.set_account('your_irsa_username', 'your_irsa_password')
-# Get IRSA account at: https://irsa.ipac.caltech.edu/account/signon/login.do
+def _make_code_cell(source: str) -> dict:
+    """Create a Jupyter notebook code cell."""
+    return {
+        "cell_type": "code",
+        "execution_count": None,
+        "metadata": {},
+        "outputs": [],
+        "source": source.splitlines(keepends=True),
+    }
 
-import warnings
+
+def _make_markdown_cell(source: str) -> dict:
+    """Create a Jupyter notebook markdown cell."""
+    return {
+        "cell_type": "markdown",
+        "metadata": {},
+        "source": source.splitlines(keepends=True),
+    }
+
+
+def _common_imports() -> str:
+    """Common imports shared by all code templates."""
+    return """import warnings
 warnings.filterwarnings('ignore')
 
 import numpy as np
@@ -24,146 +37,266 @@ from pathlib import Path
 """
 
 
+def generate_fritz_setup() -> str:
+    """Generate setup code for Fritz/SkyPortal via ztfquery."""
+    return (
+        """# ============================================================
+# Fritz/SkyPortal Setup (via ztfquery)
+# ============================================================
+# Prerequisites (run these in your terminal ONCE before using):
+#
+# 1. Install ztfquery:
+#      pip install ztfquery
+#
+# 2. Get your Fritz API token:
+#      Go to https://fritz.science/profile and copy your token.
+#
+# 3. Configure ztfquery with your Fritz token:
+#      python -c "from ztfquery.io import set_account; set_account('fritz', token_based=True)"
+#      (It will prompt you for your token and save it to ~/.ztfquery)
+#
+# Troubleshooting:
+#   - If you get 401 errors, re-run step 3 with a fresh token
+#   - Token expires? Generate a new one from your Fritz profile
+# ============================================================
+
+"""
+        + _common_imports()
+        + """
+from ztfquery import fritz
+"""
+    )
+
+
+def generate_irsa_setup() -> str:
+    """Generate setup code for IRSA access via ztfquery."""
+    return """# ============================================================
+# IRSA / ZTF Archive Setup (via ztfquery)
+# ============================================================
+# Prerequisites (run these in your terminal ONCE before using):
+#
+# 1. Install ztfquery:
+#      pip install ztfquery
+#
+# 2. Create a free IRSA account (needed for ZTF data access):
+#      https://irsa.ipac.caltech.edu/account/signon/login.do
+#
+# 3. Configure your IRSA credentials:
+#      python -c "from ztfquery import io; io.set_account('YOUR_IRSA_USERNAME', 'YOUR_IRSA_PASSWORD')"
+#
+#    This saves credentials to ~/.ztfquery/config.ini so you
+#    only need to do it once.
+#
+# Troubleshooting:
+#   - If you get authentication errors, re-run step 3
+#   - If ztfquery is slow, it's downloading from IRSA — be patient
+#   - For large queries (>50 sources), consider running overnight
+# ============================================================
+
+""" + _common_imports()
+
+
 def generate_bulk_lightcurve_query(
     source_list: list[str], filters: list[str], include_plots: bool = True
 ) -> str:
-    """Generate code to query forced photometry for multiple sources.
+    """Generate a Jupyter notebook to bulk download light curves from Fritz.
 
     Args:
         source_list: List of ZTF source names
         filters: List of filter names (e.g., ['ztfg', 'ztfr', 'ztfi'])
-        include_plots: Include plotting code
+        include_plots: Include Plotly plotting cells
 
     Returns:
-        Python code string for notebook
+        JSON string of a Jupyter notebook, to be saved as .ipynb
     """
+    from pathlib import Path
+
     source_json = json.dumps(source_list, indent=4)
     filter_json = json.dumps(filters)
 
-    code = generate_ztfquery_setup()
+    output_dir = Path("ztf_lightcurves")
+    output_dir.mkdir(exist_ok=True)
+    notebook_path = output_dir / "bulk_lightcurve_download.ipynb"
 
-    code += f"""
-from ztfquery import lightcurve
+    cells = []
 
-# Configuration
-sources = {source_json}
+    # Cell 0: Info markdown
+    cells.append(
+        _make_markdown_cell(
+            "# Bulk ZTF Light Curve Download\n"
+            "\n"
+            "Downloads **alert photometry** (detection-epoch data) from Fritz/SkyPortal.\n"
+            "\n"
+            "> **Need forced photometry?** (includes non-detections & upper limits)\n"
+            "> Use the [IRSA ZTF forced photometry service]"
+            "(https://irsa.ipac.caltech.edu/cgi-bin/ZTF/nph_light_curves) instead.\n"
+            "> Forced photometry requires a free IRSA account."
+        )
+    )
 
-filters = {filter_json}
+    # Cell 1: Setup & imports
+    cells.append(
+        _make_code_cell(
+            "# Fritz/SkyPortal Setup (via ztfquery)\n"
+            "# Prerequisites (run ONCE in your terminal before using):\n"
+            "#   1. pip install ztfquery\n"
+            "#   2. Get your Fritz API token from https://fritz.science/profile\n"
+            "#   3. python -c \"from ztfquery.io import set_account; set_account('fritz', token_based=True)\"\n"
+            "#      (saves token to ~/.ztfquery)\n"
+            "\n"
+            "import warnings\n"
+            "warnings.filterwarnings('ignore')\n"
+            "\n"
+            "import numpy as np\n"
+            "import pandas as pd\n"
+            "from pathlib import Path\n"
+            "from ztfquery import fritz\n"
+            "\n"
+            "import plotly.graph_objects as go\n"
+            "from plotly.offline import init_notebook_mode, iplot\n"
+            "init_notebook_mode(connected=True)"
+        )
+    )
 
-# Results storage
-output_dir = Path('ztf_lightcurves')
-output_dir.mkdir(exist_ok=True)
+    # Cell 2: Configuration
+    cells.append(
+        _make_code_cell(
+            f"# Configuration — edit these as needed\n"
+            f"sources = {source_json}\n"
+            f"\n"
+            f"filters = {filter_json}\n"
+            f"\n"
+            f"output_dir = Path('ztf_lightcurves')\n"
+            f"output_dir.mkdir(exist_ok=True)"
+        )
+    )
 
-results = {{}}
-errors = []
+    # Cell 3: Download
+    cells.append(
+        _make_code_cell(
+            "# Download light curves from Fritz (multiprocessed)\n"
+            "print(f'Downloading light curves for {len(sources)} sources from Fritz...')\n"
+            "print(f'Filters: {filters}')\n"
+            "print()\n"
+            "\n"
+            "fritz.bulk_download('lightcurve', sources, nprocess=4, store=True)\n"
+            "print('\\nBulk download complete.')"
+        )
+    )
 
-print(f"Querying forced photometry for {{len(sources)}} sources...")
-print(f"Filters: {{', '.join(filters)}}")
-print()
+    # Cell 4: Load, filter, save CSVs
+    cells.append(
+        _make_code_cell(
+            "# Load downloaded data, filter by band, save CSVs\n"
+            "results = {}\n"
+            "errors = []\n"
+            "\n"
+            "for source in sources:\n"
+            "    try:\n"
+            "        # download_lightcurve returns a DataFrame directly\n"
+            "        # Data is already cached locally from bulk_download above\n"
+            "        lc_data = fritz.download_lightcurve(source, store=True)\n"
+            "\n"
+            "        if lc_data is not None and len(lc_data) > 0:\n"
+            "            lc_filtered = lc_data[lc_data['filter'].isin(filters)].copy()\n"
+            "\n"
+            "            output_file = output_dir / f'{source}_lc.csv'\n"
+            "            lc_filtered.to_csv(output_file, index=False)\n"
+            "\n"
+            "            results[source] = {\n"
+            "                'data': lc_filtered,\n"
+            "                'n_points': len(lc_filtered),\n"
+            "                'filters': lc_filtered['filter'].unique().tolist(),\n"
+            "                'file': str(output_file)\n"
+            "            }\n"
+            "            print(f'✓ {source}: {len(lc_filtered)} points')\n"
+            "        else:\n"
+            "            print(f'✗ {source}: No data')\n"
+            "            errors.append({'source': source, 'error': 'No data'})\n"
+            "    except Exception as e:\n"
+            "        print(f'✗ {source}: {e}')\n"
+            "        errors.append({'source': source, 'error': str(e)})\n"
+            "\n"
+            "print(f'\\nLoaded: {len(results)}/{len(sources)}')\n"
+            "\n"
+            "# Save summary\n"
+            "summary = pd.DataFrame([\n"
+            "    {'source': src, 'n_points': info['n_points'],\n"
+            "     'filters': ','.join(info['filters']), 'file': info['file']}\n"
+            "    for src, info in results.items()\n"
+            "])\n"
+            "summary.to_csv(output_dir / 'summary.csv', index=False)\n"
+            "print(f'Summary saved to: {output_dir / \"summary.csv\"}')"
+        )
+    )
 
-# Query each source
-for source in tqdm(sources, desc="Downloading light curves"):
-    try:
-        # Download forced photometry
-        lcq = lightcurve.LCQuery.from_name(source)
-
-        # Get data as DataFrame
-        lc_data = lcq.data
-
-        if lc_data is not None and len(lc_data) > 0:
-            # Filter by requested bands
-            lc_filtered = lc_data[lc_data['filter'].isin(filters)]
-
-            # Save to CSV
-            output_file = output_dir / f"{{source}}_lc.csv"
-            lc_filtered.to_csv(output_file, index=False)
-
-            results[source] = {{
-                'data': lc_filtered,
-                'n_points': len(lc_filtered),
-                'filters': lc_filtered['filter'].unique().tolist(),
-                'file': str(output_file)
-            }}
-
-            print(f"✓ {{source}}: {{len(lc_filtered)}} points")
-        else:
-            print(f"✗ {{source}}: No data")
-            errors.append({{'source': source, 'error': 'No data returned'}})
-
-    except Exception as e:
-        print(f"✗ {{source}}: {{str(e)}}")
-        errors.append({{'source': source, 'error': str(e)}})
-
-print()
-print(f"Successfully downloaded: {{len(results)}}/{{len(sources)}}")
-print(f"Failed: {{len(errors)}}")
-
-# Save summary
-summary = pd.DataFrame([
-    {{'source': src, 'n_points': info['n_points'],
-      'filters': ','.join(info['filters']), 'file': info['file']}}
-    for src, info in results.items()
-])
-summary.to_csv(output_dir / 'summary.csv', index=False)
-print(f"\\nSummary saved to: {{output_dir / 'summary.csv'}}")
-
-if errors:
-    error_df = pd.DataFrame(errors)
-    error_df.to_csv(output_dir / 'errors.csv', index=False)
-    print(f"Errors saved to: {{output_dir / 'errors.csv'}}")
-"""
-
+    # Cell 5: Plotly interactive plots (one per source)
     if include_plots:
-        code += """
-# Plot light curves
-print("\\nGenerating plots...")
-
-fig_dir = output_dir / 'plots'
-fig_dir.mkdir(exist_ok=True)
-
-for source, info in tqdm(results.items(), desc="Creating plots"):
-    lc_data = info['data']
-
-    # Create figure
-    fig, ax = plt.subplots(figsize=(10, 6))
-
-    # Plot each filter
-    colors = {'ztfg': 'green', 'ztfr': 'red', 'ztfi': 'orange'}
-
-    for filt in info['filters']:
-        mask = lc_data['filter'] == filt
-        filt_data = lc_data[mask]
-
-        # Only plot detections (mag is not null)
-        detections = filt_data[filt_data['mag'].notna()]
-
-        if len(detections) > 0:
-            ax.errorbar(
-                detections['mjd'],
-                detections['mag'],
-                yerr=detections['magerr'],
-                fmt='o',
-                label=filt,
-                color=colors.get(filt, 'gray'),
-                alpha=0.7,
-                capsize=3
+        cells.append(
+            _make_code_cell(
+                "# Interactive Plotly light curve plots\n"
+                "filter_colors = {\n"
+                "    'ztfg': '#28a745', 'ztfr': '#dc3545', 'ztfi': '#8b0000',\n"
+                "    'sdssg': '#28a745', 'sdssr': '#dc3545', 'sdssi': '#8b0000',\n"
+                "}\n"
+                "\n"
+                "def hex_to_rgba(hex_color, alpha):\n"
+                "    h = hex_color.lstrip('#')\n"
+                "    r, g, b = int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16)\n"
+                "    return f'rgba({r},{g},{b},{alpha})'\n"
+                "\n"
+                "for source, info in results.items():\n"
+                "    df = info['data'].copy()\n"
+                "    fig = go.Figure()\n"
+                "\n"
+                "    for filt in info['filters']:\n"
+                "        df_f = df[(df['filter'] == filt) & df['mag'].notna()].sort_values('mjd')\n"
+                "        if len(df_f) == 0:\n"
+                "            continue\n"
+                "        color = filter_colors.get(filt, '#1f77b4')\n"
+                "        fig.add_trace(go.Scatter(\n"
+                "            x=df_f['mjd'], y=df_f['mag'],\n"
+                "            error_y=dict(type='data', array=df_f['magerr'], visible=True, thickness=1.5),\n"
+                "            mode='markers',\n"
+                "            marker=dict(size=6, color=hex_to_rgba(color, 0.6),\n"
+                "                        line=dict(color=color, width=1.5)),\n"
+                "            name=filt,\n"
+                "            hovertemplate='MJD: %{x:.2f}<br>Mag: %{y:.3f}<extra></extra>'\n"
+                "        ))\n"
+                "\n"
+                "    fig.update_layout(\n"
+                "        title=f'{source} Light Curve',\n"
+                "        xaxis_title='MJD', yaxis_title='AB Magnitude',\n"
+                "        yaxis=dict(autorange='reversed'),\n"
+                "        template='plotly_white', width=900, height=500\n"
+                "    )\n"
+                "    iplot(fig)"
             )
+        )
 
-    ax.invert_yaxis()
-    ax.set_xlabel('MJD', fontsize=12)
-    ax.set_ylabel('AB Magnitude', fontsize=12)
-    ax.set_title(f'{source} Light Curve', fontsize=14, fontweight='bold')
-    ax.legend()
-    ax.grid(True, alpha=0.3)
+    # Build notebook JSON
+    notebook = {
+        "nbformat": 4,
+        "nbformat_minor": 5,
+        "metadata": {
+            "kernelspec": {
+                "display_name": "Python 3",
+                "language": "python",
+                "name": "python3",
+            },
+            "language_info": {"name": "python", "version": "3.11.0"},
+        },
+        "cells": cells,
+    }
 
-    plt.tight_layout()
-    plt.savefig(fig_dir / f'{source}_lc.png', dpi=150, bbox_inches='tight')
-    plt.close()
+    with open(notebook_path, "w") as f:
+        json.dump(notebook, f, indent=1)
 
-print(f"Plots saved to: {fig_dir}")
-"""
-
-    return code
+    return (
+        f"Notebook saved to: {notebook_path}\n"
+        f"Open it in VS Code or Jupyter and run the cells to download "
+        f"light curves for {len(source_list)} sources from Fritz."
+    )
 
 
 def generate_cone_search_query(
@@ -180,7 +313,7 @@ def generate_cone_search_query(
     """
     coords_json = json.dumps(ra_dec_list, indent=4)
 
-    code = generate_ztfquery_setup()
+    code = generate_irsa_setup()
 
     code += f"""
 from ztfquery import query
@@ -274,94 +407,77 @@ def generate_fritz_bulk_query(
     """
     source_json = json.dumps(source_list, indent=4)
 
-    code = generate_ztfquery_setup()
+    code = generate_fritz_setup()
 
     code += f"""
-from ztfquery import fritz
-import os
-
 # Configuration
 sources = {source_json}
-
-# Fritz API token (set as environment variable or hardcode)
-FRITZ_TOKEN = os.getenv('FRITZ_TOKEN', 'YOUR_TOKEN_HERE')
 
 # Results storage
 output_dir = Path('fritz_data')
 output_dir.mkdir(exist_ok=True)
 
-# Initialize Fritz connection
-fq = fritz.FritzAPI(token=FRITZ_TOKEN)
-
 results = {{}}
 errors = []
 
-print(f"Querying Fritz for {{len(sources)}} sources...")
+# ---- Bulk download photometry ----
+print(f"Downloading photometry + spectra for {{len(sources)}} sources from Fritz...")
 print()
 
-# Query each source
-for source in tqdm(sources, desc="Querying sources"):
-    try:
-        # Get source data
-        source_data = fq.get_source(source)
-
-        if source_data:
-            results[source] = {{}}
-
-            # Save basic source info
-            results[source]['info'] = {{
-                'id': source_data.get('id'),
-                'ra': source_data.get('ra'),
-                'dec': source_data.get('dec'),
-                'redshift': source_data.get('redshift'),
-                'classifications': source_data.get('classifications', []),
-            }}
-
-            # Get photometry
-            photometry = source_data.get('photometry', [])
-            if photometry:
-                phot_df = pd.DataFrame(photometry)
-                phot_file = output_dir / f"{{source}}_photometry.csv"
-                phot_df.to_csv(phot_file, index=False)
-                results[source]['photometry_file'] = str(phot_file)
-                results[source]['n_phot'] = len(phot_df)
+fritz.bulk_download("lightcurve", sources, nprocess=4, store=True)
 """
 
     if include_spectra:
         code += """
-            # Get spectra
-            spectra = source_data.get('spectra', [])
-            if spectra:
-                spec_df = pd.DataFrame(spectra)
+fritz.bulk_download("spectra", sources, nprocess=4, store=True)
+"""
+
+    code += f"""
+# ---- Load and save results ----
+for source in sources:
+    try:
+        results[source] = {{}}
+
+        # download_lightcurve returns a DataFrame directly
+        # Data is already cached locally from bulk_download above
+        lc_data = fritz.download_lightcurve(source, store=True)
+        if lc_data is not None and len(lc_data) > 0:
+            phot_file = output_dir / f"{{source}}_photometry.csv"
+            lc_data.to_csv(phot_file, index=False)
+            results[source]['n_phot'] = len(lc_data)
+"""
+
+    if include_spectra:
+        code += """
+        # download_spectra returns spectral data
+        try:
+            spec_data = fritz.download_spectra(source, store=True)
+            if spec_data is not None and len(spec_data) > 0:
                 spec_file = output_dir / f"{source}_spectra.csv"
-                spec_df.to_csv(spec_file, index=False)
-                results[source]['spectra_file'] = str(spec_file)
-                results[source]['n_spectra'] = len(spec_df)
+                if hasattr(spec_data, 'to_csv'):
+                    spec_data.to_csv(spec_file, index=False)
+                results[source]['n_spectra'] = len(spec_data)
+        except Exception:
+            pass  # spectra not available for all sources
 """
 
     code += """
-            print(f"✓ {source}: {results[source].get('n_phot', 0)} phot, "
-                  f"{results[source].get('n_spectra', 0)} spectra")
-        else:
-            print(f"✗ {source}: Not found")
-            errors.append({'source': source, 'error': 'Source not found'})
+        n_phot = results[source].get('n_phot', 0)
+        n_spec = results[source].get('n_spectra', 0)
+        print(f"✓ {source}: {n_phot} phot, {n_spec} spectra")
 
     except Exception as e:
         print(f"✗ {source}: {str(e)}")
-        errors.append({'source': source, 'error': str(e)}})
+        errors.append({'source': source, 'error': str(e)})
 
 print()
-print(f"Successfully queried: {len(results)}/{len(sources)}")
+print(f"Successfully loaded: {len(results)}/{len(sources)}")
 
 # Save summary
 summary_data = []
 for src, data in results.items():
-    info = data.get('info', {})
     summary_data.append({
         'source': src,
-        'ra': info.get('ra'),
-        'dec': info.get('dec'),
-        'redshift': info.get('redshift'),
         'n_photometry': data.get('n_phot', 0),
         'n_spectra': data.get('n_spectra', 0),
     })
@@ -390,7 +506,7 @@ def generate_alert_query(source_list: list[str], with_cutouts: bool = True) -> s
     """
     source_json = json.dumps(source_list, indent=4)
 
-    code = generate_ztfquery_setup()
+    code = generate_irsa_setup()
 
     code += f"""
 from ztfquery import alert
@@ -460,7 +576,7 @@ for source in tqdm(sources, desc="Downloading alerts"):
 
     except Exception as e:
         print(f"✗ {source}: {str(e)}")
-        errors.append({'source': source, 'error': str(e)}})
+        errors.append({'source': source, 'error': str(e)})
 
 print()
 print(f"Successfully downloaded: {len(results)}/{len(sources)}")
@@ -492,7 +608,7 @@ def generate_field_visualization(field_id: int, ccd_id: int | None = None) -> st
     Returns:
         Python code string for notebook
     """
-    code = generate_ztfquery_setup()
+    code = generate_irsa_setup()
 
     code += f"""
 from ztfquery import skyvision

--- a/services/mcp_server/tools/filtering.py
+++ b/services/mcp_server/tools/filtering.py
@@ -422,19 +422,25 @@ def generate_watchlist_filter(
     Watchlists are alert-time filters that flag new detections near specified
     sky positions. They run on the Kowalski backend as part of Fritz's alert
     stream processing. This tool generates the MongoDB aggregation pipeline JSON
-    that you can copy-paste into Fritz's filter creation UI.
+    compatible with Fritz's filter system.
 
     IMPORTANT - This is an ALERT-TIME filter:
-    - Cannot be created directly via API (requires Fritz UI)
     - Runs automatically on every incoming alert from the telescope
     - Different from query-time filtering (filter_candidates tool)
+    - Uses MongoDB aggregation pipeline syntax
 
-    IMPORTANT - After Generation:
+    RECOMMENDED WORKFLOW (MongoDB Compass):
+    Fritz now recommends using MongoDB Compass for filter development:
+    1. Follow the tutorial: https://github.com/fritz-marshal/fritz/blob/main/doc/filter_tutorial.md
+    2. Use MongoDB Compass to build and test filters visually
+    3. Export the pipeline from Compass
+    4. Import to Fritz
+
+    ALTERNATIVE - Direct Use:
+    You can also use the generated JSON directly:
     1. Copy the generated JSON
-    2. Go to Fritz UI → Filters page
-    3. Create new filter and paste the JSON
-    4. Set the filter's group and stream
-    5. Save to activate monitoring
+    2. Import to Fritz or use in MongoDB Compass as a starting point
+    3. Refine and test as needed
 
     Args:
         targets: JSON-encoded list of target objects. Each target must have:

--- a/services/mcp_server/tools/filtering.py
+++ b/services/mcp_server/tools/filtering.py
@@ -1,0 +1,711 @@
+# pyright: reportMissingTypeStubs=false
+"""Candidate and source filtering tools."""
+
+import json
+from pathlib import Path
+
+import httpx
+
+from ..server import SKYPORTAL_URL, get_skyportal_token, mcp
+
+RESOURCES_DIR = Path(__file__).parent.parent / "resources"
+
+
+@mcp.resource("skyportal://filters/reference")
+def get_filter_docs() -> str:
+    """Candidate and source filtering reference guide"""
+    return (RESOURCES_DIR / "candidate_filter_reference.md").read_text()
+
+
+@mcp.tool()
+def get_candidate_filter_reference() -> str:
+    """Get the reference for filtering candidates and sources on Fritz/SkyPortal.
+
+    Returns documentation on available query parameters for the /api/candidates
+    endpoint: annotation-based filters for ML scores (real/bogus, star/galaxy),
+    classification filters, redshift, photometry annotations, and more.
+
+    Call this when a user asks to filter, search, or scan for specific types
+    of transients. It tells you what's filterable via API queries vs what
+    requires fetching data and doing custom computation.
+
+    Note: This is for query-time filtering (scanning page searches), NOT for
+    creating alert-time MongoDB filters that run on Kowalski.
+    """
+    return (RESOURCES_DIR / "candidate_filter_reference.md").read_text()
+
+
+@mcp.tool()
+async def filter_candidates(
+    group_id: int | None = None,
+    saved_status: str = "all",
+    classifications: str | None = None,
+    classifications_reject: str | None = None,
+    min_redshift: float | None = None,
+    max_redshift: float | None = None,
+    annotation_filters: str | None = None,
+    saved_after: str | None = None,
+    saved_before: str | None = None,
+    first_detected_after: str | None = None,
+    last_detected_before: str | None = None,
+    num_per_page: int = 100,
+    page_number: int = 1,
+) -> str:
+    """Search for candidates matching specific criteria on the scanning page.
+
+    This performs query-time filtering of existing candidates (not alert-time
+    filtering). Use this to search the scanning page for candidates matching
+    specific properties.
+
+    IMPORTANT - Parameter Validation:
+    Before executing this tool, ALWAYS confirm with the user that the filter
+    parameters are reasonable. Explain what the filter will return and ask if
+    they want to proceed. Examples:
+    - "I'll search for SNe Ia with braai score > 0.9 saved after 2024-01-01. Proceed?"
+    - "This will find likely galaxy transients (sgScore < 0.3). OK?"
+    - "Filtering for TDE candidates with ACAI_score > 0.8. Sound good?"
+
+    IMPORTANT - After Results:
+    After showing results, offer to display the filter configuration JSON so
+    the user can save it for future use or configure it in the UI.
+
+    Args:
+        group_id: Search within specific group ID (optional)
+        saved_status: Saved status filter. Options:
+            - "all" (default): all candidates
+            - "savedToAllSelected": saved to all selected groups
+            - "savedToAnySelected": saved to any selected group
+            - "savedToAnyAccessible": saved to any accessible group
+            - "notSavedToAnyAccessible": not saved to any accessible group
+            - "notSavedToAnySelected": not saved to any selected group
+            - "notSavedToAllSelected": not saved to all selected groups
+        classifications: Comma-separated classifications to INCLUDE
+            (e.g., "SN Ia,SN Ib/c,SN II")
+        classifications_reject: Comma-separated classifications to EXCLUDE
+            (e.g., "AGN,varstar,bogus")
+        min_redshift: Minimum redshift (float)
+        max_redshift: Maximum redshift (float)
+        annotation_filters: JSON-encoded list of annotation filters. Each filter
+            is an object with:
+            - "origin": annotation origin (e.g., "braai", "kowalski", "Kowalski")
+            - "key": annotation key (e.g., "braai", "sgScore", "ACAI_score")
+            - "min": minimum value (optional, for range filters)
+            - "max": maximum value (optional, for range filters)
+            - "value": exact value (optional, for exact match filters)
+
+            Common examples:
+            - Real/bogus: [{"origin":"braai","key":"braai","min":0.8}]
+            - Star/galaxy: [{"origin":"kowalski","key":"sgScore","max":0.3}]
+            - ACAI score: [{"origin":"Kowalski","key":"ACAI_score","min":0.8}]
+            - Combined: [{"origin":"braai","key":"braai","min":0.9},{"origin":"kowalski","key":"sgScore","max":0.3}]
+
+            Note: Available annotations depend on your instance. Use
+            get_candidate_filter_reference() or inspect sources to discover
+            annotation origins/keys available.
+        saved_after: Only candidates saved after this date (ISO: "2024-01-15")
+        saved_before: Only candidates saved before this date (ISO)
+        first_detected_after: Only sources first detected after this date
+        last_detected_before: Only sources last detected before this date
+        num_per_page: Number of results (default 100, max 500)
+        page_number: Page number for pagination (default 1)
+
+    Returns:
+        CSV table with: obj_id, ra, dec, redshift, latest_mag, latest_filter,
+        saved_at, classifications, and ML scores from annotation_filters.
+        Includes summary header with total matches and filter criteria.
+        At the end, includes the filter configuration JSON for saving/reuse.
+    """
+    token = get_skyportal_token()
+    if not token:
+        return "Not authenticated. Configure SKYPORTAL_TOKEN or send Bearer token."
+
+    # Build query parameters
+    params = {
+        "numPerPage": min(num_per_page, 500),  # Cap at 500
+        "pageNumber": page_number,
+        "savedStatus": saved_status,
+    }
+
+    if group_id is not None:
+        params["groupIDs"] = str(group_id)
+    if classifications:
+        params["classifications"] = classifications
+    if classifications_reject:
+        params["classificationsReject"] = classifications_reject
+    if min_redshift is not None:
+        params["minRedshift"] = min_redshift
+    if max_redshift is not None:
+        params["maxRedshift"] = max_redshift
+    if saved_after:
+        params["savedAfter"] = saved_after
+    if saved_before:
+        params["savedBefore"] = saved_before
+    if first_detected_after:
+        params["firstDetectedAfter"] = first_detected_after
+    if last_detected_before:
+        params["lastDetectedBefore"] = last_detected_before
+
+    # Parse annotation filters
+    parsed_annotation_filters = []
+    if annotation_filters:
+        try:
+            parsed_annotation_filters = json.loads(annotation_filters)
+            if not isinstance(parsed_annotation_filters, list):
+                return (
+                    "Error: annotation_filters must be a JSON array of filter objects"
+                )
+            params["annotationFilterList"] = ",".join(
+                json.dumps(f) for f in parsed_annotation_filters
+            )
+        except json.JSONDecodeError as e:
+            return f"Error parsing annotation_filters JSON: {e}"
+
+    # Query API
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            resp = await client.get(
+                f"{SKYPORTAL_URL}/api/candidates",
+                headers={"Authorization": f"token {token}"},
+                params=params,
+            )
+        resp.raise_for_status()
+    except httpx.HTTPStatusError as e:
+        return f"HTTP Error {e.response.status_code}: {e.response.text}"
+    except Exception as e:
+        return f"Error fetching candidates: {e}"
+
+    data = resp.json().get("data", {})
+    candidates = data.get("candidates", [])
+    total_matches = data.get("totalMatches", 0)
+
+    # Build filter config JSON for saving
+    filter_config = _build_filter_config(
+        group_id,
+        saved_status,
+        classifications,
+        classifications_reject,
+        min_redshift,
+        max_redshift,
+        parsed_annotation_filters,
+        saved_after,
+        saved_before,
+        first_detected_after,
+        last_detected_before,
+    )
+
+    if not candidates:
+        filter_summary = _build_filter_summary(
+            group_id,
+            saved_status,
+            classifications,
+            classifications_reject,
+            min_redshift,
+            max_redshift,
+            parsed_annotation_filters,
+            saved_after,
+            saved_before,
+            first_detected_after,
+            last_detected_before,
+        )
+        result = f"No candidates found matching criteria.\n{filter_summary}\n\n"
+        result += "--- Filter Configuration (for saving/reuse) ---\n"
+        result += filter_config
+        return result
+
+    # Build summary header
+    lines = [f"# Found {total_matches} candidates (showing page {page_number})"]
+    lines.append(
+        _build_filter_summary(
+            group_id,
+            saved_status,
+            classifications,
+            classifications_reject,
+            min_redshift,
+            max_redshift,
+            parsed_annotation_filters,
+            saved_after,
+            saved_before,
+            first_detected_after,
+            last_detected_before,
+        )
+    )
+    lines.append("")
+
+    # Determine annotation columns to include
+    annotation_columns = []
+    if parsed_annotation_filters:
+        for filt in parsed_annotation_filters:
+            origin = filt.get("origin", "")
+            key = filt.get("key", "")
+            col_name = f"{origin}_{key}"
+            if col_name not in annotation_columns:
+                annotation_columns.append(col_name)
+
+    # CSV header
+    header = "obj_id,ra,dec,redshift,latest_mag,latest_filter,saved_at,classifications"
+    if annotation_columns:
+        header += "," + ",".join(annotation_columns)
+    lines.append(header)
+
+    # Format each candidate
+    for cand in candidates:
+        obj_id = cand.get("id", "")
+        ra = cand.get("ra", "")
+        dec = cand.get("dec", "")
+        redshift = cand.get("redshift", "")
+
+        # Get latest photometry
+        latest_mag = ""
+        latest_filter = ""
+        photometry = cand.get("photometry", [])
+        if photometry:
+            sorted_phot = sorted(
+                photometry, key=lambda p: p.get("mjd", 0), reverse=True
+            )
+            if sorted_phot:
+                latest = sorted_phot[0]
+                latest_mag = latest.get("mag", "")
+                latest_filter = latest.get("filter", "")
+
+        # Get saved date
+        saved_at = cand.get("saved_at", "")
+        if saved_at and "T" in saved_at:
+            saved_at = saved_at.split("T")[0]
+
+        # Get classifications
+        class_list = cand.get("classifications", [])
+        if class_list:
+            class_names = [c.get("classification", "") for c in class_list]
+            classifications_str = ";".join(class_names)
+        else:
+            classifications_str = ""
+
+        # Get annotation values
+        annotation_values = {}
+        annotations = cand.get("annotations", [])
+        for annot in annotations:
+            origin = annot.get("origin", "")
+            annot_data = annot.get("data", {})
+            for key, value in annot_data.items():
+                col_name = f"{origin}_{key}"
+                annotation_values[col_name] = value
+
+        # Format numeric values
+        if ra:
+            ra = f"{float(ra):.6f}"
+        if dec:
+            dec = f"{float(dec):+.6f}"
+        if redshift:
+            redshift = f"{float(redshift):.4f}"
+        if latest_mag:
+            latest_mag = f"{float(latest_mag):.2f}"
+
+        # Build row
+        row = f"{obj_id},{ra},{dec},{redshift},{latest_mag},{latest_filter},{saved_at},{classifications_str}"
+        for col_name in annotation_columns:
+            value = annotation_values.get(col_name, "")
+            if value and isinstance(value, int | float):
+                value = f"{float(value):.3f}"
+            row += f",{value}"
+        lines.append(row)
+
+    # Add filter config at the end
+    lines.append("")
+    lines.append("--- Filter Configuration (save this for reuse) ---")
+    lines.append(filter_config)
+
+    return "\n".join(lines)
+
+
+def _build_filter_config(
+    group_id,
+    saved_status,
+    classifications,
+    classifications_reject,
+    min_redshift,
+    max_redshift,
+    annotation_filters,
+    saved_after,
+    saved_before,
+    first_detected_after,
+    last_detected_before,
+) -> str:
+    """Build JSON configuration for the filter (for saving/reuse)."""
+    config = {}
+    if group_id is not None:
+        config["group_id"] = group_id
+    if saved_status != "all":
+        config["saved_status"] = saved_status
+    if classifications:
+        config["classifications"] = classifications
+    if classifications_reject:
+        config["classifications_reject"] = classifications_reject
+    if min_redshift is not None:
+        config["min_redshift"] = min_redshift
+    if max_redshift is not None:
+        config["max_redshift"] = max_redshift
+    if annotation_filters:
+        config["annotation_filters"] = annotation_filters
+    if saved_after:
+        config["saved_after"] = saved_after
+    if saved_before:
+        config["saved_before"] = saved_before
+    if first_detected_after:
+        config["first_detected_after"] = first_detected_after
+    if last_detected_before:
+        config["last_detected_before"] = last_detected_before
+
+    return json.dumps(config, indent=2)
+
+
+def _build_filter_summary(
+    group_id,
+    saved_status,
+    classifications,
+    classifications_reject,
+    min_redshift,
+    max_redshift,
+    annotation_filters,
+    saved_after,
+    saved_before,
+    first_detected_after,
+    last_detected_before,
+) -> str:
+    """Build human-readable summary of filter criteria."""
+    criteria = []
+    if group_id:
+        criteria.append(f"group_id={group_id}")
+    if saved_status != "all":
+        criteria.append(f"saved_status={saved_status}")
+    if classifications:
+        criteria.append(f"classifications={classifications}")
+    if classifications_reject:
+        criteria.append(f"exclude={classifications_reject}")
+    if min_redshift is not None:
+        criteria.append(f"z>={min_redshift}")
+    if max_redshift is not None:
+        criteria.append(f"z<={max_redshift}")
+    if annotation_filters:
+        for filt in annotation_filters:
+            origin = filt.get("origin", "")
+            key = filt.get("key", "")
+            if "min" in filt and "max" in filt:
+                criteria.append(f"{origin}.{key}=[{filt['min']},{filt['max']}]")
+            elif "min" in filt:
+                criteria.append(f"{origin}.{key}>={filt['min']}")
+            elif "max" in filt:
+                criteria.append(f"{origin}.{key}<={filt['max']}")
+            elif "value" in filt:
+                criteria.append(f"{origin}.{key}={filt['value']}")
+    if saved_after:
+        criteria.append(f"saved_after={saved_after}")
+    if saved_before:
+        criteria.append(f"saved_before={saved_before}")
+    if first_detected_after:
+        criteria.append(f"first_detected_after={first_detected_after}")
+    if last_detected_before:
+        criteria.append(f"last_detected_before={last_detected_before}")
+
+    if criteria:
+        return "# Filters: " + ", ".join(criteria)
+    return "# Filters: none (all candidates)"
+
+
+@mcp.tool()
+def generate_watchlist_filter(
+    targets: str,
+    max_distance_arcsec: float = 2.0,
+    filter_name: str = "Watchlist",
+) -> str:
+    """Generate MongoDB filter JSON for a watchlist to monitor specific coordinates.
+
+    Watchlists are alert-time filters that flag new detections near specified
+    sky positions. They run on the Kowalski backend as part of Fritz's alert
+    stream processing. This tool generates the MongoDB aggregation pipeline JSON
+    that you can copy-paste into Fritz's filter creation UI.
+
+    IMPORTANT - This is an ALERT-TIME filter:
+    - Cannot be created directly via API (requires Fritz UI)
+    - Runs automatically on every incoming alert from the telescope
+    - Different from query-time filtering (filter_candidates tool)
+
+    IMPORTANT - After Generation:
+    1. Copy the generated JSON
+    2. Go to Fritz UI → Filters page
+    3. Create new filter and paste the JSON
+    4. Set the filter's group and stream
+    5. Save to activate monitoring
+
+    Args:
+        targets: JSON-encoded list of target objects. Each target must have:
+            - "name": Target identifier (e.g., "M31", "NGC1234")
+            - "ra": Right ascension in decimal degrees (J2000)
+            - "dec": Declination in decimal degrees (J2000)
+
+            Example:
+            '[{"name":"M31","ra":10.6847,"dec":41.2687},{"name":"Crab","ra":83.6333,"dec":22.0145}]'
+
+        max_distance_arcsec: Maximum angular separation in arcseconds for a match.
+            Alerts within this distance from any target will be flagged.
+            Default: 2.0 arcsec (typical for monitoring known sources)
+
+        filter_name: Name for this watchlist filter (for documentation)
+
+    Returns:
+        MongoDB aggregation pipeline JSON ready to paste into Fritz filter UI.
+        Includes:
+        - Instructions for use
+        - Complete pipeline with spherical distance calculation
+        - Annotations with nearest target name and distance
+        - Human-readable summary of watched positions
+    """
+    # Parse targets
+    try:
+        targets_list = json.loads(targets)
+        if not isinstance(targets_list, list):
+            return "Error: targets must be a JSON array of target objects"
+        if not targets_list:
+            return "Error: targets list cannot be empty"
+
+        # Validate each target
+        for i, target in enumerate(targets_list):
+            if not isinstance(target, dict):
+                return f"Error: target {i} must be an object with name, ra, dec"
+            if "name" not in target or "ra" not in target or "dec" not in target:
+                return f"Error: target {i} missing required fields (name, ra, dec)"
+            # Validate coordinates
+            try:
+                ra = float(target["ra"])
+                dec = float(target["dec"])
+                if not (0 <= ra < 360):
+                    return f"Error: target {i} RA must be in range [0, 360)"
+                if not (-90 <= dec <= 90):
+                    return f"Error: target {i} Dec must be in range [-90, 90]"
+            except (ValueError, TypeError):
+                return f"Error: target {i} ra/dec must be numeric"
+
+    except json.JSONDecodeError as e:
+        return f"Error parsing targets JSON: {e}"
+
+    # Build the MongoDB aggregation pipeline
+    # This implements spherical distance calculation and filtering
+    pipeline = [
+        {
+            "$addFields": {
+                "watchlist_distances": {
+                    "$map": {
+                        "input": targets_list,
+                        "as": "target",
+                        "in": {
+                            "name": "$$target.name",
+                            "distance_arcsec": {
+                                "$multiply": [
+                                    {
+                                        "$atan2": [
+                                            {
+                                                "$sqrt": {
+                                                    "$add": [
+                                                        {
+                                                            "$pow": [
+                                                                {
+                                                                    "$subtract": [
+                                                                        {
+                                                                            "$multiply": [
+                                                                                {
+                                                                                    "$cos": {
+                                                                                        "$degreesToRadians": "$candidate.dec"
+                                                                                    }
+                                                                                },
+                                                                                {
+                                                                                    "$sin": {
+                                                                                        "$degreesToRadians": {
+                                                                                            "$subtract": [
+                                                                                                "$candidate.ra",
+                                                                                                "$$target.ra",
+                                                                                            ]
+                                                                                        }
+                                                                                    }
+                                                                                },
+                                                                            ]
+                                                                        },
+                                                                        0,
+                                                                    ]
+                                                                },
+                                                                2,
+                                                            ]
+                                                        },
+                                                        {
+                                                            "$pow": [
+                                                                {
+                                                                    "$subtract": [
+                                                                        {
+                                                                            "$subtract": [
+                                                                                {
+                                                                                    "$multiply": [
+                                                                                        {
+                                                                                            "$cos": {
+                                                                                                "$degreesToRadians": "$$target.dec"
+                                                                                            }
+                                                                                        },
+                                                                                        {
+                                                                                            "$sin": {
+                                                                                                "$degreesToRadians": "$candidate.dec"
+                                                                                            }
+                                                                                        },
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "$multiply": [
+                                                                                        {
+                                                                                            "$sin": {
+                                                                                                "$degreesToRadians": "$$target.dec"
+                                                                                            }
+                                                                                        },
+                                                                                        {
+                                                                                            "$cos": {
+                                                                                                "$degreesToRadians": "$candidate.dec"
+                                                                                            }
+                                                                                        },
+                                                                                        {
+                                                                                            "$cos": {
+                                                                                                "$degreesToRadians": {
+                                                                                                    "$subtract": [
+                                                                                                        "$candidate.ra",
+                                                                                                        "$$target.ra",
+                                                                                                    ]
+                                                                                                }
+                                                                                            }
+                                                                                        },
+                                                                                    ]
+                                                                                },
+                                                                            ]
+                                                                        },
+                                                                        0,
+                                                                    ]
+                                                                },
+                                                                2,
+                                                            ]
+                                                        },
+                                                    ]
+                                                }
+                                            },
+                                            {
+                                                "$add": [
+                                                    {
+                                                        "$multiply": [
+                                                            {
+                                                                "$sin": {
+                                                                    "$degreesToRadians": "$$target.dec"
+                                                                }
+                                                            },
+                                                            {
+                                                                "$sin": {
+                                                                    "$degreesToRadians": "$candidate.dec"
+                                                                }
+                                                            },
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$multiply": [
+                                                            {
+                                                                "$cos": {
+                                                                    "$degreesToRadians": "$$target.dec"
+                                                                }
+                                                            },
+                                                            {
+                                                                "$cos": {
+                                                                    "$degreesToRadians": "$candidate.dec"
+                                                                }
+                                                            },
+                                                            {
+                                                                "$cos": {
+                                                                    "$degreesToRadians": {
+                                                                        "$subtract": [
+                                                                            "$candidate.ra",
+                                                                            "$$target.ra",
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            },
+                                                        ]
+                                                    },
+                                                ]
+                                            },
+                                        ]
+                                    },
+                                    206264.80624709636,  # Convert radians to arcseconds
+                                ]
+                            },
+                        },
+                    }
+                }
+            }
+        },
+        {
+            "$addFields": {
+                "watchlist_matches": {
+                    "$filter": {
+                        "input": "$watchlist_distances",
+                        "as": "distance_obj",
+                        "cond": {
+                            "$lte": [
+                                "$$distance_obj.distance_arcsec",
+                                max_distance_arcsec,
+                            ]
+                        },
+                    }
+                }
+            }
+        },
+        {"$match": {"watchlist_matches": {"$ne": []}}},
+        {
+            "$project": {
+                "_id": 0,
+                "candid": 1,
+                "objectId": 1,
+                "watchlist_matches": 1,
+                "closest_watchlist_target": {
+                    "$arrayElemAt": ["$watchlist_matches.name", 0]
+                },
+                "closest_watchlist_distance_arcsec": {
+                    "$arrayElemAt": ["$watchlist_matches.distance_arcsec", 0]
+                },
+            }
+        },
+    ]
+
+    # Format output with instructions
+    output_lines = [
+        f"# Watchlist Filter: {filter_name}",
+        f"# Monitoring {len(targets_list)} target(s) within {max_distance_arcsec} arcsec",
+        "",
+        "## Targets:",
+    ]
+
+    for target in targets_list:
+        output_lines.append(
+            f"#   - {target['name']}: RA={target['ra']:.6f}°, Dec={target['dec']:+.6f}°"
+        )
+
+    output_lines.extend(
+        [
+            "",
+            "## Instructions:",
+            "# 1. Copy the JSON pipeline below",
+            "# 2. Go to Fritz UI → Filters page → Create Filter",
+            "# 3. Paste into the 'Pipeline' field",
+            "# 4. Set Group and Stream for this filter",
+            "# 5. Save to activate monitoring",
+            "#",
+            "# When alerts match, they'll be annotated with:",
+            "#   - closest_watchlist_target: name of nearest target",
+            "#   - closest_watchlist_distance_arcsec: angular separation",
+            "#   - watchlist_matches: list of all matching targets",
+            "",
+            "## MongoDB Pipeline JSON:",
+            "",
+            json.dumps(pipeline, indent=2),
+        ]
+    )
+
+    return "\n".join(output_lines)

--- a/services/mcp_server/tools/observing.py
+++ b/services/mcp_server/tools/observing.py
@@ -1,0 +1,264 @@
+# pyright: reportMissingTypeStubs=false, reportUnknownMemberType=false
+# pyright: reportUnknownVariableType=false, reportUnknownArgumentType=false
+"""Observability tools: compute when sources are visible from telescopes."""
+
+import httpx
+from astropy.time import Time
+
+from ..server import SKYPORTAL_URL, get_skyportal_token, mcp
+
+# Built-in telescope locations: (lat_deg, lon_deg, elevation_m, timezone_name)
+_TELESCOPES = {
+    "keck": (19.8263, -155.4747, 4145, "US/Hawaii"),
+    "lick": (37.3414, -121.6429, 1283, "US/Pacific"),
+    "palomar": (33.3564, -116.8650, 1712, "US/Pacific"),
+    "apo": (32.7803, -105.8203, 2788, "US/Mountain"),
+    "ctio": (-30.1691, -70.8064, 2207, "America/Santiago"),
+    "gemini-n": (19.8238, -155.4690, 4213, "US/Hawaii"),
+    "gemini-s": (-30.2407, -70.7367, 2722, "America/Santiago"),
+    "vlt": (-24.6275, -70.4044, 2635, "America/Santiago"),
+    "subaru": (19.8255, -155.4761, 4163, "US/Hawaii"),
+    "ldt": (34.7443, -111.4223, 2360, "US/Arizona"),
+    "lco-coj": (-31.2727, 149.0708, 1116, "Australia/Sydney"),
+    "lco-elp": (30.6797, -104.0151, 2070, "US/Central"),
+    "lco-lsc": (-30.1674, -70.8048, 2198, "America/Santiago"),
+    "lco-ogg": (20.7075, -156.2569, 3055, "US/Hawaii"),
+    "lco-cpt": (-32.3806, 20.8106, 1460, "Africa/Johannesburg"),
+    "lco-tfn": (28.3006, -16.5106, 2390, "Atlantic/Canary"),
+}
+
+
+@mcp.tool()
+async def get_source_observability(
+    source_id: str | None = None,
+    ra: float | None = None,
+    dec: float | None = None,
+    max_airmass: float = 2.0,
+    telescopes: str = "Keck,Palomar,Gemini-N,Gemini-S,VLT",
+    date: str | None = None,
+) -> str:
+    """Compute observing windows for a source from specified telescopes.
+
+    USE THIS TOOL for all observability questions. Do NOT use the
+    /api/sources/{id}/observability endpoint (that returns a PDF image
+    which cannot be parsed).
+
+    Provide either a source_id (auto-resolves RA/Dec from SkyPortal) or
+    explicit ra/dec coordinates.
+
+    Args:
+        source_id: SkyPortal source ID (e.g., "ZTF20abwysqy"). RA/Dec will
+                   be looked up automatically. Requires authentication.
+        ra: Right ascension in decimal degrees (J2000). Not needed if
+            source_id is provided.
+        dec: Declination in decimal degrees (J2000). Not needed if
+             source_id is provided.
+        max_airmass: Maximum airmass (default 2.0, ~30 deg altitude)
+        telescopes: Comma-separated telescope names. Built-in options:
+                    Keck, Lick, Palomar, APO, CTIO, Gemini-N, Gemini-S,
+                    VLT, Subaru, LDT, LCO-COJ, LCO-ELP, LCO-LSC,
+                    LCO-OGG, LCO-CPT, LCO-TFN.
+                    Use "all" for all built-in telescopes.
+                    Also accepts "fritz" to query all telescopes from your
+                    SkyPortal instance (requires authentication).
+        date: Date to compute observability for (ISO format, default: tonight).
+              e.g., "2024-06-15"
+
+    Returns:
+        Per-telescope observing windows with rise/set times (UTC and local),
+        transit time, peak altitude, and airmass.
+    """
+    import math
+    from datetime import timezone
+    from zoneinfo import ZoneInfo
+
+    import numpy as np
+    from astropy.coordinates import AltAz, EarthLocation, SkyCoord, get_sun
+    from astropy.time import TimeDelta
+
+    # Resolve RA/Dec from source_id if needed
+    if source_id and (ra is None or dec is None):
+        token = get_skyportal_token()
+        if not token:
+            return "Authentication required to look up source coordinates. Provide ra/dec directly or authenticate."
+        try:
+            async with httpx.AsyncClient(timeout=30) as client:
+                resp = await client.get(
+                    f"{SKYPORTAL_URL}/api/sources/{source_id}",
+                    headers={"Authorization": f"token {token}"},
+                )
+            resp.raise_for_status()
+            src = resp.json().get("data", {})
+            ra = src.get("ra")
+            dec = src.get("dec")
+            if ra is None or dec is None:
+                return f"Could not resolve coordinates for source {source_id}"
+        except Exception as e:
+            return f"Error looking up source {source_id}: {e}"
+
+    if ra is None or dec is None:
+        return "Provide either source_id or both ra and dec."
+
+    target = SkyCoord(ra=ra, dec=dec, unit="deg")
+
+    if date:
+        base_time = Time(date)
+    else:
+        base_time = Time.now()
+
+    # If "fritz" is requested, fetch telescopes from SkyPortal
+    if telescopes.strip().lower() == "fritz":
+        token = get_skyportal_token()
+        if not token:
+            return "Authentication required to fetch Fritz telescopes. Use named telescopes instead."
+        try:
+            async with httpx.AsyncClient(timeout=30) as client:
+                resp = await client.get(
+                    f"{SKYPORTAL_URL}/api/telescope",
+                    headers={"Authorization": f"token {token}"},
+                )
+            resp.raise_for_status()
+            fritz_telescopes = resp.json().get("data", [])
+            tel_list = []
+            for t in fritz_telescopes:
+                if t.get("fixed_location") and t.get("lat") and t.get("lon"):
+                    tel_list.append(
+                        {
+                            "name": t.get("nickname") or t.get("name"),
+                            "lat": t["lat"],
+                            "lon": t["lon"],
+                            "elevation": t.get("elevation") or 0,
+                            "tz": "UTC",
+                        }
+                    )
+        except Exception as e:
+            return (
+                f"Error fetching Fritz telescopes: {e}. Use named telescopes instead."
+            )
+    else:
+        # Parse telescope list
+        if telescopes.strip().lower() == "all":
+            tel_names = list(_TELESCOPES.keys())
+        else:
+            tel_names = [t.strip().lower() for t in telescopes.split(",")]
+
+        tel_list = []
+        for name in tel_names:
+            if name not in _TELESCOPES:
+                available = ", ".join(t.title() for t in sorted(_TELESCOPES))
+                return f"Unknown telescope '{name}'. Available: {available}, all, fritz"
+            lat, lon, alt, tz = _TELESCOPES[name]
+            tel_list.append(
+                {
+                    "name": name.upper() if name.startswith("lco") else name.title(),
+                    "lat": lat,
+                    "lon": lon,
+                    "elevation": alt,
+                    "tz": tz,
+                }
+            )
+
+    # Compute observability for each telescope
+    # Sample every 5 minutes over the next 24 hours
+    time_grid = base_time + TimeDelta(np.linspace(0, 24 * 3600, 289), format="sec")
+
+    min_alt_deg = math.degrees(math.asin(1.0 / max_airmass))
+    sun_limit_deg = -18  # astronomical twilight
+
+    header = f"Source observability: {source_id + '  ' if source_id else ''}RA={ra:.5f}, Dec={dec:+.5f}"
+    lines = [
+        header,
+        f"Date: {base_time.isot[:10]}  |  Max airmass: {max_airmass}",
+        f"{'=' * 72}",
+    ]
+
+    for tel in tel_list:
+        location = EarthLocation(
+            lat=tel["lat"], lon=tel["lon"], height=tel["elevation"]
+        )
+        altaz_frame = AltAz(obstime=time_grid, location=location)
+
+        # Target altitude over time
+        target_altaz = target.transform_to(altaz_frame)
+        target_alt = target_altaz.alt.deg  # type: ignore
+
+        # Sun altitude (astronomical twilight: sun below -18 deg)
+        sun_altaz = get_sun(time_grid).transform_to(altaz_frame)
+        sun_alt = sun_altaz.alt.deg  # type: ignore
+
+        # Observable = target above min_alt AND sun below twilight limit
+        observable = (target_alt >= min_alt_deg) & (sun_alt <= sun_limit_deg)  # type: ignore
+
+        # LST at the start
+        lst = base_time.sidereal_time("apparent", longitude=tel["lon"])
+
+        try:
+            tz = ZoneInfo(tel["tz"])
+        except Exception:
+            tz = timezone.utc
+
+        lines.append(f"\n{tel['name']}  (lat={tel['lat']:+.2f}, lon={tel['lon']:+.2f})")
+        lines.append(f"  LST now: {lst}")
+
+        if not np.any(observable):
+            lines.append(
+                "  NOT OBSERVABLE tonight (target below airmass limit or daytime)"
+            )
+            # Still show transit info
+            peak_idx = np.argmax(target_alt)  # type: ignore
+            peak_alt = target_alt[peak_idx]  # type: ignore
+            if peak_alt > 0:  # type: ignore
+                transit_utc = time_grid[peak_idx].datetime.replace(tzinfo=timezone.utc)  # type: ignore
+                transit_local = transit_utc.astimezone(tz)
+                lines.append(
+                    f"  Peak alt: {peak_alt:.1f} deg at "
+                    f"{transit_utc.strftime('%H:%M')} UTC / "
+                    f"{transit_local.strftime('%H:%M')} local"
+                )
+            else:
+                lines.append("  Source never rises above horizon from this site")
+            continue
+
+        # Find observable windows
+        obs_changes = np.diff(observable.astype(int))
+        rise_indices = np.where(obs_changes == 1)[0] + 1
+        set_indices = np.where(obs_changes == -1)[0] + 1
+
+        # Handle edge cases: observable at start/end
+        if observable[0]:
+            rise_indices = np.concatenate([[0], rise_indices])
+        if observable[-1]:
+            set_indices = np.concatenate([set_indices, [len(observable) - 1]])
+
+        for ri, si in zip(rise_indices, set_indices):
+            rise_utc = time_grid[ri].datetime.replace(tzinfo=timezone.utc)  # type: ignore
+            set_utc = time_grid[si].datetime.replace(tzinfo=timezone.utc)  # type: ignore
+            rise_local = rise_utc.astimezone(tz)
+            set_local = set_utc.astimezone(tz)
+            duration_hrs = (set_utc - rise_utc).total_seconds() / 3600
+
+            lines.append(
+                f"  Observable: {rise_utc.strftime('%H:%M')}–{set_utc.strftime('%H:%M')} UTC"
+                f"  ({rise_local.strftime('%H:%M')}–{set_local.strftime('%H:%M')} local)"
+                f"  [{duration_hrs:.1f} hrs]"
+            )
+
+        # Transit (peak altitude)
+        # Only consider nighttime peak
+        night_mask = sun_alt <= sun_limit_deg  # type: ignore
+        if np.any(night_mask):
+            night_alt = np.where(night_mask, target_alt, -90)  # type: ignore
+            peak_idx = np.argmax(night_alt)
+            peak_alt = night_alt[peak_idx]
+            peak_airmass = (
+                1.0 / math.sin(math.radians(peak_alt)) if peak_alt > 0 else float("inf")
+            )
+            transit_utc = time_grid[peak_idx].datetime.replace(tzinfo=timezone.utc)  # type: ignore
+            transit_local = transit_utc.astimezone(tz)
+            lines.append(
+                f"  Transit: {transit_utc.strftime('%H:%M')} UTC / "
+                f"{transit_local.strftime('%H:%M')} local  "
+                f"(alt={peak_alt:.1f}\u00b0, airmass={peak_airmass:.2f})"
+            )
+
+    return "\n".join(lines)

--- a/services/mcp_server/tools/source_products.py
+++ b/services/mcp_server/tools/source_products.py
@@ -1,0 +1,771 @@
+# pyright: reportMissingTypeStubs=false
+"""Single-source data product tools: photometry, spectra, classifications, comments."""
+
+import csv
+import io
+
+import httpx
+
+from ..server import SKYPORTAL_URL, get_skyportal_token, mcp
+
+# ─── Source ID Resolution Helper ────────────────────────────────────────────
+
+
+async def resolve_source_id(name_or_id: str) -> str | None:
+    """Resolve ZTF name, TNS name, or SkyPortal ID to canonical SkyPortal obj_id.
+
+    Accepts any of:
+    - SkyPortal obj_id (e.g., "ZTF21aaaaaaa")
+    - ZTF designation (e.g., "ZTF21aaaaaaa")
+    - TNS name (e.g., "AT2021abc", "SN2021xyz")
+
+    Returns:
+        SkyPortal obj_id if found, None if not found or error
+    """
+    token = get_skyportal_token()
+    if not token:
+        return None
+
+    # Try direct lookup first (assume it's already an obj_id)
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            resp = await client.get(
+                f"{SKYPORTAL_URL}/api/sources/{name_or_id}",
+                headers={"Authorization": f"token {token}"},
+            )
+        if resp.is_success:
+            data = resp.json().get("data", {})
+            return data.get("id")
+    except Exception:
+        pass
+
+    # If direct lookup failed, try searching by name
+    # This handles TNS names stored in altdata
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            # Search for sources - SkyPortal's search handles various name formats
+            resp = await client.get(
+                f"{SKYPORTAL_URL}/api/sources",
+                headers={"Authorization": f"token {token}"},
+                params={"sourceID": name_or_id, "includeComments": "false"},
+            )
+        if resp.is_success:
+            sources = resp.json().get("data", {}).get("sources", [])
+            if sources:
+                return sources[0].get("id")
+    except Exception:
+        pass
+
+    return None
+
+
+@mcp.tool()
+async def get_source_photometry(
+    source_name: str,
+    format: str = "mag",
+    magsys: str = "ab",
+    filters: str | None = None,
+) -> str:
+    """Retrieve photometry for a source as a CSV table.
+
+    Returns all photometry points for the source in CSV format, suitable for
+    direct analysis or loading into a pandas DataFrame.
+
+    Columns returned (mag format):
+        mjd, filter, mag, magerr, limiting_mag, snr, instrument_name, origin
+
+    Columns returned (flux format):
+        mjd, filter, flux, fluxerr, snr, instrument_name, origin
+
+    Args:
+        source_name: Source identifier - can be SkyPortal obj_id, ZTF name, or TNS name
+        format: Output format — "mag" (default) or "flux"
+        magsys: Magnitude system — "ab" (default), "vega", etc.
+        filters: Comma-separated photometric filter names to include
+                 (e.g., "ztfg,ztfr,ztfi"). If omitted, returns all filters.
+
+    Returns:
+        CSV-formatted text with one row per photometry point, sorted by MJD.
+        Includes a summary header comment with source ID and number of points.
+    """
+    token = get_skyportal_token()
+    if not token:
+        return "Not authenticated. Configure SKYPORTAL_TOKEN or send Bearer token."
+
+    # Resolve source name to obj_id
+    source_id = await resolve_source_id(source_name)
+    if not source_id:
+        return f"Error: Could not resolve '{source_name}' to a SkyPortal source."
+
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            resp = await client.get(
+                f"{SKYPORTAL_URL}/api/sources/{source_id}/photometry",
+                headers={"Authorization": f"token {token}"},
+                params={"format": format, "magsys": magsys},
+            )
+        resp.raise_for_status()
+    except httpx.HTTPStatusError as e:
+        return f"HTTP Error {e.response.status_code}: {e.response.text}"
+    except Exception as e:
+        return f"Error fetching photometry: {e}"
+
+    data = resp.json().get("data", [])
+    if not data:
+        return f"No photometry found for source {source_id}"
+
+    # Filter by band if requested
+    if filters:
+        allowed = {f.strip() for f in filters.split(",")}
+        data = [p for p in data if p.get("filter") in allowed]
+        if not data:
+            return f"No photometry found for source {source_id} in filters: {filters}"
+
+    # Sort by MJD
+    data.sort(key=lambda p: p.get("mjd", 0))
+
+    # Build CSV
+    if format == "flux":
+        columns = [
+            "mjd",
+            "filter",
+            "flux",
+            "fluxerr",
+            "snr",
+            "instrument_name",
+            "origin",
+        ]
+    else:
+        columns = [
+            "mjd",
+            "filter",
+            "mag",
+            "magerr",
+            "limiting_mag",
+            "snr",
+            "instrument_name",
+            "origin",
+        ]
+
+    output = io.StringIO()
+    # Summary comment
+    unique_filters = sorted({p.get("filter", "") for p in data})
+    output.write(
+        f"# {source_id}: {len(data)} points, filters: {', '.join(unique_filters)}\n"
+    )
+
+    writer = csv.DictWriter(output, fieldnames=columns, extrasaction="ignore")
+    writer.writeheader()
+    for point in data:
+        row = {col: point.get(col, "") for col in columns}
+        # Round numeric values for readability
+        for key in ("mjd", "mag", "magerr", "limiting_mag", "flux", "fluxerr", "snr"):
+            if key in row and row[key] not in ("", None):
+                try:
+                    row[key] = round(float(row[key]), 5)
+                except (ValueError, TypeError):
+                    pass
+        writer.writerow(row)
+
+    return output.getvalue()
+
+
+@mcp.tool()
+async def get_source_spectra(
+    source_name: str,
+    format: str = "csv",
+) -> str:
+    """Retrieve spectra for a source.
+
+    Returns all spectra for the source. For CSV format, returns one spectrum
+    per output block with wavelength and flux columns.
+
+    Args:
+        source_name: Source identifier - can be SkyPortal obj_id, ZTF name, or TNS name (e.g., "ZTF21aaaaaaa")
+        format: Output format — "csv" (default) or "json"
+
+    Returns:
+        For CSV: Each spectrum as a separate CSV block with wavelength, flux,
+        (and error if available), preceded by a header with metadata.
+        For JSON: Raw API response as formatted JSON.
+    """
+    token = get_skyportal_token()
+    if not token:
+        return "Not authenticated. Configure SKYPORTAL_TOKEN or send Bearer token."
+
+    # Resolve source name to obj_id
+    source_id = await resolve_source_id(source_name)
+    if not source_id:
+        return f"Error: Could not resolve '{source_name}' to a SkyPortal source."
+
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            resp = await client.get(
+                f"{SKYPORTAL_URL}/api/sources/{source_id}/spectra",
+                headers={"Authorization": f"token {token}"},
+            )
+        resp.raise_for_status()
+    except httpx.HTTPStatusError as e:
+        return f"HTTP Error {e.response.status_code}: {e.response.text}"
+    except Exception as e:
+        return f"Error fetching spectra: {e}"
+
+    data = resp.json().get("data", [])
+    if not data:
+        return f"No spectra found for source {source_id}"
+
+    if format == "json":
+        import json
+
+        return json.dumps(data, indent=2)
+
+    # CSV format: one spectrum per block
+    results = [f"Found {len(data)} spectrum/spectra for {source_id}\n"]
+
+    for i, spec in enumerate(data, 1):
+        wavelengths = spec.get("wavelengths", [])
+        fluxes = spec.get("fluxes", [])
+        errors = spec.get("errors")
+        observed_at = spec.get("observed_at", "unknown")
+        instrument = spec.get("instrument_name", "unknown")
+        origin = spec.get("origin", "")
+
+        if not wavelengths or not fluxes:
+            continue
+
+        results.append(
+            f"\n# Spectrum {i}: observed {observed_at}, "
+            f"instrument: {instrument}, origin: {origin}"
+        )
+        results.append(f"# {len(wavelengths)} points\n")
+
+        output = io.StringIO()
+        if errors:
+            writer = csv.writer(output)
+            writer.writerow(["wavelength", "flux", "error"])
+            for w, f, e in zip(wavelengths, fluxes, errors):
+                writer.writerow([w, f, e])
+        else:
+            writer = csv.writer(output)
+            writer.writerow(["wavelength", "flux"])
+            for w, f in zip(wavelengths, fluxes):
+                writer.writerow([w, f])
+
+        results.append(output.getvalue())
+
+    return "\n".join(results)
+
+
+@mcp.tool()
+async def get_source_classifications(source_name: str) -> str:
+    """Retrieve classifications for a source.
+
+    Returns all classifications assigned to the source, including the
+    classification name, probability, and who made the classification.
+
+    Args:
+        source_name: Source identifier - can be SkyPortal obj_id, ZTF name, or TNS name (e.g., "ZTF21aaaaaaa")
+
+    Returns:
+        Summary of classifications with classification type, probability,
+        classifier name, and classification date.
+    """
+    token = get_skyportal_token()
+    if not token:
+        return "Not authenticated. Configure SKYPORTAL_TOKEN or send Bearer token."
+
+    # Resolve source name to obj_id
+    source_id = await resolve_source_id(source_name)
+    if not source_id:
+        return f"Error: Could not resolve '{source_name}' to a SkyPortal source."
+
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            resp = await client.get(
+                f"{SKYPORTAL_URL}/api/sources/{source_id}/classifications",
+                headers={"Authorization": f"token {token}"},
+            )
+        resp.raise_for_status()
+    except httpx.HTTPStatusError as e:
+        return f"HTTP Error {e.response.status_code}: {e.response.text}"
+    except Exception as e:
+        return f"Error fetching classifications: {e}"
+
+    data = resp.json().get("data", [])
+    if not data:
+        return f"No classifications found for source {source_id}"
+
+    lines = [f"Classifications for {source_id}:\n"]
+    for cls in data:
+        classification = cls.get("classification", "Unknown")
+        probability = cls.get("probability")
+        author = cls.get("author_name", "Unknown")
+        created_at = cls.get("created_at", "Unknown")
+        taxonomy = cls.get("taxonomy_name", "")
+
+        prob_str = f" (p={probability:.3f})" if probability is not None else ""
+        tax_str = f" [{taxonomy}]" if taxonomy else ""
+
+        lines.append(
+            f"  • {classification}{prob_str}{tax_str}\n    by {author} on {created_at}"
+        )
+
+    return "\n".join(lines)
+
+
+@mcp.tool()
+async def get_source_comments_and_annotations(source_name: str) -> str:
+    """Retrieve comments and annotations for a source.
+
+    Returns a summary of user comments and system/ML annotations on the source.
+    Comments are human-readable notes; annotations are structured data (e.g.,
+    ML scores, cross-match results).
+
+    Args:
+        source_name: Source identifier - can be SkyPortal obj_id, ZTF name, or TNS name (e.g., "ZTF21aaaaaaa")
+
+    Returns:
+        Summary with comments (text, author, date) and annotations
+        (key-value pairs with origin).
+    """
+    token = get_skyportal_token()
+    if not token:
+        return "Not authenticated. Configure SKYPORTAL_TOKEN or send Bearer token."
+
+    # Resolve source name to obj_id
+    source_id = await resolve_source_id(source_name)
+    if not source_id:
+        return f"Error: Could not resolve '{source_name}' to a SkyPortal source."
+
+    # Fetch both comments and source data (which includes annotations)
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            # Get comments
+            comments_resp = await client.get(
+                f"{SKYPORTAL_URL}/api/sources/{source_id}/comments",
+                headers={"Authorization": f"token {token}"},
+            )
+            # Get source (includes annotations)
+            source_resp = await client.get(
+                f"{SKYPORTAL_URL}/api/sources/{source_id}",
+                headers={"Authorization": f"token {token}"},
+            )
+        comments_resp.raise_for_status()
+        source_resp.raise_for_status()
+    except httpx.HTTPStatusError as e:
+        return f"HTTP Error {e.response.status_code}: {e.response.text}"
+    except Exception as e:
+        return f"Error fetching comments/annotations: {e}"
+
+    comments = comments_resp.json().get("data", [])
+    source_data = source_resp.json().get("data", {})
+    annotations = source_data.get("annotations", [])
+
+    lines = [f"Comments and annotations for {source_id}:\n"]
+
+    # Comments section
+    if comments:
+        lines.append("\n## Comments\n")
+        for comment in comments:
+            text = comment.get("text", "")
+            author = comment.get("author", {}).get("username", "Unknown")
+            created_at = comment.get("created_at", "Unknown")
+            lines.append(f"  [{created_at}] {author}:")
+            lines.append(f"    {text}\n")
+    else:
+        lines.append("\n## Comments\n  (none)\n")
+
+    # Annotations section
+    if annotations:
+        lines.append("\n## Annotations\n")
+        for annot in annotations:
+            origin = annot.get("origin", "Unknown")
+            data = annot.get("data", {})
+            lines.append(f"  • {origin}:")
+            for key, value in data.items():
+                lines.append(f"      {key}: {value}")
+            lines.append("")
+    else:
+        lines.append("\n## Annotations\n  (none)\n")
+
+    return "\n".join(lines)
+
+
+@mcp.tool()
+async def get_source_host_galaxy(source_name: str) -> str:
+    """Retrieve host galaxy information for a source.
+
+    Returns the associated host galaxy from SkyPortal's galaxy catalogs,
+    including angular separation (offset) and physical distance.
+
+    SkyPortal can link sources to host galaxies from catalogs like GLADE+.
+    If a host association exists, this returns the galaxy's properties.
+
+    Args:
+        source_name: Source identifier - can be SkyPortal obj_id, ZTF name, or TNS name (e.g., "ZTF21aaaaaaa")
+
+    Returns:
+        Host galaxy summary with name, position, redshift, distance, stellar mass,
+        angular offset from source, and physical separation. If no host is
+        associated, returns a message indicating this.
+    """
+    token = get_skyportal_token()
+    if not token:
+        return "Not authenticated. Configure SKYPORTAL_TOKEN or send Bearer token."
+
+    # Resolve source name to obj_id
+    source_id = await resolve_source_id(source_name)
+    if not source_id:
+        return f"Error: Could not resolve '{source_name}' to a SkyPortal source."
+
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            resp = await client.get(
+                f"{SKYPORTAL_URL}/api/sources/{source_id}",
+                headers={"Authorization": f"token {token}"},
+            )
+        resp.raise_for_status()
+    except httpx.HTTPStatusError as e:
+        return f"HTTP Error {e.response.status_code}: {e.response.text}"
+    except Exception as e:
+        return f"Error fetching source: {e}"
+
+    data = resp.json().get("data", {})
+    host = data.get("host")
+
+    if not host:
+        return f"No host galaxy associated with source {source_id}"
+
+    # Extract key host galaxy properties
+    name = host.get("name", "Unknown")
+    alt_name = host.get("alt_name")
+    ra = host.get("ra")
+    dec = host.get("dec")
+    redshift = host.get("redshift")
+    redshift_error = host.get("redshift_error")
+    distmpc = host.get("distmpc")
+    distmpc_unc = host.get("distmpc_unc")
+    mstar = host.get("mstar")
+    magb = host.get("magb")
+    magk = host.get("magk")
+    catalog_name = host.get("catalog_name", "Unknown")
+
+    # Get offset and distance computed by SkyPortal
+    host_offset = data.get("host_offset")  # arcsec
+    host_distance = data.get("host_distance")  # kpc
+
+    lines = [f"Host galaxy for {source_id}:\n"]
+
+    # Galaxy identification
+    lines.append(f"  Name: {name}")
+    if alt_name:
+        lines.append(f"  Alt. name: {alt_name}")
+    lines.append(f"  Catalog: {catalog_name}\n")
+
+    # Position
+    if ra is not None and dec is not None:
+        lines.append(f"  Position: RA={ra:.6f}, Dec={dec:+.6f} (J2000)")
+
+    # Separation from source
+    if host_offset is not None:
+        lines.append(f"  Angular offset: {host_offset:.2f} arcsec")
+    if host_distance is not None:
+        lines.append(f"  Physical distance: {host_distance:.2f} kpc\n")
+    else:
+        lines.append("")
+
+    # Redshift and distance
+    if redshift is not None:
+        z_str = f"z = {redshift:.6f}"
+        if redshift_error is not None:
+            z_str += f" ± {redshift_error:.6f}"
+        lines.append(f"  Redshift: {z_str}")
+
+    if distmpc is not None:
+        dist_str = f"D = {distmpc:.1f} Mpc"
+        if distmpc_unc is not None:
+            dist_str += f" ± {distmpc_unc:.1f} Mpc"
+        lines.append(f"  Distance: {dist_str}\n")
+    else:
+        lines.append("")
+
+    # Galaxy properties
+    if mstar is not None:
+        lines.append(f"  Stellar mass: log(M*/M☉) = {mstar:.2f}")
+    if magb is not None:
+        lines.append(f"  B-band magnitude: {magb:.2f} mag")
+    if magk is not None:
+        lines.append(f"  K-band magnitude: {magk:.2f} mag")
+
+    return "\n".join(lines)
+
+
+@mcp.tool()
+async def get_tns_summary(source_name: str) -> str:
+    """SUMMARY TOOL: Generate complete TNS/AstroNote report for a transient.
+
+    **USE THIS SINGLE TOOL when asked to create TNS reports, AstroNotes, or
+    comprehensive source summaries.** It combines all relevant data in one call.
+
+    This tool retrieves and formats ALL information needed for TNS submissions:
+    - Source identification (coordinates in deg and HMS/DMS)
+    - Discovery information (first detection, magnitude, date, instrument)
+    - Latest photometry and peak brightness
+    - Classification (type, probability, classifier)
+    - Spectroscopy (dates, instruments, redshift)
+    - Host galaxy information
+
+    Accepts ANY source identifier: SkyPortal obj_id, ZTF name, or TNS name.
+
+    **When to use:**
+    - User asks to "create/generate/write TNS report"
+    - User asks to "draft AstroNote" or "prepare ATel"
+    - User asks for "summary of [source]"
+    - User mentions "TNS submission" or "classification report"
+
+    **Do NOT** call multiple other tools (photometry, spectra, classifications)
+    separately when this single tool provides everything together.
+
+    Args:
+        source_name: Source identifier - can be:
+            - SkyPortal obj_id (e.g., "ZTF21aaaaaaa")
+            - ZTF designation (e.g., "ZTF21aaaaaaa")
+            - TNS name (e.g., "AT2021abc", "SN2021xyz")
+
+    Returns:
+        Formatted text summary with all TNS-relevant information, ready to
+        copy into TNS forms or use as AstroNote draft. Includes coordinates,
+        discovery data, photometry, classification, spectra, and host info.
+
+        **IMPORTANT:** When presenting this to the user, display the summary
+        in a markdown code block (```text) for easy reading and copying.
+    """
+    token = get_skyportal_token()
+    if not token:
+        return "Not authenticated. Configure SKYPORTAL_TOKEN or send Bearer token."
+
+    # Resolve source name to obj_id
+    obj_id = await resolve_source_id(source_name)
+    if not obj_id:
+        return f"Error: Could not resolve '{source_name}' to a SkyPortal source. Try using the exact SkyPortal obj_id."
+
+    # Fetch comprehensive source data
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            resp = await client.get(
+                f"{SKYPORTAL_URL}/api/sources/{obj_id}",
+                headers={"Authorization": f"token {token}"},
+                params={
+                    "includePhotometry": "true",
+                    "includeSpectra": "true",
+                    "includeComments": "false",
+                },
+            )
+        resp.raise_for_status()
+        data = resp.json().get("data", {})
+    except httpx.HTTPStatusError as e:
+        return f"HTTP Error {e.response.status_code}: {e.response.text}"
+    except Exception as e:
+        return f"Error fetching source: {e}"
+
+    # Extract key information
+    ra = data.get("ra")
+    dec = data.get("dec")
+    redshift = data.get("redshift")
+    redshift_error = data.get("redshift_error")
+
+    # Get TNS info if available
+    altdata = data.get("altdata", {})
+    tns_info = altdata.get("tns", {}) if altdata else {}
+    tns_name = tns_info.get("name")
+
+    # Construct TNS URL if source is already reported
+    tns_url = None
+    if tns_name:
+        # TNS URL format: https://www.wis-tns.org/object/{name}
+        tns_url = f"https://www.wis-tns.org/object/{tns_name}"
+
+    # Get classifications
+    classifications = data.get("classifications", [])
+    latest_class = None
+    if classifications:
+        sorted_classes = sorted(
+            classifications, key=lambda x: x.get("created_at", ""), reverse=True
+        )
+        latest_class = sorted_classes[0] if sorted_classes else None
+
+    # Get photometry
+    photometry = data.get("photometry", [])
+    first_det = None
+    latest_det = None
+    peak_mag = None
+
+    if photometry:
+        sorted_phot = sorted(photometry, key=lambda x: x.get("mjd", 0))
+        first_det = sorted_phot[0]
+        latest_det = sorted_phot[-1]
+
+        # Find peak (brightest = minimum magnitude)
+        mags = [p["mag"] for p in photometry if p.get("mag") is not None]
+        if mags:
+            peak_mag = min(mags)
+
+    # Get spectra
+    spectra = data.get("spectra", [])
+    latest_spectrum = None
+    if spectra:
+        sorted_spectra = sorted(
+            spectra, key=lambda x: x.get("observed_at", ""), reverse=True
+        )
+        latest_spectrum = sorted_spectra[0]
+
+    # Build summary
+    lines = ["=" * 80]
+    lines.append("TNS / ASTRONOTE SUMMARY")
+    lines.append("=" * 80)
+    lines.append("")
+
+    # Source Identification
+    lines.append("## SOURCE IDENTIFICATION")
+    lines.append(f"SkyPortal ID:   {obj_id}")
+    if tns_name:
+        lines.append(f"TNS Name:       {tns_name}")
+        if tns_url:
+            lines.append(f"TNS Report:     {tns_url}")
+            lines.append("                ⚠️  This source is already reported to TNS")
+    if ra is not None and dec is not None:
+        lines.append(f"RA (J2000):     {ra:.6f}°  ({_deg_to_hms(ra)})")
+        lines.append(f"Dec (J2000):    {dec:+.6f}°  ({_deg_to_dms(dec)})")
+    lines.append("")
+
+    # Discovery Information
+    lines.append("## DISCOVERY INFORMATION")
+    if first_det:
+        mjd = first_det.get("mjd")
+        mag = first_det.get("mag")
+        magerr = first_det.get("magerr")
+        filt = first_det.get("filter", "")
+        instrument = first_det.get("instrument_name", "Unknown")
+
+        if mjd:
+            from astropy.time import Time
+
+            t = Time(mjd, format="mjd")
+            iso_date = str(t.iso).split()[0]  # YYYY-MM-DD
+            lines.append(f"First Detection:  MJD {mjd:.2f} ({iso_date})")
+        if mag is not None:
+            mag_str = f"{mag:.2f}"
+            if magerr:
+                mag_str += f" ± {magerr:.2f}"
+            lines.append(f"Discovery Mag:    {mag_str} ({filt})")
+        lines.append(f"Instrument:       {instrument}")
+    else:
+        lines.append("No photometry available")
+    lines.append("")
+
+    # Latest Photometry
+    lines.append("## LATEST PHOTOMETRY")
+    if latest_det:
+        mjd = latest_det.get("mjd")
+        mag = latest_det.get("mag")
+        magerr = latest_det.get("magerr")
+        filt = latest_det.get("filter", "")
+
+        if mjd:
+            from astropy.time import Time
+
+            t = Time(mjd, format="mjd")
+            iso_date = str(t.iso).split()[0]
+            lines.append(f"Date:       MJD {mjd:.2f} ({iso_date})")
+        if mag is not None:
+            mag_str = f"{mag:.2f}"
+            if magerr:
+                mag_str += f" ± {magerr:.2f}"
+            lines.append(f"Magnitude:  {mag_str} ({filt})")
+
+        # Summary stats
+        if len(photometry) > 1:
+            lines.append(
+                f"Peak mag:   {peak_mag:.2f} (from {len(photometry)} detections)"
+            )
+            lines.append("            Note: Peak = min(mag), not from light curve fit")
+    lines.append("")
+
+    # Classification
+    lines.append("## CLASSIFICATION")
+    if latest_class:
+        class_name = latest_class.get("classification", "Unknown")
+        class_date = latest_class.get("created_at", "")
+        probability = latest_class.get("probability")
+        author = latest_class.get("author_name", "")
+
+        lines.append(f"Type:        {class_name}")
+        if probability is not None:
+            lines.append(f"Probability: {probability:.2f}")
+        if class_date:
+            lines.append(f"Date:        {class_date.split('T')[0]}")
+        if author:
+            lines.append(f"Classifier:  {author}")
+    else:
+        lines.append("No classification available")
+    lines.append("")
+
+    # Spectroscopy & Redshift
+    lines.append("## SPECTROSCOPY & REDSHIFT")
+    if redshift is not None:
+        z_str = f"{redshift:.4f}"
+        if redshift_error:
+            z_str += f" ± {redshift_error:.4f}"
+        lines.append(f"Redshift:    {z_str}")
+
+    if latest_spectrum:
+        spec_date = latest_spectrum.get("observed_at", "")
+        instrument = latest_spectrum.get("instrument_name", "")
+
+        if spec_date:
+            lines.append(f"Latest Spectrum: {spec_date.split('T')[0]}")
+        if instrument:
+            lines.append(f"Instrument:      {instrument}")
+        lines.append(f"Total Spectra:   {len(spectra)}")
+
+    if not redshift and not latest_spectrum:
+        lines.append("No spectroscopic data available")
+    lines.append("")
+
+    # Host Galaxy
+    lines.append("## HOST GALAXY")
+    host_offset = altdata.get("host_offset") if altdata else None
+    if host_offset is not None:
+        lines.append(f"Host Offset: {host_offset:.2f} arcsec")
+    else:
+        lines.append("Host information not available")
+    lines.append("")
+
+    # Footer
+    lines.append("=" * 80)
+    lines.append(f"Generated from SkyPortal source: {obj_id}")
+    if source_name != obj_id:
+        lines.append(f"(Resolved from input: {source_name})")
+    lines.append("Ready for TNS submission or AstroNote drafting")
+    lines.append("=" * 80)
+
+    return "\n".join(lines)
+
+
+def _deg_to_hms(deg: float) -> str:
+    """Convert RA in degrees to HH:MM:SS.SS format."""
+    hours = deg / 15.0
+    h = int(hours)
+    m = int((hours - h) * 60)
+    s = ((hours - h) * 60 - m) * 60
+    return f"{h:02d}h{m:02d}m{s:05.2f}s"
+
+
+def _deg_to_dms(deg: float) -> str:
+    """Convert Dec in degrees to DD:MM:SS.S format."""
+    sign = "+" if deg >= 0 else "-"
+    deg = abs(deg)
+    d = int(deg)
+    m = int((deg - d) * 60)
+    s = ((deg - d) * 60 - m) * 60
+    return f"{sign}{d:02d}d{m:02d}m{s:04.1f}s"

--- a/services/mcp_server/tools/source_products.py
+++ b/services/mcp_server/tools/source_products.py
@@ -173,21 +173,25 @@ async def get_source_photometry(
 @mcp.tool()
 async def get_source_spectra(
     source_name: str,
-    format: str = "csv",
+    format: str = "summary",
+    verbose: bool = False,
 ) -> str:
     """Retrieve spectra for a source.
 
-    Returns all spectra for the source. For CSV format, returns one spectrum
-    per output block with wavelength and flux columns.
+    By default returns a summary to avoid token overflow. Use verbose=True or
+    format="csv" to get full spectral data.
 
     Args:
         source_name: Source identifier - can be SkyPortal obj_id, ZTF name, or TNS name (e.g., "ZTF21aaaaaaa")
-        format: Output format — "csv" (default) or "json"
+        format: Output format — "summary" (default), "csv", or "json"
+        verbose: If True with format="summary", includes full CSV data (use with caution for sources with many spectra)
 
     Returns:
-        For CSV: Each spectrum as a separate CSV block with wavelength, flux,
-        (and error if available), preceded by a header with metadata.
-        For JSON: Raw API response as formatted JSON.
+        - Summary (default): List of spectra with metadata and Fritz link
+        - CSV: Each spectrum as a separate CSV block with wavelength, flux columns
+        - JSON: Raw API response as formatted JSON
+
+    Note: For bulk spectral data downloads, use generate_fritz_bulk_query_code tool.
     """
     token = get_skyportal_token()
     if not token:
@@ -210,16 +214,45 @@ async def get_source_spectra(
     except Exception as e:
         return f"Error fetching spectra: {e}"
 
-    data = resp.json().get("data", [])
+    response_data = resp.json().get("data", {})
+    data = response_data.get("spectra", [])
     if not data:
         return f"No spectra found for source {source_id}"
 
+    # JSON format: return raw data
     if format == "json":
         import json
 
         return json.dumps(data, indent=2)
 
-    # CSV format: one spectrum per block
+    # Summary format (default): metadata only
+    if format == "summary" and not verbose:
+        fritz_url = f"{SKYPORTAL_URL}/source/{source_id}"
+        results = [
+            f"# {source_id}: {len(data)} spectrum/spectra",
+            f"# View on Fritz: {fritz_url}\n",
+        ]
+
+        for i, spec in enumerate(data, 1):
+            wavelengths = spec.get("wavelengths", [])
+            fluxes = spec.get("fluxes", [])
+            observed_at = spec.get("observed_at", "unknown")
+            instrument = spec.get("instrument_name", "unknown")
+            origin = spec.get("origin", "") or "none"
+
+            num_points = len(wavelengths) if wavelengths else 0
+            has_errors = "yes" if spec.get("errors") else "no"
+
+            results.append(
+                f"{i}. {observed_at} | {instrument} | {num_points} points | errors: {has_errors} | origin: {origin}"
+            )
+
+        results.append(
+            f"\nTo download full spectral data, use: generate_fritz_bulk_query_code"
+        )
+        return "\n".join(results)
+
+    # CSV format or verbose summary: full wavelength/flux data
     results = [f"Found {len(data)} spectrum/spectra for {source_id}\n"]
 
     for i, spec in enumerate(data, 1):


### PR DESCRIPTION
## Summary

Adds an [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server to SkyPortal, enabling AI assistants (Claude Code, Claude Desktop, Cursor, etc.) to interact with SkyPortal data through a standardized protocol.

The MCP server lets users interact with SkyPortal through natural language via AI assistants. For example, a user can ask "draft a TNS report for AT2024abc" and get a formatted report with coordinates, photometry, classification, and host galaxy info pulled automatically. They can ask to analyze a light curve and get a Jupyter notebook with interactive Plotly plots and rise/fade metrics. Or they can plan observations by asking when a source is visible from Keck tonight. See [`doc/mcp_server.md`](doc/mcp_server.md) for the full list of tools and example prompts.

**This is a draft PR for incremental review.** The server is functional and tested against Fritz, but I'm looking for feedback on tool design and integration approach.

## Architecture

The MCP server lives in `services/mcp_server/` and connects to any SkyPortal instance via its existing REST API. No changes to SkyPortal core — it's a standalone service that reads data through the API. It supports two transport modes:
- **HTTP/SSE** (default): Multi-user, runs as a web server behind nginx
- **STDIO**: Single-user, runs as a local subprocess (for development/testing)

**Baselayer integration:** The MCP server runs as a supervised service (`supervisor.conf`) and reads its port from `config.yaml` (`ports.mcp`, default 8000). On the baselayer side, I've added an nginx proxy rule (`location /mcp` → MCP port) to route requests to the server. I'd appreciate feedback on whether this integration approach works — and if so, what port number you'd like me to use. I'll submit a separate PR to baselayer once that's confirmed.

**Authentication:** In HTTP mode, MCP clients pass the user's SkyPortal API token as a Bearer header on each request. The server validates it against SkyPortal's `/api/internal/profile` endpoint, so all data access respects the user's existing permissions. In stdio mode (local development), the token is read from the `SKYPORTAL_TOKEN` environment variable.

**Dependencies (server-side):** `fastmcp`, `mcp`, `httpx`, `numpy`, `astropy`, `pyyaml`. Some tools generate notebook code that references packages like `plotly`, `ztfquery`, and `pandas`, but those are user-side dependencies that run on the user's machine, not the server.

## Tools

### Source data tools — `source_products.py`
- `get_source_photometry` — photometry as CSV (mag or flux format)
- `get_source_spectra` — spectra with summary/CSV/JSON formats
- `get_source_classifications` — classification history
- `get_source_comments_and_annotations` — comments + ML annotations
- `get_source_host_galaxy` — host galaxy association
- `get_tns_summary` — comprehensive TNS/AstroNote report generator

### Analysis tools — `analysis.py`
- `analyze_light_curve` — multi-band rise/fade/duration analysis, generates Jupyter notebooks with interactive Plotly plots
- `analyze_color_evolution` — color curves (g-r) with matched/interpolated methods

### Observing tools — `observing.py`, `astro_utils.py`
- `get_source_observability` — observing windows for multiple telescopes
- `convert_time` — MJD/JD/ISO/Unix conversion
- `get_survey_urls` — links to Legacy Survey, PanSTARRS, SDSS, NED, etc.
- `search_sources_near_position` — cone search in SkyPortal
- `get_ztf_cutout_urls` — IRSA ZTF image cutout URLs

### Filtering tools — `filtering.py`
- `get_candidate_filter_reference` — documentation for available filters
- `filter_candidates` — query-time candidate search with ML score filters
- `generate_watchlist_filter` — MongoDB pipeline for alert-time monitoring

### Bulk/codegen tools — `bulk_analysis.py`, `code_templates.py`
- `generate_bulk_lightcurve_code` — Fritz-based notebook for bulk alert photometry download
- `generate_fritz_bulk_query_code` — bulk photometry + spectra from Fritz
- `generate_cone_search_code` — ZTF cone search at multiple positions
- `generate_alert_download_code` — ZTF alert packet download
- `generate_field_visualization_code` — ZTF field/CCD sky map

### API passthrough — `api.py`
- `call_skyportal_api` — raw SkyPortal API access for any endpoint

### Resources & documentation
- `resources/` — API reference, tools guide, filter documentation
- `doc/mcp_server.md` — setup instructions, tool reference, example prompts

## Feedback requested

1. **Tool coverage** — What other tools would be useful? Are any of these unnecessary?
2. **Filtering tools** — I've heard from users that writing filters and watchlists is a pain point, so I built some tools to help with that. However, I know filtering is moving to MongoDB Compass with BOOM, and I'm not entirely sure how that pipeline works yet. Would love guidance on the best way to handle this — should the MCP tools generate Compass-compatible filters, or is there a better integration point?
3. **Bulk download tools** — I'm unsure whether these are useful as MCP tools or better left as standalone scripts. If they are useful, what's the best way to implement them — should they go through IRSA, and is the use case more for alert photometry, forced photometry, or both?
4. **Baselayer integration** — See above — feedback on the port number and nginx proxy approach would be appreciated.
5. **Testing** — What should unit/integration tests look like for MCP tools? Happy to work with whoever owns the test infrastructure on this.

## Test plan

- Manually tested all tools against Fritz using Claude Code and Claude Desktop
- Source data tools: verified photometry, spectra, classifications, host galaxy, and TNS summary output against Fritz UI
- Analysis tools: confirmed light curve and color evolution notebooks render correctly with Plotly
- Observing tools: tested observability windows, time conversion, survey URLs, and cone search
- Filtering tools: tested candidate queries and watchlist filter generation
- Automated unit/integration tests: TBD — looking for guidance on test infrastructure (see feedback item 5)

Happy to hop on a call to discuss any of this.