### PR TITLE
fix: fix division by zero when computing object position with zero fluxerr

### DIFF
--- a/skyportal/handlers/api/obj.py
+++ b/skyportal/handlers/api/obj.py
@@ -282,6 +282,7 @@ class ObjPositionHandler(BaseHandler):
                     for p in photometry
                     if not np.isnan(p.flux)
                     and not np.isnan(p.fluxerr)
+                    and p.fluxerr != 0
                     and p.ra is not None
                     and not np.isnan(p.ra)
                     and p.dec is not None


### PR DESCRIPTION
This PR is fixing the ZeroDivisionError we have on a ICARE source (it comes from 3 phot points with fluxerr=0)

<img width="481" height="89" alt="image" src="https://github.com/user-attachments/assets/533543f4-2824-4280-80b2-9b602658aa00" />

Photometry points with fluxerr=0 passed the nan/null pre-filter and caused a ZeroDivisionError line 272 in obj.py. I have added fluxerr != 0 check to exclude them before the division.