### PR TITLE
fix: bugfix patch /api/photometry drops origin updates

### DIFF
--- a/skyportal/models/schema.py
+++ b/skyportal/models/schema.py
@@ -871,6 +871,8 @@ class PhotometryFlux(_Schema, PhotBase):
         )
         if "alert_id" in data and data["alert_id"] is not None:
             p.alert_id = data["alert_id"]
+        if "origin" in data:
+            p.origin = data["origin"]
         return p
 
 
@@ -1062,6 +1064,8 @@ class PhotometryMag(_Schema, PhotBase):
         )
         if "alert_id" in data and data["alert_id"] is not None:
             p.alert_id = data["alert_id"]
+        if "origin" in data:
+            p.origin = data["origin"]
         return p
 
 

--- a/skyportal/models/schema.py
+++ b/skyportal/models/schema.py
@@ -871,7 +871,7 @@ class PhotometryFlux(_Schema, PhotBase):
         )
         if "alert_id" in data and data["alert_id"] is not None:
             p.alert_id = data["alert_id"]
-        if "origin" in data and data["origin"] is not None and data["origin"] != "":
+        if isinstance(data.get("origin"), str) and data["origin"].strip() != "":
             p.origin = data["origin"]
         return p
 
@@ -1064,7 +1064,7 @@ class PhotometryMag(_Schema, PhotBase):
         )
         if "alert_id" in data and data["alert_id"] is not None:
             p.alert_id = data["alert_id"]
-        if "origin" in data and data["origin"] is not None and data["origin"] != "":
+        if isinstance(data.get("origin"), str) and data["origin"].strip() != "":
             p.origin = data["origin"]
         return p
 

--- a/skyportal/models/schema.py
+++ b/skyportal/models/schema.py
@@ -871,7 +871,7 @@ class PhotometryFlux(_Schema, PhotBase):
         )
         if "alert_id" in data and data["alert_id"] is not None:
             p.alert_id = data["alert_id"]
-        if "origin" in data:
+        if "origin" in data and data["origin"] is not None and data["origin"] != "":
             p.origin = data["origin"]
         return p
 
@@ -1064,7 +1064,7 @@ class PhotometryMag(_Schema, PhotBase):
         )
         if "alert_id" in data and data["alert_id"] is not None:
             p.alert_id = data["alert_id"]
-        if "origin" in data:
+        if "origin" in data and data["origin"] is not None and data["origin"] != "":
             p.origin = data["origin"]
         return p
 


### PR DESCRIPTION
When we are sending a PATCH request to /api/photometry/<id> with a new origin value, it returns HTTP 200 but the field is never updated in the database.

Adding origin to the Photometry constructor in both parse_flux and parse_mag is resolving the issue.

This is needed by GRANDMA users to update origin of some points.