### PR TITLE
SkyPortal __version__ import: don't require full venv

### DIFF
--- a/skyportal/__init__.py
+++ b/skyportal/__init__.py
@@ -1,25 +1,27 @@
 __version__ = "1.4.0"
 
-# Monkey-patch matplotlib for simsurvey compatibility with matplotlib >= 3.8
-# simsurvey imports matplotlib.docstring which was renamed to matplotlib._docstring
-import matplotlib
+try:
+    # Monkey-patch matplotlib for simsurvey compatibility with matplotlib >= 3.8
+    # simsurvey imports matplotlib.docstring which was renamed to matplotlib._docstring
+    import matplotlib
 
-if not hasattr(matplotlib, "docstring"):
-    matplotlib.docstring = matplotlib._docstring
+    if not hasattr(matplotlib, "docstring"):
+        matplotlib.docstring = matplotlib._docstring
 
-# Register numpy types with psycopg2 for numpy 2.x compatibility
-# numpy 2 scalars no longer inherit from Python builtins, so psycopg2
-# needs explicit adapters to serialize them in SQL parameters
-import numpy as np
-from psycopg2.extensions import AsIs, register_adapter
+    # Register numpy types with psycopg2 for numpy 2.x compatibility
+    # numpy 2 scalars no longer inherit from Python builtins, so psycopg2
+    # needs explicit adapters to serialize them in SQL parameters
+    import numpy as np
+    from psycopg2.extensions import AsIs, register_adapter
 
+    def _adapt_numpy_scalar(val):
+        return AsIs(repr(float(val)))
 
-def _adapt_numpy_scalar(val):
-    return AsIs(repr(float(val)))
-
-
-for _np_type in [np.float64, np.float32, np.int64, np.int32, np.bool_]:
-    register_adapter(_np_type, _adapt_numpy_scalar)
+    for _np_type in [np.float64, np.float32, np.int64, np.int32, np.bool_]:
+        register_adapter(_np_type, _adapt_numpy_scalar)
+except ImportError:
+    # if the packages to monkey-patch are not available, just skip the patching
+    pass
 
 if "dev" in __version__:
     # Append last commit date and hash to dev version information, if available


### PR DESCRIPTION
I ran into issues getting Fritz up and running w/ the last version of skyportal, where we monkeypatch matplotlib and numpy, because Fritz reads `skyportal/__init__.py` to grab `__version__` but doesn't have matplotlib and numpy as this point. It doesn't make sense to require these dependencies just to grab a version number, and in general there is no need to monkeypatch a library that's not installed! So, this PR adds skip monkey-patching if the libraries aren't installed yet (so one can import skyportal.__version__ without having a full env going on).