### PR TITLE
Fix unique constraint violation when sharing spectra with already-linked groups

### DIFF
--- a/skyportal/handlers/api/mmadetector.py
+++ b/skyportal/handlers/api/mmadetector.py
@@ -549,7 +549,10 @@ class MMADetectorSpectrumHandler(BaseHandler):
                     )
 
                 if groups:
-                    spectrum.groups = spectrum.groups + groups
+                    existing_group_ids = {g.id for g in spectrum.groups}
+                    new_groups = [g for g in groups if g.id not in existing_group_ids]
+                    if new_groups:
+                        spectrum.groups = spectrum.groups + new_groups
 
             for k in data:
                 setattr(spectrum, k, data[k])

--- a/skyportal/handlers/api/sharing.py
+++ b/skyportal/handlers/api/sharing.py
@@ -78,7 +78,7 @@ class SharingHandler(BaseHandler):
 
             if phot_ids:
                 valid_phot = session.scalars(
-                    Photometry.select(session.user_or_token, mode="update").where(
+                    Photometry.select(session.user_or_token).where(
                         Photometry.id.in_(phot_ids)
                     )
                 ).all()
@@ -88,11 +88,17 @@ class SharingHandler(BaseHandler):
                 ]
 
                 if len(invalid_phot_ids) > 0:
-                    return self.error(
-                        f"Cannot share photometry IDs {invalid_phot_ids}: not found or you are not the owner."
-                    )
+                    return self.error(f"Invalid photometry IDs: {invalid_phot_ids}.")
 
                 for phot in valid_phot:
+                    if (
+                        phot.owner_id != self.associated_user_object.id
+                        and "System admin"
+                        not in self.associated_user_object.permissions
+                    ):
+                        return self.error(
+                            f"Cannot share photometry id {phot.id}: you are not the owner of this point."
+                        )
                     existing_group_ids = {g.id for g in phot.groups}
                     for group in groups:
                         if group.id not in existing_group_ids:

--- a/skyportal/handlers/api/sharing.py
+++ b/skyportal/handlers/api/sharing.py
@@ -62,7 +62,9 @@ class SharingHandler(BaseHandler):
 
         with self.Session() as session:
             valid_groups = session.scalars(
-                Group.select(self.associated_user_object).where(Group.id.in_(group_ids))
+                Group.select(session.user_or_token)
+                .where(Group.id.in_(group_ids))
+                .distinct()
             ).all()
             valid_group_ids = [g.id for g in valid_groups]
             invalid_group_ids = [gid for gid in group_ids if gid not in valid_group_ids]
@@ -75,9 +77,8 @@ class SharingHandler(BaseHandler):
             spec_obj_internal_keys = []
 
             if phot_ids:
-                # valid_phot = Photometry.query.filter(Photometry.id.in_(phot_ids))
                 valid_phot = session.scalars(
-                    Photometry.select(self.associated_user_object).where(
+                    Photometry.select(session.user_or_token, mode="update").where(
                         Photometry.id.in_(phot_ids)
                     )
                 ).all()
@@ -87,26 +88,20 @@ class SharingHandler(BaseHandler):
                 ]
 
                 if len(invalid_phot_ids) > 0:
-                    return self.error(f"Invalid photometry IDs: {invalid_phot_ids}.")
+                    return self.error(
+                        f"Cannot share photometry IDs {invalid_phot_ids}: not found or you are not the owner."
+                    )
 
                 for phot in valid_phot:
-                    # Ensure user has access to data being shared
-                    if (
-                        phot.owner_id != self.associated_user_object.id
-                        and "System admin"
-                        not in self.associated_user_object.permissions
-                    ):
-                        return self.error(
-                            f"Cannot share photometry id {phot.id}: you are not the owner of this point."
-                        )
+                    existing_group_ids = {g.id for g in phot.groups}
                     for group in groups:
-                        phot.groups.append(group)
-                    # Grab obj_id for use in websocket message below
+                        if group.id not in existing_group_ids:
+                            phot.groups.append(group)
                     phot_obj_ids.append(phot.obj_id)
 
             if spec_ids:
                 valid_spec = session.scalars(
-                    Spectrum.select(self.associated_user_object).where(
+                    Spectrum.select(session.user_or_token, mode="update").where(
                         Spectrum.id.in_(spec_ids)
                     )
                 ).all()
@@ -116,21 +111,15 @@ class SharingHandler(BaseHandler):
                 ]
 
                 if len(invalid_spec_ids) > 0:
-                    return self.error(f"Invalid spectrum IDs: {invalid_spec_ids}.")
+                    return self.error(
+                        f"Cannot share spectrum IDs {invalid_spec_ids}: not found or you are not the owner."
+                    )
 
                 for spec in valid_spec:
-                    # Ensure user has access to data being shared
-                    if (
-                        spec.owner_id != self.associated_user_object.id
-                        and "System admin"
-                        not in self.associated_user_object.permissions
-                    ):
-                        return self.error(
-                            f"Cannot share spectrum id {spec.id}: you are not the owner of this spectrum."
-                        )
+                    existing_group_ids = {g.id for g in spec.groups}
                     for group in groups:
-                        spec.groups.append(group)
-                    # Grab obj_id for use in websocket message below
+                        if group.id not in existing_group_ids:
+                            spec.groups.append(group)
                     spec_obj_internal_keys.append(spec.obj.internal_key)
 
             session.commit()
@@ -138,15 +127,16 @@ class SharingHandler(BaseHandler):
             phot_obj_ids = set(phot_obj_ids)
             spec_obj_internal_keys = set(spec_obj_internal_keys)
 
-        for obj_id in phot_obj_ids:
-            self.push(
-                action="skyportal/REFRESH_SOURCE_PHOTOMETRY", payload={"obj_id": obj_id}
-            )
+            for obj_id in phot_obj_ids:
+                self.push(
+                    action="skyportal/REFRESH_SOURCE_PHOTOMETRY",
+                    payload={"obj_id": obj_id},
+                )
 
-        for obj_internal_key in spec_obj_internal_keys:
-            self.push(
-                action="skyportal/REFRESH_SOURCE_SPECTRA",
-                payload={"obj_internal_key": obj_internal_key},
-            )
+            for obj_internal_key in spec_obj_internal_keys:
+                self.push(
+                    action="skyportal/REFRESH_SOURCE_SPECTRA",
+                    payload={"obj_internal_key": obj_internal_key},
+                )
 
-        return self.success()
+            return self.success()

--- a/skyportal/handlers/api/spectrum.py
+++ b/skyportal/handlers/api/spectrum.py
@@ -925,7 +925,10 @@ class SpectrumHandler(BaseHandler):
                     )
 
                 if groups:
-                    spectrum.groups = spectrum.groups + groups
+                    existing_group_ids = {g.id for g in spectrum.groups}
+                    new_groups = [g for g in groups if g.id not in existing_group_ids]
+                    if new_groups:
+                        spectrum.groups = spectrum.groups + new_groups
 
             if pi:
                 existing_pis = spectrum.pis

--- a/skyportal/tests/frontend/test_data_management.py
+++ b/skyportal/tests/frontend/test_data_management.py
@@ -45,9 +45,10 @@ def test_delete_spectrum(driver, public_source):
     driver.get(f"/become_user/{spectrum.owner_id}")
     driver.get(f"/share_data/{public_source.id}")
 
-    delete = driver.wait_for_xpath(
-        "//*[contains(@data-testid, 'delete-spectrum-button')]",
+    delete_button_xpath = (
+        "//*[@data-testid='spectrum-table']//button[.//*[@data-testid='DeleteIcon']]"
     )
+    delete = driver.wait_for_xpath(delete_button_xpath)
     x = delete.location["x"]
     y = delete.location["y"]
     scroll_by_coord = f"window.scrollTo({x},{y});"
@@ -56,9 +57,7 @@ def test_delete_spectrum(driver, public_source):
     driver.execute_script(scroll_nav_out_of_way)
 
     driver.scroll_to_element_and_click(delete)
-    driver.click_xpath(
-        "//*[contains(@data-testid, 'delete-spectrum-button')]", scroll_parent=True
-    )
+    driver.click_xpath(delete_button_xpath, scroll_parent=True)
     driver.click_xpath("//*[@data-testid='yes-delete']", scroll_parent=True)
 
     driver.wait_for_xpath_to_disappear(

--- a/skyportal/tests/frontend/test_data_management.py
+++ b/skyportal/tests/frontend/test_data_management.py
@@ -45,9 +45,7 @@ def test_delete_spectrum(driver, public_source):
     driver.get(f"/become_user/{spectrum.owner_id}")
     driver.get(f"/share_data/{public_source.id}")
 
-    delete_button_xpath = (
-        "//*[@data-testid='spectrum-table']//button[.//*[@data-testid='DeleteIcon']]"
-    )
+    delete_button_xpath = f"//*[@data-testid='delete-spectrum-button-{spectrum.id}']"
     delete = driver.wait_for_xpath(delete_button_xpath)
     x = delete.location["x"]
     y = delete.location["y"]

--- a/static/js/components/RecurringAPIPage.jsx
+++ b/static/js/components/RecurringAPIPage.jsx
@@ -77,7 +77,6 @@ const RecurringAPIPage = () => {
     return (
       <div>
         <IconButton
-          key={recurringAPI.id}
           id="delete_button"
           onClick={() => openDialog(recurringAPI.id)}
         >

--- a/static/js/components/allocation/AllocationTable.jsx
+++ b/static/js/components/allocation/AllocationTable.jsx
@@ -255,14 +255,12 @@ const AllocationTable = ({
     return (
       <div className={classes.allocationManage}>
         <IconButton
-          key={`edit_${allocation.id}`}
           id={`edit_button_${allocation.id}`}
           onClick={() => setAllocationToEdit(allocation.id)}
         >
           <EditIcon />
         </IconButton>
         <IconButton
-          key={`delete_${allocation.id}`}
           id={`delete_button_${allocation.id}`}
           onClick={() => setAllocationToDelete(allocation.id)}
         >

--- a/static/js/components/analysis/AnalysisServicePage.jsx
+++ b/static/js/components/analysis/AnalysisServicePage.jsx
@@ -181,7 +181,6 @@ const AnalysisServiceList = ({ analysisServices, deletePermission }) => {
     return (
       <div className={classes.analysisServiceManage}>
         <Button
-          key={`delete_${analysis_service.id}`}
           id={`delete_button_${analysis_service.id}`}
           onClick={() => openDeleteDialog(analysis_service.id)}
           disabled={!deletePermission}

--- a/static/js/components/candidate/ScanningProfilesList.jsx
+++ b/static/js/components/candidate/ScanningProfilesList.jsx
@@ -288,7 +288,6 @@ const ScanningProfilesList = ({
           <EditIcon />
         </IconButton>
         <IconButton
-          key={`delete_${dataIndex}`}
           id={`delete_button_${dataIndex}`}
           onClick={() => deleteProfile(dataIndex)}
         >

--- a/static/js/components/classification/ShowClassification.jsx
+++ b/static/js/components/classification/ShowClassification.jsx
@@ -163,7 +163,6 @@ const ClassificationRow = ({ classifications, fontSize }) => {
             </div>
             <div>
               <Button
-                key={classification.id}
                 id="delete_classification"
                 classes={{
                   root: classes.classificationDelete,

--- a/static/js/components/followup_request/DefaultFollowupRequestList.jsx
+++ b/static/js/components/followup_request/DefaultFollowupRequestList.jsx
@@ -203,7 +203,6 @@ const DefaultFollowupRequestList = ({
     return (
       <div className={classes.defaultFollowupRequestManage}>
         <Button
-          key={`delete_${default_followup_request.id}`}
           id={`delete_button_${default_followup_request.id}`}
           onClick={() => openDeleteDialog(default_followup_request.id)}
           disabled={!deletePermission}

--- a/static/js/components/galaxy/GalaxyPage.jsx
+++ b/static/js/components/galaxy/GalaxyPage.jsx
@@ -183,7 +183,6 @@ const GalaxyList = ({ catalogs, setCatalogs }) => {
             />
             {permission && (
               <IconButton
-                key={catalog}
                 id="delete_button"
                 onClick={() => openDialog(catalog.catalog_name)}
                 disabled={!permission}

--- a/static/js/components/gcn/DefaultGcnTagTable.jsx
+++ b/static/js/components/gcn/DefaultGcnTagTable.jsx
@@ -3,7 +3,6 @@ import { JSONTree } from "react-json-tree";
 import { useDispatch } from "react-redux";
 import PropTypes from "prop-types";
 import { createTheme, ThemeProvider, useTheme } from "@mui/material/styles";
-import makeStyles from "@mui/styles/makeStyles";
 import CircularProgress from "@mui/material/CircularProgress";
 
 import MUIDataTable from "mui-datatables";
@@ -14,22 +13,6 @@ import DeleteIcon from "@mui/icons-material/Delete";
 import * as defaultGcnTagsActions from "../../ducks/default_gcn_tags";
 import Button from "../Button";
 import ConfirmDeletionDialog from "../ConfirmDeletionDialog";
-
-const useStyles = makeStyles((theme) => ({
-  container: {
-    width: "100%",
-    minWidth: "40vw",
-    overflow: "scroll",
-  },
-  eventTags: {
-    marginLeft: "0.5rem",
-    "& > div": {
-      margin: "0.25rem",
-      color: "white",
-      background: theme.palette.primary.main,
-    },
-  },
-}));
 
 // Tweak responsive styling
 const getMuiTheme = (theme) =>
@@ -65,7 +48,6 @@ const getMuiTheme = (theme) =>
   });
 
 const DefaultGcnTagTable = ({ default_gcn_tags }) => {
-  const classes = useStyles();
   const theme = useTheme();
 
   const dispatch = useDispatch();
@@ -111,13 +93,9 @@ const DefaultGcnTagTable = ({ default_gcn_tags }) => {
   const renderDelete = (dataIndex) => {
     const default_gcn_tag = default_gcn_tags[dataIndex];
     return (
-      <div>
+      <>
         <Button
-          key={default_gcn_tag.id}
           id="delete_button"
-          classes={{
-            root: classes.defaultGcnTagDelete,
-          }}
           onClick={() => openDialog(default_gcn_tag.id)}
         >
           <DeleteIcon />
@@ -128,7 +106,7 @@ const DefaultGcnTagTable = ({ default_gcn_tags }) => {
           closeDialog={closeDialog}
           resourceName="defaultGcnTag"
         />
-      </div>
+      </>
     );
   };
 
@@ -174,19 +152,17 @@ const DefaultGcnTagTable = ({ default_gcn_tags }) => {
     sort: true,
   };
 
+  if (!default_gcn_tags) return <CircularProgress />;
+
   return (
-    <div className={classes.container}>
-      {default_gcn_tags ? (
-        <ThemeProvider theme={getMuiTheme(theme)}>
-          <MUIDataTable
-            data={default_gcn_tags}
-            options={options}
-            columns={columns}
-          />
-        </ThemeProvider>
-      ) : (
-        <CircularProgress />
-      )}
+    <div style={{ width: "100%", minWidth: "40vw", overflow: "scroll" }}>
+      <ThemeProvider theme={getMuiTheme(theme)}>
+        <MUIDataTable
+          data={default_gcn_tags}
+          options={options}
+          columns={columns}
+        />
+      </ThemeProvider>
     </div>
   );
 };

--- a/static/js/components/gcn/GcnLocalizationsTable.jsx
+++ b/static/js/components/gcn/GcnLocalizationsTable.jsx
@@ -281,7 +281,6 @@ const GcnLocalizationsTable = ({ localizations }) => {
       return (
         <div>
           <Button
-            key={localization.id}
             id="delete_button"
             classes={{
               root: classes.localizationDelete,

--- a/static/js/components/instrument/InstrumentTable.jsx
+++ b/static/js/components/instrument/InstrumentTable.jsx
@@ -244,7 +244,6 @@ const InstrumentTable = ({
     return (
       <div className={classes.instrumentManage}>
         <Button
-          key={`edit_${instrument.id}`}
           id={`edit_button_${instrument.id}`}
           onClick={() => openEditDialog(instrument.id)}
           disabled={!deletePermission}
@@ -252,7 +251,6 @@ const InstrumentTable = ({
           <EditIcon />
         </Button>
         <Button
-          key={`delete_${instrument.id}`}
           id={`delete_button_${instrument.id}`}
           onClick={() => openDeleteDialog(instrument.id)}
           disabled={!deletePermission}

--- a/static/js/components/observing_run/AssignmentList.jsx
+++ b/static/js/components/observing_run/AssignmentList.jsx
@@ -187,14 +187,12 @@ const AssignmentList = ({ assignments }) => {
     return (
       <div className={classes.assignmentManage}>
         <IconButton
-          key={`edit_assignment_${assignment.id}`}
           id={`edit_button_assignment_${assignment.id}`}
           onClick={() => openEditDialog(assignment.id)}
         >
           <EditIcon />
         </IconButton>
         <IconButton
-          key={`delete_assignment_${assignment.id}`}
           id={`delete_button_assignment_${assignment.id}`}
           onClick={() => openDeleteDialog(assignment.id)}
         >

--- a/static/js/components/observing_run/ObservingRunPage.jsx
+++ b/static/js/components/observing_run/ObservingRunPage.jsx
@@ -181,7 +181,6 @@ const DeleteObservingRunDialog = ({ run, deletePermission }) => {
   return (
     <div>
       <Button
-        key={`${run.id}-delete_button`}
         id="delete_button"
         classes={{
           root: classes.observingRunDelete,

--- a/static/js/components/photometry/PhotometryTable.jsx
+++ b/static/js/components/photometry/PhotometryTable.jsx
@@ -445,9 +445,7 @@ const PhotometryTable = ({ obj_id, open, onClose, magsys, setMagsys, t0 }) => {
                 <div>
                   <IconButton
                     primary
-                    onClick={() => {
-                      setDeleteDialogOpen(phot.id);
-                    }}
+                    onClick={() => setDeleteDialogOpen(phot.id)}
                     size="small"
                     type="submit"
                     data-testid={`deleteRequest_${photometry.id}`}

--- a/static/js/components/photometry/UploadPhotometry.jsx
+++ b/static/js/components/photometry/UploadPhotometry.jsx
@@ -12,6 +12,7 @@ import CardContent from "@mui/material/CardContent";
 import Box from "@mui/material/Box";
 import Tooltip from "@mui/material/Tooltip";
 import HelpOutlineIcon from "@mui/icons-material/HelpOutline";
+import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import CircularProgress from "@mui/material/CircularProgress";
 import Typography from "@mui/material/Typography";
 import makeStyles from "@mui/styles/makeStyles";
@@ -119,7 +120,7 @@ const UploadPhotometryForm = () => {
     if (!dataRows.every((row) => row.length === headerLength)) {
       return "Invalid input: All data rows must have the same number of columns as header row";
     }
-    // eslint-disable-next-line no-restricted-syntax
+
     for (const col of ["mjd", "filter", "magsys"]) {
       if (!header.includes(col)) {
         return `Invalid input: Missing required column: ${col}`;
@@ -252,6 +253,17 @@ const UploadPhotometryForm = () => {
 
   return (
     <div>
+      <Link
+        to={`/source/${id}`}
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: "4px",
+          marginBottom: "0.5rem",
+        }}
+      >
+        <ArrowBackIcon fontSize="small" /> Back to source
+      </Link>
       <Typography variant="h5">
         Upload photometry for source&nbsp;
         <Link to={`/source/${id}`} role="link">

--- a/static/js/components/release/ReleasesList.jsx
+++ b/static/js/components/release/ReleasesList.jsx
@@ -126,18 +126,10 @@ const ReleasesList = () => {
                   </Button>
                   {manageSourcesAccess && release.group_ids.length > 0 && (
                     <>
-                      <Button
-                        onClick={() => {
-                          handleViewEdit(release);
-                        }}
-                      >
+                      <Button onClick={() => handleViewEdit(release)}>
                         <EditIcon />
                       </Button>
-                      <Button
-                        onClick={() => {
-                          deleteRelease(release.id);
-                        }}
-                      >
+                      <Button onClick={() => deleteRelease(release.id)}>
                         <DeleteIcon />
                       </Button>
                     </>

--- a/static/js/components/source/AnnotationsTable.jsx
+++ b/static/js/components/source/AnnotationsTable.jsx
@@ -193,7 +193,6 @@ const AnnotationsTable = ({
               }}
               size="small"
               type="submit"
-              data-testid={`deleteAllocation_${annotation.id}`}
             >
               <DeleteIcon />
             </IconButton>

--- a/static/js/components/source/ShareDataForm.jsx
+++ b/static/js/components/source/ShareDataForm.jsx
@@ -416,7 +416,12 @@ const ShareDataForm = ({ route }) => {
             </div>
           </DialogContent>
         </Dialog>
-        <IconButton onClick={() => setOpen(true)} size="large" color="error">
+        <IconButton
+          onClick={() => setOpen(true)}
+          size="large"
+          color="error"
+          data-testid={`delete-spectrum-button-${specid}`}
+        >
           <DeleteIcon />
         </IconButton>
       </div>

--- a/static/js/components/source/ShareDataForm.jsx
+++ b/static/js/components/source/ShareDataForm.jsx
@@ -10,7 +10,7 @@ import Typography from "@mui/material/Typography";
 import Autocomplete from "@mui/material/Autocomplete";
 import TextField from "@mui/material/TextField";
 import IconButton from "@mui/material/IconButton";
-import DeleteForeverIcon from "@mui/icons-material/DeleteForever";
+import DeleteIcon from "@mui/icons-material/Delete";
 import GetAppIcon from "@mui/icons-material/GetApp";
 import Dialog from "@mui/material/Dialog";
 import Grid from "@mui/material/Grid";
@@ -330,10 +330,11 @@ const ShareDataForm = ({ route }) => {
       )
     : [];
 
-  const makeRenderSingleUser = (dataIndex, key) => {
-    const user = specRows[dataIndex][key];
-    return user && <UserContactLink user={user} />;
-  };
+  const makeRenderSingleUser = (key) =>
+    function RenderSingleUser(dataIndex) {
+      const user = specRows[dataIndex][key];
+      return user && <UserContactLink user={user} />;
+    };
 
   const renderMultipleUsers = (users) => {
     return (
@@ -399,9 +400,7 @@ const ShareDataForm = ({ route }) => {
               spectrum again from scratch.
             </div>
             <div>
-              <Button onClick={() => setOpen(false)}>
-                No, do not delete the spectrum.
-              </Button>
+              <Button onClick={() => setOpen(false)}>Cancel</Button>
               <Button
                 onClick={async () => {
                   setOpen(false);
@@ -412,13 +411,13 @@ const ShareDataForm = ({ route }) => {
                 }}
                 data-testid="yes-delete"
               >
-                Yes, delete the spectrum.
+                Confirm
               </Button>
             </div>
           </DialogContent>
         </Dialog>
-        <IconButton onClick={() => setOpen(true)} size="large">
-          <DeleteForeverIcon />
+        <IconButton onClick={() => setOpen(true)} size="large" color="error">
+          <DeleteIcon />
         </IconButton>
       </div>
     );
@@ -487,8 +486,7 @@ const ShareDataForm = ({ route }) => {
       name: "owner",
       label: "Uploaded by",
       options: {
-        customBodyRenderLite: (dataIndex) =>
-          makeRenderSingleUser(dataIndex, "owner"),
+        customBodyRenderLite: makeRenderSingleUser("owner"),
         filter: false,
       },
     },

--- a/static/js/components/source/ShareDataForm.jsx
+++ b/static/js/components/source/ShareDataForm.jsx
@@ -2,11 +2,11 @@ import React, { Suspense, useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import { Link } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
+import { Controller, useForm } from "react-hook-form";
 import MUIDataTable from "mui-datatables";
 import { useTheme } from "@mui/material/styles";
 import makeStyles from "@mui/styles/makeStyles";
 import Typography from "@mui/material/Typography";
-import { Controller, useForm } from "react-hook-form";
 import Autocomplete from "@mui/material/Autocomplete";
 import TextField from "@mui/material/TextField";
 import IconButton from "@mui/material/IconButton";
@@ -21,6 +21,7 @@ import Papa from "papaparse";
 import ReactJson from "react-json-view";
 import CircularProgress from "@mui/material/CircularProgress";
 import Paper from "@mui/material/Paper";
+import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 
 import { showNotification } from "baselayer/components/Notifications";
 import Button from "../Button";
@@ -34,8 +35,8 @@ import withRouter from "../withRouter";
 
 import * as photometryActions from "../../ducks/photometry";
 import * as spectraActions from "../../ducks/spectra";
-import { deleteSpectrum } from "../../ducks/spectra";
 import * as sourceActions from "../../ducks/source";
+import { deleteSpectrum } from "../../ducks/spectra";
 import { useSourceStyles } from "./Source";
 
 import SpectraPlot from "../plot/SpectraPlot";
@@ -329,40 +330,28 @@ const ShareDataForm = ({ route }) => {
       )
     : [];
 
-  const makeRenderSingleUser = (key) => {
-    const RenderSingleUser = (dataIndex) => {
-      const user = specRows[dataIndex][key];
-      if (user) {
-        return <UserContactLink user={user} />;
-      }
-      return <div />;
-    };
-    return RenderSingleUser;
+  const makeRenderSingleUser = (dataIndex, key) => {
+    const user = specRows[dataIndex][key];
+    return user && <UserContactLink user={user} />;
   };
 
   const renderMultipleUsers = (users) => {
-    if (users) {
-      return users.map((user) => <UserContactLink user={user} key={user.id} />);
-    }
-    return <div />;
+    return (
+      users &&
+      users.map((user) => <UserContactLink user={user} key={user.id} />)
+    );
   };
 
   const renderPIs = (dataIndex) => {
     const externalPI = specRows[dataIndex]?.external_pi;
     const users = specRows[dataIndex]?.pis;
-    if (externalPI) {
-      return <div>{externalPI}</div>;
-    }
-    return renderMultipleUsers(users);
+    return externalPI || renderMultipleUsers(users);
   };
 
   const renderReducers = (dataIndex) => {
     const externalReducer = specRows[dataIndex]?.external_reducer;
     const users = specRows[dataIndex]?.reducers;
-    if (externalReducer) {
-      return <div>{externalReducer}</div>;
-    }
-    return renderMultipleUsers(users);
+    return externalReducer || renderMultipleUsers(users);
   };
 
   const renderReducerContacts = (dataIndex) => {
@@ -376,10 +365,7 @@ const ShareDataForm = ({ route }) => {
   const renderObservers = (dataIndex) => {
     const externalObserver = specRows[dataIndex]?.external_observer;
     const users = specRows[dataIndex]?.observers;
-    if (externalObserver) {
-      return <div>{externalObserver}</div>;
-    }
-    return renderMultipleUsers(users);
+    return externalObserver || renderMultipleUsers(users);
   };
 
   const renderObserverContacts = (dataIndex) => {
@@ -413,11 +399,7 @@ const ShareDataForm = ({ route }) => {
               spectrum again from scratch.
             </div>
             <div>
-              <Button
-                onClick={() => {
-                  setOpen(false);
-                }}
-              >
+              <Button onClick={() => setOpen(false)}>
                 No, do not delete the spectrum.
               </Button>
               <Button
@@ -435,13 +417,7 @@ const ShareDataForm = ({ route }) => {
             </div>
           </DialogContent>
         </Dialog>
-        <IconButton
-          onClick={() => {
-            setOpen(true);
-          }}
-          data-testid={`delete-spectrum-button-${specid}`}
-          size="large"
-        >
+        <IconButton onClick={() => setOpen(true)} size="large">
           <DeleteForeverIcon />
         </IconButton>
       </div>
@@ -476,7 +452,8 @@ const ShareDataForm = ({ route }) => {
     const specid = specRows[dataIndex].id;
     const spectrum = sourceSpectra.find((spec) => spec.id === specid);
     const [open, setOpen] = useState(false);
-    return spectrum.altdata ? (
+    if (!spectrum.altdata) return null;
+    return (
       <>
         <Dialog
           open={open}
@@ -494,19 +471,10 @@ const ShareDataForm = ({ route }) => {
             </div>
           </DialogContent>
         </Dialog>
-        <Button
-          secondary
-          onClick={() => {
-            setOpen(true);
-          }}
-          data-testid={`altdata-spectrum-button-${specid}`}
-          size="small"
-        >
+        <Button secondary onClick={() => setOpen(true)} size="small">
           Show altdata
         </Button>
       </>
-    ) : (
-      <div />
     );
   };
 
@@ -519,7 +487,8 @@ const ShareDataForm = ({ route }) => {
       name: "owner",
       label: "Uploaded by",
       options: {
-        customBodyRenderLite: makeRenderSingleUser("owner"),
+        customBodyRenderLite: (dataIndex) =>
+          makeRenderSingleUser(dataIndex, "owner"),
         filter: false,
       },
     },
@@ -617,7 +586,18 @@ const ShareDataForm = ({ route }) => {
 
   return (
     <>
-      <div data-testid="photometry-div">
+      <div>
+        <Link
+          to={`/source/${route.id}`}
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: "4px",
+            marginBottom: "0.5rem",
+          }}
+        >
+          <ArrowBackIcon fontSize="small" /> Back to source
+        </Link>
         <Typography variant="h5">
           Share Source Data -&nbsp;
           <Link to={`/source/${route.id}`} role="link">

--- a/static/js/components/source/SourceAlias.jsx
+++ b/static/js/components/source/SourceAlias.jsx
@@ -127,7 +127,6 @@ const SourceAlias = ({ source }) => {
                 size="small"
                 onClick={() => handleDelete(a)}
                 className={classes.deleteButton}
-                data-testid={`deleteAlias-${a}`}
               >
                 <DeleteIcon fontSize="small" />
               </IconButton>

--- a/static/js/components/spatial_catalog/SpatialCatalogPage.jsx
+++ b/static/js/components/spatial_catalog/SpatialCatalogPage.jsx
@@ -248,7 +248,6 @@ const SpatialCatalogList = ({ catalogs, deletePermission }) => {
               classes={textClasses}
             />
             <Button
-              key={catalog}
               id="delete_button"
               classes={{
                 root: classes.catalogDelete,

--- a/static/js/components/spectrum/UploadSpectrum.jsx
+++ b/static/js/components/spectrum/UploadSpectrum.jsx
@@ -11,6 +11,7 @@ import Typography from "@mui/material/Typography";
 import Accordion from "@mui/material/Accordion";
 import Grid from "@mui/material/Grid";
 import HelpOutlineIcon from "@mui/icons-material/HelpOutline";
+import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import CircularProgress from "@mui/material/CircularProgress";
 import embed from "vega-embed";
 import dayjs from "dayjs";
@@ -668,6 +669,17 @@ const UploadSpectrumForm = ({ route }) => {
     <Grid container spacing={3}>
       <Grid item md={4} sm={12}>
         <Paper sx={{ position: "relative" }}>
+          <Link
+            to={`/source/${route.id}`}
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: "4px",
+              marginBottom: "0.5rem",
+            }}
+          >
+            <ArrowBackIcon fontSize="small" /> Back to source
+          </Link>
           <Typography variant="h6">
             Upload Spectrum ASCII File for&nbsp;
             <Link to={`/source/${route.id}`}>{route.id}</Link>

--- a/static/js/components/spectrum/UploadSpectrum.jsx
+++ b/static/js/components/spectrum/UploadSpectrum.jsx
@@ -750,7 +750,7 @@ const UploadSpectrumForm = ({ route }) => {
       </Grid>
       {parsed && (
         <Grid item md={8} sm={12}>
-          <Paper>
+          <Paper sx={{ position: "sticky", top: 74 }}>
             <Box
               sx={{ display: "flex", justifyContent: "space-between", mb: 2 }}
             >

--- a/static/js/components/survey_efficiency/DefaultSurveyEfficiencyTable.jsx
+++ b/static/js/components/survey_efficiency/DefaultSurveyEfficiencyTable.jsx
@@ -231,7 +231,6 @@ const DefaultSurveyEfficiencyTable = ({
     return (
       <div>
         <Button
-          key={default_survey_efficiency.id}
           id="delete_button"
           classes={{
             root: classes.defaultSurveyEfficiencyDelete,

--- a/static/js/components/taxonomy/TaxonomyTable.jsx
+++ b/static/js/components/taxonomy/TaxonomyTable.jsx
@@ -216,7 +216,6 @@ const TaxonomyTable = ({
           <EditIcon />
         </Button>
         <Button
-          key={`delete_${taxonomy.id}`}
           id={`delete_button_${taxonomy.id}`}
           onClick={() => openDeleteDialog(taxonomy.id)}
           disabled={!deletePermission}

--- a/static/js/components/telescope/TelescopeTable.jsx
+++ b/static/js/components/telescope/TelescopeTable.jsx
@@ -187,7 +187,6 @@ const TelescopeTable = ({
     return (
       <div className={classes.telescopeManage}>
         <Button
-          key={`delete_${telescope.id}`}
           id={`delete_button_${telescope.id}`}
           onClick={() => openDeleteDialog(telescope.id)}
           disabled={!deletePermission}


### PR DESCRIPTION
Fix the error that occurs when adding a list of groups to a spectrum with some groups are already linked.
```
(psycopg2.errors.Unique Violation) duplicate key value violates unique constraint "group_spectra_forward_ind" DETAIL: Key (group_id, spectr_id)=(1747, 52845) already exists. [SQL: INSERT INTO group_spectra (group_id, spectr_id, created_at, modified) VALUES (% (group_id)s, % (spectr_id)s, timezone(% (timezone_1)s, CURRENT_TIMESTAMP), timezone (%(timezone_1)s, CURRENT_TIMESTAMP)) RETURNING group_spectra.id] [parameters: {'group_id: 1747, 'spectr_id': 52845, 'timezone_1': 'UTC'}] (Background on this error at: https://sqlalche.me/e/20/gkpj)
```

- Fix unique constraint violation when sharing spectra and photometry with groups by adding `distinct()` when retrieving groups to avoid duplicates, and by checking for existing group IDs when updating photometry/spectroscopy.
- Move `self.push()` inside the session to avoid `sqlalchemy.orm.exc.DetachedInstanceError`.
- Improve Spectrum preview component positioning in UploadSpectrum for better visibility.
- Remove unnecessary key attributes from button components in various tables for cleaner code.
- Add back navigation link to source in Share, Upload Photometry, and Upload Spectrum components. Clean up code in ShareDataForm.jsx.