### PR TITLE
Enhance numpy adapter for psycopg2 to handle NaN and Inf values

### DIFF
--- a/skyportal/__init__.py
+++ b/skyportal/__init__.py
@@ -11,14 +11,27 @@ try:
     # Register numpy types with psycopg2 for numpy 2.x compatibility
     # numpy 2 scalars no longer inherit from Python builtins, so psycopg2
     # needs explicit adapters to serialize them in SQL parameters
+    import math
+
     import numpy as np
     from psycopg2.extensions import AsIs, register_adapter
 
-    def _adapt_numpy_scalar(val):
-        return AsIs(repr(float(val)))
+    def _adapt_numpy_float(val):
+        f = float(val)
+        if math.isnan(f):
+            return AsIs("'NaN'::float")
+        if math.isinf(f):
+            return AsIs("'%s'::float" % ("Infinity" if f > 0 else "-Infinity"))
+        return AsIs(repr(f))
 
-    for _np_type in [np.float64, np.float32, np.int64, np.int32, np.bool_]:
-        register_adapter(_np_type, _adapt_numpy_scalar)
+    def _adapt_numpy_int(val):
+        return AsIs(int(val))
+
+    for _np_type in [np.float64, np.float32]:
+        register_adapter(_np_type, _adapt_numpy_float)
+    for _np_type in [np.int64, np.int32]:
+        register_adapter(_np_type, _adapt_numpy_int)
+    register_adapter(np.bool_, lambda val: AsIs("true" if val else "false"))
 except ImportError:
     # if the packages to monkey-patch are not available, just skip the patching
     pass

--- a/skyportal/models/spectrum.py
+++ b/skyportal/models/spectrum.py
@@ -34,6 +34,14 @@ class NumpyArray(sa.types.TypeDecorator):
 
     impl = psql.ARRAY(sa.Float)
 
+    def process_bind_param(self, value, dialect):
+        if value is None:
+            return value
+        # Convert to a Python list of native floats so psycopg2's Float adapter
+        # handles NaN/Inf correctly (numpy.float64 NaN serializes as unquoted
+        # `nan` which PostgreSQL interprets as a column reference).
+        return [float(x) for x in value]
+
     def process_result_value(self, value, dialect):
         return np.array(value)
 


### PR DESCRIPTION
After receiving reports of spectrum upload not working, I looked into why it was happening. It turns out to be due to NumPy 2.x. Some scalar types are not recognizable by psycopg2 anymore which causes an error in the spectrum upload. 

This pull request updates how NumPy types are adapted for PostgreSQL compatibility, especially to handle special float values (NaN, Infinity) correctly with psycopg2 and NumPy 2.x. It also ensures that arrays of floats are properly serialized for database storage.

**Improvements to NumPy type adaptation for PostgreSQL:**

* Added explicit adapters for NumPy float and int types to handle special float values (NaN, Infinity, -Infinity) when serializing to SQL, ensuring correct quoting and type casting for PostgreSQL compatibility (`skyportal/__init__.py`).
* Registered a custom adapter for `np.bool_` to serialize as SQL booleans (`true`/`false`) instead of integers (`0`/`1`) (`skyportal/__init__.py`).

**Improvements to array serialization in SQLAlchemy models:**

* Modified the `NumpyArray` custom type to convert NumPy arrays to native Python floats before binding parameters, ensuring correct handling of special float values in arrays stored in PostgreSQL (`skyportal/models/spectrum.py`).