### PR TITLE
photstats n+1 behavior

### DIFF
--- a/skyportal/models/phot_stat.py
+++ b/skyportal/models/phot_stat.py
@@ -430,39 +430,46 @@ class PhotStat(Base):
 
         """
 
+        # Read fields once. See full_update for why we avoid Photometry.to_dict().
         if isinstance(phot, Photometry):
-            phot = phot.to_dict()
-        elif not isinstance(phot, dict):
+            filt = phot.filter
+            mjd = phot.mjd
+            flux = phot.flux
+            fluxerr = phot.fluxerr
+            origin = phot.origin or ""
+            original_user_data = phot.original_user_data
+        elif isinstance(phot, dict):
+            filt = phot["filter"]
+            mjd = phot["mjd"]
+            flux = phot["flux"]
+            fluxerr = phot["fluxerr"]
+            origin = phot.get("origin", "")
+            original_user_data = phot.get("original_user_data")
+        else:
             raise TypeError("phot must be a dict or Photometry object")
 
-        filt = phot["filter"]
-        mjd = phot["mjd"]
-        origin = phot.get("origin", "")
-        if phot["flux"] > 0:
-            mag = -2.5 * np.log10(phot["flux"]) + PHOT_ZP
+        if flux is not None and flux > 0:
+            mag = -2.5 * np.log10(flux) + PHOT_ZP
         else:
             mag = np.nan
-        if phot["flux"] and phot["fluxerr"]:
-            snr = phot["flux"] / phot["fluxerr"]
+        if flux and fluxerr:
+            snr = flux / fluxerr
         else:
             snr = np.nan
-        det = phot["flux"] and phot["fluxerr"]  # legal, non zero values
+        det = flux and fluxerr  # legal, non zero values
         det = det and not np.isnan(snr) and snr > PHOT_DETECTION_THRESHOLD
 
         if not det:  # get limiting magnitude for non-detection
-            if (
-                "original_user_data" in phot
-                and phot["original_user_data"] is not None
-                and "limiting_mag" in phot["original_user_data"]
-            ):
-                user_data = phot["original_user_data"]
-                if isinstance(user_data, str):
-                    user_data = json.loads(user_data)
-                lim = user_data["limiting_mag"]
+            if isinstance(original_user_data, str):
+                try:
+                    original_user_data = json.loads(original_user_data)
+                except (TypeError, ValueError):
+                    original_user_data = None
+            if original_user_data is not None and "limiting_mag" in original_user_data:
+                lim = original_user_data["limiting_mag"]
             else:
-                fluxerr = phot["fluxerr"]
-                fivesigma = 5 * fluxerr
-                lim = -2.5 * np.log10(fivesigma) + PHOT_ZP
+                fivesigma = 5 * fluxerr if fluxerr else 0
+                lim = -2.5 * np.log10(fivesigma) + PHOT_ZP if fivesigma > 0 else np.nan
 
         # make sure a non detection has a limiting magnitude
         if not det and np.isnan(lim):
@@ -677,32 +684,50 @@ class PhotStat(Base):
         dets_no_forced_phot = []
         lims = []
         for phot in phot_list:
+            # Read fields once. For ORM instances, accessing attributes goes
+            # through the identity map without round-tripping; for expired
+            # instances it triggers at most a single refresh. Calling
+            # Photometry.to_dict() here used to issue one SELECT per row
+            # because Base.to_dict() has an expired-instance refresh fallback.
             if isinstance(phot, Photometry):
-                phot = phot.to_dict()
-            elif not isinstance(phot, dict):
+                filt = phot.filter
+                mjd = phot.mjd
+                flux = phot.flux
+                fluxerr = phot.fluxerr
+                origin = phot.origin or ""
+                original_user_data = phot.original_user_data
+                mag = None  # Photometry has no stored mag; computed from flux below
+            elif isinstance(phot, dict):
+                filt = phot["filter"]
+                mjd = phot["mjd"]
+                flux = phot["flux"]
+                fluxerr = phot["fluxerr"]
+                origin = phot.get("origin", "")
+                original_user_data = phot.get("original_user_data")
+                mag = phot.get("mag")
+            else:
                 raise TypeError("phot must be a dict or Photometry object")
 
-            filters.append(phot["filter"])
-            mjds.append(phot["mjd"])
+            filters.append(filt)
+            mjds.append(mjd)
 
-            if "mag" in phot:
-                mags.append(phot["mag"])
-            elif phot["flux"] is not None and phot["flux"] > 0:
-                mags.append(-2.5 * np.log10(phot["flux"]) + PHOT_ZP)
+            if mag is not None:
+                mags.append(mag)
+            elif flux is not None and flux > 0:
+                mags.append(-2.5 * np.log10(flux) + PHOT_ZP)
             else:
                 mags.append(np.nan)
 
             is_detected = (
-                phot["flux"] is not None
-                and phot["fluxerr"] is not None
-                and phot["fluxerr"] > 0
-                and phot["flux"] / phot["fluxerr"] > PHOT_DETECTION_THRESHOLD
+                flux is not None
+                and fluxerr is not None
+                and fluxerr > 0
+                and flux / fluxerr > PHOT_DETECTION_THRESHOLD
             )
             dets.append(is_detected)
 
             if (
-                not phot.get("origin")
-                in ["fp", "forced phot", "forced photometry", "alert_fp"]
+                origin not in ["fp", "forced phot", "forced photometry", "alert_fp"]
                 and is_detected
             ):
                 dets_no_forced_phot.append(True)
@@ -710,14 +735,18 @@ class PhotStat(Base):
                 dets_no_forced_phot.append(False)
 
             if not is_detected:
+                if isinstance(original_user_data, str):
+                    try:
+                        original_user_data = json.loads(original_user_data)
+                    except (TypeError, ValueError):
+                        original_user_data = None
                 if (
-                    "original_user_data" in phot
-                    and phot["original_user_data"] is not None
-                    and "limiting_mag" in phot["original_user_data"]
+                    original_user_data is not None
+                    and "limiting_mag" in original_user_data
                 ):
-                    lims.append(phot["original_user_data"]["limiting_mag"])
+                    lims.append(original_user_data["limiting_mag"])
                 else:
-                    fivesigma = 5 * phot["fluxerr"]
+                    fivesigma = 5 * fluxerr if fluxerr else 0
                     if fivesigma > 0:
                         lims.append(-2.5 * np.log10(fivesigma) + PHOT_ZP)
                     else:

--- a/skyportal/models/phot_stat.py
+++ b/skyportal/models/phot_stat.py
@@ -468,7 +468,7 @@ class PhotStat(Base):
             if original_user_data is not None and "limiting_mag" in original_user_data:
                 lim = original_user_data["limiting_mag"]
             else:
-                fivesigma = 5 * fluxerr if fluxerr else 0
+                fivesigma = 5 * fluxerr
                 lim = -2.5 * np.log10(fivesigma) + PHOT_ZP if fivesigma > 0 else np.nan
 
         # make sure a non detection has a limiting magnitude
@@ -746,7 +746,7 @@ class PhotStat(Base):
                 ):
                     lims.append(original_user_data["limiting_mag"])
                 else:
-                    fivesigma = 5 * fluxerr if fluxerr else 0
+                    fivesigma = 5 * fluxerr
                     if fivesigma > 0:
                         lims.append(-2.5 * np.log10(fivesigma) + PHOT_ZP)
                     else:


### PR DESCRIPTION
Sentry is often telling us that we have an n+1 issue:

e.g.
db - SELECT photometry.mjd AS photometry_mjd, photometry.flux AS photometry_flux, photometry.fluxerr AS photometry_fluxerr, photometry.filter AS photometry_filter, photometry.ra_unc AS photometry_ra_unc, photometry.dec_unc AS photometry_dec_unc, photome...

This PR attempts to fix that.