### PR TITLE
Thumbnail.jsx: no smoothing

### DIFF
--- a/static/js/components/thumbnail/Thumbnail.jsx
+++ b/static/js/components/thumbnail/Thumbnail.jsx
@@ -185,7 +185,12 @@ const Thumbnail = ({
                 className={imgClasses}
                 title={alt}
                 loading="lazy"
-                style={{ opacity: status === "loaded" ? 1 : 0 }}
+                style={{
+                  opacity: status === "loaded" ? 1 : 0,
+                  ...(imgSrc?.startsWith("data:")
+                    ? { imageRendering: "pixelated" }
+                    : {}),
+                }}
                 onLoad={() => setStatus("loaded")}
                 onError={(e) => {
                   e.target.onerror = null;


### PR DESCRIPTION
I noticed when playing with displaying LSST cutouts in some places of the fritz frontend (and those can have a small number of pixels when compared to how large we want it to be on the screen), that data looked blurry. By default the browser will take low res canvas and do some interpolation to scale it up to whatever is the desired image size using some bilinear resampling. But that basically makes your pixels look blurry as hell.

Obviously we don't want to present altered scientific data to the user, so forcing the browser to render as "pixelated" (that preserves the pixelated look of the original data) is best.

Context: This is required to finalize porting BOOM features over to Fritz (to support frontend stuff, like searched for alerts).

References:
- https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/image-rendering