### PR TITLE
Valkey cache

### DIFF
--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -566,8 +566,8 @@ database:
     # transaction; guards the pool against leaked transactions (0 = disabled).
     idle_transaction_timeout: 0
 
-# Valkey connection. We mirror BOOM's `redis:` block (Valkey speaks the redis
-# protocol, so the redis client talks to it directly).
+# Valkey connection. Valkey speaks the redis protocol, so a standard redis
+# client talks to it directly; these keys are the redis client's host/port/db.
 redis:
   host: localhost
   port: 6379

--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -566,6 +566,22 @@ database:
     # transaction; guards the pool against leaked transactions (0 = disabled).
     idle_transaction_timeout: 0
 
+# Valkey connection. We mirror BOOM's `redis:` block (Valkey speaks the redis
+# protocol, so the redis client talks to it directly).
+redis:
+  host: localhost
+  port: 6379
+  db: 0
+
+cache:
+  # When false (default), `get_cache()` returns a no-op cache and nothing uses
+  # Valkey — behavior is unchanged until caching is explicitly enabled.
+  enabled: false
+  ttl:
+    # Default time-to-live (seconds) for cached entries when a caller does not
+    # specify one.
+    default: 300
+
 server:
   # From https://console.developers.google.com/
   #

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -42,8 +42,8 @@ services:
       timeout: 5s
       retries: 10
 
-  # Valkey, configured to match BOOM's (same image + dev settings) since both
-  # talk to the redis protocol. Backs skyportal.utils.valkey_cache.
+  # Valkey (redis-protocol) server backing skyportal.utils.valkey_cache.
+  # ALLOW_EMPTY_PASSWORD is for local development only.
   valkey:
     image: valkey/valkey:7.2.6
     container_name: valkey

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -45,7 +45,7 @@ services:
   # Valkey (redis-protocol) server backing skyportal.utils.valkey_cache.
   # ALLOW_EMPTY_PASSWORD is for local development only.
   valkey:
-    image: valkey/valkey:7.2.6
+    image: valkey/valkey:9.1.0
     container_name: valkey
     ports:
       - "6379:6379"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -42,7 +42,28 @@ services:
       timeout: 5s
       retries: 10
 
+  # Valkey, configured to match BOOM's (same image + dev settings) since both
+  # talk to the redis protocol. Backs skyportal.utils.valkey_cache.
+  valkey:
+    image: valkey/valkey:7.2.6
+    container_name: valkey
+    ports:
+      - "6379:6379"
+    environment:
+      # ALLOW_EMPTY_PASSWORD is recommended only for development.
+      - ALLOW_EMPTY_PASSWORD=yes
+      - VALKEY_DISABLE_COMMANDS=FLUSHDB,FLUSHALL
+    volumes:
+      - valkeydata:/data
+    restart: on-failure:3
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
 volumes:
   dbdata:
+  valkeydata:
   thumbnails:
   persistentdata:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,9 @@ dependencies = [
     # floor here so the lock can't resolve to a vulnerable version and the bump
     # sticks (a lock-only floor reverts to baselayer's on the next uv resolve).
     "tornado>=6.5.6",
+    # redis-py client (talks to the Valkey server); MIT-licensed, so track the
+    # latest. Valkey 7.2 speaks RESP2/3, which redis-py 8.x supports.
+    "redis>=5.0.0, <9.0.0",
     "geojson==3.2.0",
     "typing-extensions==4.15.0",
     "swifttools==3.0.23",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ dependencies = [
     # sticks (a lock-only floor reverts to baselayer's on the next uv resolve).
     "tornado>=6.5.6",
     # redis-py client (talks to the Valkey server); MIT-licensed, so track the
-    # latest. Valkey 7.2 speaks RESP2/3, which redis-py 8.x supports.
+    # latest. Valkey speaks RESP2/3, which redis-py 8.x supports.
     "redis>=5.0.0, <9.0.0",
     "geojson==3.2.0",
     "typing-extensions==4.15.0",

--- a/skyportal/tests/utils/test_valkey_cache.py
+++ b/skyportal/tests/utils/test_valkey_cache.py
@@ -1,0 +1,131 @@
+"""Unit tests for the generic async Valkey cache (skyportal.utils.valkey_cache).
+
+These run without a Valkey server: the no-op / disabled paths and the BOOM-style
+URL construction need nothing, the wrapper logic (JSON round-trip, prefix
+deletion) is exercised against a tiny in-memory fake client, and graceful
+degradation is verified against an unreachable port.
+"""
+
+import asyncio
+import fnmatch
+
+from skyportal.utils.valkey_cache import (
+    ValkeyCache,
+    _NoOpCache,
+    get_cache,
+)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+class _FakeRedis:
+    """Minimal async stand-in for redis.asyncio, backed by a dict, exposing just
+    the methods ValkeyCache uses (get/set/unlink/scan_iter)."""
+
+    def __init__(self):
+        self.store = {}
+        self.expirations = {}
+
+    async def get(self, key):
+        return self.store.get(key)
+
+    async def set(self, key, value, ex=None):
+        self.store[key] = value
+        self.expirations[key] = ex
+        return True
+
+    async def unlink(self, key):
+        self.store.pop(key, None)
+        self.expirations.pop(key, None)
+        return 1
+
+    async def scan_iter(self, match=None, count=None):
+        # redis glob matching ("prefix*"); iterate a snapshot since we mutate.
+        for key in list(self.store):
+            if match is None or fnmatch.fnmatch(key, match):
+                yield key
+
+
+def test_noop_cache_methods():
+    """A disabled/no-op cache answers every operation as a miss, never raising."""
+    cache = _NoOpCache()
+    assert _run(cache.get("k")) is None
+    assert _run(cache.get_json("k")) is None
+    assert _run(cache.set("k", "v")) is False
+    assert _run(cache.set_json("k", {"a": 1})) is False
+    assert _run(cache.delete("k")) is False
+    assert _run(cache.delete_prefix("p:")) == 0
+
+
+def test_get_cache_disabled_returns_noop():
+    """With cache.enabled false (the default), get_cache returns a no-op cache so
+    callers need no conditional logic and behavior is unchanged."""
+    cache = get_cache()
+    assert isinstance(cache, _NoOpCache)
+
+
+def test_url_construction_and_lazy_connect():
+    """ValkeyCache builds BOOM's redis://host:port/db URI and does not open a
+    connection until first use."""
+    cache = ValkeyCache(host="example", port=1234, db=2, default_ttl=42)
+    assert cache._url == "redis://example:1234/2"
+    assert cache._client is None  # lazy: no connection at construction
+
+
+def test_json_roundtrip_with_fake_client():
+    """set_json encodes and get_json decodes the same value."""
+    cache = ValkeyCache(default_ttl=99)
+    cache._client = _FakeRedis()
+
+    value = {"obj_id": "ZTF1", "points": [1, 2, 3], "nested": {"x": True}}
+    assert _run(cache.set_json("photcache:v1:ZTF1:scope:variant", value)) is True
+    assert _run(cache.get_json("photcache:v1:ZTF1:scope:variant")) == value
+    # Default TTL is applied when none is supplied.
+    assert cache._client.expirations["photcache:v1:ZTF1:scope:variant"] == 99
+
+
+def test_get_json_miss_returns_none():
+    cache = ValkeyCache()
+    cache._client = _FakeRedis()
+    assert _run(cache.get_json("absent")) is None
+
+
+def test_explicit_ttl_overrides_default():
+    cache = ValkeyCache(default_ttl=99)
+    cache._client = _FakeRedis()
+    _run(cache.set("k", "v", ttl=5))
+    assert cache._client.expirations["k"] == 5
+
+
+def test_delete_and_delete_prefix():
+    """delete removes one key; delete_prefix removes only the matching prefix and
+    reports the count, leaving other objects' entries intact."""
+    cache = ValkeyCache()
+    cache._client = _FakeRedis()
+    _run(cache.set("photcache:v1:ZTF1:s1:v1", "a"))
+    _run(cache.set("photcache:v1:ZTF1:s2:v1", "b"))
+    _run(cache.set("photcache:v1:ZTF2:s1:v1", "c"))  # different object
+
+    assert _run(cache.delete("photcache:v1:ZTF1:s1:v1")) is True
+    assert _run(cache.get("photcache:v1:ZTF1:s1:v1")) is None
+
+    removed = _run(cache.delete_prefix("photcache:v1:ZTF1:"))
+    assert removed == 1  # only the remaining ZTF1 entry
+    assert _run(cache.get("photcache:v1:ZTF1:s2:v1")) is None
+    # The other object's entry is untouched.
+    assert _run(cache.get("photcache:v1:ZTF2:s1:v1")) == "c"
+
+
+def test_graceful_degradation_when_unreachable():
+    """A real client pointed at a closed port must degrade to misses/no-ops
+    (log and carry on), never propagating an exception to the caller."""
+    # Port 6: a reserved, unused port -> connection refused fast.
+    cache = ValkeyCache(host="127.0.0.1", port=6)
+    assert _run(cache.get("k")) is None
+    assert _run(cache.get_json("k")) is None
+    assert _run(cache.set("k", "v")) is False
+    assert _run(cache.set_json("k", {"a": 1})) is False
+    assert _run(cache.delete("k")) is False
+    assert _run(cache.delete_prefix("p:")) == 0

--- a/skyportal/tests/utils/test_valkey_cache.py
+++ b/skyportal/tests/utils/test_valkey_cache.py
@@ -1,6 +1,6 @@
 """Unit tests for the generic async Valkey cache (skyportal.utils.valkey_cache).
 
-These run without a Valkey server: the no-op / disabled paths and the BOOM-style
+These run without a Valkey server: the no-op / disabled paths and the
 URL construction need nothing, the wrapper logic (JSON round-trip, prefix
 deletion) is exercised against a tiny in-memory fake client, and graceful
 degradation is verified against an unreachable port.
@@ -67,7 +67,7 @@ def test_get_cache_disabled_returns_noop():
 
 
 def test_url_construction_and_lazy_connect():
-    """ValkeyCache builds BOOM's redis://host:port/db URI and does not open a
+    """ValkeyCache builds the redis://host:port/db URI and does not open a
     connection until first use."""
     cache = ValkeyCache(host="example", port=1234, db=2, default_ttl=42)
     assert cache._url == "redis://example:1234/2"

--- a/skyportal/utils/valkey_cache.py
+++ b/skyportal/utils/valkey_cache.py
@@ -7,10 +7,9 @@ network-shared cache entries (expensive-query memoization, broker-canonical
 read-through caches, rate-limit counters, ...). Feature code builds its own
 namespaced keys and TTLs on top of it.
 
-Connection conventions deliberately mirror BOOM, which talks to the same Valkey
-server: a ``redis:`` config block (``host``/``port``), a ``redis://{host}:{port}/``
-URI, and a single pooled async connection. (Valkey speaks the redis protocol, so
-the Python ``redis.asyncio`` client — like BOOM's redis crate — is the client.)
+Valkey speaks the redis protocol, so the Python ``redis.asyncio`` client talks to
+it directly. Connection settings come from a ``redis:`` config block
+(``host``/``port``/``db``); the client opens a single pooled async connection.
 
 Design notes:
 - The ``redis`` client is imported lazily and ``cfg`` is read lazily, so this
@@ -18,7 +17,7 @@ Design notes:
   loaded config.
 - Every operation is best-effort: a connection error is logged and swallowed
   (returning a miss / no-op), so the cache can never take down a code path that
-  uses it. BOOM takes the same "log and carry on" stance on Valkey errors.
+  uses it.
 - When ``cache.enabled`` is false (the default), :func:`get_cache` returns a
   no-op cache so callers need no conditional logic.
 """
@@ -38,14 +37,13 @@ class ValkeyCache:
     """
 
     def __init__(self, host="localhost", port=6379, db=0, default_ttl=300):
-        # Mirror BOOM's `redis://{host}:{port}/` connection string.
         self._url = f"redis://{host}:{port}/{db}"
         self._default_ttl = default_ttl
         self._client = None
 
     def _connect(self):
-        # redis-py's async client maintains its own connection pool (the
-        # analogue of BOOM's MultiplexedConnection); create it once and reuse.
+        # redis-py's async client maintains its own connection pool; create it
+        # once and reuse it process-wide.
         if self._client is None:
             import redis.asyncio as redis  # lazy: optional dependency
 
@@ -149,8 +147,8 @@ def get_cache():
     """Return the process-wide :class:`ValkeyCache`, or a no-op cache when
     disabled.
 
-    Reads the ``redis:`` config block (``host``/``port``/``db``, emulating BOOM)
-    plus ``cache.enabled`` and ``cache.ttl.default``. With ``cache.enabled``
+    Reads the ``redis:`` config block (``host``/``port``/``db``) plus
+    ``cache.enabled`` and ``cache.ttl.default``. With ``cache.enabled``
     false (the default) this returns a no-op cache, so call sites need no
     conditional logic and behavior is unchanged until caching is turned on.
     """

--- a/skyportal/utils/valkey_cache.py
+++ b/skyportal/utils/valkey_cache.py
@@ -1,0 +1,170 @@
+"""Generic async key/value cache backed by Valkey.
+
+This is a small, domain-agnostic caching layer for SkyPortal — distinct from the
+disk-based ``Cache`` in :mod:`skyportal.utils.cache` (which stores cutout files
+on disk). It provides a process-wide async client for short-lived,
+network-shared cache entries (expensive-query memoization, broker-canonical
+read-through caches, rate-limit counters, ...). Feature code builds its own
+namespaced keys and TTLs on top of it.
+
+Connection conventions deliberately mirror BOOM, which talks to the same Valkey
+server: a ``redis:`` config block (``host``/``port``), a ``redis://{host}:{port}/``
+URI, and a single pooled async connection. (Valkey speaks the redis protocol, so
+the Python ``redis.asyncio`` client — like BOOM's redis crate — is the client.)
+
+Design notes:
+- The ``redis`` client is imported lazily and ``cfg`` is read lazily, so this
+  module imports fine without the optional dependency, a running Valkey, or a
+  loaded config.
+- Every operation is best-effort: a connection error is logged and swallowed
+  (returning a miss / no-op), so the cache can never take down a code path that
+  uses it. BOOM takes the same "log and carry on" stance on Valkey errors.
+- When ``cache.enabled`` is false (the default), :func:`get_cache` returns a
+  no-op cache so callers need no conditional logic.
+"""
+
+import json
+
+from baselayer.log import make_log
+
+log = make_log("valkey_cache")
+
+
+class ValkeyCache:
+    """Thin async wrapper over a pooled ``redis.asyncio`` client.
+
+    All methods are best-effort: any error is logged and swallowed (returning a
+    miss / no-op) so a Valkey outage degrades gracefully to the un-cached path.
+    """
+
+    def __init__(self, host="localhost", port=6379, db=0, default_ttl=300):
+        # Mirror BOOM's `redis://{host}:{port}/` connection string.
+        self._url = f"redis://{host}:{port}/{db}"
+        self._default_ttl = default_ttl
+        self._client = None
+
+    def _connect(self):
+        # redis-py's async client maintains its own connection pool (the
+        # analogue of BOOM's MultiplexedConnection); create it once and reuse.
+        if self._client is None:
+            import redis.asyncio as redis  # lazy: optional dependency
+
+            self._client = redis.from_url(
+                self._url,
+                socket_timeout=2,
+                socket_connect_timeout=2,
+            )
+        return self._client
+
+    async def get(self, key):
+        """Return the raw cached bytes for ``key``, or None on miss/error."""
+        try:
+            return await self._connect().get(key)
+        except Exception as e:
+            log(f"get failed [{key}]: {e}")
+            return None
+
+    async def set(self, key, value, ttl=None):
+        """Set ``key`` to raw ``value`` with a TTL (seconds). Returns success."""
+        try:
+            await self._connect().set(key, value, ex=ttl or self._default_ttl)
+            return True
+        except Exception as e:
+            log(f"set failed [{key}]: {e}")
+            return False
+
+    async def get_json(self, key):
+        """Return the JSON-decoded cached value for ``key``, or None."""
+        raw = await self.get(key)
+        if raw is None:
+            return None
+        try:
+            return json.loads(raw)
+        except Exception as e:
+            log(f"decode failed [{key}]: {e}")
+            return None
+
+    async def set_json(self, key, value, ttl=None):
+        """JSON-encode ``value`` and cache it under ``key``."""
+        try:
+            payload = json.dumps(value, default=str)
+        except Exception as e:
+            log(f"encode failed [{key}]: {e}")
+            return False
+        return await self.set(key, payload, ttl=ttl)
+
+    async def delete(self, key):
+        """Delete a single key."""
+        try:
+            await self._connect().unlink(key)
+            return True
+        except Exception as e:
+            log(f"delete failed [{key}]: {e}")
+            return False
+
+    async def delete_prefix(self, prefix):
+        """Delete every key beginning with ``prefix``. Returns the count removed.
+
+        Uses non-blocking ``SCAN`` + ``UNLINK`` so it never stalls the server
+        the way ``KEYS`` would.
+        """
+        deleted = 0
+        try:
+            client = self._connect()
+            async for key in client.scan_iter(match=f"{prefix}*", count=200):
+                await client.unlink(key)
+                deleted += 1
+        except Exception as e:
+            log(f"delete_prefix failed [{prefix}]: {e}")
+        return deleted
+
+
+class _NoOpCache:
+    """Stand-in used when caching is disabled, so callers never branch."""
+
+    async def get(self, key):
+        return None
+
+    async def set(self, key, value, ttl=None):
+        return False
+
+    async def get_json(self, key):
+        return None
+
+    async def set_json(self, key, value, ttl=None):
+        return False
+
+    async def delete(self, key):
+        return False
+
+    async def delete_prefix(self, prefix):
+        return 0
+
+
+_cache = None
+_noop = _NoOpCache()
+
+
+def get_cache():
+    """Return the process-wide :class:`ValkeyCache`, or a no-op cache when
+    disabled.
+
+    Reads the ``redis:`` config block (``host``/``port``/``db``, emulating BOOM)
+    plus ``cache.enabled`` and ``cache.ttl.default``. With ``cache.enabled``
+    false (the default) this returns a no-op cache, so call sites need no
+    conditional logic and behavior is unchanged until caching is turned on.
+    """
+    global _cache
+    from baselayer.app.env import load_env
+
+    _, cfg = load_env()
+    if not cfg.get("cache.enabled", False):
+        return _noop
+    if _cache is None:
+        _cache = ValkeyCache(
+            host=cfg.get("redis.host", "localhost"),
+            port=int(cfg.get("redis.port", 6379)),
+            db=int(cfg.get("redis.db", 0) or 0),
+            default_ttl=int(cfg.get("cache.ttl.default", 300)),
+        )
+    return _cache


### PR DESCRIPTION
This PR enables a Valkey cache, which will be required for broker -> marshal photometry pass through.