### PR TITLE
Fix delete superseded github action

### DIFF
--- a/.github/workflows/delete-superseded-runs.yaml
+++ b/.github/workflows/delete-superseded-runs.yaml
@@ -49,7 +49,7 @@ jobs:
           # The list endpoint returns runs sorted by created_at descending,
           # so per_page=1 gives us the latest one. Pass the query params via
           # `-f` so branch names with `/` or special chars are URL-encoded.
-          latest_run_number=$(gh api \
+          latest_run_number=$(gh api -X GET \
             -f branch="$BRANCH" -f per_page=1 \
             "/repos/$REPO/actions/workflows/$WORKFLOW_ID/runs" \
             --jq '.workflow_runs[0].run_number // empty')

--- a/skyportal/handlers/base.py
+++ b/skyportal/handlers/base.py
@@ -18,7 +18,6 @@ def resolve_cast(annotation):
     """Resolve a parameter annotation to a cast callable.
 
     Handles ``Optional[T]`` / ``T | None`` by unwrapping to the inner type and
-
     setting ``allow_none=True``. Returns ``(cast_fn, allow_none)``.
 
     If the annotation is a Union with more than one non-None member, returns

--- a/skyportal/handlers/base.py
+++ b/skyportal/handlers/base.py
@@ -18,6 +18,7 @@ def resolve_cast(annotation):
     """Resolve a parameter annotation to a cast callable.
 
     Handles ``Optional[T]`` / ``T | None`` by unwrapping to the inner type and
+
     setting ``allow_none=True``. Returns ``(cast_fn, allow_none)``.
 
     If the annotation is a Union with more than one non-None member, returns


### PR DESCRIPTION
Fix `gh api` call by use explicitly GET method for fetching latest GitHub action run number. To fix `gh api` from using POST method when arguments are passed.