### PR TITLE
Reduce bundle size

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -135,7 +135,7 @@
         "openapi-typescript": "7.13.0",
         "typescript": "5.7.3",
         "typescript-eslint": "8.60.1",
-        "webpack-bundle-analyzer": "^5.3.0",
+        "webpack-bundle-analyzer": "5.3.0",
       },
     },
   },

--- a/bun.lock
+++ b/bun.lock
@@ -135,6 +135,7 @@
         "openapi-typescript": "7.13.0",
         "typescript": "5.7.3",
         "typescript-eslint": "8.60.1",
+        "webpack-bundle-analyzer": "^5.3.0",
       },
     },
   },
@@ -963,7 +964,7 @@
 
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
-    "commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
+    "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 
     "complex.js": ["complex.js@2.4.3", "", {}, "sha512-UrQVSUur14tNX6tiP4y8T4w4FeJAX3bi2cIv0pu/DTLFNxoq7z2Yh83Vfzztj6Px3X/lubqQ9IrPp7Bpn6p4MQ=="],
 
@@ -1517,7 +1518,7 @@
 
     "hpack.js": ["hpack.js@2.1.6", "", { "dependencies": { "inherits": "^2.0.1", "obuf": "^1.0.0", "readable-stream": "^2.0.1", "wbuf": "^1.1.0" } }, "sha512-zJxVehUdMGIKsRaNt7apO2Gqp0BdqW5yaiGHXXmbpvxgBYVZnAql+BJb4RO5ad2MgpbZKn5G6nMnegrH1FcNYQ=="],
 
-    "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
+    "html-escaper": ["html-escaper@3.0.3", "", {}, "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ=="],
 
     "html-url-attributes": ["html-url-attributes@3.0.1", "", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
 
@@ -2363,7 +2364,7 @@
 
     "simple-swizzle": ["simple-swizzle@0.2.4", "", { "dependencies": { "is-arrayish": "^0.3.1" } }, "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw=="],
 
-    "sirv": ["sirv@2.0.4", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ=="],
+    "sirv": ["sirv@3.0.2", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g=="],
 
     "slugify": ["slugify@1.4.7", "", {}, "sha512-tf+h5W1IrjNm/9rKKj0JU2MDMruiopx0jjVA5zCdBtcGjfp0+c5rHw/zADLC3IeKlGHtVbHtpfzvYA0OYT+HKg=="],
 
@@ -2691,7 +2692,7 @@
 
     "webpack": ["webpack@5.108.3", "", { "dependencies": { "@types/estree": "^1.0.8", "@types/json-schema": "^7.0.15", "@webassemblyjs/ast": "^1.14.1", "@webassemblyjs/wasm-edit": "^1.14.1", "@webassemblyjs/wasm-parser": "^1.14.1", "acorn": "^8.16.0", "acorn-import-phases": "^1.0.3", "browserslist": "^4.28.1", "chrome-trace-event": "^1.0.2", "enhanced-resolve": "^5.22.2", "es-module-lexer": "^2.1.0", "eslint-scope": "5.1.1", "events": "^3.2.0", "graceful-fs": "^4.2.11", "loader-runner": "^4.3.2", "mime-db": "^1.54.0", "minimizer-webpack-plugin": "^5.6.1", "neo-async": "^2.6.2", "schema-utils": "^4.3.3", "tapable": "^2.3.0", "watchpack": "^2.5.2", "webpack-sources": "^3.5.0" }, "peerDependencies": { "webpack-cli": "*" }, "optionalPeers": ["webpack-cli"], "bin": { "webpack": "bin/webpack.js" } }, "sha512-hOpaCHmQVVY66IVTjofnH14IgSdmod2aquSGHGuYig/OIdWge01Hk2Wt988DZcwXumFUT4+FvJY5N+ikl8o/ww=="],
 
-    "webpack-bundle-analyzer": ["webpack-bundle-analyzer@4.10.2", "", { "dependencies": { "@discoveryjs/json-ext": "0.5.7", "acorn": "^8.0.4", "acorn-walk": "^8.0.0", "commander": "^7.2.0", "debounce": "^1.2.1", "escape-string-regexp": "^4.0.0", "gzip-size": "^6.0.0", "html-escaper": "^2.0.2", "opener": "^1.5.2", "picocolors": "^1.0.0", "sirv": "^2.0.3", "ws": "^7.3.1" }, "bin": { "webpack-bundle-analyzer": "lib/bin/analyzer.js" } }, "sha512-vJptkMm9pk5si4Bv922ZbKLV8UTT4zib4FPgXMhgzUny0bfDDkLXAVQs3ly3fS4/TN9ROFtb0NFrm04UXFE/Vw=="],
+    "webpack-bundle-analyzer": ["webpack-bundle-analyzer@5.3.0", "", { "dependencies": { "@discoveryjs/json-ext": "^0.6.3", "acorn": "^8.0.4", "acorn-walk": "^8.0.0", "commander": "^14.0.2", "escape-string-regexp": "^5.0.0", "html-escaper": "^3.0.3", "opener": "^1.5.2", "picocolors": "^1.0.0", "sirv": "^3.0.2", "ws": "^8.19.0" }, "bin": { "webpack-bundle-analyzer": "lib/bin/analyzer.js" } }, "sha512-PEhAoqiJ+47d0uLMx/+zo5XOvaU+Vk6N2ZLht7H3n09QLy/fhyvqGNwjdRUHJDgMN8crBR2ZwVHkIswT3Xuawg=="],
 
     "webpack-dev-middleware": ["webpack-dev-middleware@7.4.5", "", { "dependencies": { "colorette": "^2.0.10", "memfs": "^4.43.1", "mime-types": "^3.0.1", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "schema-utils": "^4.0.0" }, "peerDependencies": { "webpack": "^5.0.0" }, "optionalPeers": ["webpack"] }, "sha512-uxQ6YqGdE4hgDKNf7hUiPXOdtkXvBJXrfEGYSx7P7LC8hnUYGK70X6xQXUvXeNyBDDcsiQXpG2m3G9vxowaEuA=="],
 
@@ -2827,6 +2828,8 @@
 
     "@rjsf/validator-ajv8/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
+    "@rspack/cli/webpack-bundle-analyzer": ["webpack-bundle-analyzer@4.10.2", "", { "dependencies": { "@discoveryjs/json-ext": "0.5.7", "acorn": "^8.0.4", "acorn-walk": "^8.0.0", "commander": "^7.2.0", "debounce": "^1.2.1", "escape-string-regexp": "^4.0.0", "gzip-size": "^6.0.0", "html-escaper": "^2.0.2", "opener": "^1.5.2", "picocolors": "^1.0.0", "sirv": "^2.0.3", "ws": "^7.3.1" }, "bin": { "webpack-bundle-analyzer": "lib/bin/analyzer.js" } }, "sha512-vJptkMm9pk5si4Bv922ZbKLV8UTT4zib4FPgXMhgzUny0bfDDkLXAVQs3ly3fS4/TN9ROFtb0NFrm04UXFE/Vw=="],
+
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
@@ -2864,6 +2867,10 @@
     "concat-stream/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
     "cosmiconfig/parse-json": ["parse-json@5.2.0", "", { "dependencies": { "@babel/code-frame": "^7.0.0", "error-ex": "^1.3.1", "json-parse-even-better-errors": "^2.3.0", "lines-and-columns": "^1.1.6" } }, "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg=="],
+
+    "d3-dsv/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
+
+    "d3-geo-projection/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
 
     "dnd-core/redux": ["redux@4.2.1", "", { "dependencies": { "@babel/runtime": "^7.9.2" } }, "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w=="],
 
@@ -3031,7 +3038,9 @@
 
     "webpack/schema-utils": ["schema-utils@4.3.3", "", { "dependencies": { "@types/json-schema": "^7.0.9", "ajv": "^8.9.0", "ajv-formats": "^2.1.1", "ajv-keywords": "^5.1.0" } }, "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA=="],
 
-    "webpack-bundle-analyzer/ws": ["ws@7.5.11", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA=="],
+    "webpack-bundle-analyzer/@discoveryjs/json-ext": ["@discoveryjs/json-ext@0.6.3", "", {}, "sha512-4B4OijXeVNOPZlYA2oEwWOTkzyltLao+xbotHQeqN++Rv27Y6s818+n2Qkp8q+Fxhn0t/5lA5X1Mxktud8eayQ=="],
+
+    "webpack-bundle-analyzer/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
     "webpack-dev-middleware/colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
 
@@ -3060,6 +3069,14 @@
     "@redocly/openapi-core/minimatch/brace-expansion": ["brace-expansion@2.1.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA=="],
 
     "@rjsf/validator-ajv8/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "@rspack/cli/webpack-bundle-analyzer/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
+
+    "@rspack/cli/webpack-bundle-analyzer/html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
+
+    "@rspack/cli/webpack-bundle-analyzer/sirv": ["sirv@2.0.4", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ=="],
+
+    "@rspack/cli/webpack-bundle-analyzer/ws": ["ws@7.5.11", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.7", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA=="],
 

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "openapi-typescript": "7.13.0",
     "typescript": "5.7.3",
     "typescript-eslint": "8.60.1",
-    "webpack-bundle-analyzer": "^5.3.0"
+    "webpack-bundle-analyzer": "5.3.0"
   },
   "overrides": {
     "yargs": "^17.7.2",

--- a/package.json
+++ b/package.json
@@ -138,7 +138,8 @@
     "json-loader": "0.5.7",
     "openapi-typescript": "7.13.0",
     "typescript": "5.7.3",
-    "typescript-eslint": "8.60.1"
+    "typescript-eslint": "8.60.1",
+    "webpack-bundle-analyzer": "^5.3.0"
   },
   "overrides": {
     "yargs": "^17.7.2",

--- a/rspack.config.js
+++ b/rspack.config.js
@@ -30,10 +30,13 @@ const config = (env, argv) => {
             chunks: "initial",
             priority: 10,
           },
+          // `chunks: "initial"` so MUI modules only reached by lazy routes
+          // (e.g. @mui/x-data-grid in Sources/Candidates pages) stay async
+          // instead of being pulled into the initial mui chunk.
           mui: {
             test: /[\\/]node_modules[\\/]@mui[\\/]/,
             name: "mui",
-            chunks: "all",
+            chunks: "initial",
             priority: 20,
           },
           d3: {
@@ -141,6 +144,14 @@ const config = (env, argv) => {
     plugins: [
       // Uncomment the following line to enable bundle size analysis
       // new BundleAnalyzerPlugin(),
+      // Drop moment's per-locale string files (es, fr, ja, ...) — SkyPortal only
+      // formats dates in English. Saves ~600 KB on pages that pull in moment
+      // (notably `ShiftCalendar` via react-big-calendar). Does NOT affect
+      // timezone math: that comes from `moment-timezone`, which is not a dep.
+      new rspack.IgnorePlugin({
+        resourceRegExp: /^\.\/locale$/,
+        contextRegExp: /moment$/,
+      }),
       new rspack.HtmlRspackPlugin({
         template: "./static/index_base.html",
         filename: "../index.html",

--- a/rspack.config.js
+++ b/rspack.config.js
@@ -1,10 +1,7 @@
 const path = require("path");
 const rspack = require("@rspack/core");
 
-// Bundle treemap: `ANALYZE=1 bun run build` writes static/build/bundle-report.html.
-const BundleAnalyzerPlugin = process.env.ANALYZE
-  ? require("webpack-bundle-analyzer").BundleAnalyzerPlugin
-  : null;
+// const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
 const config = (env, argv) => {
   const isProduction = argv?.mode === "production";
@@ -142,17 +139,8 @@ const config = (env, argv) => {
       ],
     },
     plugins: [
-      ...(BundleAnalyzerPlugin
-        ? [
-            new BundleAnalyzerPlugin({
-              analyzerMode: "static",
-              reportFilename: "bundle-report.html",
-              openAnalyzer: false,
-              generateStatsFile: true,
-              statsFilename: "bundle-stats.json",
-            }),
-          ]
-        : []),
+      // Uncomment the following line to enable bundle size analysis
+      // new BundleAnalyzerPlugin(),
       new rspack.HtmlRspackPlugin({
         template: "./static/index_base.html",
         filename: "../index.html",

--- a/rspack.config.js
+++ b/rspack.config.js
@@ -1,17 +1,16 @@
 const path = require("path");
 const rspack = require("@rspack/core");
 
-// const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
+// Bundle treemap: `ANALYZE=1 bun run build` writes static/build/bundle-report.html.
+const BundleAnalyzerPlugin = process.env.ANALYZE
+  ? require("webpack-bundle-analyzer").BundleAnalyzerPlugin
+  : null;
 
 const config = (env, argv) => {
   const isProduction = argv?.mode === "production";
   return {
     entry: {
-      main: [
-        "core-js/stable",
-        "regenerator-runtime/runtime",
-        path.resolve(__dirname, "static/js/components/templates/Main.tsx"),
-      ],
+      main: path.resolve(__dirname, "static/js/components/templates/Main.tsx"),
     },
     output: {
       path: path.resolve(__dirname, "static/build"),
@@ -24,10 +23,14 @@ const config = (env, argv) => {
       splitChunks: {
         chunks: "all",
         cacheGroups: {
+          // `chunks: "initial"` keeps the big shared vendors chunk to only the
+          // libs reached on first paint. Modules used solely by lazy routes
+          // (mathjs, dygraphs, moment, react-big-calendar, @rjsf/*, etc.) stay
+          // in their own async chunks instead of being shipped on initial load.
           vendor: {
             test: /[\\/]node_modules[\\/]/,
             name: "vendors",
-            chunks: "all",
+            chunks: "initial",
             priority: 10,
           },
           mui: {
@@ -60,22 +63,15 @@ const config = (env, argv) => {
     },
     module: {
       rules: [
-        // Transform JS/TS with rspack's built-in Rust/SWC loader instead of
-        // babel-loader. SWC needs an explicit parser per syntax, so this is
-        // split into two rules (TS/TSX and JS/JSX). Type *checking* remains a
-        // separate `tsc --noEmit` step (npm run typecheck); SWC, like the old
-        // @babel/preset-typescript, only strips types during bundling.
+        // Transform JS/TS with rspack's built-in Rust/SWC loader. Type
+        // *checking* remains a separate `tsc --noEmit` step.
         //
-        // `jsc.target: "es5"` reproduces what @babel/preset-env emitted here:
-        // with no `targets`/browserslist configured, preset-env lowers all
-        // ES2015+ down to ES5. Matching that target is deliberate — it keeps
-        // runtime behavior identical (e.g. `const`/`let` lower to hoisted `var`,
-        // so code that reads a not-yet-initialized binding gets `undefined`
-        // instead of a TDZ ReferenceError). A more modern target would change
-        // that behavior and surface latent bugs. No `env` block is used: like
-        // preset-env's default `useBuiltIns: false`, polyfills come solely from
-        // the `core-js/stable` + `regenerator-runtime/runtime` entry imports,
-        // not per-file/usage injection.
+        // `jsc.target: "es2020"` covers all browsers from ~2020+ natively (async/await,
+        // optional chaining, nullish coalescing, Promise, etc.), so the entry no longer
+        // needs `core-js/stable` + `regenerator-runtime/runtime` polyfills. This also
+        // restores `const`/`let` TDZ semantics — if a binding is read before init it
+        // throws `ReferenceError` instead of returning `undefined` (the ES5 lowering
+        // hid these as latent bugs).
         {
           // TypeScript / TSX
           test: /\.tsx?$/,
@@ -86,7 +82,7 @@ const config = (env, argv) => {
             jsc: {
               parser: { syntax: "typescript", tsx: true },
               transform: { react: { runtime: "automatic" } },
-              target: "es5",
+              target: "es2020",
             },
           },
         },
@@ -100,7 +96,7 @@ const config = (env, argv) => {
             jsc: {
               parser: { syntax: "ecmascript", jsx: true },
               transform: { react: { runtime: "automatic" } },
-              target: "es5",
+              target: "es2020",
             },
           },
         },
@@ -146,8 +142,17 @@ const config = (env, argv) => {
       ],
     },
     plugins: [
-      // Uncomment the following line to enable bundle size analysis
-      // new BundleAnalyzerPlugin(),
+      ...(BundleAnalyzerPlugin
+        ? [
+            new BundleAnalyzerPlugin({
+              analyzerMode: "static",
+              reportFilename: "bundle-report.html",
+              openAnalyzer: false,
+              generateStatsFile: true,
+              statsFilename: "bundle-stats.json",
+            }),
+          ]
+        : []),
       new rspack.HtmlRspackPlugin({
         template: "./static/index_base.html",
         filename: "../index.html",
@@ -175,6 +180,9 @@ const config = (env, argv) => {
           __dirname,
           "node_modules/react-resizable/css",
         ),
+        // Some transitive deps still ship CJS lodash; alias to lodash-es so
+        // both versions dedupe and the ES tree-shakes properly.
+        lodash: "lodash-es",
       },
       extensions: [".js", ".jsx", ".ts", ".tsx", ".json"],
       // Needed for non-polyfilled node modules; we aim to remove this when possible


### PR DESCRIPTION
This PR trims our initial bundle from 14MB to ~7MB by requiring ES2020 and using vendors: initial (so that vendored packages only load when needed from a page).
