### PR TITLE
Add export feature to grid toolbars across multiple components

### DIFF
--- a/static/js/components/RecurringAPIPage.tsx
+++ b/static/js/components/RecurringAPIPage.tsx
@@ -146,7 +146,7 @@ const RecurringAPIPage = () => {
   }
 
   const CustomToolbar = () => (
-    <DataGridToolbar showQuickFilter={false}>
+    <DataGridToolbar showQuickFilter={false} showExport>
       <IconButton
         name="new_recurring_api_form"
         onClick={() => setOpenNewForm(true)}

--- a/static/js/components/TagManagement.tsx
+++ b/static/js/components/TagManagement.tsx
@@ -278,7 +278,7 @@ const TagManagement = () => {
 
   function CustomToolbar() {
     return (
-      <DataGridToolbar showFilter showQuickFilter={false}>
+      <DataGridToolbar showFilter showQuickFilter={false} showExport>
         <Tooltip title="Create new tag">
           <IconButton
             onClick={handleCreateClick}

--- a/static/js/components/allocation/AllocationTable.tsx
+++ b/static/js/components/allocation/AllocationTable.tsx
@@ -351,7 +351,7 @@ const AllocationTable = ({
   ].filter(Boolean);
 
   const CustomToolbar = () => (
-    <DataGridToolbar>
+    <DataGridToolbar showExport>
       <IconButton
         name="new_allocation"
         size="small"

--- a/static/js/components/analysis/AnalysisServicePage.tsx
+++ b/static/js/components/analysis/AnalysisServicePage.tsx
@@ -311,7 +311,7 @@ const AnalysisServiceList = ({
     () =>
       function AnalysisServiceToolbar() {
         return (
-          <DataGridToolbar>
+          <DataGridToolbar showExport>
             {deletePermission && (
               <IconButton
                 name="new_analysis_service"

--- a/static/js/components/followup_request/DefaultFollowupRequestList.tsx
+++ b/static/js/components/followup_request/DefaultFollowupRequestList.tsx
@@ -223,7 +223,7 @@ const DefaultFollowupRequestList = ({
   ];
 
   const CustomToolbar = () => (
-    <DataGridToolbar showQuickFilter={false}>
+    <DataGridToolbar showQuickFilter={false} showExport>
       <IconButton
         name="new_default_followup_request"
         onClick={() => openNewDialog()}

--- a/static/js/components/followup_request/FollowupRequestLists.tsx
+++ b/static/js/components/followup_request/FollowupRequestLists.tsx
@@ -619,7 +619,7 @@ const FollowupRequestLists = ({
   const makeToolbar = () =>
     function FollowupRequestToolbar() {
       return (
-        <DataGridToolbar>
+        <DataGridToolbar showExport>
           {showDownload && (
             <Tooltip title="Download CSV">
               <IconButton

--- a/static/js/components/galaxy/GalaxyTable.tsx
+++ b/static/js/components/galaxy/GalaxyTable.tsx
@@ -89,7 +89,7 @@ const GalaxyTable = ({
     () =>
       function GalaxyTableToolbar() {
         return (
-          <DataGridToolbar showQuickFilter={false}>
+          <DataGridToolbar showQuickFilter={false} showExport>
             <Tooltip title="Filter Table">
               <IconButton
                 size="small"

--- a/static/js/components/instrument/InstrumentTable.tsx
+++ b/static/js/components/instrument/InstrumentTable.tsx
@@ -347,7 +347,7 @@ const InstrumentTable = ({
 
   const CustomToolbar = function InstrumentTableToolbar() {
     return (
-      <DataGridToolbar showQuickFilter={false}>
+      <DataGridToolbar showQuickFilter={false} showExport>
         <TextField
           variant="standard"
           size="small"

--- a/static/js/components/observation/QueuedObservationsTable.tsx
+++ b/static/js/components/observation/QueuedObservationsTable.tsx
@@ -297,7 +297,7 @@ const QueuedObservationsTable = ({
   };
 
   const CustomToolbar = () => (
-    <DataGridToolbar>
+    <DataGridToolbar showExport>
       <Tooltip title="Filter Table">
         <IconButton
           size="small"

--- a/static/js/components/observation_plan/DefaultObservationPlanTable.tsx
+++ b/static/js/components/observation_plan/DefaultObservationPlanTable.tsx
@@ -192,7 +192,7 @@ const DefaultObservationPlanTable = ({
   ];
 
   const CustomToolbar = () => (
-    <DataGridToolbar>
+    <DataGridToolbar showExport>
       <IconButton size="small" onClick={() => setNewDialogOpen(true)}>
         <AddIcon />
       </IconButton>

--- a/static/js/components/observing_run/RunSummary.tsx
+++ b/static/js/components/observing_run/RunSummary.tsx
@@ -532,7 +532,7 @@ const RunSummary = ({ route }: RunSummaryProps) => {
 
   function CustomToolbar() {
     return (
-      <DataGridToolbar showQuickFilter={false}>
+      <DataGridToolbar showQuickFilter={false} showExport>
         <IconButton name="clouds" onClick={() => setDialog(true)}>
           <CloudIcon />
         </IconButton>

--- a/static/js/components/photometry/PhotometryTable.tsx
+++ b/static/js/components/photometry/PhotometryTable.tsx
@@ -380,7 +380,7 @@ const PhotometryTable = ({
     () =>
       function PhotometryTableToolbar() {
         return (
-          <DataGridToolbar showQuickFilter>
+          <DataGridToolbar showQuickFilter showExport>
             <Button
               size="small"
               startIcon={<DownloadIcon />}

--- a/static/js/components/source/SourceTable.tsx
+++ b/static/js/components/source/SourceTable.tsx
@@ -1695,7 +1695,7 @@ const SourceTable = ({
     () =>
       function SourceTableToolbar() {
         return (
-          <DataGridToolbar showQuickFilter={false}>
+          <DataGridToolbar showQuickFilter={false} showExport>
             <Tooltip title="Filter Table">
               <IconButton
                 size="small"

--- a/static/js/components/survey_efficiency/DefaultSurveyEfficiencyTable.tsx
+++ b/static/js/components/survey_efficiency/DefaultSurveyEfficiencyTable.tsx
@@ -253,7 +253,7 @@ const DefaultSurveyEfficiencyTable = ({
   ];
 
   const CustomToolbar = () => (
-    <DataGridToolbar showQuickFilter={false}>
+    <DataGridToolbar showQuickFilter={false} showExport>
       <IconButton
         name="new_default_survey_efficiency"
         size="small"

--- a/static/js/components/taxonomy/TaxonomyTable.tsx
+++ b/static/js/components/taxonomy/TaxonomyTable.tsx
@@ -260,7 +260,7 @@ const TaxonomyTable = ({
 
   const CustomToolbar = function TaxonomyTableToolbar() {
     return (
-      <DataGridToolbar showQuickFilter={false}>
+      <DataGridToolbar showQuickFilter={false} showExport>
         <IconButton
           name="new_taxonomy"
           onClick={() => {

--- a/static/js/components/telescope/TelescopeTable.tsx
+++ b/static/js/components/telescope/TelescopeTable.tsx
@@ -270,7 +270,7 @@ const TelescopeTable = ({
     () =>
       function TelescopeTableToolbar() {
         return (
-          <DataGridToolbar>
+          <DataGridToolbar showExport>
             <IconButton
               name="new_telescope"
               onClick={() => setNewDialogOpen(true)}

--- a/static/js/components/user/UserInvitations.tsx
+++ b/static/js/components/user/UserInvitations.tsx
@@ -628,7 +628,7 @@ const UserInvitations = () => {
 
   const CustomToolbar = function UserInvitationsToolbar() {
     return (
-      <DataGridToolbar showQuickFilter={false}>
+      <DataGridToolbar showQuickFilter={false} showExport>
         <Tooltip title="Filter Table">
           <IconButton
             size="small"

--- a/static/js/components/user/UserManagement.tsx
+++ b/static/js/components/user/UserManagement.tsx
@@ -208,7 +208,7 @@ const UserManagement = () => {
     () =>
       function UserManagementToolbar() {
         return (
-          <DataGridToolbar showQuickFilter={false}>
+          <DataGridToolbar showQuickFilter={false} showExport>
             <Tooltip title="Filter Table">
               <IconButton
                 size="small"


### PR DESCRIPTION
Export used to be a default feature in mui-datatables which got deprecated. They got replaced by data grids in #6145 which do not have the export as a default feature. This PR aims to explicitly display the export button which got lost on the way.