### PR TITLE
Remove legacy peer deps flag as it doesn't exist for Bun

### DIFF
--- a/.github/workflows/test_api_and_frontend.yaml
+++ b/.github/workflows/test_api_and_frontend.yaml
@@ -137,8 +137,6 @@ jobs:
           createdb -h localhost -U skyportal skyportal_test
           psql -U skyportal -h localhost -c "GRANT ALL PRIVILEGES ON DATABASE skyportal_test TO skyportal;" skyportal_test
 
-          export NPM_CONFIG_LEGACY_PEER_DEPS="true"
-
           # Install dependencies, and initialize the database
           uv sync --inexact --group dev
 

--- a/.github/workflows/test_migrations.yaml
+++ b/.github/workflows/test_migrations.yaml
@@ -136,7 +136,6 @@ jobs:
         run: |
           export PYTHONPATH=$PYTHONPATH:$(pwd)
           # do not be so demanding of the npm packaging, needed until we get to mui 5
-          export NPM_CONFIG_LEGACY_PEER_DEPS="true"
           make dependencies
 
       - name: Save current Alembic head on main
@@ -193,8 +192,6 @@ jobs:
           createdb -h localhost -U skyportal skyportal_test
           psql -U skyportal -h localhost -c "GRANT ALL PRIVILEGES ON DATABASE skyportal_test TO skyportal;" skyportal_test
 
-          export NPM_CONFIG_LEGACY_PEER_DEPS="true"
-
           # The reference commit uses uv, so install its pinned dependencies
           # straight from its own uv.lock (reproducible; no manual pip pins).
           make dependencies
@@ -211,7 +208,6 @@ jobs:
 
       - name: Test loading demo data
         run: |
-          export NPM_CONFIG_LEGACY_PEER_DEPS="true"
           make run &
           sleep 180 && make load_demo_data
           # `kill %1` alone is racy — `make run` often backgrounds supervisord
@@ -271,7 +267,6 @@ jobs:
       - name: Run migration
         run: |
           # do not be so demanding of the npm packaging, needed until we get to mui 5
-          export NPM_CONFIG_LEGACY_PEER_DEPS="true"
           # Update to latest dependencies
           make dependencies
           PYTHONPATH=. .venv/bin/python -m alembic -x config=config.yaml upgrade head
@@ -312,7 +307,6 @@ jobs:
           createdb -h localhost -U skyportal skyportal2_test
           psql -U skyportal -h localhost -c "GRANT ALL PRIVILEGES ON DATABASE skyportal2_test TO skyportal;" skyportal2_test
 
-          export NPM_CONFIG_LEGACY_PEER_DEPS="true"
           make db_init
 
           make run &

--- a/.github/workflows/test_migrations.yaml
+++ b/.github/workflows/test_migrations.yaml
@@ -135,7 +135,6 @@ jobs:
       - name: Install SkyPortal dependencies
         run: |
           export PYTHONPATH=$PYTHONPATH:$(pwd)
-          # do not be so demanding of the npm packaging, needed until we get to mui 5
           make dependencies
 
       - name: Save current Alembic head on main
@@ -266,7 +265,6 @@ jobs:
 
       - name: Run migration
         run: |
-          # do not be so demanding of the npm packaging, needed until we get to mui 5
           # Update to latest dependencies
           make dependencies
           PYTHONPATH=. .venv/bin/python -m alembic -x config=config.yaml upgrade head

--- a/.github/workflows/test_models.yaml
+++ b/.github/workflows/test_models.yaml
@@ -136,7 +136,6 @@ jobs:
           createdb -h localhost -U skyportal skyportal_test
           psql -U skyportal -h localhost -c "GRANT ALL PRIVILEGES ON DATABASE skyportal_test TO skyportal;" skyportal_test
 
-          export NPM_CONFIG_LEGACY_PEER_DEPS="true"
           uv sync --inexact --group dev
           make db_init
 
@@ -145,7 +144,6 @@ jobs:
       - name: Refresh SkyPortal dependencies for tested version
         run: |
           export PYTHONPATH=$PYTHONPATH:$(pwd)
-          export NPM_CONFIG_LEGACY_PEER_DEPS="true"
           make dependencies
 
       # Lint the diff once (on shard 0), not once per shard.

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-legacy-peer-deps=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ ARG DEBIAN_FRONTEND=noninteractive
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 ENV NODE_MAJOR=20
-ENV NPM_CONFIG_LEGACY_PEER_DEPS=true
 ENV PATH="/root/.cargo/bin:${PATH}"
 # Point sncosmo at the vendored data in the skyportal-data submodule (baked in
 # by `ADD . /skyportal`). SNCOSMO_DATA_DIR takes precedence over the config's

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -298,7 +298,7 @@ If you have trouble running `make run` and see this error:
 make[1]: *** [dependencies] Error 1
 make: *** [run] Error 2
 ```
-You may need to run `npm install --legacy-peer-deps` and then try `make run` again.
+You may need to run `bun install` and then try `make run` again.
 
 ---
 

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -298,7 +298,7 @@ If you have trouble running `make run` and see this error:
 make[1]: *** [dependencies] Error 1
 make: *** [run] Error 2
 ```
-You may need to run `bun install` and then try `make run` again.
+You may need to run `bun install --frozen-lockfile` and then try `make run` again.
 
 ---
 


### PR DESCRIPTION
The legacy peer deps flag doesn't exist for Bun so it isn't needed after switching from npm to bun