### PR TITLE
make filters in requests appear

### DIFF
--- a/skyportal/facility_apis/blanco.py
+++ b/skyportal/facility_apis/blanco.py
@@ -142,6 +142,10 @@ class BLANCO_NEWFIRM_Request:
 class BLANCOAPI(FollowUpAPI):
     """An interface to BLANCO operations."""
 
+    alias_lookup = {
+        "observation_choices": "Request",
+    }
+
     @staticmethod
     def delete(request, session, **kwargs):
         """Delete a follow-up request from BLANCO queue.

--- a/skyportal/facility_apis/lco.py
+++ b/skyportal/facility_apis/lco.py
@@ -553,6 +553,10 @@ def download_observations(request_id, ar):
 class LCOAPI(FollowUpAPI):
     """An interface to LCO operations."""
 
+    alias_lookup = {
+        "observation_choices": "Request",
+    }
+
     @staticmethod
     def delete(request, session, **kwargs):
         """Delete a follow-up request from LCO queue (all instruments).

--- a/skyportal/facility_apis/lt.py
+++ b/skyportal/facility_apis/lt.py
@@ -352,6 +352,10 @@ class SPRATRequest(LTRequest):
 class LTAPI(FollowUpAPI):
     """An interface to LT operations."""
 
+    alias_lookup = {
+        "observation_choices": "Request",
+    }
+
     @staticmethod
     def delete(request, session, **kwargs):
         """Delete a follow-up request from LT queue (all instruments).

--- a/skyportal/facility_apis/soar.py
+++ b/skyportal/facility_apis/soar.py
@@ -392,6 +392,10 @@ class SOAR_TripleSpec_Request:
 class SOARAPI(FollowUpAPI):
     """An interface to SOAR operations."""
 
+    alias_lookup = {
+        "observation_choices": "Request",
+    }
+
     @staticmethod
     def delete(request, session, **kwargs):
         """Delete a follow-up request from SOAR queue (all instruments).

--- a/skyportal/facility_apis/trt.py
+++ b/skyportal/facility_apis/trt.py
@@ -156,6 +156,10 @@ def download_observations(request_id, urls):
 class TRTAPI(FollowUpAPI):
     """SkyPortal interface to the Thai Robotic Telescope"""
 
+    alias_lookup = {
+        "observation_choices": "Request",
+    }
+
     @staticmethod
     def submit(request, session, **kwargs):
         """Submit a follow-up request to TRT.

--- a/skyportal/facility_apis/ttt.py
+++ b/skyportal/facility_apis/ttt.py
@@ -120,6 +120,10 @@ def validate_request_to_ttt(request, proposal_id):
 class TTTAPI(FollowUpAPI):
     """SkyPortal interface to the Two-meter Twin Telescope"""
 
+    alias_lookup = {
+        "observation_choices": "Request",
+    }
+
     @staticmethod
     def submit(request, session, **kwargs):
         """Submit a follow-up request to TTT.

--- a/skyportal/tests/external/test_followup_requests.py
+++ b/skyportal/tests/external/test_followup_requests.py
@@ -721,7 +721,9 @@ def add_followup_request_using_frontend_and_verify_Spectral(
         ).first
     ).to_be_visible()
 
-    show_followup_columns(page, instrument_id, "exposure_time", "observation_choices")
+    # observation_choices is aliased to the "Request" column, which is shown by
+    # default, so only the hidden exposure_time column needs revealing.
+    show_followup_columns(page, instrument_id, "exposure_time")
 
     expect(
         page.locator(
@@ -785,7 +787,9 @@ def add_followup_request_using_frontend_and_verify_Sinistro(
         ).first
     ).to_be_visible()
 
-    show_followup_columns(page, instrument_id, "exposure_time", "observation_choices")
+    # observation_choices is aliased to the "Request" column, which is shown by
+    # default, so only the hidden exposure_time column needs revealing.
+    show_followup_columns(page, instrument_id, "exposure_time")
 
     expect(
         page.locator(

--- a/static/js/components/followup_request/FollowupRequestLists.tsx
+++ b/static/js/components/followup_request/FollowupRequestLists.tsx
@@ -53,6 +53,9 @@ const displayedColumns = [
   "request",
   "filter",
   "filters",
+  // Filter/band keys for instruments that don't alias them (e.g. TTT, LCO, LT)
+  "observation_choice",
+  "observation_choices",
   "field_ids",
   "priority",
   "status",


### PR DESCRIPTION
This PR ensures the filters in an instrument request actually appear on the front-end.