### PR TITLE
make target name visible when downloading run summary

### DIFF
--- a/static/js/components/observing_run/RunSummary.tsx
+++ b/static/js/components/observing_run/RunSummary.tsx
@@ -316,6 +316,7 @@ const RunSummary = ({ route }: RunSummaryProps) => {
       headerName: "Target Name",
       flex: 1,
       minWidth: 120,
+      valueGetter: (_value: any, row: any) => row.obj?.id,
       renderCell: (params: any) => {
         const objid = params.row.obj?.id;
         return (


### PR DESCRIPTION
Target name was not properly downloaded in the run summary csv