### PR TITLE
photometry id -> bigint

### DIFF
--- a/alembic/versions/52b02a40ac4d_photometry_bigint_id.py
+++ b/alembic/versions/52b02a40ac4d_photometry_bigint_id.py
@@ -1,0 +1,68 @@
+"""photometry bigint id
+
+Widen photometry.id, its sequence, and the four inbound FK columns from int4
+to bigint to avoid sequence overflow.
+
+Revision ID: 52b02a40ac4d
+Revises: 363f77c7a441
+Create Date: 2026-07-14
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "52b02a40ac4d"
+down_revision = "363f77c7a441"
+branch_labels = None
+depends_on = None
+
+# (table, column) pairs for the inbound FKs referencing photometry.id.
+FK_COLUMNS = [
+    ("annotations_on_photometry", "photometry_id"),
+    ("photometryvalidations", "photometry_id"),
+    ("group_photometry", "photometr_id"),
+    ("stream_photometry", "photometr_id"),
+]
+
+
+def upgrade():
+    op.execute("ALTER SEQUENCE photometry_id_seq AS bigint")
+    op.alter_column(
+        "photometry",
+        "id",
+        existing_type=sa.Integer(),
+        type_=sa.BigInteger(),
+        existing_nullable=False,
+        autoincrement=True,
+    )
+    for table, column in FK_COLUMNS:
+        op.alter_column(
+            table,
+            column,
+            existing_type=sa.Integer(),
+            type_=sa.BigInteger(),
+            existing_nullable=False,
+        )
+
+
+def downgrade():
+    for table, column in FK_COLUMNS:
+        op.alter_column(
+            table,
+            column,
+            existing_type=sa.BigInteger(),
+            type_=sa.Integer(),
+            existing_nullable=False,
+        )
+    op.alter_column(
+        "photometry",
+        "id",
+        existing_type=sa.BigInteger(),
+        type_=sa.Integer(),
+        existing_nullable=False,
+        autoincrement=True,
+    )
+    op.execute("ALTER SEQUENCE photometry_id_seq AS integer")

--- a/skyportal/models/photometry.py
+++ b/skyportal/models/photometry.py
@@ -61,6 +61,15 @@ class Photometry(conesearch_alchemy.Point, Base):
 
     __tablename__ = "photometry"
 
+    # bigint PK. Inbound FKs use bare ForeignKey("photometry.id") so they infer
+    # bigint too.
+    id = sa.Column(
+        sa.BigInteger,
+        primary_key=True,
+        autoincrement=True,
+        doc="Unique object identifier.",
+    )
+
     # created_at is never queried on this 1B-row table; skip the dead index.
     index_created_at = False
 

--- a/static/js/types/api.ts
+++ b/static/js/types/api.ts
@@ -32420,6 +32420,8 @@ export interface components {
             readonly owner?: components["schemas"]["User"];
             readonly annotations?: components["schemas"]["AnnotationOnPhotometry"][];
             readonly validations?: components["schemas"]["PhotometryValidation"][];
+            /** @description Unique object identifier. */
+            id?: number;
             /** @description MJD of the observation. */
             mjd: number;
             /** @description Flux of the observation in µJy. Corresponds to an AB Zeropoint of 23.9 in all filters. */
@@ -32461,8 +32463,6 @@ export interface components {
             owner_id: number;
             ra?: number | null;
             dec?: number | null;
-            /** @description Unique object identifier. */
-            id?: number;
         };
         SinglePhotometry: {
             /** @enum {string} */


### PR DESCRIPTION
This PR moves the photometry table IDs to bigint (important as our photometry tables have passed a billion rows).