### PR TITLE
Fix stream check issue

### DIFF
--- a/skyportal/handlers/api/group_admission_request.py
+++ b/skyportal/handlers/api/group_admission_request.py
@@ -204,11 +204,14 @@ class GroupAdmissionRequestHandler(BaseHandler):
                     f"User {user_id} is already a member of group {group_id}"
                 )
             # Ensure user has sufficient stream access for target group
-            if group.streams:
+            if group.streams and "System admin" not in requesting_user.permissions:
+                accessible_stream_ids = {
+                    stream.id for stream in requesting_user.streams
+                }
                 missing_streams = [
                     stream
                     for stream in group.streams
-                    if stream not in requesting_user.accessible_streams
+                    if stream.id not in accessible_stream_ids
                 ]
                 if missing_streams:
                     stream_names = ", ".join(


### PR DESCRIPTION
Compare `stream.id` with `accessible_stream_ids` instead of comparing the `stream` object with `requesting_user.accessible_streams`. Since the async endpoints were introduced, the objects can come from different database sessions, so the object comparison is always false.