### PR TITLE
Use Python builtin logger?

### DIFF
--- a/services/facility_queue/facility_queue.py
+++ b/services/facility_queue/facility_queue.py
@@ -11,7 +11,7 @@ from requests.auth import HTTPBasicAuth
 
 from baselayer.app.env import load_env
 from baselayer.app.models import init_db
-from baselayer.log import make_log
+from skyportal.log import make_log
 from skyportal.models import (
     DBSession,
     FacilityTransactionRequest,
@@ -81,7 +81,7 @@ def service():
                     if followup_request is not None:
                         queue.append(req.id)
         except Exception as e:
-            log(f"Error retrieving requests to process: {e}")
+            log.error(f"Error retrieving requests to process: {e}")
             time.sleep(15)
             continue
 
@@ -93,7 +93,7 @@ def service():
 
         for req_id in queue:
             if req_id is None:
-                log("No request ID found in queue. Continuing to next request.")
+                log.info("No request ID found in queue. Continuing to next request.")
                 continue
 
             time.sleep(5)
@@ -105,17 +105,19 @@ def service():
                         )
                     ).first()
                     if req is None:
-                        log(f"Facility transaction request {req_id} not found.")
+                        log.info(f"Facility transaction request {req_id} not found.")
                         continue
 
-                    log(f"Executing request {req.id}")
+                    log.info(f"Executing request {req.id}")
                     followup_request = session.scalars(
                         sa.select(FollowupRequest).where(
                             FollowupRequest.id == req.followup_request_id
                         )
                     ).first()
                     if followup_request is None:
-                        log(f"Follow-up request {req.followup_request_id} not found.")
+                        log.info(
+                            f"Follow-up request {req.followup_request_id} not found."
+                        )
                         continue
                     instrument = followup_request.allocation.instrument
                     altdata = followup_request.allocation.altdata
@@ -155,10 +157,10 @@ def service():
                                     req.status = "complete"
                                     session.add(req)
                                     session.commit()
-                                    log(f"Job with ID {req.id} completed")
+                                    log.info(f"Job with ID {req.id} completed")
                                     continue
                                 except Exception as e:
-                                    log(f"Error committing photometry: {str(e)}")
+                                    log.error(f"Error committing photometry: {str(e)}")
                                     status = f"error: {str(e)}"
                                     if followup_request.status != status:
                                         followup_request.status = status
@@ -169,7 +171,7 @@ def service():
                                     continue
 
                             elif json_response["starttimestamp"]:
-                                log(
+                                log.info(
                                     f"Job {req.id}: running (started at {json_response['starttimestamp']})"
                                 )
                                 status = f"Job is running (started at {json_response['starttimestamp']})"
@@ -179,7 +181,7 @@ def service():
                                 req.last_query = utcnow_naive()
                                 session.add(req)
                                 session.commit()
-                                log(f"Job {req.id}: {status}")
+                                log.info(f"Job {req.id}: {status}")
                             else:
                                 status = f"Waiting for job to start (queued at {json_response['timestamp']})"
                                 if followup_request.status != status:
@@ -188,7 +190,7 @@ def service():
                                 req.last_query = utcnow_naive()
                                 session.add(req)
                                 session.commit()
-                                log(f"Job {req.id}: {status}")
+                                log.info(f"Job {req.id}: {status}")
                         else:
                             status = f"error: {response.content}"
                             if followup_request.status != status:
@@ -197,7 +199,7 @@ def service():
                             req.last_query = utcnow_naive()
                             session.add(req)
                             session.commit()
-                            log(f"Job {req.id}: {status}")
+                            log.info(f"Job {req.id}: {status}")
 
                     elif instrument.name == "ZTF":
                         from skyportal.facility_apis.ztf import commit_photometry
@@ -216,7 +218,7 @@ def service():
                         )
 
                         if "Zero records returned" in str(response.text):
-                            log(
+                            log.info(
                                 "Found no records yet for this ZTF forced photometry account."
                             )
                             continue
@@ -235,7 +237,7 @@ def service():
                                 req.last_query = utcnow_naive()
                                 session.add(req)
                                 session.commit()
-                                log(f"Job {req.id}: {status}")
+                                log.info(f"Job {req.id}: {status}")
                                 continue
 
                             index_match = None
@@ -264,7 +266,7 @@ def service():
                                 req.last_query = utcnow_naive()
                                 session.add(req)
                                 session.commit()
-                                log(f"Job {req.id}: {status}")
+                                log.info(f"Job {req.id}: {status}")
                                 continue
 
                             lightcurve = row["lightcurve"]
@@ -280,7 +282,7 @@ def service():
                                 req.status = "complete"
                                 session.add(req)
                                 session.commit()
-                                log(
+                                log.info(
                                     f"Job with ID {req.id} has no forced photometry: {exitcode_text}"
                                 )
                             else:
@@ -298,7 +300,7 @@ def service():
                                     req.status = "complete"
                                     session.add(req)
                                     session.commit()
-                                    log(f"Job with ID {req.id} completed")
+                                    log.info(f"Job with ID {req.id} completed")
                                 except Exception as e:
                                     if "Failed to commit photometry" in str(e):
                                         status = f"error: {str(e)}"
@@ -310,7 +312,7 @@ def service():
                                     req.last_query = utcnow_naive()
                                     session.add(req)
                                     session.commit()
-                                    log(f"Job {req.id}: {status}")
+                                    log.info(f"Job {req.id}: {status}")
                         elif (
                             "Error: database is busy; try again a minute later."
                             in str(response.content)
@@ -322,7 +324,7 @@ def service():
                             req.last_query = utcnow_naive()
                             session.add(req)
                             session.commit()
-                            log(f"Job {req.id}: {status}")
+                            log.info(f"Job {req.id}: {status}")
                         else:
                             status = f"error: {response.content}"
                             if followup_request.status != status:
@@ -331,12 +333,12 @@ def service():
                             req.last_query = utcnow_naive()
                             session.add(req)
                             session.commit()
-                            log(f"Job {req.id}: {status}")
+                            log.info(f"Job {req.id}: {status}")
                     else:
-                        log(f"Job {req.id}: API for {instrument.name} unknown")
+                        log.info(f"Job {req.id}: API for {instrument.name} unknown")
 
                 except Exception as e:
-                    log(f"Error processing follow-up request {req_id}: {str(e)}")
+                    log.error(f"Error processing follow-up request {req_id}: {str(e)}")
                     try:
                         session.rollback()
                     except Exception:
@@ -347,5 +349,5 @@ if __name__ == "__main__":
     try:
         service()
     except Exception as e:
-        log(f"Error occurred in service: {e}")
+        log.error(f"Error occurred in service: {e}")
         raise e

--- a/services/gcn_service/gcn_service.py
+++ b/services/gcn_service/gcn_service.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 import os
-import traceback
 import uuid
 
 import lxml
@@ -271,9 +270,8 @@ def poll_events(*args, **kwargs):
                                     notify=False,
                                 )
                         except Exception as e:
-                            traceback.print_exc()
-                            log.error(
-                                f"Failed to ingest gcn_event from {message.topic()}: {e}"
+                            log.exception(
+                                f"Failed to ingest gcn_event from {message.topic()}"
                             )
                             return
 
@@ -331,8 +329,7 @@ def poll_events(*args, **kwargs):
                 asyncio.run(_ingest())
 
         except Exception as e:
-            traceback.print_exc()
-            log.error(f"Failed to consume gcn event: {e}")
+            log.exception("Failed to consume gcn event")
 
 
 def service():

--- a/services/gcn_service/gcn_service.py
+++ b/services/gcn_service/gcn_service.py
@@ -12,7 +12,6 @@ from gcn_kafka import Consumer
 from baselayer.app import models
 from baselayer.app.env import load_env
 from baselayer.app.models import init_db
-from baselayer.log import make_log
 from skyportal.handlers.api.gcn import (
     get_json_tags,
     get_tags,
@@ -20,6 +19,7 @@ from skyportal.handlers.api.gcn import (
     post_gcnevent_from_xml,
     post_skymap_from_notice,
 )
+from skyportal.log import make_log
 from skyportal.models import GcnEvent, User
 from skyportal.utils.gcn import (
     from_igwn_gwalert,
@@ -65,10 +65,12 @@ def get_root_from_payload(payload):
 
 def is_configured():
     if client_id is None or client_id == "":
-        log("No client_id configured to poll gcn events (config: gcn.client_id")
+        log.info("No client_id configured to poll gcn events (config: gcn.client_id")
         return False
     if client_secret is None or client_secret == "":
-        log("No client_secret configured to poll gcn events (config: gcn.client_secret")
+        log.info(
+            "No client_secret configured to poll gcn events (config: gcn.client_secret"
+        )
         return False
     if (
         voevent_notice_types is None
@@ -77,7 +79,7 @@ def is_configured():
     ) and (
         json_notice_types is None or json_notice_types == "" or json_notice_types == []
     ):
-        log(
+        log.info(
             "No notice_types configured to poll gcn events (config: gcn.notice_types and/or gcn.json_notice_types)"
         )
         return False
@@ -103,12 +105,12 @@ def poll_events(*args, **kwargs):
             domain=cfg["gcn.server"],
         )
     except Exception as e:
-        log(f"Failed to initiate consumer to poll gcn events: {e}")
+        log.error(f"Failed to initiate consumer to poll gcn events: {e}")
         return
     try:
         consumer.subscribe(voevent_notice_types + json_notice_types)
     except Exception as e:
-        log(f"Failed to subscribe to gcn events: {e}")
+        log.error(f"Failed to subscribe to gcn events: {e}")
         return
     while True:
         try:
@@ -148,13 +150,13 @@ def poll_events(*args, **kwargs):
                             "./WhereWhen/ObsDataLocation/ObservationLocation"
                         )
                         if loc is None:
-                            log(
+                            log.info(
                                 f"Rejecting gcn_event from {topic} due to missing location"
                             )
                             continue
                         error = loc.find("./AstroCoords/Position2D/Error2Radius")
                         if error is None:
-                            log(
+                            log.info(
                                 f"Rejecting gcn_event from {topic} due to missing error"
                             )
                             continue
@@ -163,7 +165,7 @@ def poll_events(*args, **kwargs):
                             if error < 0:
                                 raise ValueError("error is negative")
                         except ValueError:
-                            log(
+                            log.info(
                                 f"Rejecting gcn_event from {topic} due to invalid error: {error}"
                             )
                             continue
@@ -187,14 +189,14 @@ def poll_events(*args, **kwargs):
                             not isinstance(pval_bayesian, int | float)
                             or pval_bayesian > 0.05
                         ):
-                            log(
+                            log.info(
                                 f"Rejecting gcn_event from {topic} due to pval_bayesian: {pval_bayesian}"
                             )
                             continue
 
                 tags_intersection = list(set(tags).intersection(set(reject_tags)))
                 if len(tags_intersection) > 0:
-                    log(
+                    log.info(
                         f"Rejecting gcn_event from {topic} due to tag(s): {tags_intersection}"
                     )
                     continue
@@ -207,7 +209,7 @@ def poll_events(*args, **kwargs):
                             sa.select(User).where(User.id == user_id)
                         )
                         if user is None:
-                            log(
+                            log.info(
                                 f"User {user_id} not found in DB, cannot ingest gcn_event"
                             )
                             return
@@ -233,13 +235,13 @@ def poll_events(*args, **kwargs):
                                     )
                                 )
                             if existing_event is None:
-                                log(
+                                log.info(
                                     f"No event found to retract for gcn_event from {message.topic()}, skipping"
                                 )
                                 return
 
                         # event ingestion
-                        log(f"Ingesting gcn_event from {message.topic()}")
+                        log.info(f"Ingesting gcn_event from {message.topic()}")
                         try:
                             if alert_type == "voevent":
                                 (
@@ -270,7 +272,7 @@ def poll_events(*args, **kwargs):
                                 )
                         except Exception as e:
                             traceback.print_exc()
-                            log(
+                            log.error(
                                 f"Failed to ingest gcn_event from {message.topic()}: {e}"
                             )
                             return
@@ -287,7 +289,7 @@ def poll_events(*args, **kwargs):
                             )
 
                         if status in ["available", "cone", "healpix_file"]:
-                            log(
+                            log.info(
                                 f"Ingesting skymap for gcn_event: {dateobs}, notice_id: {notice_id}"
                             )
                             try:
@@ -307,15 +309,15 @@ def poll_events(*args, **kwargs):
                                     request_body, timeout=30
                                 )
                             except Exception as e:
-                                log(
+                                log.error(
                                     f"Failed to ingest skymap for gcn_event: {dateobs}, notice_id: {notice_id}: {e}"
                                 )
                         elif status == "unavailable":
-                            log(
+                            log.info(
                                 f"No skymap available for gcn_event: {dateobs}, notice_id: {notice_id} with url: {metadata.get('url', None)}"
                             )
                         else:
-                            log(
+                            log.info(
                                 f"No skymap available for gcn_event: {dateobs}, notice_id: {notice_id}"
                             )
 
@@ -330,7 +332,7 @@ def poll_events(*args, **kwargs):
 
         except Exception as e:
             traceback.print_exc()
-            log(f"Failed to consume gcn event: {e}")
+            log.error(f"Failed to consume gcn event: {e}")
 
 
 def service():
@@ -340,11 +342,11 @@ def service():
         try:
             poll_events()
         except Exception as e:
-            log(e)
+            log.info(e)
 
 
 if __name__ == "__main__":
     try:
         service()
     except Exception as e:
-        log(f"Error: {e}")
+        log.error(f"Error: {e}")

--- a/services/health_monitor/health_monitor.py
+++ b/services/health_monitor/health_monitor.py
@@ -4,7 +4,7 @@ import time
 import requests
 
 from baselayer.app.env import load_env
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 env, cfg = load_env()
 log = make_log("health")
@@ -72,12 +72,12 @@ def restart_app(app_nr):
     try:
         subprocess.run(supervisorctl + cmd, check=True)
     except subprocess.CalledProcessError as e:
-        log(f"Failure calling supervisorctl; could not restart app {app_nr}")
-        log(f"Exception: {e}")
+        log.info(f"Failure calling supervisorctl; could not restart app {app_nr}")
+        log.info(f"Exception: {e}")
 
 
 if __name__ == "__main__":
-    log(
+    log.info(
         f"Monitoring system health [{SECONDS_BETWEEN_CHECKS}s interval, max downtime {ALLOWED_DOWNTIME_SECONDS}s, max times down {ALLOWED_TIMES_DOWN}]"
     )
 
@@ -86,7 +86,7 @@ if __name__ == "__main__":
     downtimes = {}
 
     while not migrated():
-        log("Database not migrated; waiting")
+        log.info("Database not migrated; waiting")
         time.sleep(30)
 
     while True:
@@ -99,11 +99,11 @@ if __name__ == "__main__":
         up = all_backends - down
         newly_seen = up - backends_seen
         if newly_seen:
-            log(f"New healthy app(s) {newly_seen}")
+            log.info(f"New healthy app(s) {newly_seen}")
 
         recovered = set(downtimes) & up
         if recovered:
-            log(f"App(s) recovered: {recovered}")
+            log.info(f"App(s) recovered: {recovered}")
 
         backends_seen = backends_seen | newly_seen
 
@@ -118,11 +118,11 @@ if __name__ == "__main__":
             if downtime > ALLOWED_DOWNTIME_SECONDS:
                 message = f"App {app} unresponsive {times_down} times, total of {downtime:.1f}s"
                 if times_down >= ALLOWED_TIMES_DOWN:
-                    log(f"{message}: restarting")
+                    log.info(f"{message}: restarting")
                     # Give app a few second head start to fire up
                     downtimes[app] = DownStatus(
                         nr_times=0, timestamp=time.time() + STARTUP_GRACE_SECONDS
                     )
                     restart_app(app)
                 else:
-                    log(message)
+                    log.info(message)

--- a/services/hermes_skyportal_sync/hermes_skyportal_sync.py
+++ b/services/hermes_skyportal_sync/hermes_skyportal_sync.py
@@ -7,7 +7,6 @@ and synchronizes it with SkyPortal by creating sources and uploading photometry.
 
 import json
 import time
-import traceback
 import uuid
 from collections import Counter, defaultdict
 from datetime import UTC, datetime, timedelta
@@ -439,8 +438,7 @@ class SourceProcessor:
             log_verbose.info(f"    ✓ Successfully synced {obj_id}")
 
         except Exception as e:
-            log.info(f"    ✗ Error syncing {obj_id} with SkyPortal: {e}")
-            traceback.print_exc()
+            log.exception(f"    ✗ Error syncing {obj_id} with SkyPortal")
             session.rollback()
 
 
@@ -570,13 +568,11 @@ class HermesSyncService:
                 try:
                     self.processor.process_message(session, data)
                 except Exception as e:
-                    log.error(f"Error processing message: {e}")
-                    traceback.print_exc()
+                    log.exception("Error processing message")
                     session.rollback()
 
         except Exception as e:
-            log.error(f"Error in Kafka message handler: {e}")
-            traceback.print_exc()
+            log.exception("Error in Kafka message handler")
 
     def _cleanup(self) -> None:
         """Clean up resources."""

--- a/services/hermes_skyportal_sync/hermes_skyportal_sync.py
+++ b/services/hermes_skyportal_sync/hermes_skyportal_sync.py
@@ -19,8 +19,8 @@ from confluent_kafka import Consumer
 
 from baselayer.app.env import load_env
 from baselayer.app.models import init_db, session_context_id
-from baselayer.log import make_log
 from skyportal.handlers.api.photometry import nan_to_none
+from skyportal.log import make_log
 from skyportal.models import (
     DBSession,
     Group,
@@ -61,7 +61,7 @@ def create_or_get_obj(session, obj_id: str, ra: float, dec: float):
     if obj is None:
         obj = Obj(id=obj_id, ra=ra, dec=dec)
         session.add(obj)
-        log(f"Created new Obj: {obj_id}")
+        log.info(f"Created new Obj: {obj_id}")
 
 
 def build_instrument_mapping(session, tns_ids: list[int]):
@@ -134,7 +134,7 @@ def create_source(session, obj_id: str, group_ids: list[int], user_id: int):
             )
             session.add(source)
             sources_created += 1
-            log(f"Created Source for {obj_id} in group {group_id}")
+            log.info(f"Created Source for {obj_id} in group {group_id}")
 
     if sources_created > 0:
         session.flush()
@@ -291,7 +291,7 @@ class SourceProcessor:
             Kafka message data
         """
         title = data.get("title", "No title")
-        log_verbose(f"Processing message: {title}")
+        log_verbose.info(f"Processing message: {title}")
 
         targets = data.get("data", {}).get("targets", [])
         photometry = data.get("data", {}).get("photometry", [])
@@ -317,9 +317,9 @@ class SourceProcessor:
         ra = target.get("ra")
         dec = target.get("dec")
 
-        log_verbose(f"  Target: {name}")
-        log_verbose(f"    RA: {ra}")
-        log_verbose(f"    Dec: {dec}")
+        log_verbose.info(f"  Target: {name}")
+        log_verbose.info(f"    RA: {ra}")
+        log_verbose.info(f"    Dec: {dec}")
 
         target_photometry = [p for p in photometry if p.get("target_name") == name]
 
@@ -330,9 +330,9 @@ class SourceProcessor:
             )
 
             for inst_key, count in sorted(instrument_counts.items()):
-                log_verbose(f"      {inst_key}: {count} points")
+                log_verbose.info(f"      {inst_key}: {count} points")
         else:
-            log_verbose("    No photometry data for this target")
+            log_verbose.info("    No photometry data for this target")
 
         self._sync_with_skyportal(session, name, target, target_photometry)
 
@@ -366,7 +366,9 @@ class SourceProcessor:
                     not self.instrument_name_mapping
                     and not self.instrument_tns_id_mapping
                 ):
-                    log_verbose("    ✗ No instruments configured, skipping photometry")
+                    log_verbose.info(
+                        "    ✗ No instruments configured, skipping photometry"
+                    )
                     return
 
                 # Group photometry by resolved instrument_id
@@ -410,10 +412,10 @@ class SourceProcessor:
                         unresolved_instruments[key] += 1
 
                 for tns_id, count in matched_by_tns_id.items():
-                    log_verbose(f"    Matched {count} points by TNS ID {tns_id}")
+                    log_verbose.info(f"    Matched {count} points by TNS ID {tns_id}")
 
                 for key, count in unresolved_instruments.items():
-                    log_verbose(
+                    log_verbose.info(
                         f"    ✗ Instrument '{key}' not in configured instruments, skipping {count} points"
                     )
 
@@ -429,15 +431,15 @@ class SourceProcessor:
 
                     skipped_count = len(inst_phot) - added_count - duplicate_count
                     inst_name = inst_phot[0].get("instrument", instrument_id)
-                    log_verbose(
+                    log_verbose.info(
                         f"    → {inst_name}: {added_count} added, {duplicate_count} duplicates skipped, {skipped_count} invalid/skipped"
                     )
 
             session.commit()
-            log_verbose(f"    ✓ Successfully synced {obj_id}")
+            log_verbose.info(f"    ✓ Successfully synced {obj_id}")
 
         except Exception as e:
-            log(f"    ✗ Error syncing {obj_id} with SkyPortal: {e}")
+            log.info(f"    ✗ Error syncing {obj_id} with SkyPortal: {e}")
             traceback.print_exc()
             session.rollback()
 
@@ -476,7 +478,7 @@ class HermesSyncService:
         instrument_names = (
             list(instrument_name_mapping.keys()) if instrument_name_mapping else []
         )
-        log_verbose(
+        log_verbose.info(
             f"Initialized Hermes sync service with bot_user_id={bot_user_id}, "
             f"group_ids={group_ids}, instruments={instrument_names}"
         )
@@ -511,15 +513,15 @@ class HermesSyncService:
 
     def run(self) -> None:
         """Main monitoring loop."""
-        log("Starting Hermes SkyPortal Synchronization Service")
-        log_verbose(f"Username: {self.username}")
-        log_verbose(f"Read from start: {self.from_start}")
-        log_verbose(f"Max age (days): {self.max_age_days}")
+        log.info("Starting Hermes SkyPortal Synchronization Service")
+        log_verbose.info(f"Username: {self.username}")
+        log_verbose.info(f"Read from start: {self.from_start}")
+        log_verbose.info(f"Max age (days): {self.max_age_days}")
 
         self.consumer = self.build_consumer()
         self.consumer.subscribe([self.topic])
-        log_verbose(f"Subscribed to {self.topic}")
-        log("Waiting for messages...")
+        log_verbose.info(f"Subscribed to {self.topic}")
+        log.info("Waiting for messages...")
 
         try:
             while True:
@@ -529,12 +531,12 @@ class HermesSyncService:
                     continue
 
                 if msg.error():
-                    log(f"Kafka error: {msg.error()}")
+                    log.info(f"Kafka error: {msg.error()}")
                     continue
 
                 ts = msg.timestamp()[1]
                 if ts > 0 and self.is_too_old(ts):
-                    log_verbose(f"Skipping old message (offset {msg.offset()})")
+                    log_verbose.info(f"Skipping old message (offset {msg.offset()})")
                     continue
 
                 self._process_kafka_message(msg)
@@ -548,19 +550,19 @@ class HermesSyncService:
             ts = msg.timestamp()[1]
             if ts > 0:
                 msg_timestamp = datetime.fromtimestamp(ts / 1000, tz=UTC)
-                log_verbose("=" * 60)
-                log_verbose(f"Message timestamp: {msg_timestamp.isoformat()}")
+                log_verbose.info("=" * 60)
+                log_verbose.info(f"Message timestamp: {msg_timestamp.isoformat()}")
 
             payload = msg.value()
             if not payload:
-                log_verbose("Empty payload received")
+                log_verbose.info("Empty payload received")
                 return
 
             try:
                 data = json.loads(payload)
             except json.JSONDecodeError as e:
-                log(f"JSON parse error: {e}")
-                log(f"Raw payload: {payload[:200]}...")
+                log.info(f"JSON parse error: {e}")
+                log.info(f"Raw payload: {payload[:200]}...")
                 return
 
             session_context_id.set(uuid.uuid4().hex)
@@ -568,19 +570,19 @@ class HermesSyncService:
                 try:
                     self.processor.process_message(session, data)
                 except Exception as e:
-                    log(f"Error processing message: {e}")
+                    log.error(f"Error processing message: {e}")
                     traceback.print_exc()
                     session.rollback()
 
         except Exception as e:
-            log(f"Error in Kafka message handler: {e}")
+            log.error(f"Error in Kafka message handler: {e}")
             traceback.print_exc()
 
     def _cleanup(self) -> None:
         """Clean up resources."""
         if self.consumer:
             self.consumer.close()
-            log("Hermes sync service stopped")
+            log.info("Hermes sync service stopped")
 
 
 @check_loaded(logger=log)
@@ -613,7 +615,7 @@ def service(*args, **kwargs):
 
     missing = [name for name, value in required_configs.items() if not value]
     if missing:
-        log(
+        log.info(
             f"Missing required configuration: {', '.join(missing)}. "
             "Please configure these values in config.yaml"
         )
@@ -623,11 +625,11 @@ def service(*args, **kwargs):
     with DBSession() as session:
         bot_user = session.scalar(sa.select(User).where(User.id == bot_user_id))
         if bot_user is None:
-            log(
+            log.info(
                 f"Bot user with ID {bot_user_id} not found. Please create a bot user or configure 'bot_user_id' in config.yaml"
             )
             return
-        log(f"Using bot user: {bot_user.username} (ID: {bot_user_id})")
+        log.info(f"Using bot user: {bot_user.username} (ID: {bot_user_id})")
 
         # Build instrument mapping from TNS IDs
         if instrument_tns_ids:
@@ -636,22 +638,22 @@ def service(*args, **kwargs):
             )
 
             if missing_tns_ids:
-                log(
+                log.warning(
                     f"Warning: Instruments with TNS IDs {missing_tns_ids} not found in database. "
                 )
 
             if instrument_name_mapping:
-                log_verbose(
+                log_verbose.info(
                     f"Configured instruments: {list(instrument_name_mapping.keys())}"
                 )
             else:
-                log(
+                log.warning(
                     "Warning: No instruments found for configured TNS IDs. Photometry will be skipped."
                 )
         else:
             instrument_name_mapping = {}
             instrument_tns_id_mapping = {}
-            log(
+            log.warning(
                 "Warning: No instrument_tns_ids configured. Photometry will be skipped. "
                 "Please configure 'app.hermes.sync.instrument_tns_ids' in config.yaml"
             )
@@ -676,5 +678,5 @@ if __name__ == "__main__":
     try:
         service()
     except Exception as e:
-        log(f"Error starting Hermes sync service: {str(e)}")
+        log.error(f"Error starting Hermes sync service: {str(e)}")
         raise e

--- a/services/ngsf_analysis_service/app.py
+++ b/services/ngsf_analysis_service/app.py
@@ -6,7 +6,6 @@ import json
 import os
 import subprocess
 import tempfile
-import traceback
 import uuid
 import zipfile
 
@@ -240,8 +239,7 @@ def run_ngsf_model(data_dict):
         )
 
     except Exception as e:
-        log.info(f"Exception while running the model: {e}")
-        log.error(f"{traceback.format_exc()}")
+        log.exception("Exception while running the model")
         log.info(f"Data: {data}")
         rez.update({"status": "failure", "message": f"problem running the model {e}"})
     finally:
@@ -274,9 +272,8 @@ class MainHandler(tornado.web.RequestHandler):
         """
         try:
             data_dict = tornado.escape.json_decode(self.request.body)
-        except json.decoder.JSONDecodeError:
-            err = traceback.format_exc()
-            log.info(f"JSON decode error: {err}")
+        except json.decoder.JSONDecodeError as e:
+            log.info(f"JSON decode error: {e}")
             return self.error(400, "Invalid JSON")
 
         required_keys = ["inputs", "callback_url", "callback_method"]

--- a/services/ngsf_analysis_service/app.py
+++ b/services/ngsf_analysis_service/app.py
@@ -22,7 +22,7 @@ from astropy.table import Table
 from tornado.ioloop import IOLoop
 
 from baselayer.app.env import load_env
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 _, cfg = load_env()
 log = make_log("ngsf_analysis_service")
@@ -40,9 +40,9 @@ def upload_analysis_results(results, data_dict, request_timeout=60):
     Upload the results to the webhook.
     """
 
-    log("Uploading results to webhook")
+    log.info("Uploading results to webhook")
     if data_dict["callback_method"] != "POST":
-        log("Callback URL is not a POST URL. Skipping.")
+        log.info("Callback URL is not a POST URL. Skipping.")
         return
     url = data_dict["callback_url"]
     try:
@@ -56,9 +56,9 @@ def upload_analysis_results(results, data_dict, request_timeout=60):
         # we cannot write back to the SkyPortal instance.
         # So returning something doesn't make sense in this case.
         # Just log it and move on...
-        log("Callback URL timedout. Skipping.")
+        log.info("Callback URL timedout. Skipping.")
     except Exception as e:
-        log(f"Callback exception {e}.")
+        log.info(f"Callback exception {e}.")
 
 
 def run_ngsf_model(data_dict):
@@ -240,9 +240,9 @@ def run_ngsf_model(data_dict):
         )
 
     except Exception as e:
-        log(f"Exception while running the model: {e}")
-        log(f"{traceback.format_exc()}")
-        log(f"Data: {data}")
+        log.info(f"Exception while running the model: {e}")
+        log.error(f"{traceback.format_exc()}")
+        log.info(f"Data: {data}")
         rez.update({"status": "failure", "message": f"problem running the model {e}"})
     finally:
         # clean up local files
@@ -276,13 +276,13 @@ class MainHandler(tornado.web.RequestHandler):
             data_dict = tornado.escape.json_decode(self.request.body)
         except json.decoder.JSONDecodeError:
             err = traceback.format_exc()
-            log(f"JSON decode error: {err}")
+            log.info(f"JSON decode error: {err}")
             return self.error(400, "Invalid JSON")
 
         required_keys = ["inputs", "callback_url", "callback_method"]
         for key in required_keys:
             if key not in data_dict:
-                log(f"missing required key {key} in data_dict")
+                log.info(f"missing required key {key} in data_dict")
                 return self.error(400, f"missing required key {key} in data_dict")
 
         def ngsf_analysis_done_callback(
@@ -303,7 +303,7 @@ class MainHandler(tornado.web.RequestHandler):
                 # catch all the exceptions and log them,
                 # try to write back to SkyPortal something
                 # informative.
-                logger(f"{str(future.exception())[:1024]} {e}")
+                logger.info(f"{str(future.exception())[:1024]} {e}")
                 result = {
                     "status": "failure",
                     "message": f"{str(future.exception())[:1024]}{e}",
@@ -332,5 +332,5 @@ if __name__ == "__main__":
     ngsf_analysis = make_app()
     port = cfg["analysis_services.ngsf_analysis_service.port"]
     ngsf_analysis.listen(port)
-    log(f"Listening on port {port}")
+    log.info(f"Listening on port {port}")
     tornado.ioloop.IOLoop.current().start()

--- a/services/notification_queue/notification_queue.py
+++ b/services/notification_queue/notification_queue.py
@@ -17,9 +17,9 @@ from twilio.twiml.voice_response import Say, VoiceResponse
 from baselayer.app.env import load_env
 from baselayer.app.flow import Flow
 from baselayer.app.models import init_db
-from baselayer.log import make_log
 from skyportal.app_utils import get_app_base_url
 from skyportal.email_utils import send_email
+from skyportal.log import make_log
 from skyportal.models import (
     Allocation,
     AnalysisService,
@@ -214,11 +214,11 @@ def send_slack_notification(target):
             data=data,
             headers={"Content-Type": "application/json"},
         )
-        log(
+        log.info(
             f"Sent slack notification to user {target['user']['id']} at slack_url: {integration_url}, body: {target['text']}, resource_type: {resource_type}"
         )
     except Exception as e:
-        log(f"Error sending slack notification: {e}")
+        log.error(f"Error sending slack notification: {e}")
 
 
 def send_email_notification(target):
@@ -281,14 +281,14 @@ def send_email_notification(target):
                     subject=subject,
                     body=body,
                 )
-                log(
+                log.info(
                     f"Sent email notification to user {target['user']['id']} at email: {target['user']['contact_email']}, subject: {subject}, body: {body}, resource_type: {resource_type}"
                 )
             except Exception as e:
-                log(f"Error sending email notification: {e}")
+                log.error(f"Error sending email notification: {e}")
 
     except Exception as e:
-        log(f"Error sending email notification: {e}")
+        log.error(f"Error sending email notification: {e}")
 
 
 def send_sms_notification(target):
@@ -326,11 +326,11 @@ def send_sms_notification(target):
                 from_=from_number,
                 to=target["user"]["contact_phone"].e164,
             )
-            log(
+            log.info(
                 f"Sent SMS notification to user {target['user']['id']} at phone number: {target['user']['contact_phone'].e164}, body: {target['text']}, resource_type: {resource_type}"
             )
         except Exception as e:
-            log(f"Error sending sms notification: {e}")
+            log.error(f"Error sending sms notification: {e}")
 
 
 def send_phone_notification(target):
@@ -370,11 +370,11 @@ def send_phone_notification(target):
                 from_=from_number,
                 to=target["user"]["contact_phone"].e164,
             )
-            log(
+            log.info(
                 f"Sent Phone Call notification to user {target['user']['id']} at phone number: {target['user']['contact_phone'].e164}, message: {message}, resource_type: {resource_type}"
             )
         except Exception as e:
-            log(f"Error sending phone call notification: {e}")
+            log.error(f"Error sending phone call notification: {e}")
 
 
 def send_whatsapp_notification(target):
@@ -412,11 +412,11 @@ def send_whatsapp_notification(target):
                 from_="whatsapp:" + str(from_number),
                 to="whatsapp" + str(target["user"]["contact_phone"].e164),
             )
-            log(
+            log.info(
                 f"Sent WhatsApp notification to user {target['user']['id']} at phone number: {target['user']['contact_phone'].e164}, body: {target['text']}, resource_type: {resource_type}"
             )
         except Exception as e:
-            log(f"Error sending WhatsApp notification: {e}")
+            log.error(f"Error sending WhatsApp notification: {e}")
 
 
 def push_frontend_notification(target):
@@ -431,12 +431,12 @@ def push_frontend_notification(target):
         user_id = None
 
     if user_id is None:
-        log(
+        log.error(
             "Error sending frontend notification: user_id or user.id not found in notification's target"
         )
         return
     resource_type = notification_resource_type(target)
-    log(
+    log.info(
         f"Sent frontend notification to user {user_id}, body: {target['text']}, resource_type: {resource_type}"
     )
     ws_flow = Flow()
@@ -472,7 +472,9 @@ def service(queue):
             send_email_notification(notification)
             send_slack_notification(notification)
         except Exception as e:
-            log(f"Error processing notification ID {notification['id']}: {str(e)}")
+            log.error(
+                f"Error processing notification ID {notification['id']}: {str(e)}"
+            )
 
 
 def api(queue):
@@ -1506,14 +1508,14 @@ def api(queue):
                                                 queue.append(target)
                         except Exception as e:
                             failure_count += 1
-                            log(
+                            log.error(
                                 f"Error processing notification for user {user.id}: {str(e)}"
                             )
                             DBSession().rollback()
                             continue
 
                     if failure_count == nb_users and nb_users > 0:
-                        log("Failed to notify all users")
+                        log.error("Failed to notify all users")
                         raise Exception("Failed to notify all users")
                     self.set_status(200)
                     return self.write(
@@ -1524,7 +1526,7 @@ def api(queue):
                         }
                     )
                 except Exception as e:
-                    log(f"Error processing notification: {str(e)}")
+                    log.error(f"Error processing notification: {str(e)}")
                     DBSession().rollback()
                     self.set_status(400)
                     return self.write(
@@ -1549,16 +1551,16 @@ if __name__ == "__main__":
         t2.start()
 
         while True:
-            log(f"Current notification queue length: {len(queue)}")
+            log.info(f"Current notification queue length: {len(queue)}")
             time.sleep(60)
             if not t.is_alive():
-                log("Notification queue service thread died, restarting")
+                log.info("Notification queue service thread died, restarting")
                 t = Thread(target=service, args=(queue,))
                 t.start()
             if not t2.is_alive():
-                log("Notification queue API thread died, restarting")
+                log.info("Notification queue API thread died, restarting")
                 t2 = Thread(target=api, args=(queue,))
                 t2.start()
     except Exception as e:
-        log(f"Error starting notification queue: {str(e)}")
+        log.error(f"Error starting notification queue: {str(e)}")
         raise e

--- a/services/observation_plan_queue/observation_plan_queue.py
+++ b/services/observation_plan_queue/observation_plan_queue.py
@@ -10,11 +10,11 @@ from baselayer.app import models
 from baselayer.app.env import load_env
 from baselayer.app.flow import Flow
 from baselayer.app.models import init_db
-from baselayer.log import make_log
 from skyportal.handlers.api.observation_plan import (
     post_survey_efficiency_analysis,
     send_observation_plan,
 )
+from skyportal.log import make_log
 from skyportal.models import (
     DBSession,
     DefaultObservationPlanRequest,
@@ -52,7 +52,7 @@ def mark_failed(rids):
                     pr.status = "failed to process"
             session.commit()
     except Exception as e:
-        log(f"Error marking observation plan requests {rids} as failed: {e}")
+        log.error(f"Error marking observation plan requests {rids} as failed: {e}")
 
 
 def prioritize_requests(requests):
@@ -171,13 +171,13 @@ def prioritize_requests(requests):
         return plan_with_priority["plan_id"]
     except Exception as e:
         traceback.print_exc()
-        log(f"Error occured prioritizing the observation plan queue: {e}")
+        log.error(f"Error occured prioritizing the observation plan queue: {e}")
         return 0
 
 
 @check_loaded(logger=log)
 def service(*args, **kwargs):
-    log("Starting observation plan queue.")
+    log.info("Starting observation plan queue.")
     while True:
         try:
             # 1. Read/claim (short txn): pick the plan(s) to process and snapshot
@@ -243,7 +243,7 @@ def service(*args, **kwargs):
                     time.sleep(5)
                     continue
 
-                log(f"Prioritizing {len(requests)} observation plan requests...")
+                log.info(f"Prioritizing {len(requests)} observation plan requests...")
 
                 index = prioritize_requests(requests)
 
@@ -276,9 +276,9 @@ def service(*args, **kwargs):
             except Exception as e:
                 traceback.print_exc()
                 if is_combined:
-                    log(f"Error processing combined plans: {rids}: {str(e)}")
+                    log.error(f"Error processing combined plans: {rids}: {str(e)}")
                 else:
-                    log(
+                    log.error(
                         f"Error processing observation plan: {e.args[0] if e.args else e}"
                     )
                 mark_failed(rids)
@@ -298,7 +298,7 @@ def service(*args, **kwargs):
                     )
                     if plan_request is None:
                         continue
-                    log(f"Plan {rid} status: {plan_request.status}")
+                    log.info(f"Plan {rid} status: {plan_request.status}")
                     if plan_request.status == "running":
                         plan_request.status = "complete"
                 session.commit()
@@ -312,9 +312,11 @@ def service(*args, **kwargs):
                         payload={"gcnEvent_dateobs": dateobs},
                     )
             except Exception as e:
-                log(f"Error refreshing observation plan requests on the frontend: {e}")
+                log.error(
+                    f"Error refreshing observation plan requests on the frontend: {e}"
+                )
 
-            log(f"Generated plans: {plan_ids}")
+            log.info(f"Generated plans: {plan_ids}")
 
             # 4. Per-plan post-processing (auto-send + survey efficiency). Same
             # split: snapshot in a short txn, then run the async calls with no txn.
@@ -383,20 +385,20 @@ def service(*args, **kwargs):
                                 "Need at least one observation to evaluate efficiency"
                                 in str(e)
                             ):
-                                log(
+                                log.error(
                                     f"Error processing default survey efficiency for plan {id}: {e}"
                                 )
                             else:
                                 raise e
                 except Exception as e:
                     traceback.print_exc()
-                    log(
+                    log.error(
                         f"Error occured processing default queue submission or survey efficiency for plan {id}: {e}"
                     )
                     time.sleep(2)
 
         except Exception as e:
-            log(f"Error occured processing the observation plan queue: {e}")
+            log.error(f"Error occured processing the observation plan queue: {e}")
             time.sleep(2)
 
 
@@ -404,5 +406,5 @@ if __name__ == "__main__":
     try:
         service()
     except Exception as e:
-        log(f"Error starting observation plan queue: {str(e)}")
+        log.error(f"Error starting observation plan queue: {str(e)}")
         raise e

--- a/services/observation_plan_queue/observation_plan_queue.py
+++ b/services/observation_plan_queue/observation_plan_queue.py
@@ -1,7 +1,6 @@
 import asyncio
 import itertools
 import time
-import traceback
 
 import arrow
 import sqlalchemy as sa
@@ -170,8 +169,7 @@ def prioritize_requests(requests):
 
         return plan_with_priority["plan_id"]
     except Exception as e:
-        traceback.print_exc()
-        log.error(f"Error occured prioritizing the observation plan queue: {e}")
+        log.exception("Error occured prioritizing the observation plan queue")
         return 0
 
 
@@ -273,14 +271,11 @@ def service(*args, **kwargs):
                             return await api.submit(rid, s, asynchronous=False)
 
                     plan_ids = [asyncio.run(_submit())]
-            except Exception as e:
-                traceback.print_exc()
+            except Exception:
                 if is_combined:
-                    log.error(f"Error processing combined plans: {rids}: {str(e)}")
+                    log.exception(f"Error processing combined plans: {rids}")
                 else:
-                    log.error(
-                        f"Error processing observation plan: {e.args[0] if e.args else e}"
-                    )
+                    log.exception("Error processing observation plan")
                 mark_failed(rids)
                 time.sleep(2)
                 continue
@@ -391,9 +386,8 @@ def service(*args, **kwargs):
                             else:
                                 raise e
                 except Exception as e:
-                    traceback.print_exc()
-                    log.error(
-                        f"Error occured processing default queue submission or survey efficiency for plan {id}: {e}"
+                    log.exception(
+                        f"Error occured processing default queue submission or survey efficiency for plan {id}"
                     )
                     time.sleep(2)
 

--- a/services/openai_analysis_service/app.py
+++ b/services/openai_analysis_service/app.py
@@ -5,7 +5,6 @@ import io
 import json
 import os
 import tempfile
-import traceback
 
 import joblib
 import numpy as np
@@ -385,9 +384,8 @@ class SummarizeHandler(tornado.web.RequestHandler):
         """
         try:
             data_dict = tornado.escape.json_decode(self.request.body)
-        except json.decoder.JSONDecodeError:
-            err = traceback.format_exc()
-            log.info(f"JSON decode error: {err}")
+        except json.decoder.JSONDecodeError as e:
+            log.info(f"JSON decode error: {e}")
             return self.error(400, "Invalid JSON")
 
         required_keys = ["inputs", "callback_url", "callback_method"]

--- a/services/openai_analysis_service/app.py
+++ b/services/openai_analysis_service/app.py
@@ -19,7 +19,7 @@ from pinecone import Pinecone
 from tornado.ioloop import IOLoop
 
 from baselayer.app.env import load_env
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 _, cfg = load_env()
 log = make_log("openai_analysis_service")
@@ -37,7 +37,7 @@ if (
     and summarize_embedding_config.get("index_name")
     and summarize_embedding_config.get("index_size")
 ):
-    log("initializing pinecone...")
+    log.info("initializing pinecone...")
     pinecone_client = Pinecone(
         api_key=summarize_embedding_config.get("api_key"),
     )
@@ -64,7 +64,7 @@ if (
         if has_pod_spec:
             USE_PINECONE = True
         else:
-            log(
+            log.info(
                 "Pod spec not found in the config file, cannot create index in pinecone"
             )
 
@@ -90,11 +90,11 @@ if (
                 dimension=summarize_embedding_config.get("index_size"),
                 spec=spec,
             )
-            log(f"index {summarize_embedding_index} created in pinecone")
+            log.info(f"index {summarize_embedding_index} created in pinecone")
     else:
         USE_PINECONE = True
 else:
-    log(
+    log.info(
         "Pinecone access does not seem to be configured in the config file, not using pinecone"
     )
 
@@ -125,9 +125,9 @@ def upload_analysis_results(results, data_dict, request_timeout=60):
     Upload the results to the webhook.
     """
 
-    log("Uploading results to webhook")
+    log.info("Uploading results to webhook")
     if data_dict["callback_method"] != "POST":
-        log("Callback URL is not a POST URL. Skipping.")
+        log.info("Callback URL is not a POST URL. Skipping.")
         return
     url = data_dict["callback_url"]
     try:
@@ -141,9 +141,9 @@ def upload_analysis_results(results, data_dict, request_timeout=60):
         # we cannot write back to the SkyPortal instance.
         # So returning something doesn't make sense in this case.
         # Just log it and move on...
-        log("Callback URL timedout. Skipping.")
+        log.info("Callback URL timedout. Skipping.")
     except Exception as e:
-        log(f"Callback exception {e}.")
+        log.info(f"Callback exception {e}.")
 
 
 def create_summary_string(source_id, prompt, comments, classifications, redshift):
@@ -198,7 +198,9 @@ def run_openai_summarization(data_dict):
     rez = {"status": "failure", "message": "", "analysis": {}}
 
     if analysis_parameters.get("openai_api_key") is None:
-        log("No OpenAI API key set. Skipping and setting this analysis to failure.")
+        log.info(
+            "No OpenAI API key set. Skipping and setting this analysis to failure."
+        )
         rez.update(
             {
                 "status": "failure",
@@ -249,7 +251,7 @@ def run_openai_summarization(data_dict):
         )
         return rez
 
-    log("Running OpenAI summarization")
+    log.info("Running OpenAI summarization")
     # create the summary string
     summary_string = create_summary_string(
         source_id, analysis_parameters.get("prompt"), comments, classifications, z
@@ -283,7 +285,7 @@ def run_openai_summarization(data_dict):
             presence_penalty=analysis_parameters["presence_penalty"],
         )
     except Exception as e:
-        log(f"OpenAI summarization failed {e}")
+        log.info(f"OpenAI summarization failed {e}")
         rez.update(
             {
                 "status": "failure",
@@ -316,7 +318,7 @@ def run_openai_summarization(data_dict):
                 model=summarize_embedding_config.get("model", "text-embedding-3-small"),
             )
         except Exception as e:
-            log(f"OpenAI embedding failed {e}")
+            log.info(f"OpenAI embedding failed {e}")
             rez.update(
                 {
                     "status": "failure",
@@ -359,7 +361,7 @@ def run_openai_summarization(data_dict):
         }
     )
 
-    log(f"OpenAI summarization for {source_id} completed")
+    log.info(f"OpenAI summarization for {source_id} completed")
     return rez
 
 
@@ -385,13 +387,13 @@ class SummarizeHandler(tornado.web.RequestHandler):
             data_dict = tornado.escape.json_decode(self.request.body)
         except json.decoder.JSONDecodeError:
             err = traceback.format_exc()
-            log(f"JSON decode error: {err}")
+            log.info(f"JSON decode error: {err}")
             return self.error(400, "Invalid JSON")
 
         required_keys = ["inputs", "callback_url", "callback_method"]
         for key in required_keys:
             if key not in data_dict:
-                log(f"missing required key {key} in data_dict")
+                log.info(f"missing required key {key} in data_dict")
                 return self.error(400, f"missing required key {key} in data_dict")
 
         def openai_analysis_done_callback(
@@ -412,7 +414,7 @@ class SummarizeHandler(tornado.web.RequestHandler):
                 # catch all the exceptions and log them,
                 # try to write back to SkyPortal something
                 # informative.
-                logger(f"{str(future.exception())[:1024]} {e}")
+                logger.info(f"{str(future.exception())[:1024]} {e}")
                 result = {
                     "status": "failure",
                     "message": f"{str(future.exception())[:1024]}{e}",
@@ -444,5 +446,5 @@ if __name__ == "__main__":
     openai_analysis = make_app()
     port = cfg["analysis_services.openai_analysis_service.port"]
     openai_analysis.listen(port)
-    log(f"Listening on port {port}")
+    log.info(f"Listening on port {port}")
     tornado.ioloop.IOLoop.current().start()

--- a/services/pdl_service/pdl_service.py
+++ b/services/pdl_service/pdl_service.py
@@ -7,8 +7,8 @@ from watchdog.observers import Observer
 from baselayer.app import models
 from baselayer.app.env import load_env
 from baselayer.app.models import init_db
-from baselayer.log import make_log
 from skyportal.handlers.api.earthquake import post_earthquake_from_xml
+from skyportal.log import make_log
 
 env, cfg = load_env()
 
@@ -49,11 +49,11 @@ def service():
             observer.join()
 
         except Exception as e:
-            log(f"Failed to consume earthquake: {e}")
+            log.error(f"Failed to consume earthquake: {e}")
 
 
 if __name__ == "__main__":
     try:
         service()
     except Exception as e:
-        log(f"Error: {e}")
+        log.error(f"Error: {e}")

--- a/services/recurring_apis/recurring_apis.py
+++ b/services/recurring_apis/recurring_apis.py
@@ -6,7 +6,7 @@ from astropy.time import Time
 
 from baselayer.app.env import load_env
 from baselayer.app.models import init_db
-from baselayer.log import make_log
+from skyportal.log import make_log
 from skyportal.models import DBSession, RecurringAPI, User, UserNotification
 from skyportal.tests import api
 from skyportal.utils.naive_datetime import utcnow_naive
@@ -34,7 +34,7 @@ def perform_api_calls():
                 )
             ).all()
         except Exception as e:
-            log(e)
+            log.info(e)
             return
 
         for recurring_api in recurring_apis:
@@ -63,7 +63,9 @@ def perform_api_calls():
                     params=data,
                 )
             else:
-                log("Unable to execute recurring API calls that are not GET or POST")
+                log.error(
+                    "Unable to execute recurring API calls that are not GET or POST"
+                )
                 continue
 
             while True:
@@ -82,7 +84,7 @@ def perform_api_calls():
                 else:
                     text_to_send = f"Failed call to recurring API {recurring_api.id}: {str(data)}; will try again {recurring_api.next_call}, remaining calls before deactivation: {recurring_api.number_of_retries}."
 
-            log(text_to_send)
+            log.info(text_to_send)
             session.add(recurring_api)
             session.add(
                 UserNotification(
@@ -116,7 +118,7 @@ def service(*args, **kwargs):
         try:
             perform_api_calls()
         except Exception as e:
-            log(e)
+            log.info(e)
 
 
 if __name__ == "__main__":

--- a/services/reminders/reminders.py
+++ b/services/reminders/reminders.py
@@ -1,5 +1,4 @@
 import time
-import traceback
 from datetime import timedelta
 
 from baselayer.app.env import load_env
@@ -52,9 +51,8 @@ def send_reminders():
                 for reminder_class in reminder_classes
             )
             reminders = [reminder for sublist in reminders for reminder in sublist]
-        except Exception as e:
-            log.info(e)
-            traceback.print_exc()
+        except Exception:
+            log.exception("Error fetching due reminders")
 
         ws_flow = Flow()
         for reminder in reminders:
@@ -128,9 +126,9 @@ def send_reminders():
                             "</body></html>"
                         ),
                     )
-                except Exception as e:
-                    log(
-                        f"Failed to send reminder email to {reminder.user.contact_email}: {e}"
+                except Exception:
+                    log.exception(
+                        f"Failed to send reminder email to {reminder.user.contact_email}"
                     )
 
             session.add(
@@ -170,9 +168,8 @@ def send_reminders():
             next_reminders = [
                 reminder for reminder in next_reminders if reminder is not None
             ]
-        except Exception as e:
-            log.info(e)
-            traceback.print_exc()
+        except Exception:
+            log.exception("Error updating next reminders")
 
         if len(next_reminders) > 0:
             next_reminder = min(next_reminders, key=lambda x: x.next_reminder)
@@ -187,9 +184,8 @@ def service(*args, **kwargs):
     while True:
         try:
             send_reminders()
-        except Exception as e:
-            log.info(e)
-            traceback.print_exc()
+        except Exception:
+            log.exception("Error sending reminders")
 
 
 if __name__ == "__main__":

--- a/services/reminders/reminders.py
+++ b/services/reminders/reminders.py
@@ -5,9 +5,9 @@ from datetime import timedelta
 from baselayer.app.env import load_env
 from baselayer.app.flow import Flow
 from baselayer.app.models import User, init_db
-from baselayer.log import make_log
 from skyportal.app_utils import get_app_base_url
 from skyportal.email_utils import send_email
+from skyportal.log import make_log
 from skyportal.models import (
     DBSession,
     Reminder,
@@ -53,7 +53,7 @@ def send_reminders():
             )
             reminders = [reminder for sublist in reminders for reminder in sublist]
         except Exception as e:
-            log(e)
+            log.info(e)
             traceback.print_exc()
 
         ws_flow = Flow()
@@ -171,7 +171,7 @@ def send_reminders():
                 reminder for reminder in next_reminders if reminder is not None
             ]
         except Exception as e:
-            log(e)
+            log.info(e)
             traceback.print_exc()
 
         if len(next_reminders) > 0:
@@ -188,7 +188,7 @@ def service(*args, **kwargs):
         try:
             send_reminders()
         except Exception as e:
-            log(e)
+            log.info(e)
             traceback.print_exc()
 
 

--- a/services/sharing_service_submission_queue/sharing_service_submission_queue.py
+++ b/services/sharing_service_submission_queue/sharing_service_submission_queue.py
@@ -12,7 +12,7 @@ from sqlalchemy import and_, or_
 from baselayer.app.env import load_env
 from baselayer.app.flow import Flow
 from baselayer.app.models import init_db, session_context_id
-from baselayer.log import make_log
+from skyportal.log import make_log
 from skyportal.models import (
     DBSession,
     Obj,
@@ -242,7 +242,7 @@ def process_submission_request(submission_request, session):
 
     except Exception as e:
         notif_type = "Warning" if isinstance(e, SharingServicesWarning) else "Error"
-        log(str(e))
+        log.info(str(e))
         try:
             flow = Flow()
             flow.push(
@@ -331,7 +331,7 @@ def process_submission_requests():
                             submission_request.tns_status = "processing"
                         session.commit()
                 except Exception as e:
-                    log(f"Error getting sharing submission request: {str(e)}")
+                    log.error(f"Error getting sharing submission request: {str(e)}")
                     continue
 
                 submission_request_id = submission_request.id
@@ -342,11 +342,11 @@ def process_submission_requests():
                     try:
                         session.rollback()
                     except Exception as rollback_err:
-                        log(f"Error rolling back session: {str(rollback_err)}")
+                        log.error(f"Error rolling back session: {str(rollback_err)}")
                     else:
                         try:
                             traceback.print_exc()
-                            log(
+                            log.error(
                                 f"Error processing sharing submission request {submission_request_id}: {str(e)}"
                             )
                             submission_request = session.scalar(
@@ -368,13 +368,13 @@ def process_submission_requests():
                                 },
                             )
                         except Exception as e:
-                            log(
+                            log.error(
                                 f"Error updating sharing submission request status: {str(e)}"
                             )
         except Exception as e:
             # A dropped DB connection can raise on the DBSession context-manager
             # exit (ROLLBACK), outside the inner try/except; retry instead of dying.
-            log(f"Error in submission request loop, retrying: {e}")
+            log.error(f"Error in submission request loop, retrying: {e}")
             time.sleep(5)
             continue
 
@@ -402,7 +402,7 @@ def validate_submission_requests():
                             < datetime.now(UTC) - timedelta(minutes=5),
                         )
                     ).all()
-                    log(
+                    log.info(
                         f"Found {len(failed_submission_requests)} failed TNS submission requests to re-set..."
                     )
                     for submission_request in failed_submission_requests:
@@ -463,21 +463,21 @@ def validate_submission_requests():
                                 )
                             )
                         ):
-                            log(
+                            log.info(
                                 f"TNS submission request {submission_request.id} for object {submission_request.obj_id} seems to have been successful, setting as confirmed"
                             )
                             submission_request.tns_status = "confirmed"
                             continue
 
                         # not reported on TNS by this sharing service yet, re-set the submission request to pending
-                        log(
+                        log.info(
                             f"Re-setting failed TNS submission request {submission_request.id} for object {submission_request.obj_id}"
                         )
                         submission_request.tns_status = "pending"
                     if len(failed_submission_requests) > 0:
                         session.commit()
                 except Exception as e:
-                    log(f"Error re-setting failed TNS submission requests: {e}")
+                    log.error(f"Error re-setting failed TNS submission requests: {e}")
                     session.rollback()
 
                 try:
@@ -497,11 +497,11 @@ def validate_submission_requests():
                     )
                     if submission_request is None:
                         # here we add an extra sleep to avoid hammering the TNS API
-                        log("Waiting for TNS submission requests to validate...")
+                        log.info("Waiting for TNS submission requests to validate...")
                         time.sleep(25)
                         continue
 
-                    log(
+                    log.info(
                         f"Checking TNS submission request {submission_request.id} for object {submission_request.obj_id}"
                     )
 
@@ -513,7 +513,7 @@ def validate_submission_requests():
                         )
                     )
                     if sharing_service is None:
-                        log(
+                        log.error(
                             "Could not find sharing service for this submission request"
                         )
                         continue
@@ -531,7 +531,7 @@ def validate_submission_requests():
                         submission_request.tns_response = serialized_response
                         session.merge(submission_request)
                         session.commit()
-                        log(
+                        log.info(
                             f"AT report of {submission_request.obj_id} already exists on TNS"
                         )
                     elif not err and tns_source and serialized_response:
@@ -551,7 +551,7 @@ def validate_submission_requests():
                         submission_request.tns_response = serialized_response
                         session.merge(submission_request)
                         session.commit()
-                        log(
+                        log.info(
                             f"AT report of {submission_request.obj_id} submitted to TNS as {tns_source}"
                         )
                         try:
@@ -581,7 +581,7 @@ def validate_submission_requests():
                                 json={"tns_source": tns_source},
                             )
                         except Exception as e:
-                            log(f"Error submitting TNS name to retrieval queue: {e}")
+                            log.error(f"Error submitting TNS name to retrieval queue: {e}")
                     elif err == "report not found":
                         # Sometimes TNS accepts a report but it disappears.
                         # If it's been <1 min since last update, wait; otherwise, mark as pending to retry.
@@ -592,7 +592,7 @@ def validate_submission_requests():
                             submission_request.tns_submission_id = None
                             session.merge(submission_request)
                             session.commit()
-                            log(
+                            log.info(
                                 f"AT report submission of {submission_request.obj_id} not found on TNS, retrying"
                             )
                     elif err is not None and serialized_response is not None:
@@ -600,20 +600,20 @@ def validate_submission_requests():
                         submission_request.response = serialized_response
                         session.merge(submission_request)
                         session.commit()
-                        log(f"Error checking TNS report: {err}")
+                        log.error(f"Error checking TNS report: {err}")
                     else:
-                        log(
+                        log.error(
                             f"Error checking TNS report - source {tns_source}, response {serialized_response}, err {err}"
                         )
                 except Exception as e:
                     session.rollback()
                     traceback.print_exc()
-                    log(f"Unexpected error checking TNS report: {str(e)}")
+                    log.info(f"Unexpected error checking TNS report: {str(e)}")
                     continue
         except Exception as e:
             # A dropped DB connection can raise on the DBSession context-manager
             # exit (ROLLBACK), outside the inner try/except; retry instead of dying.
-            log(f"Error in validation loop, retrying: {e}")
+            log.error(f"Error in validation loop, retrying: {e}")
             time.sleep(5)
             continue
 
@@ -625,12 +625,12 @@ def service(*args, **kwargs):
     t.start()
     t2.start()
     while True:
-        log("Sharing service submission queue heartbeat")
+        log.info("Sharing service submission queue heartbeat")
         time.sleep(120)
         # Exit if either worker thread died (e.g. DB connection drop in a context
         # manager exit, outside the loop's try/except) so supervisor restarts us.
         if not (t.is_alive() and t2.is_alive()):
-            log("A sharing service worker thread died, exiting for supervisor restart")
+            log.error("A sharing service worker thread died, exiting for supervisor restart")
             sys.exit(1)
 
 
@@ -638,5 +638,5 @@ if __name__ == "__main__":
     try:
         service()
     except Exception as e:
-        log(f"Error starting sharing service submission queue: {str(e)}")
+        log.error(f"Error starting sharing service submission queue: {str(e)}")
         raise e

--- a/services/sharing_service_submission_queue/sharing_service_submission_queue.py
+++ b/services/sharing_service_submission_queue/sharing_service_submission_queue.py
@@ -1,6 +1,5 @@
 import sys
 import time
-import traceback
 import uuid
 from datetime import UTC, datetime, timedelta
 from threading import Thread
@@ -345,9 +344,8 @@ def process_submission_requests():
                         log.error(f"Error rolling back session: {str(rollback_err)}")
                     else:
                         try:
-                            traceback.print_exc()
-                            log.error(
-                                f"Error processing sharing submission request {submission_request_id}: {str(e)}"
+                            log.exception(
+                                f"Error processing sharing submission request {submission_request_id}"
                             )
                             submission_request = session.scalar(
                                 sa.select(SharingServiceSubmission).where(
@@ -581,7 +579,9 @@ def validate_submission_requests():
                                 json={"tns_source": tns_source},
                             )
                         except Exception as e:
-                            log.error(f"Error submitting TNS name to retrieval queue: {e}")
+                            log.error(
+                                f"Error submitting TNS name to retrieval queue: {e}"
+                            )
                     elif err == "report not found":
                         # Sometimes TNS accepts a report but it disappears.
                         # If it's been <1 min since last update, wait; otherwise, mark as pending to retry.
@@ -607,8 +607,7 @@ def validate_submission_requests():
                         )
                 except Exception as e:
                     session.rollback()
-                    traceback.print_exc()
-                    log.info(f"Unexpected error checking TNS report: {str(e)}")
+                    log.exception("Unexpected error checking TNS report")
                     continue
         except Exception as e:
             # A dropped DB connection can raise on the DBSession context-manager
@@ -630,7 +629,9 @@ def service(*args, **kwargs):
         # Exit if either worker thread died (e.g. DB connection drop in a context
         # manager exit, outside the loop's try/except) so supervisor restarts us.
         if not (t.is_alive() and t2.is_alive()):
-            log.error("A sharing service worker thread died, exiting for supervisor restart")
+            log.error(
+                "A sharing service worker thread died, exiting for supervisor restart"
+            )
             sys.exit(1)
 
 

--- a/services/slack/slack.py
+++ b/services/slack/slack.py
@@ -1,5 +1,4 @@
 import json
-import traceback
 
 import tornado.escape
 import tornado.ioloop
@@ -34,9 +33,8 @@ class MainHandler(tornado.web.RequestHandler):
         """
         try:
             data = tornado.escape.json_decode(self.request.body)
-        except json.decoder.JSONDecodeError:
-            err = traceback.format_exc()
-            log.info(err)
+        except json.decoder.JSONDecodeError as e:
+            log.info(f"JSON decode error: {e}")
             return self.error(400, "Invalid JSON")
 
         url = data.pop("url", "")

--- a/services/slack/slack.py
+++ b/services/slack/slack.py
@@ -7,7 +7,7 @@ import tornado.web
 from tornado.httpclient import AsyncHTTPClient
 
 from baselayer.app.env import load_env
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 env, cfg = load_env()
 log = make_log("slack")
@@ -36,7 +36,7 @@ class MainHandler(tornado.web.RequestHandler):
             data = tornado.escape.json_decode(self.request.body)
         except json.decoder.JSONDecodeError:
             err = traceback.format_exc()
-            log(err)
+            log.info(err)
             return self.error(400, "Invalid JSON")
 
         url = data.pop("url", "")
@@ -54,12 +54,12 @@ class MainHandler(tornado.web.RequestHandler):
                 headers={"Content-type": "application/json"},
             )
             if response.code != 200:
-                log(
+                log.info(
                     f"Slack POST failed with code {response.code}: {str(response.body)}"
                 )
                 return self.error(response.code, str(response.body))
         except Exception as e:
-            log(f"Error posting to Slack: {e}")
+            log.error(f"Error posting to Slack: {e}")
 
 
 def make_app():
@@ -75,5 +75,5 @@ if __name__ == "__main__":
 
     port = cfg.get("slack.microservice_port", 64100)
     slack_poster.listen(port)
-    log(f"Listening on port {port}")
+    log.info(f"Listening on port {port}")
     tornado.ioloop.IOLoop.current().start()

--- a/services/sn_analysis_service/app.py
+++ b/services/sn_analysis_service/app.py
@@ -16,7 +16,7 @@ from astropy.table import Table
 from tornado.ioloop import IOLoop
 
 from baselayer.app.env import load_env
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 _, cfg = load_env()
 log = make_log("sn_analysis_service")
@@ -34,9 +34,9 @@ def upload_analysis_results(results, data_dict, request_timeout=60):
     Upload the results to the webhook.
     """
 
-    log("Uploading results to webhook")
+    log.info("Uploading results to webhook")
     if data_dict["callback_method"] != "POST":
-        log("Callback URL is not a POST URL. Skipping.")
+        log.info("Callback URL is not a POST URL. Skipping.")
         return
     url = data_dict["callback_url"]
     try:
@@ -50,9 +50,9 @@ def upload_analysis_results(results, data_dict, request_timeout=60):
         # we cannot write back to the SkyPortal instance.
         # So returning something doesn't make sense in this case.
         # Just log it and move on...
-        log("Callback URL timedout. Skipping.")
+        log.info("Callback URL timedout. Skipping.")
     except Exception as e:
-        log(f"Callback exception {e}.")
+        log.info(f"Callback exception {e}.")
 
 
 def run_sn_model(data_dict):
@@ -214,13 +214,13 @@ def run_sn_model(data_dict):
                 }
             )
         else:
-            log("Fit failed.")
+            log.info("Fit failed.")
             rez.update({"status": "failure", "message": "model failed to converge"})
 
     except Exception as e:
-        log(f"Exception while running the model: {e}")
-        log(f"{traceback.format_exc()}")
-        log(f"Data: {data}")
+        log.info(f"Exception while running the model: {e}")
+        log.error(f"{traceback.format_exc()}")
+        log.info(f"Data: {data}")
         rez.update({"status": "failure", "message": f"problem running the model {e}"})
     finally:
         # clean up local files
@@ -254,13 +254,13 @@ class MainHandler(tornado.web.RequestHandler):
             data_dict = tornado.escape.json_decode(self.request.body)
         except json.decoder.JSONDecodeError:
             err = traceback.format_exc()
-            log(f"JSON decode error: {err}")
+            log.info(f"JSON decode error: {err}")
             return self.error(400, "Invalid JSON")
 
         required_keys = ["inputs", "callback_url", "callback_method"]
         for key in required_keys:
             if key not in data_dict:
-                log(f"missing required key {key} in data_dict")
+                log.info(f"missing required key {key} in data_dict")
                 return self.error(400, f"missing required key {key} in data_dict")
 
         def sn_analysis_done_callback(
@@ -281,7 +281,7 @@ class MainHandler(tornado.web.RequestHandler):
                 # catch all the exceptions and log them,
                 # try to write back to SkyPortal something
                 # informative.
-                logger(f"{str(future.exception())[:1024]} {e}")
+                logger.info(f"{str(future.exception())[:1024]} {e}")
                 result = {
                     "status": "failure",
                     "message": f"{str(future.exception())[:1024]}{e}",
@@ -310,5 +310,5 @@ if __name__ == "__main__":
     sn_analysis = make_app()
     port = cfg["analysis_services.sn_analysis_service.port"]
     sn_analysis.listen(port)
-    log(f"Listening on port {port}")
+    log.info(f"Listening on port {port}")
     tornado.ioloop.IOLoop.current().start()

--- a/services/sn_analysis_service/app.py
+++ b/services/sn_analysis_service/app.py
@@ -3,7 +3,6 @@ import functools
 import json
 import os
 import tempfile
-import traceback
 
 import joblib
 import matplotlib
@@ -218,8 +217,7 @@ def run_sn_model(data_dict):
             rez.update({"status": "failure", "message": "model failed to converge"})
 
     except Exception as e:
-        log.info(f"Exception while running the model: {e}")
-        log.error(f"{traceback.format_exc()}")
+        log.exception("Exception while running the model")
         log.info(f"Data: {data}")
         rez.update({"status": "failure", "message": f"problem running the model {e}"})
     finally:
@@ -252,9 +250,8 @@ class MainHandler(tornado.web.RequestHandler):
         """
         try:
             data_dict = tornado.escape.json_decode(self.request.body)
-        except json.decoder.JSONDecodeError:
-            err = traceback.format_exc()
-            log.info(f"JSON decode error: {err}")
+        except json.decoder.JSONDecodeError as e:
+            log.info(f"JSON decode error: {e}")
             return self.error(400, "Invalid JSON")
 
         required_keys = ["inputs", "callback_url", "callback_method"]

--- a/services/spectral_cube_analysis_service/app.py
+++ b/services/spectral_cube_analysis_service/app.py
@@ -17,7 +17,7 @@ import tornado.web
 from tornado.ioloop import IOLoop
 
 from baselayer.app.env import load_env
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 _, cfg = load_env()
 log = make_log("spectral_cube_analysis_service")
@@ -38,9 +38,9 @@ def upload_analysis_results(results, data_dict, request_timeout=60):
     Upload the results to the webhook.
     """
 
-    log("Uploading results to webhook")
+    log.info("Uploading results to webhook")
     if data_dict["callback_method"] != "POST":
-        log("Callback URL is not a POST URL. Skipping.")
+        log.info("Callback URL is not a POST URL. Skipping.")
         return
     url = data_dict["callback_url"]
     try:
@@ -54,9 +54,9 @@ def upload_analysis_results(results, data_dict, request_timeout=60):
         # we cannot write back to the SkyPortal instance.
         # So returning something doesn't make sense in this case.
         # Just log it and move on...
-        log("Callback URL timedout. Skipping.")
+        log.info("Callback URL timedout. Skipping.")
     except Exception as e:
-        log(f"Callback exception {e}.")
+        log.info(f"Callback exception {e}.")
 
 
 def run_spectral_cube_model(data_dict):
@@ -208,7 +208,7 @@ def run_spectral_cube_model(data_dict):
             )
     except Exception as e:
         traceback.print_exc()
-        log(f"Exception: {e}")
+        log.info(f"Exception: {e}")
         rez.update({"status": "failure", "message": f"problem running the model {e}"})
     finally:
         # clean up local files
@@ -243,13 +243,13 @@ class MainHandler(tornado.web.RequestHandler):
             data_dict = tornado.escape.json_decode(self.request.body)
         except json.decoder.JSONDecodeError:
             err = traceback.format_exc()
-            log(f"JSON decode error: {err}")
+            log.info(f"JSON decode error: {err}")
             return self.error(400, "Invalid JSON")
 
         required_keys = ["inputs", "callback_url", "callback_method"]
         for key in required_keys:
             if key not in data_dict:
-                log(f"missing required key {key} in data_dict")
+                log.info(f"missing required key {key} in data_dict")
                 return self.error(400, f"missing required key {key} in data_dict")
 
         def spectral_cube_analysis_done_callback(
@@ -270,7 +270,7 @@ class MainHandler(tornado.web.RequestHandler):
                 # catch all the exceptions and log them,
                 # try to write back to SkyPortal something
                 # informative.
-                logger(f"{str(future.exception())[:1024]} {e}")
+                logger.info(f"{str(future.exception())[:1024]} {e}")
                 result = {
                     "status": "failure",
                     "message": f"{str(future.exception())[:1024]}{e}",
@@ -302,5 +302,5 @@ if __name__ == "__main__":
     spectral_cube_analysis = make_app()
     port = cfg["analysis_services.spectral_cube_analysis_service.port"]
     spectral_cube_analysis.listen(port)
-    log(f"Listening on port {port}")
+    log.info(f"Listening on port {port}")
     tornado.ioloop.IOLoop.current().start()

--- a/services/spectral_cube_analysis_service/app.py
+++ b/services/spectral_cube_analysis_service/app.py
@@ -4,7 +4,6 @@ import io
 import json
 import os
 import tempfile
-import traceback
 
 import joblib
 import matplotlib
@@ -207,8 +206,7 @@ def run_spectral_cube_model(data_dict):
                 }
             )
     except Exception as e:
-        traceback.print_exc()
-        log.info(f"Exception: {e}")
+        log.exception("Exception while running the model")
         rez.update({"status": "failure", "message": f"problem running the model {e}"})
     finally:
         # clean up local files
@@ -241,9 +239,8 @@ class MainHandler(tornado.web.RequestHandler):
         """
         try:
             data_dict = tornado.escape.json_decode(self.request.body)
-        except json.decoder.JSONDecodeError:
-            err = traceback.format_exc()
-            log.info(f"JSON decode error: {err}")
+        except json.decoder.JSONDecodeError as e:
+            log.info(f"JSON decode error: {e}")
             return self.error(400, "Invalid JSON")
 
         required_keys = ["inputs", "callback_url", "callback_method"]

--- a/services/thumbnail_queue/thumbnail_queue.py
+++ b/services/thumbnail_queue/thumbnail_queue.py
@@ -9,7 +9,7 @@ from baselayer.app import models
 from baselayer.app.env import load_env
 from baselayer.app.flow import Flow
 from baselayer.app.models import init_db
-from baselayer.log import make_log
+from skyportal.log import make_log
 from skyportal.models import (
     Obj,
     Thumbnail,
@@ -155,7 +155,7 @@ async def _run_loop():
     while True:
         if time.time() - heartbeat > 60:
             heartbeat = time.time()
-            log("Thumbnail queue heartbeat.")
+            log.info("Thumbnail queue heartbeat.")
         try:
             # Classify remote thumbnails left NULL by before_insert (fetch runs
             # off the event loop with no txn held). Isolated so a failure here
@@ -163,7 +163,7 @@ async def _run_loop():
             try:
                 await classify_pending_grayscale()
             except Exception as e:
-                log(f"Error classifying pending thumbnails: {str(e)}")
+                log.error(f"Error classifying pending thumbnails: {str(e)}")
 
             internal_key = None
             # 1. Read/claim: find one obj missing thumbnails and snapshot what we
@@ -176,7 +176,9 @@ async def _run_loop():
                 await set_statement_timeout(session)
                 obj, err = await fetch_obj(session)
                 if err is not None:
-                    log(f"Error fetching object with missing thumbnails: {str(err)}")
+                    log.error(
+                        f"Error fetching object with missing thumbnails: {str(err)}"
+                    )
                     await asyncio.sleep(1)
                     continue
                 if obj is None:
@@ -186,9 +188,9 @@ async def _run_loop():
                 thumbnails = list(THUMBNAIL_TYPES - set(existing_thumbnail_types))
                 obj_id = obj.id
                 if len(thumbnails) == 0:
-                    log(f"Source {obj_id} has all thumbnails.")
+                    log.info(f"Source {obj_id} has all thumbnails.")
                     continue
-                log(f"Processing thumbnail request for object {obj_id}.")
+                log.info(f"Processing thumbnail request for object {obj_id}.")
 
             # 2. Resolve the slow PanSTARRS cutout URL off the event loop with no
             # DB transaction open. `obj` is detached but its attributes are loaded.
@@ -207,14 +209,14 @@ async def _run_loop():
                         )
                         internal_key = obj.internal_key
                 except Exception as e:
-                    log(
+                    log.error(
                         f"Error processing thumbnail request for object {obj_id}: {str(e)}"
                     )
                     if isinstance(e, sa.exc.SQLAlchemyError):
                         try:
                             await session.rollback()
                         except Exception as rollback_err:
-                            log(
+                            log.error(
                                 f"Error rolling back session after thumbnail failure for object {obj_id}: {str(rollback_err)}"
                             )
 
@@ -231,7 +233,7 @@ async def _run_loop():
                     payload={"id": internal_key},
                 )
         except Exception as e:
-            log(f"Error processing thumbnail request: {str(e)}")
+            log.error(f"Error processing thumbnail request: {str(e)}")
             await asyncio.sleep(5)
 
 
@@ -244,5 +246,5 @@ if __name__ == "__main__":
     try:
         service()
     except Exception as e:
-        log(f"Error starting thumbnail queue: {str(e)}")
+        log.error(f"Error starting thumbnail queue: {str(e)}")
         raise e

--- a/services/tns_retrieval_queue/tns_retrieval_queue.py
+++ b/services/tns_retrieval_queue/tns_retrieval_queue.py
@@ -19,10 +19,10 @@ from baselayer.app import models
 from baselayer.app.env import load_env
 from baselayer.app.flow import Flow
 from baselayer.app.models import init_db
-from baselayer.log import make_log
 from skyportal.handlers.api.photometry import add_external_photometry
 from skyportal.handlers.api.source import post_source_async
 from skyportal.handlers.api.spectrum import post_spectrum
+from skyportal.log import make_log
 from skyportal.models import DBSession, Group, Obj, Source, User
 from skyportal.utils.calculations import great_circle_distance
 from skyportal.utils.parse import is_null
@@ -71,7 +71,7 @@ def refresh_obj_on_frontend(obj, user_id="*"):
             payload={"obj_key": obj.internal_key},
         )
     except Exception:
-        log(f"Error refreshing object {obj.id} on frontend")
+        log.error(f"Error refreshing object {obj.id} on frontend")
 
 
 def add_tns_name_to_existing_objs(tns_name, tns_source_data, tns_ra, tns_dec, session):
@@ -132,10 +132,10 @@ def add_tns_name_to_existing_objs(tns_name, tns_source_data, tns_ra, tns_dec, se
                     continue
 
                 session.commit()
-                log(f"Updated object {obj.id} with TNS name {tns_name}")
+                log.info(f"Updated object {obj.id} with TNS name {tns_name}")
                 refresh_obj_on_frontend(obj)
             except Exception as e:
-                log(f"Error updating object: {str(e)}")
+                log.error(f"Error updating object: {str(e)}")
                 session.rollback()
 
 
@@ -158,14 +158,14 @@ def add_tns_photometry(tns_name, tns_source, tns_source_data, public_group_id, s
 
     user = session.scalar(sa.select(User).where(User.id == USER_ID))
     if user is None:
-        log(
+        log.error(
             f"Error getting user {USER_ID}, required to add photometry with add_external_photometry()"
         )
         return
 
     photometry = tns_source_data.get("photometry", [])
     if len(photometry) == 0:
-        log(f"No photometry found on TNS for source {tns_source}")
+        log.info(f"No photometry found on TNS for source {tns_source}")
         return
 
     failed_photometry = []
@@ -183,7 +183,7 @@ def add_tns_photometry(tns_name, tns_source, tns_source_data, public_group_id, s
         except Exception as e:
             failed_photometry.append(phot)
             failed_photometry_errors.append(str(e))
-            log(f"Cannot read TNS photometry {str(phot)}: {str(e)}")
+            log.error(f"Cannot read TNS photometry {str(phot)}: {str(e)}")
             continue
         if read_photometry:
             try:
@@ -200,11 +200,11 @@ def add_tns_photometry(tns_name, tns_source, tns_source_data, public_group_id, s
                 continue
 
     if len(failed_photometry) > 0:
-        log(
+        log.error(
             f"Failed to retrieve {len(failed_photometry)}/{len(photometry)} TNS photometry points from {tns_name}: {str(list(set(failed_photometry_errors)))}"
         )
     else:
-        log(
+        log.info(
             f"Successfully retrieved {len(photometry)} TNS photometry points from {tns_name}"
         )
 
@@ -227,7 +227,7 @@ def add_tns_spectra(tns_name, tns_source, tns_source_data, public_group_id, sess
     """
     spectra = tns_source_data.get("spectra", [])
     if len(spectra) == 0:
-        log(f"No spectra found on TNS for source {tns_source}")
+        log.info(f"No spectra found on TNS for source {tns_source}")
         return
 
     failed_spectra = []
@@ -237,7 +237,7 @@ def add_tns_spectra(tns_name, tns_source, tns_source_data, public_group_id, sess
         try:
             data = read_tns_spectrum(spectrum, session)
         except Exception as e:
-            log(f"Cannot read TNS spectrum {str(spectrum)}: {str(e)}")
+            log.error(f"Cannot read TNS spectrum {str(spectrum)}: {str(e)}")
             continue
         data["obj_id"] = tns_source
         data["group_ids"] = [public_group_id]
@@ -250,11 +250,11 @@ def add_tns_spectra(tns_name, tns_source, tns_source_data, public_group_id, sess
         asyncio.run(_post_spectrum())
 
     if len(failed_spectra) > 0:
-        log(
+        log.error(
             f"Failed to retrieve {len(failed_spectra)}/{len(spectra)} TNS spectra from {tns_name}: {str(list(set(failed_spectra_errors)))}"
         )
     else:
-        log(f"Successfully retrieved {len(spectra)} TNS spectra from {tns_name}")
+        log.info(f"Successfully retrieved {len(spectra)} TNS spectra from {tns_name}")
 
 
 def process_queue(queue):
@@ -266,7 +266,7 @@ def process_queue(queue):
         Tasks to be processed
     """
     if TNS_URL is None or bot_id is None or bot_name is None or api_key is None:
-        log("TNS watcher not configured, skipping")
+        log.info("TNS watcher not configured, skipping")
         return
     tns_headers = get_tns_headers(bot_id, bot_name)
 
@@ -286,7 +286,7 @@ def process_queue(queue):
                     sa.select(Group).where(Group.name == cfg["misc.public_group_name"])
                 )
                 if public_group is None:
-                    log(
+                    log.warning(
                         f"WARNING: Public group {cfg['misc.public_group_name']} not found in the database, stopping TNS watcher"
                     )
                     return
@@ -299,7 +299,7 @@ def process_queue(queue):
                         sa.select(Obj).where(Obj.id == task.get("obj_id"))
                     )
                     if existing_obj is None:
-                        log(
+                        log.info(
                             f"Object {task['obj_id']} not found in the database, skipping"
                         )
                         continue
@@ -313,7 +313,7 @@ def process_queue(queue):
                         radius=float(task.get("radius", DEFAULT_RADIUS)),
                         closest=True,  # get the closest object to the input coordinates as the TNS source
                     )
-                    log(
+                    log.info(
                         f"Found TNS source {tns_source} for object {existing_obj.id} with prefix {tns_prefix}"
                     )
                     if is_null(tns_source):
@@ -330,9 +330,9 @@ def process_queue(queue):
                         tns_name = f"{tns_prefix} {tns_source}"
                     else:
                         tns_name = tns_source
-                    log(f"Processing TNS source {tns_name}")
+                    log.info(f"Processing TNS source {tns_name}")
                 else:
-                    log("No obj_id or tns_name provided, skipping")
+                    log.info("No obj_id or tns_name provided, skipping")
                     continue
 
                 # fetch the data from TNS
@@ -366,7 +366,7 @@ def process_queue(queue):
                     time.sleep(retry_delay)
 
                 if status_code != 200:
-                    log(f"Error getting TNS data for {tns_name}: {r.text}")
+                    log.error(f"Error getting TNS data for {tns_name}: {r.text}")
                     continue
 
                 try:
@@ -374,7 +374,9 @@ def process_queue(queue):
                 except Exception:
                     tns_source_data = None
                 if tns_source_data is None:
-                    log(f"Error getting TNS data for {tns_name}: no reply in data")
+                    log.error(
+                        f"Error getting TNS data for {tns_name}: no reply in data"
+                    )
                     continue
 
                 try:
@@ -385,14 +387,14 @@ def process_queue(queue):
                         .get("message", None)
                     )
                     if msg == "No results found.":
-                        log(f"Could not find {tns_name} on TNS at {TNS_URL}")
+                        log.error(f"Could not find {tns_name} on TNS at {TNS_URL}")
                         continue
                 except Exception:
                     pass
 
                 tns_prefix = tns_source_data.get("name_prefix", None)
                 if tns_prefix is None:
-                    log(
+                    log.error(
                         f"Error processing TNS source {tns_name}: obj has no prefix ({str(r.json())})"
                     )
                     continue
@@ -404,7 +406,7 @@ def process_queue(queue):
                     tns_source_data.get("decdeg", None),
                 )
                 if ra is None or dec is None:
-                    log(f"Error processing TNS source {tns_name}: no coordinates")
+                    log.error(f"Error processing TNS source {tns_name}: no coordinates")
                     continue
 
                 if existing_obj:
@@ -434,7 +436,7 @@ def process_queue(queue):
                         existing_tns_obj.tns_name = tns_name
                         existing_tns_obj.tns_info = tns_source_data
                         session.commit()
-                        log(
+                        log.info(
                             f"TNS obj {tns_name} already exists in the database, updated its TNS name."
                         )
                         refresh_obj_on_frontend(existing_tns_obj)
@@ -442,7 +444,7 @@ def process_queue(queue):
                     # if the obj does not exist or if it exists but is saved to the public group,
                     # we create/save the TNS source to the public group
                     if existing_tns_public_source is None:
-                        log(
+                        log.info(
                             f"Saving TNS source {tns_name} to the database (public group)"
                         )
                         new_source_data = {
@@ -477,7 +479,7 @@ def process_queue(queue):
                         )
         except Exception as e:
             traceback.print_exc()
-            log(f"Error processing TNS source {tns_name}: {e}")
+            log.error(f"Error processing TNS source {tns_name}: {e}")
             user_id = task.get("user_id", None)
             if user_id is not None:
                 flow = Flow()
@@ -510,7 +512,7 @@ def tns_watcher(queue):
         The queue to add the TNS sources to, shared across threads
     """
     if not TNS_URL or not bot_id or not bot_name or not api_key or not look_back_days:
-        log("TNS watcher not configured, skipping")
+        log.info("TNS watcher not configured, skipping")
         return
     tns_headers = get_tns_headers(bot_id, bot_name)
 
@@ -535,14 +537,16 @@ def tns_watcher(queue):
                         "obj_id": None,
                     }
                 )
-                log(f"Added TNS source {tns_source['id']} to the queue for processing")
+                log.info(
+                    f"Added TNS source {tns_source['id']} to the queue for processing"
+                )
 
             # if we got any sources, we update the start date to now - 1 hour
             # otherwise we keep querying TNS starting from same start date
             if tns_sources:
                 start_date = datetime.now() - timedelta(hours=1)
         except Exception as e:
-            log(f"Error getting TNS sources: {e}, retrying in 4 minutes")
+            log.error(f"Error getting TNS sources: {e}, retrying in 4 minutes")
 
         time.sleep(60 * 4)  # sleep for 4 minutes
 
@@ -622,7 +626,7 @@ def service(*args, **kwargs):
     t2.start()
     t3.start()
     while True:
-        log(f"Current TNS retrieval queue length: {len(queue)}")
+        log.info(f"Current TNS retrieval queue length: {len(queue)}")
         time.sleep(120)
         # Exit if any worker thread died (e.g. DB connection drop in a context
         # manager exit, outside the loop's try/except) so supervisor restarts us.
@@ -636,4 +640,4 @@ if __name__ == "__main__":
     try:
         service()
     except Exception as e:
-        log(f"Error occurred in TNS retrieval queue: {str(e)}")
+        log.error(f"Error occurred in TNS retrieval queue: {str(e)}")

--- a/services/tns_retrieval_queue/tns_retrieval_queue.py
+++ b/services/tns_retrieval_queue/tns_retrieval_queue.py
@@ -2,7 +2,6 @@ import asyncio
 import json
 import sys
 import time
-import traceback
 import urllib
 from datetime import datetime, timedelta
 from threading import Thread
@@ -478,8 +477,7 @@ def process_queue(queue):
                             session,
                         )
         except Exception as e:
-            traceback.print_exc()
-            log.error(f"Error processing TNS source {tns_name}: {e}")
+            log.exception(f"Error processing TNS source {tns_name}")
             user_id = task.get("user_id", None)
             if user_id is not None:
                 flow = Flow()
@@ -631,7 +629,9 @@ def service(*args, **kwargs):
         # Exit if any worker thread died (e.g. DB connection drop in a context
         # manager exit, outside the loop's try/except) so supervisor restarts us.
         if not (t.is_alive() and t2.is_alive() and t3.is_alive()):
-            log("A TNS retrieval worker thread died, exiting for supervisor restart")
+            log.error(
+                "A TNS retrieval worker thread died, exiting for supervisor restart"
+            )
             sys.exit(1)
 
 

--- a/services/watch_list/watch_list.py
+++ b/services/watch_list/watch_list.py
@@ -6,12 +6,12 @@ from astropy.time import Time
 
 from baselayer.app.env import load_env
 from baselayer.app.models import init_db
-from baselayer.log import make_log
 from skyportal.handlers.api.alert import (
     alert_available,
     get_alerts_by_position,
     post_alert,
 )
+from skyportal.log import make_log
 from skyportal.models import DBSession, Listing, Telescope, User
 from skyportal.utils.naive_datetime import utcnow_naive
 from skyportal.utils.services import check_loaded
@@ -46,7 +46,7 @@ def check_watch_list(time_info):
                 Listing.select(user).where(Listing.list_name == "watchlist")
             ).all()
         except Exception as e:
-            log(e)
+            log.info(e)
             return
 
         listing_ids = [listing.id for listing in listings]
@@ -198,11 +198,11 @@ def check_watch_list(time_info):
                         timeout=30,
                     )
                     if resp.status_code != 200:
-                        log(
+                        log.info(
                             f"Notification request failed for {request_body['target_class_name']} with ID {request_body['target_id']}: {resp.content}"
                         )
             except Exception as e:
-                log(e)
+                log.info(e)
                 DBSession.rollback()
                 continue
     end = time.time()
@@ -219,13 +219,13 @@ def service(*args, **kwargs):
             try:
                 time_info = ztf_observing_times()
             except Exception as e:
-                log(e)
+                log.info(e)
                 time.sleep(5)
                 continue
             try:
                 check_watch_list(time_info)
             except Exception as e:
-                log(e)
+                log.info(e)
                 time.sleep(5)
         else:
             time.sleep(60)

--- a/skyportal/app_server.py
+++ b/skyportal/app_server.py
@@ -4,7 +4,6 @@ from sentry_sdk.integrations.tornado import TornadoIntegration
 
 from baselayer.app.app_server import MainPageHandler
 from baselayer.app.model_util import create_tables
-from baselayer.log import make_log
 from skyportal.handlers import BecomeUserHandler, LogoutHandler
 from skyportal.handlers.api import (
     ACLHandler,
@@ -246,6 +245,7 @@ from skyportal.handlers.public import (
     ReportHandler,
     SourcePageHandler,
 )
+from skyportal.log import make_log
 
 from . import model_util, openapi
 from .models import init_db

--- a/skyportal/enum_types.py
+++ b/skyportal/enum_types.py
@@ -1,4 +1,3 @@
-import inspect
 from enum import Enum
 
 import astropy.units as u
@@ -9,7 +8,7 @@ from sncosmo.bandpasses import _BANDPASSES
 from sncosmo.magsystems import _MAGSYSTEMS
 
 from baselayer.app.env import load_env
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from .broker_apis import BROKERS
 from .facility_apis import APIS, LISTENERS
@@ -34,7 +33,7 @@ for additional_bandpasses in cfg.get("additional_bandpasses", []):
     if not name:
         continue
     if name in existing_bandpasses_names:
-        log(
+        log.info(
             f"Additional Bandpass name={name} is already in the sncosmo registry. Skipping."
         )
     try:
@@ -42,14 +41,14 @@ for additional_bandpasses in cfg.get("additional_bandpasses", []):
         transmission = np.array(additional_bandpasses.get("transmission"))
         band = sncosmo.Bandpass(wavelength, transmission, name=name, wave_unit=u.AA)
     except Exception as e:
-        log(f"Could not make bandpass for {name}: {e}")
+        log.error(f"Could not make bandpass for {name}: {e}")
         continue
 
     sncosmo.registry.register(band)
     additional_bandpasses_names.append(name)
 
 if len(additional_bandpasses_names) > 0:
-    log(f"registered custom bandpasses: {additional_bandpasses_names}")
+    log.info(f"registered custom bandpasses: {additional_bandpasses_names}")
 
 
 def force_render_enum_markdown(values):

--- a/skyportal/facility_apis/atlas.py
+++ b/skyportal/facility_apis/atlas.py
@@ -13,7 +13,7 @@ from sqlalchemy.orm import scoped_session, selectinload, sessionmaker
 
 from baselayer.app.env import load_env
 from baselayer.app.flow import Flow
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ..utils import http
 from ..utils.naive_datetime import utcnow_naive
@@ -259,7 +259,7 @@ def commit_photometry(
 
     except Exception as e:
         session.rollback()
-        log(f"Unable to commit photometry for {request_id}: {e}")
+        log.error(f"Unable to commit photometry for {request_id}: {e}")
         raise Exception(f"Unable to commit photometry for {request_id}: {e}")
     finally:
         if parent_session is None:

--- a/skyportal/facility_apis/blanco.py
+++ b/skyportal/facility_apis/blanco.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import selectinload
 
 from baselayer.app.env import load_env
 from baselayer.app.flow import Flow
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ..utils import http
 from ..utils.naive_datetime import utcnow_naive

--- a/skyportal/facility_apis/gemini.py
+++ b/skyportal/facility_apis/gemini.py
@@ -1,6 +1,5 @@
 import asyncio
 import functools
-import traceback
 from datetime import timedelta
 from json import JSONDecodeError
 
@@ -363,7 +362,7 @@ class GEMINIAPI(FollowUpAPI):
         try:
             gemini_request = await GeminiRequest.create(request, session)
         except Exception as e:
-            log.error(traceback.format_exc())
+            log.exception("Error building Gemini request")
             raise ValueError(f"Error building Gemini request: {e}")
 
         failed_requests = []

--- a/skyportal/facility_apis/gemini.py
+++ b/skyportal/facility_apis/gemini.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import selectinload
 
 from baselayer.app.env import load_env
 from baselayer.app.flow import Flow
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ..utils import http
 from ..utils.calculations import deg2dms, deg2hms
@@ -79,7 +79,7 @@ class GeminiRequest:
         ).all()
 
         if len(photometry) == 0:
-            log(
+            log.info(
                 f"No photometry found for {request.obj.id}, defaulting to object position"
             )
         else:
@@ -90,7 +90,7 @@ class GeminiRequest:
                     how="snr2",
                 )
             except JSONDecodeError:
-                log(
+                log.error(
                     f"Error calculating best position for {request.obj.id}, defaulting to object position"
                 )
                 best_ra, best_dec = request.obj.ra, request.obj.dec
@@ -363,7 +363,7 @@ class GEMINIAPI(FollowUpAPI):
         try:
             gemini_request = await GeminiRequest.create(request, session)
         except Exception as e:
-            log(traceback.format_exc())
+            log.error(traceback.format_exc())
             raise ValueError(f"Error building Gemini request: {e}")
 
         failed_requests = []
@@ -390,7 +390,7 @@ class GEMINIAPI(FollowUpAPI):
             else:
                 request.status = f"submitted: not all templates were submitted successfully, {failure_ids} failed"
 
-            log(
+            log.error(
                 f"Failed to submit some Gemini request for {request.id} (obj {request.obj.id}, template_ids {failure_ids}): {' / '.join(fail['content'] for fail in failed_requests)}"
             )
             try:
@@ -404,7 +404,7 @@ class GEMINIAPI(FollowUpAPI):
                     },
                 )
             except Exception as e:
-                log(f"Failed to send notification: {e}")
+                log.error(f"Failed to send notification: {e}")
 
         # Record the last request/response (params encoded in r.url).
         transaction = FacilityTransaction(

--- a/skyportal/facility_apis/growth_india.py
+++ b/skyportal/facility_apis/growth_india.py
@@ -15,7 +15,7 @@ from paramiko import SSHClient
 from scp import SCPClient
 from sqlalchemy.orm import selectinload
 
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from . import MMAAPI, GenericRequest
 

--- a/skyportal/facility_apis/lco.py
+++ b/skyportal/facility_apis/lco.py
@@ -12,7 +12,7 @@ from tornado.ioloop import IOLoop
 
 from baselayer.app.env import load_env
 from baselayer.app.flow import Flow
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ..utils import http
 from ..utils.naive_datetime import utcnow_naive
@@ -551,7 +551,7 @@ def download_observations(request_id, results, count):
         session.commit()
     except Exception as e:
         session.rollback()
-        log(f"Unable to post data for {request_id}: {e}")
+        log.error(f"Unable to post data for {request_id}: {e}")
     finally:
         session.close()
         Session.remove()

--- a/skyportal/facility_apis/lt.py
+++ b/skyportal/facility_apis/lt.py
@@ -13,7 +13,7 @@ from suds import Client
 
 from baselayer.app.env import load_env
 from baselayer.app.flow import Flow
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ..utils import http
 from ..utils.naive_datetime import utcnow_naive
@@ -136,7 +136,7 @@ class LTRequest:
             etree.SubElement(date_const, "DateTimeStart", system="UT", value=start)
             etree.SubElement(date_const, "DateTimeEnd", system="UT", value=end)
         except Exception as e:
-            log(f"Error parsing dates for LT request: {e}")
+            log.error(f"Error parsing dates for LT request: {e}")
             raise ValueError(
                 "Error parsing dates for LT request, should be in ISO format"
             )
@@ -457,7 +457,7 @@ class LTAPI(FollowUpAPI):
                     "skyportal/REFRESH_FOLLOWUP_REQUESTS",
                 )
         else:
-            log(
+            log.info(
                 f"Unknown mode {mode} response from LT. Unable to delete request {request.id} from LT queue: {response}"
             )
 
@@ -541,7 +541,7 @@ class IOOAPI(LTAPI):
         else:
             error = list(response_rtml.iter("{http://www.rtml.org/v3.1a}Error"))[0].text
             request.status = f"rejected: {error}"
-            log(
+            log.error(
                 f"Failed to submit IOO request: {str(error)}. Full payload: {str(full_payload)}"
             )
             try:
@@ -555,7 +555,7 @@ class IOOAPI(LTAPI):
                     },
                 )
             except Exception as e:
-                log(f"Failed to send notification: {e}")
+                log.error(f"Failed to send notification: {e}")
 
         transaction = FacilityTransaction(
             request=http.serialize_requests_request_xml(full_payload),
@@ -711,7 +711,7 @@ class IOIAPI(LTAPI):
         else:
             error = list(response_rtml.iter("{http://www.rtml.org/v3.1a}Error"))[0].text
             request.status = f"rejected: {error}"
-            log(
+            log.error(
                 f"Failed to submit IOI request: {str(error)}. Full payload: {str(full_payload)}"
             )
             try:
@@ -725,7 +725,7 @@ class IOIAPI(LTAPI):
                     },
                 )
             except Exception as e:
-                log(f"Failed to send notification: {e}")
+                log.error(f"Failed to send notification: {e}")
 
         transaction = FacilityTransaction(
             request=http.serialize_requests_request_xml(full_payload),
@@ -882,7 +882,7 @@ class SPRATAPI(LTAPI):
         else:
             error = list(response_rtml.iter("{http://www.rtml.org/v3.1a}Error"))[0].text
             request.status = f"rejected: {error}"
-            log(
+            log.error(
                 f"Failed to submit SPRAT request: {str(error)}. Full payload: {str(full_payload)}"
             )
             try:
@@ -896,7 +896,7 @@ class SPRATAPI(LTAPI):
                     },
                 )
             except Exception as e:
-                log(f"Failed to send notification: {e}")
+                log.error(f"Failed to send notification: {e}")
 
         transaction = FacilityTransaction(
             request=http.serialize_requests_request_xml(full_payload),

--- a/skyportal/facility_apis/mmt/binospec.py
+++ b/skyportal/facility_apis/mmt/binospec.py
@@ -1,4 +1,4 @@
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from .. import FollowUpAPI
 from .mmt_utils import (

--- a/skyportal/facility_apis/mmt/mmirs.py
+++ b/skyportal/facility_apis/mmt/mmirs.py
@@ -1,4 +1,4 @@
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from .. import FollowUpAPI
 from .mmt_utils import (

--- a/skyportal/facility_apis/mmt/mmt_utils.py
+++ b/skyportal/facility_apis/mmt/mmt_utils.py
@@ -314,7 +314,7 @@ async def submit_mmt_request(
                 request.last_modified_by_id, "skyportal/REFRESH_FOLLOWUP_REQUESTS"
             )
     except Exception as e:
-        log(f"Failed to send notification: {str(e)}")
+        log.error(f"Failed to send notification: {str(e)}")
 
 
 async def delete_mmt_request(session, request, log, **kwargs):
@@ -410,7 +410,7 @@ async def delete_mmt_request(session, request, log, **kwargs):
                 "skyportal/REFRESH_FOLLOWUP_REQUESTS",
             )
     except Exception as e:
-        log(f"Failed to send notification: {str(e)}")
+        log.error(f"Failed to send notification: {str(e)}")
 
 
 mmt_properties = {

--- a/skyportal/facility_apis/nicer.py
+++ b/skyportal/facility_apis/nicer.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import selectinload
 
 from baselayer.app.env import load_env
 from baselayer.app.flow import Flow
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ..utils import http
 from ..utils.naive_datetime import utcnow_naive

--- a/skyportal/facility_apis/observation_plan.py
+++ b/skyportal/facility_apis/observation_plan.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm import joinedload, selectinload
 
 from baselayer.app.env import load_env
 from baselayer.app.flow import Flow
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ..email_utils import send_email
 from ..utils import http
@@ -207,7 +207,7 @@ class MMAAPI(FollowUpAPI):
                 request.status = "running"
                 await session.commit()
 
-                log(
+                log.info(
                     f"Created observation plan request for ID {plan.id} in session {plan._sa_instance_state.session_id}"
                 )
 
@@ -225,7 +225,7 @@ class MMAAPI(FollowUpAPI):
                     f"plan_name {request.payload['queue_name']} already exists."
                 )
 
-        log(f"Generating schedule for observation plan {plan.id}")
+        log.info(f"Generating schedule for observation plan {plan.id}")
         requester_id = request.requester.id
 
         if asynchronous:
@@ -297,7 +297,7 @@ class MMAAPI(FollowUpAPI):
         ):
             request.status = "complete"
             await session.commit()
-            log(
+            log.info(
                 f"Plan {plan.id} is already complete. Marking request {request.id} as complete."
             )
             return plan.id
@@ -310,7 +310,7 @@ class MMAAPI(FollowUpAPI):
             and plan.status == "pending submission"
             and request.status == "running"
         ):
-            log(
+            log.info(
                 f"Plan {plan.id} has been pending submission for more than 24 hours. Deleting and creating a new plan."
             )
             await session.delete(plan)
@@ -381,7 +381,7 @@ class MMAAPI(FollowUpAPI):
             request.status = "running"
             await session.commit()
 
-            log(
+            log.info(
                 f"Created observation plan request for ID {plan.id} in session {plan._sa_instance_state.session_id}"
             )
 
@@ -397,7 +397,7 @@ class MMAAPI(FollowUpAPI):
                 "skyportal/REFRESH_OBSERVATION_PLAN_NAMES",
             )
 
-            log(f"Generating schedule for observation plan {plan.id}")
+            log.info(f"Generating schedule for observation plan {plan.id}")
             requester_id = request.requester.id
 
             if asynchronous:

--- a/skyportal/facility_apis/ps1.py
+++ b/skyportal/facility_apis/ps1.py
@@ -7,7 +7,7 @@ from tornado.ioloop import IOLoop
 
 from baselayer.app.env import load_env
 from baselayer.app.flow import Flow
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ..utils import http
 from ..utils.calculations import great_circle_distance
@@ -131,7 +131,7 @@ def commit_photometry(text_response, request_id, instrument_id, user_id):
 
     except Exception as e:
         session.rollback()
-        log(f"Unable to commit photometry for {request_id}: {e}")
+        log.error(f"Unable to commit photometry for {request_id}: {e}")
     finally:
         session.close()
         Session.remove()
@@ -311,7 +311,7 @@ class PS1API(FollowUpAPI):
                     raise ValueError("No data returned in request")
                 request.status = "submitted"
             except Exception as e:
-                log(str(e))
+                log.info(str(e))
                 request.status = "No DR2 source"
         else:
             request.status = f"rejected: {content}"

--- a/skyportal/facility_apis/sedm.py
+++ b/skyportal/facility_apis/sedm.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import selectinload
 
 from baselayer.app.env import load_env
 from baselayer.app.flow import Flow
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ..utils import http
 from ..utils.naive_datetime import utcnow_naive
@@ -320,7 +320,7 @@ class SEDMAPI(FollowUpAPI):
                 )
         except Exception as e:
             traceback.print_exc()
-            log(f"Error sending notification: {e}")
+            log.error(f"Error sending notification: {e}")
 
     @staticmethod
     async def delete(request, session, **kwargs):
@@ -471,7 +471,7 @@ class SEDMAPI(FollowUpAPI):
                 )
         except Exception as e:
             traceback.print_exc()
-            log(f"Error sending notification: {e}")
+            log.error(f"Error sending notification: {e}")
 
     @staticmethod
     def prepare_payload(payload, existing_payload=None):

--- a/skyportal/facility_apis/sedm.py
+++ b/skyportal/facility_apis/sedm.py
@@ -1,5 +1,4 @@
 import json
-import traceback
 from copy import deepcopy
 from datetime import timedelta
 
@@ -319,8 +318,7 @@ class SEDMAPI(FollowUpAPI):
                     is_update=False,
                 )
         except Exception as e:
-            traceback.print_exc()
-            log.error(f"Error sending notification: {e}")
+            log.exception("Error sending notification")
 
     @staticmethod
     async def delete(request, session, **kwargs):
@@ -470,8 +468,7 @@ class SEDMAPI(FollowUpAPI):
                     is_update=True,
                 )
         except Exception as e:
-            traceback.print_exc()
-            log.error(f"Error sending notification: {e}")
+            log.exception("Error sending notification")
 
     @staticmethod
     def prepare_payload(payload, existing_payload=None):

--- a/skyportal/facility_apis/sedmv2.py
+++ b/skyportal/facility_apis/sedmv2.py
@@ -15,7 +15,7 @@ from tornado.ioloop import IOLoop
 
 from baselayer.app.env import load_env
 from baselayer.app.flow import Flow
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ..utils import http
 from ..utils.instrument_log import read_logs
@@ -382,16 +382,16 @@ class SEDMV2API(FollowUpAPI):
         altdata = allocation.altdata
 
         if altdata.get("ssh_host") is None:
-            log(f"Host not specified for instrument with ID {instrument.id}")
+            log.info(f"Host not specified for instrument with ID {instrument.id}")
             return
         if altdata.get("ssh_port", 22) is None:
-            log(f"Port not specified for instrument with ID {instrument.id}")
+            log.info(f"Port not specified for instrument with ID {instrument.id}")
             return
         if altdata.get("ssh_username") is None:
-            log(f"Username not specified for instrument with ID {instrument.id}")
+            log.info(f"Username not specified for instrument with ID {instrument.id}")
             return
         if altdata.get("ssh_password") is None:
-            log(f"Password not specified for instrument with ID {instrument.id}")
+            log.info(f"Password not specified for instrument with ID {instrument.id}")
             return
 
         def _fetch_status():
@@ -420,7 +420,9 @@ class SEDMV2API(FollowUpAPI):
             await session.commit()
 
         except Exception as e:
-            log(f"Unable to commit status for instrument with ID {instrument.id}: {e}")
+            log.error(
+                f"Unable to commit status for instrument with ID {instrument.id}: {e}"
+            )
             await session.rollback()
             raise e
 
@@ -608,7 +610,9 @@ def fetch_nightly_logs(instrument_id, altdata, request_start, request_end):
             logs = read_logs(r.text)
 
             if not logs["logs"]:
-                log(f"Log for {day} unavailable for instrument with ID {instrument_id}")
+                log.info(
+                    f"Log for {day} unavailable for instrument with ID {instrument_id}"
+                )
                 continue
 
             start_date = None
@@ -639,7 +643,7 @@ def fetch_nightly_logs(instrument_id, altdata, request_start, request_end):
             session.commit()
 
     except Exception as e:
-        log(f"Unable to commit logs for instrument with ID {instrument_id}: {e}")
+        log.error(f"Unable to commit logs for instrument with ID {instrument_id}: {e}")
     finally:
         session.close()
         Session.remove()

--- a/skyportal/facility_apis/soar.py
+++ b/skyportal/facility_apis/soar.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import selectinload
 
 from baselayer.app.env import load_env
 from baselayer.app.flow import Flow
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ..utils import http
 from ..utils.naive_datetime import utcnow_naive

--- a/skyportal/facility_apis/swift.py
+++ b/skyportal/facility_apis/swift.py
@@ -5,7 +5,6 @@ import json
 import os
 import tarfile
 import tempfile
-import traceback
 from datetime import timedelta
 
 import aiohttp
@@ -667,8 +666,7 @@ class UVOTXRTAPI(FollowUpAPI):
                     is_update=False,
                 )
         except Exception as e:
-            traceback.print_exc()
-            log.error(f"Error sending notification: {e}")
+            log.exception("Error sending notification")
 
     form_json_schema = {
         "type": "object",

--- a/skyportal/facility_apis/swift.py
+++ b/skyportal/facility_apis/swift.py
@@ -19,7 +19,7 @@ from tornado.ioloop import IOLoop
 
 from baselayer.app.env import load_env
 from baselayer.app.flow import Flow
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ..utils import http
 from ..utils.naive_datetime import utcnow_naive
@@ -403,7 +403,7 @@ def download_observations(request_id, oq):
 
     except Exception as e:
         session.rollback()
-        log(f"Unable to post data for {request_id}: {e}")
+        log.error(f"Unable to post data for {request_id}: {e}")
     finally:
         session.close()
         Session.remove()
@@ -572,7 +572,7 @@ class UVOTXRTAPI(FollowUpAPI):
                 request.status = "submitted"
             else:
                 request.status = f"rejected: {content}"
-                log(
+                log.error(
                     f"Failed to submit Swift request for {request.id} (obj {request.obj.id}): {content}"
                 )
                 try:
@@ -586,7 +586,7 @@ class UVOTXRTAPI(FollowUpAPI):
                         },
                     )
                 except Exception as e:
-                    log(f"Failed to send notification: {e}")
+                    log.error(f"Failed to send notification: {e}")
 
             transaction = FacilityTransaction(
                 request=http.serialize_aiohttp_request("POST", API_URL, None, payload),
@@ -668,7 +668,7 @@ class UVOTXRTAPI(FollowUpAPI):
                 )
         except Exception as e:
             traceback.print_exc()
-            log(f"Error sending notification: {e}")
+            log.error(f"Error sending notification: {e}")
 
     form_json_schema = {
         "type": "object",

--- a/skyportal/facility_apis/tarot.py
+++ b/skyportal/facility_apis/tarot.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm import selectinload
 
 from baselayer.app.env import load_env
 from baselayer.app.flow import Flow
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ..utils import http
 from ..utils.calculations import get_next_valid_observing_time
@@ -513,7 +513,7 @@ class TAROTAPI(FollowUpAPI):
                     request.last_modified_by_id, "skyportal/REFRESH_FOLLOWUP_REQUESTS"
                 )
         except Exception as e:
-            log(f"Failed to send notification: {str(e)}")
+            log.error(f"Failed to send notification: {str(e)}")
 
     @staticmethod
     @catch_timeout_and_no_endpoint
@@ -707,7 +707,7 @@ class TAROTAPI(FollowUpAPI):
                     },
                 )
         except Exception as e:
-            log(f"Failed to send notification: {str(e)}")
+            log.error(f"Failed to send notification: {str(e)}")
 
     @staticmethod
     @catch_timeout_and_no_endpoint
@@ -809,7 +809,7 @@ class TAROTAPI(FollowUpAPI):
                     "skyportal/REFRESH_FOLLOWUP_REQUESTS",
                 )
         except Exception as e:
-            log(f"Failed to send notification: {str(e)}")
+            log.error(f"Failed to send notification: {str(e)}")
 
     def custom_json_schema(instrument, user, **kwargs):
         config = instrument.configuration_data

--- a/skyportal/facility_apis/tess.py
+++ b/skyportal/facility_apis/tess.py
@@ -9,7 +9,7 @@ from tornado.ioloop import IOLoop
 
 from baselayer.app.env import load_env
 from baselayer.app.flow import Flow
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from . import FollowUpAPI
 
@@ -161,7 +161,7 @@ def commit_photometry(lc, request_id, instrument_id, user_id):
 
     except Exception as e:
         session.rollback()
-        log(f"Unable to commit photometry for {request_id}: {e}")
+        log.error(f"Unable to commit photometry for {request_id}: {e}")
     finally:
         session.close()
         Session.remove()

--- a/skyportal/facility_apis/trt.py
+++ b/skyportal/facility_apis/trt.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm import selectinload
 
 from baselayer.app.env import load_env
 from baselayer.app.flow import Flow
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ..utils import http
 from ..utils.naive_datetime import utcnow_naive
@@ -136,7 +136,7 @@ def download_observations(request_id, urls):
                         bot=True,
                     )
                 except Exception as e:
-                    log(
+                    log.info(
                         f"TRT API Retrieve: unable to download data for {request_id}: {e}"
                     )
                     comment = Comment(
@@ -151,7 +151,7 @@ def download_observations(request_id, urls):
             session.commit()
         except Exception as e:
             session.rollback()
-            log(f"Unable to post data for {request_id}: {e}")
+            log.error(f"Unable to post data for {request_id}: {e}")
 
 
 class TRTAPI(FollowUpAPI):
@@ -252,7 +252,7 @@ class TRTAPI(FollowUpAPI):
                     },
                 )
         except Exception as e:
-            log(f"Failed to send notification: {e}")
+            log.error(f"Failed to send notification: {e}")
 
     @staticmethod
     async def get(request, session, **kwargs):
@@ -400,7 +400,7 @@ class TRTAPI(FollowUpAPI):
                     },
                 )
         except Exception as e:
-            log(f"Failed to send notification: {e}")
+            log.error(f"Failed to send notification: {e}")
 
     @staticmethod
     async def delete(request, session, **kwargs):

--- a/skyportal/facility_apis/ttt.py
+++ b/skyportal/facility_apis/ttt.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import selectinload
 
 from baselayer.app.env import load_env
 from baselayer.app.flow import Flow
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ..utils import http
 from ..utils.naive_datetime import utcnow_naive
@@ -215,7 +215,7 @@ class TTTAPI(FollowUpAPI):
                     },
                 )
         except Exception as e:
-            log(f"Failed to send notification: {e}")
+            log.error(f"Failed to send notification: {e}")
 
     @staticmethod
     async def delete(request, session, **kwargs):

--- a/skyportal/facility_apis/winter/spring.py
+++ b/skyportal/facility_apis/winter/spring.py
@@ -1,4 +1,4 @@
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from .. import FollowUpAPI
 from .winter_utils import (

--- a/skyportal/facility_apis/winter/winter.py
+++ b/skyportal/facility_apis/winter/winter.py
@@ -1,4 +1,4 @@
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from .. import FollowUpAPI
 from .winter_utils import (

--- a/skyportal/facility_apis/winter/winter_utils.py
+++ b/skyportal/facility_apis/winter/winter_utils.py
@@ -287,7 +287,7 @@ async def submit_request(request, session, camera, log, **kwargs):
         request.status = "submitted"
     else:
         request.status = f"rejected: {content}"
-        log(
+        log.error(
             f"Failed to submit {camera} request for {request.id} (obj {request.obj.id}): {content}"
         )
         try:
@@ -301,7 +301,7 @@ async def submit_request(request, session, camera, log, **kwargs):
                 },
             )
         except Exception as e:
-            log(f"Failed to send notification for failed {camera} request: {e}")
+            log.error(f"Failed to send notification for failed {camera} request: {e}")
 
     transaction = FacilityTransaction(
         request=http.serialize_aiohttp_request("POST", url, None, [payload]),
@@ -346,7 +346,7 @@ async def submit_request(request, session, camera, log, **kwargs):
             )
     except Exception as e:
         traceback.print_exc()
-        log(f"Error sending notification: {e}")
+        log.error(f"Error sending notification: {e}")
 
 
 def build_form_json_schema(filter_defaults):

--- a/skyportal/facility_apis/winter/winter_utils.py
+++ b/skyportal/facility_apis/winter/winter_utils.py
@@ -1,5 +1,4 @@
 import json
-import traceback
 import urllib
 from datetime import timedelta
 
@@ -345,8 +344,7 @@ async def submit_request(request, session, camera, log, **kwargs):
                 is_update=False,
             )
     except Exception as e:
-        traceback.print_exc()
-        log.error(f"Error sending notification: {e}")
+        log.exception("Error sending notification")
 
 
 def build_form_json_schema(filter_defaults):

--- a/skyportal/facility_apis/ztf.py
+++ b/skyportal/facility_apis/ztf.py
@@ -21,7 +21,7 @@ from tornado.ioloop import IOLoop
 from baselayer.app.env import load_env
 from baselayer.app.flow import Flow
 from baselayer.app.models import async_plain_session_factory
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ..utils import http
 from ..utils.naive_datetime import utcnow_naive
@@ -572,7 +572,7 @@ class ZTFAPI(FollowUpAPI):
                 await session.delete(transaction)
             await session.delete(request)
             await session.commit()
-            log(f"Deleted request {request.id} from ZTF queue.")
+            log.info(f"Deleted request {request.id} from ZTF queue.")
         else:
             raise ValueError("Unknown request type.")
 
@@ -1091,7 +1091,7 @@ class ZTFMMAAPI(MMAAPI):
                         },
                     )
         except Exception as e:
-            log(
+            log.error(
                 f"Error marking observation plan request (with same queue name) status as deleted from queue: {e}"
             )
 
@@ -1282,7 +1282,7 @@ def fetch_depot_observations(instrument_id, session, depot_url, jd_start, jd_end
         r = session.head(url)
 
         if r.status_code == 401:
-            log(
+            log.info(
                 f"Unauthorized access to depot for instrument ID {instrument_id} for JD: {jd}"
             )
             continue
@@ -1293,7 +1293,9 @@ def fetch_depot_observations(instrument_id, session, depot_url, jd_start, jd_end
             obstable = pd.DataFrame(r.json())
 
             if obstable.empty:
-                log(f"No observations for instrument ID {instrument_id} for JD: {jd}")
+                log.info(
+                    f"No observations for instrument ID {instrument_id} for JD: {jd}"
+                )
                 continue
             # only want successfully reduced images
             obstable = obstable[obstable["status"] == 0]
@@ -1327,7 +1329,7 @@ def fetch_depot_observations(instrument_id, session, depot_url, jd_start, jd_end
                         obstable[col] = obstable[col].str.strip()
 
                 if obstable.empty:
-                    log(
+                    log.info(
                         f"No observations for instrument ID {instrument_id} for JD: {jd}"
                     )
                     continue
@@ -1347,10 +1349,10 @@ def fetch_depot_observations(instrument_id, session, depot_url, jd_start, jd_end
                         ]
                     ]
                 except KeyError as e:
-                    log(
+                    log.error(
                         f"Could not find expected columns in depot file for JD {jd}: {e}"
                     )
-                    log(f"Depot file head:\n{obstable.head(1)}")
+                    log.info(f"Depot file head:\n{obstable.head(1)}")
                     continue
 
                 # move rows with NaN values in any of the columns
@@ -1368,7 +1370,7 @@ def fetch_depot_observations(instrument_id, session, depot_url, jd_start, jd_end
                 )
 
                 if obstable.empty:
-                    log(
+                    log.info(
                         f"No observations for instrument ID {instrument_id} for JD: {jd}"
                     )
                     continue
@@ -1438,7 +1440,7 @@ def fetch_tap_observations(instrument_id, client, request_str):
     obstable = job.fetch_result().to_table()
     obstable = obstable.filled().to_pandas()
     if obstable.empty:
-        log(
+        log.info(
             f"No observations for instrument ID {instrument_id} for request: {request_str}"
         )
         return

--- a/skyportal/handlers/api/analysis.py
+++ b/skyportal/handlers/api/analysis.py
@@ -23,7 +23,7 @@ from baselayer.app.access import auth_or_token, permissions
 from baselayer.app.env import load_env
 from baselayer.app.flow import Flow
 from baselayer.app.model_util import recursive_to_dict
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ...app_utils import get_app_base_url
 from ...enum_types import (
@@ -517,7 +517,7 @@ def post_analysis(
             session.add(user_notification)
             session.commit()
         except Exception as e:
-            log(f"Could not add notification: {e}")
+            log.error(f"Could not add notification: {e}")
 
     def analysis_done_callback(
         future,
@@ -538,10 +538,10 @@ def post_analysis(
                     logger.error(f"Analysis {analysis_id} not found")
                     return
             except Exception as e:
-                log(f"Could not access Analysis {analysis_id} {e}.")
+                log.error(f"Could not access Analysis {analysis_id} {e}.")
                 return
         else:
-            log(f"Invalid analysis_resource_type: {analysis_resource_type}")
+            log.info(f"Invalid analysis_resource_type: {analysis_resource_type}")
             return
 
         analysis.last_activity = utcnow_naive()
@@ -554,7 +554,7 @@ def post_analysis(
             analysis.status = "failure"
             analysis.status_message = str(future.exception())[:1024]
         finally:
-            logger(
+            logger.info(
                 f"[id={analysis_id} service={analysis_service_id}] status='{analysis.status}' message='{analysis.status_message}'"
             )
             session.commit()
@@ -567,7 +567,7 @@ def post_analysis(
                         payload={"obj_key": analysis.obj.internal_key},
                     )
                 except Exception as e:
-                    logger(f"Could not refresh analyses: {e}")
+                    logger.error(f"Could not refresh analyses: {e}")
 
     # Start the analysis service in a separate thread and log any exceptions
     x = IOLoop.current().run_in_executor(None, external_analysis_service)
@@ -806,7 +806,7 @@ async def post_analysis_async(
             session.add(user_notification)
             await session.commit()
         except Exception as e:
-            log(f"Could not add notification: {e}")
+            log.error(f"Could not add notification: {e}")
 
     def analysis_done_callback(
         future,
@@ -831,10 +831,10 @@ async def post_analysis_async(
                         logger.error(f"Analysis {analysis_id} not found")
                         return
                 except Exception as e:
-                    log(f"Could not access Analysis {analysis_id} {e}.")
+                    log.error(f"Could not access Analysis {analysis_id} {e}.")
                     return
             else:
-                log(f"Invalid analysis_resource_type: {analysis_resource_type}")
+                log.info(f"Invalid analysis_resource_type: {analysis_resource_type}")
                 return
 
             analysis.last_activity = utcnow_naive()
@@ -847,7 +847,7 @@ async def post_analysis_async(
                 analysis.status = "failure"
                 analysis.status_message = str(future.exception())[:1024]
             finally:
-                logger(
+                logger.info(
                     f"[id={analysis_id} service={analysis_service_id}] status='{analysis.status}' message='{analysis.status_message}'"
                 )
                 db_session.commit()
@@ -860,7 +860,7 @@ async def post_analysis_async(
                             payload={"obj_key": analysis.obj.internal_key},
                         )
                     except Exception as e:
-                        logger(f"Could not refresh analyses: {e}")
+                        logger.error(f"Could not refresh analyses: {e}")
 
     # Start the analysis service in a separate thread and log any exceptions
     x = IOLoop.current().run_in_executor(None, external_analysis_service)
@@ -1926,7 +1926,7 @@ class AnalysisHandler(BaseHandler):
                             payload={"obj_key": obj_internal_key},
                         )
                 except Exception as e:
-                    log(f"Error pushing updates to source: {e}")
+                    log.error(f"Error pushing updates to source: {e}")
 
                 return self.success()
             else:
@@ -2286,7 +2286,7 @@ class AnalysisUploadOnlyHandler(BaseHandler):
                 message = f"Saved upload_only analysis data at {analysis.filename}. Message: {analysis.status_message}"
             else:
                 message = f"Note: empty analysis upload_only results. Message: {analysis.status_message}"
-            log(message)
+            log.info(message)
             await session.commit()
             return self.success(data={"id": analysis.id, "message": message})
 

--- a/skyportal/handlers/api/analysis.py
+++ b/skyportal/handlers/api/analysis.py
@@ -190,7 +190,9 @@ def deredden_photometry_df(df, ra, dec):
     # partially-corrected multi-survey light curve isn't a silent surprise.
     skipped = sorted(f for f, v in a_lambda.items() if v is None)
     if skipped:
-        log(f"deredden: no extinction coefficient for {skipped}; left uncorrected")
+        log.warning(
+            f"deredden: no extinction coefficient for {skipped}; left uncorrected"
+        )
     a = df["filter"].map(a_lambda).astype(float)
     mask = a.notna()
     if not mask.any():

--- a/skyportal/handlers/api/annotation.py
+++ b/skyportal/handlers/api/annotation.py
@@ -7,7 +7,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import selectinload
 
 from baselayer.app.access import auth_or_token, permissions
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ...models import (
     Annotation,
@@ -206,7 +206,7 @@ class AnnotationHandler(BaseHandler):
                 if query_size >= SIZE_WARNING_THRESHOLD:
                     end = time.time()
                     duration = end - start
-                    log(
+                    log.info(
                         f"User {self.associated_user_object.id} annotation query returned {query_size} bytes in {duration} seconds"
                     )
                 return self.success(data=query_output)
@@ -239,7 +239,7 @@ class AnnotationHandler(BaseHandler):
             if query_size >= SIZE_WARNING_THRESHOLD:
                 end = time.time()
                 duration = end - start
-                log(
+                log.info(
                     f"User {self.associated_user_object.id} annotation query returned {query_size} bytes in {duration} seconds"
                 )
 

--- a/skyportal/handlers/api/candidate/candidate.py
+++ b/skyportal/handlers/api/candidate/candidate.py
@@ -24,7 +24,7 @@ from sqlalchemy.types import Boolean, Float, Integer, String
 from baselayer.app.access import auth_or_token, permissions
 from baselayer.app.env import load_env
 from baselayer.app.model_util import recursive_to_dict
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ....models import (
     Allocation,
@@ -787,7 +787,7 @@ class CandidateHandler(BaseHandler):
                 if query_size >= SIZE_WARNING_THRESHOLD:
                     end = time.time()
                     duration = end - start
-                    log(
+                    log.info(
                         f"User {self.associated_user_object.id} candidate query for object {obj_id} returned {query_size} bytes in {duration} seconds"
                     )
 
@@ -1516,7 +1516,7 @@ class CandidateHandler(BaseHandler):
             if query_size >= SIZE_WARNING_THRESHOLD:
                 end = time.time()
                 duration = end - start
-                log(
+                log.info(
                     f"User {self.associated_user_object.id} candidate query returned {query_size} bytes in {duration} seconds"
                 )
 
@@ -1966,7 +1966,7 @@ class BulkDeleteCandidatesHandler(BaseHandler):
             session.commit()
 
             remaining = int(session.scalar(count_stmt) or 0)
-            log(
+            log.info(
                 f"Bulk-deleted {n} unsaved candidate object(s) older than "
                 f"{max_age_months} months; {remaining} remaining."
             )

--- a/skyportal/handlers/api/candidate/candidate_filter.py
+++ b/skyportal/handlers/api/candidate/candidate_filter.py
@@ -5,7 +5,7 @@ import sqlalchemy as sa
 from sqlalchemy.sql.expression import func
 
 from baselayer.app.access import auth_or_token
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ....models import (
     Candidate,

--- a/skyportal/handlers/api/candidate/scan_report.py
+++ b/skyportal/handlers/api/candidate/scan_report.py
@@ -2,7 +2,7 @@ import sqlalchemy as sa
 from sqlalchemy.orm import selectinload
 
 from baselayer.app.access import auth_or_token
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ....models import Filter, Group, Source
 from ....models.candidate import Candidate
@@ -57,7 +57,7 @@ async def get_sources_by_objs_in_range(
         )
         return result.all()
     except Exception as e:
-        log(f"Error while retrieving saved candidates: {e}")
+        log.error(f"Error while retrieving saved candidates: {e}")
         return []
 
 

--- a/skyportal/handlers/api/candidate/scan_report_item.py
+++ b/skyportal/handlers/api/candidate/scan_report_item.py
@@ -2,7 +2,7 @@ from astropy.time import Time
 from sqlalchemy.orm import selectinload
 
 from baselayer.app.access import auth_or_token
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from .... import facility_apis
 from ....models import FollowupRequest, Obj, Source

--- a/skyportal/handlers/api/catalog_services.py
+++ b/skyportal/handlers/api/catalog_services.py
@@ -18,7 +18,7 @@ from tornado.ioloop import IOLoop
 from baselayer.app.access import auth_or_token
 from baselayer.app.env import load_env
 from baselayer.app.flow import Flow
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 try:
     from .alert import post_alert
@@ -195,7 +195,7 @@ def fetch_transients(allocation_id, user_id, group_ids, payload):
 
             program_id_selector = list(program_id_selector)
 
-            log("Querying kowalski for sources")
+            log.info("Querying kowalski for sources")
             # Query kowalski
             sources = query_kowalski(
                 token=altdata["access_token"],
@@ -221,20 +221,20 @@ def fetch_transients(allocation_id, user_id, group_ids, payload):
             session.commit()
 
             obj_ids = []
-            log(f"Found {len(sources)} sources, posting...")
+            log.info(f"Found {len(sources)} sources, posting...")
             for source in sources:
-                log(f"Retrieving {source['id']}")
+                log.info(f"Retrieving {source['id']}")
                 s = session.scalars(
                     Obj.select(user).where(Obj.id == source["id"])
                 ).first()
                 if s is None:
-                    log(f"Posting {source['id']} as source")
+                    log.info(f"Posting {source['id']} as source")
                     source["group_ids"] = group_ids
                     (obj_id,) = post_source(source, user_id, session)
                     obj_ids.append(obj_id)
 
                 if alert_available:
-                    log(f"Posting photometry from {source['id']}")
+                    log.info(f"Posting photometry from {source['id']}")
                     post_alert(
                         source["id"],
                         group_ids,
@@ -242,7 +242,7 @@ def fetch_transients(allocation_id, user_id, group_ids, payload):
                         session,
                         program_id_selector=program_id_selector,
                     )
-            log("Finished querying Kowalski for sources")
+            log.info("Finished querying Kowalski for sources")
 
         elif payload["catalogName"] == "ZTF-Fink":
             instrument = session.scalars(
@@ -256,16 +256,16 @@ def fetch_transients(allocation_id, user_id, group_ids, payload):
                 healpix, level=payload["localizationCumprob"]
             )
 
-            log("Querying Fink for sources")
+            log.info("Querying Fink for sources")
             sources = query_fink(
                 jd_trigger, ra_center, dec_center, max_days=dt, within_days=dt
             )
 
             obj_ids = []
-            log("Looping over sources")
+            log.info("Looping over sources")
             for source in sources:
                 df = source.pop("data")
-                log(f"Retrieving {source['id']}")
+                log.info(f"Retrieving {source['id']}")
 
                 data_out = {
                     "obj_id": source["id"],
@@ -287,10 +287,10 @@ def fetch_transients(allocation_id, user_id, group_ids, payload):
                     # executor. The obj is already committed by post_source above, so
                     # the bridge's separate session can see it.
                     asyncio.run(commit_external_photometry(data_out, user_id))
-                    log(f"Photometry committed to database for {source['id']}")
+                    log.info(f"Photometry committed to database for {source['id']}")
                 else:
-                    log(f"No photometry to commit to database for {source['id']}")
-            log("Finished querying Fink for sources")
+                    log.info(f"No photometry to commit to database for {source['id']}")
+            log.info("Finished querying Fink for sources")
 
         elif payload["catalogName"] == "LSXPS":
             telescope_name = "Swift"
@@ -300,9 +300,9 @@ def fetch_transients(allocation_id, user_id, group_ids, payload):
             if telescope is None:
                 raise AttributeError(f"Expected a Telescope named {telescope_name}")
             instrument = telescope.instruments[0]
-            log("Querying Swift for sources")
+            log.info("Querying Swift for sources")
             obj_ids = fetch_swift_transients(instrument.id, user_id, group_ids)
-            log("Finished querying Swift for sources")
+            log.info("Finished querying Swift for sources")
 
         elif payload["catalogName"] == "Gaia":
             telescope_name = "Gaia"
@@ -312,14 +312,14 @@ def fetch_transients(allocation_id, user_id, group_ids, payload):
             if telescope is None:
                 raise AttributeError(f"Expected a Telescope named {telescope_name}")
             instrument = telescope.instruments[0]
-            log("Querying Gaia for sources")
+            log.info("Querying Gaia for sources")
             obj_ids = fetch_gaia_transients(
                 instrument.id,
                 user_id,
                 group_ids,
                 {"start_date": start_date, "end_date": end_date},
             )
-            log("Finished querying Gaia for sources")
+            log.info("Finished querying Gaia for sources")
         elif payload["catalogName"] == "TESS":
             telescope_name = "TESS"
             telescope = session.scalars(
@@ -328,14 +328,14 @@ def fetch_transients(allocation_id, user_id, group_ids, payload):
             if telescope is None:
                 raise AttributeError(f"Expected a Telescope named {telescope_name}")
             instrument = telescope.instruments[0]
-            log("Querying TESS for sources")
+            log.info("Querying TESS for sources")
             obj_ids = fetch_tess_transients(
                 instrument.id,
                 user_id,
                 group_ids,
                 {"start_date": start_date, "end_date": end_date},
             )
-            log("Finished querying TESS for sources")
+            log.info("Finished querying TESS for sources")
         else:
             return AttributeError(f"Catalog name {payload['catalogName']} unknown")
 
@@ -363,7 +363,7 @@ def fetch_transients(allocation_id, user_id, group_ids, payload):
                 payload={},
             )
         except Exception as e:
-            log(f"Could not add notification: {e}")
+            log.error(f"Could not add notification: {e}")
 
         # frontend refresh
         try:
@@ -376,7 +376,7 @@ def fetch_transients(allocation_id, user_id, group_ids, payload):
             pass
 
     except Exception as e:
-        return log(f"Unable to commit transient catalog: {e}")
+        return log.error(f"Unable to commit transient catalog: {e}")
 
 
 class SwiftLSXPSQueryHandler(BaseHandler):
@@ -572,9 +572,9 @@ def fetch_swift_transients(instrument_id, user_id, group_ids):
                         # async add_external_photometry, bridged from this sync executor;
                         # obj already committed above so the bridge's session sees it.
                         asyncio.run(commit_external_photometry(data_out, user_id))
-                        log(f"Photometry committed to database for {obj_id}")
+                        log.info(f"Photometry committed to database for {obj_id}")
                     else:
-                        log(f"No photometry to commit to database for {obj_id}")
+                        log.info(f"No photometry to commit to database for {obj_id}")
 
                 if transient in q.spectra:
                     filenames = glob.glob(f"{tmpdirname}/{transient}/interval*")
@@ -599,7 +599,7 @@ def fetch_swift_transients(instrument_id, user_id, group_ids):
         return obj_ids
 
     except Exception as e:
-        return log(f"Unable to commit Swift XRT transient catalog: {e}")
+        return log.error(f"Unable to commit Swift XRT transient catalog: {e}")
 
 
 class GaiaPhotometricAlertsQueryHandler(BaseHandler):
@@ -724,7 +724,7 @@ def fetch_gaia_transients(instrument_id, user_id, group_ids, payload):
                 nretries = nretries + 1
                 time.sleep(10)
         if not file_read:
-            log("Failed to read Gaia alert catalog")
+            log.error("Failed to read Gaia alert catalog")
             return
 
         start_date = payload.get("start_date", None)
@@ -760,7 +760,7 @@ def fetch_gaia_transients(instrument_id, user_id, group_ids, payload):
                     header_start=1,
                 )
             except FileNotFoundError:
-                log(f"Gaia alert {name} not found.")
+                log.info(f"Gaia alert {name} not found.")
                 continue
 
             lc["mjd"] = Time(lc["JD(TCB)"], format="jd").mjd
@@ -816,13 +816,13 @@ def fetch_gaia_transients(instrument_id, user_id, group_ids, payload):
                 # async add_external_photometry, bridged from this sync executor;
                 # obj already committed above so the bridge's session sees it.
                 asyncio.run(commit_external_photometry(data_out, user_id))
-                log(f"Photometry committed to database for {obj_id}")
+                log.info(f"Photometry committed to database for {obj_id}")
             else:
-                log(f"No photometry to commit to database for {obj_id}")
+                log.info(f"No photometry to commit to database for {obj_id}")
 
         return obj_ids
     except Exception as e:
-        return log(f"Unable to commit Gaia Photometric Alert catalog: {e}")
+        return log.error(f"Unable to commit Gaia Photometric Alert catalog: {e}")
 
 
 class TessTransientsQueryHandler(BaseHandler):
@@ -949,7 +949,7 @@ def fetch_tess_transients(instrument_id, user_id, group_ids, payload):
                 nretries = nretries + 1
                 time.sleep(10)
         if not file_read:
-            log("Failed to read TESS alert catalog")
+            log.error("Failed to read TESS alert catalog")
             return
 
         start_date = payload.get("start_date", None)
@@ -985,16 +985,16 @@ def fetch_tess_transients(instrument_id, user_id, group_ids, payload):
                     header_start=1,
                 )
             except FileNotFoundError:
-                log(f"TESS alert {name} not found.")
+                log.info(f"TESS alert {name} not found.")
                 continue
             except Exception:
-                log(
+                log.info(
                     f"TESS alert {name} could not be ingested: {lightcurve_url}/lc_{name}_cleaned"
                 )
                 continue
 
             if "BTJD" not in list(lc.columns):
-                log(
+                log.info(
                     f"TESS alert {name} could not be ingested: {lightcurve_url}/lc_{name}_cleaned"
                 )
                 continue
@@ -1063,7 +1063,7 @@ def fetch_tess_transients(instrument_id, user_id, group_ids, payload):
             if len(df.index) > 0:
                 try:
                     post_photometric_series(data_out, df, {}, user, session)
-                    log(f"Photometry committed to database for {obj_id}")
+                    log.info(f"Photometry committed to database for {obj_id}")
                 except Exception:
                     ps = session.scalars(
                         sa.select(PhotometricSeries).where(
@@ -1073,12 +1073,12 @@ def fetch_tess_transients(instrument_id, user_id, group_ids, payload):
                     ).first()
                     if ps is not None:
                         update_photometric_series(ps, data_out, df, {}, user, session)
-                        log(f"Photometry updated in database for {obj_id}")
+                        log.info(f"Photometry updated in database for {obj_id}")
                     else:
-                        log(f"No photometry to commit to database for {obj_id}")
+                        log.info(f"No photometry to commit to database for {obj_id}")
             else:
-                log(f"No photometry to commit to database for {obj_id}")
+                log.info(f"No photometry to commit to database for {obj_id}")
 
         return obj_ids
     except Exception as e:
-        return log(f"Unable to commit TESS transient catalog: {e}")
+        return log.error(f"Unable to commit TESS transient catalog: {e}")

--- a/skyportal/handlers/api/comment.py
+++ b/skyportal/handlers/api/comment.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import selectinload, undefer
 
 from baselayer.app.access import auth_or_token, permissions
 from baselayer.app.env import load_env
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ...models import (
     Allocation,
@@ -350,7 +350,7 @@ class CommentHandler(BaseHandler):
                 if query_size >= SIZE_WARNING_THRESHOLD:
                     end = time.time()
                     duration = end - start
-                    log(
+                    log.info(
                         f"User {self.associated_user_object.id} comment query returned {query_size} bytes in {duration} seconds"
                     )
 
@@ -435,7 +435,7 @@ class CommentHandler(BaseHandler):
             if query_size >= SIZE_WARNING_THRESHOLD:
                 end = time.time()
                 duration = end - start
-                log(
+                log.info(
                     f"User {self.associated_user_object.id} comment query returned {query_size} bytes in {duration} seconds"
                 )
 
@@ -1494,7 +1494,7 @@ class CommentAttachmentHandler(BaseHandler):
                         attachment = get_fits_preview(attachment_name, attachment)
                         attachment_name = os.path.splitext(attachment_name)[0] + ".png"
                     except Exception as e:
-                        log(f"Cannot render {attachment_name} as image: {str(e)}")
+                        log.error(f"Cannot render {attachment_name} as image: {str(e)}")
                         return self.error(
                             f"Cannot render {attachment_name} as image: {str(e)}"
                         )
@@ -1522,7 +1522,7 @@ class CommentAttachmentHandler(BaseHandler):
 
             query_size = sizeof(comment_data)
             if query_size >= SIZE_WARNING_THRESHOLD:
-                log(
+                log.info(
                     f"User {self.associated_user_object.id} comment attachment query ({table.__tablename__} with ID {comment_id}) returned {query_size} bytes"
                 )
 

--- a/skyportal/handlers/api/earthquake.py
+++ b/skyportal/handlers/api/earthquake.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm.attributes import set_attribute
 
 from baselayer.app.access import auth_or_token
 from baselayer.app.custom_exceptions import AccessError
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ...models import (
     EarthquakeEvent,

--- a/skyportal/handlers/api/followup_request.py
+++ b/skyportal/handlers/api/followup_request.py
@@ -44,7 +44,7 @@ from tornado.ioloop import IOLoop
 from baselayer.app.access import auth_or_token, permissions
 from baselayer.app.flow import Flow
 from baselayer.app.models import async_plain_session_factory
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ...models import (
     Allocation,
@@ -684,7 +684,7 @@ async def post_followup_request_async(
                         tns_time = tns_info.get("discoverydate", None)
                         tns_time = arrow.get(tns_time).datetime
                 except Exception as e:
-                    log(
+                    log.error(
                         f"Error parsing TNS info for source {existing_tns_source.id}: {e}, skipping."
                     )
                     continue
@@ -843,8 +843,8 @@ async def post_followup_request_async(
             refresh_requests=refresh_requests,
         )
     except Exception as e:
-        log(f"Failed to submit follow-up request: {e}, traceback:")
-        log(traceback.format_exc())
+        log.error(f"Failed to submit follow-up request: {e}, traceback:")
+        log.error(traceback.format_exc())
         followup_request.status = f"failed to submit: {e}"
         raise
     finally:
@@ -1022,20 +1022,20 @@ async def _post_default_followup_requests_async(
                                 candidate, session
                             )
                             await session.commit()
-                            log(
+                            log.info(
                                 f"Bumped priority of existing followup request "
                                 f"{candidate.id} for {obj_id} (allocation "
                                 f"{allocation_id}) from {existing_priority} to {new_priority}."
                             )
                         except Exception as e:
                             await session.rollback()
-                            log(
+                            log.error(
                                 f"Failed to bump priority of followup request "
                                 f"{candidate.id} for {obj_id} (allocation "
                                 f"{allocation_id}): {e}"
                             )
                     else:
-                        log(
+                        log.info(
                             f"Skipping default followup request for {obj_id} with "
                             f"allocation ID {allocation_id} because an equivalent one "
                             f"already exists."
@@ -1054,7 +1054,7 @@ async def _post_default_followup_requests_async(
                 await post_followup_request_async(
                     data, constraints, session, refresh_source=False
                 )
-                log(
+                log.info(
                     f"Posted default followup request for {obj_id} with allocation ID {allocation_id}."
                 )
 
@@ -1090,13 +1090,13 @@ async def _post_default_followup_requests_async(
                 # A failed trigger constraint raises ValueError("...not
                 # submitting request"); that is an expected skip, not an error.
                 if "not submitting request" in str(e):
-                    log(
+                    log.info(
                         f"Not submitting default followup request for {obj_id} with "
                         f"allocation ID {allocation_id} (constraint not met): {e}"
                     )
                 else:
                     traceback.print_exc()
-                    log(f"Error posting default followup request: {e}")
+                    log.error(f"Error posting default followup request: {e}")
 
 
 def post_default_followup_requests(obj_id, default_followup_request_ids, user_id):
@@ -1590,7 +1590,7 @@ class FollowupRequestHandler(BaseHandler):
                     and constraints is not None
                     and len(list(constraints.keys())) > 0
                 ):
-                    log(
+                    log.info(
                         f"Not submitting request with allocation_id {data['allocation_id']}: {e}"
                     )
                     return self.success(
@@ -2039,7 +2039,7 @@ def observation_schedule(
     # FIXME: account for different instrument readout times
     read_out = 10.0 * u.s
 
-    log(f"Generating requested schedule for {instrument.name}")
+    log.info(f"Generating requested schedule for {instrument.name}")
 
     start_time = time.time()
 
@@ -2156,7 +2156,7 @@ def observation_schedule(
             else:
                 toos.append(False)
 
-    log(
+    log.info(
         f"Assembled {len(blocks)} observations in schedule for {instrument.name} in {time.time() - start_time} s"
     )
 
@@ -2221,7 +2221,9 @@ def observation_schedule(
     # Call the schedule with the observing blocks and schedule to schedule the blocks
     prior_scheduler(blocks, priority_schedule)
 
-    log(f"Generated schedule for {instrument.name} in {time.time() - start_time} s")
+    log.info(
+        f"Generated schedule for {instrument.name} in {time.time() - start_time} s"
+    )
 
     if len(priority_schedule.observing_blocks) == 0:
         raise ValueError("Scheduling failed: there are probably no observable targets.")

--- a/skyportal/handlers/api/followup_request.py
+++ b/skyportal/handlers/api/followup_request.py
@@ -7,7 +7,6 @@ import operator
 import re
 import tempfile
 import time
-import traceback
 import uuid
 from datetime import timedelta
 
@@ -843,8 +842,7 @@ async def post_followup_request_async(
             refresh_requests=refresh_requests,
         )
     except Exception as e:
-        log.error(f"Failed to submit follow-up request: {e}, traceback:")
-        log.error(traceback.format_exc())
+        log.exception("Failed to submit follow-up request")
         followup_request.status = f"failed to submit: {e}"
         raise
     finally:
@@ -1095,8 +1093,7 @@ async def _post_default_followup_requests_async(
                         f"allocation ID {allocation_id} (constraint not met): {e}"
                     )
                 else:
-                    traceback.print_exc()
-                    log.error(f"Error posting default followup request: {e}")
+                    log.exception("Error posting default followup request")
 
 
 def post_default_followup_requests(obj_id, default_followup_request_ids, user_id):
@@ -1823,7 +1820,7 @@ class FollowupRequestHandler(BaseHandler):
                 )
                 await session.commit()
             except Exception as e:
-                traceback.print_exc()
+                log.exception("Failed to delete follow-up request")
                 return self.error(f"Failed to delete follow-up request: {e}")
             return self.success()
 

--- a/skyportal/handlers/api/galaxy.py
+++ b/skyportal/handlers/api/galaxy.py
@@ -20,7 +20,7 @@ from tornado.ioloop import IOLoop
 
 from baselayer.app.access import auth_or_token, permissions
 from baselayer.app.env import load_env
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ...models import (
     DBSession,
@@ -888,9 +888,9 @@ def delete_galaxies(catalog_id):
                 sa.delete(GalaxyCatalog).where(GalaxyCatalog.id == catalog_id)
             )
             session.commit()
-            log(f"Deleted galaxy catalog with id {catalog_id}")
+            log.info(f"Deleted galaxy catalog with id {catalog_id}")
     except Exception as e:
-        log(f"Unable to delete galaxy catalog with id {catalog_id}: {e}")
+        log.error(f"Unable to delete galaxy catalog with id {catalog_id}: {e}")
 
 
 def add_galaxies(catalog_metadata, catalog_data):
@@ -971,9 +971,9 @@ def add_galaxies(catalog_metadata, catalog_data):
 
         session.add_all(galaxies)
         session.commit()
-        return log("Generated galaxy table")
+        return log.info("Generated galaxy table")
     except Exception as e:
-        return log(f"Unable to generate galaxy table: {e}")
+        return log.error(f"Unable to generate galaxy table: {e}")
     finally:
         session.close()
         Session.remove()
@@ -1138,9 +1138,9 @@ def add_glade(file_path=None, file_url=None):
         datafile = "http://elysium.elte.hu/~dalyag/GLADE+.txt"
 
     if datafile.startswith("http"):
-        log(f"add_glade - Downloading {datafile}")
+        log.info(f"add_glade - Downloading {datafile}")
     else:
-        log(f"add_glade - Reading {datafile}")
+        log.info(f"add_glade - Reading {datafile}")
 
     # if the GLADE GalaxyCatalog does not exist in the DB yet,
     # create it first
@@ -1351,13 +1351,13 @@ def add_glade(file_path=None, file_url=None):
             output.close()
             DBSession().commit()
             end_timer = time.perf_counter()
-            log(
+            log.info(
                 f"add_glade - File part {ii}: Added {length} galaxies (including {blueshift_length} with a negative redshift) in {end_timer - start_timer:0.4f} seconds"
             )
         except Exception as e:
-            log(f"add_glade - File part {ii}: Error: {e}")
+            log.info(f"add_glade - File part {ii}: Error: {e}")
             continue
-    log(
+    log.info(
         f"add_glade - Added a total of {full_length} galaxies (including {full_blueshift_length} with a negative redshift) to the database in {time.perf_counter() - start_loop_timer:0.4f} seconds"
     )
     return full_length, full_blueshift_length

--- a/skyportal/handlers/api/gcn.py
+++ b/skyportal/handlers/api/gcn.py
@@ -9,7 +9,6 @@ import json
 import operator  # noqa: F401
 import os
 import tempfile
-import traceback
 from urllib.parse import urlparse, urlsplit
 
 import arrow
@@ -219,9 +218,8 @@ async def post_gcn_source(
         if not (
             isinstance(e, ValueError) and "could not convert string to float" in str(e)
         ):
-            log.error(traceback.format_exc())
-            log.error(
-                f"Failed to create source for event {dateobs} with Localization {localization_name}: {str(e)}."
+            log.exception(
+                f"Failed to create source for event {dateobs} with Localization {localization_name}"
             )
     finally:
         return False
@@ -2331,9 +2329,8 @@ def add_tiles_and_properties_and_contour(
         )
         session.rollback()
     except Exception as e:
-        traceback.print_exc()
-        log.error(
-            f"Unable to generate tiles / properties / contour for localization {localization_id}: {e}"
+        log.exception(
+            f"Unable to generate tiles / properties / contour for localization {localization_id}"
         )
         session.rollback()
     finally:
@@ -2760,9 +2757,8 @@ def add_observation_plans(localization_id, user_id, parent_session=None):
             )
         log.info(f"Triggered observation plans for localization {localization_id}")
     except Exception as e:
-        traceback.print_exc()
-        log.error(
-            f"Unable to trigger observation plans for localization {localization_id}: {e}"
+        log.exception(
+            f"Unable to trigger observation plans for localization {localization_id}"
         )
     finally:
         if parent_session is None:
@@ -2799,9 +2795,8 @@ def add_tiles_properties_contour_and_obsplan(
         )
         add_observation_plans(localization_id, user_id, session)
     except Exception as e:
-        traceback.print_exc()
-        log.error(
-            f"Unable to generate tiles / properties / observation plans / contour for localization {localization_id}: {e}"
+        log.exception(
+            f"Unable to generate tiles / properties / observation plans / contour for localization {localization_id}"
         )
     finally:
         if parent_session is None:

--- a/skyportal/handlers/api/gcn.py
+++ b/skyportal/handlers/api/gcn.py
@@ -49,7 +49,7 @@ from baselayer.app.access import auth_or_token, permissions
 from baselayer.app.env import load_env
 from baselayer.app.flow import Flow
 from baselayer.app.json_util import to_json
-from baselayer.log import make_log
+from skyportal.log import make_log
 from skyportal.models.gcn import SOURCE_RADIUS_THRESHOLD
 from skyportal.models.photometry import Photometry
 
@@ -149,7 +149,7 @@ async def post_gcn_source(
     try:
         ra, dec, error = (float(val) for val in localization_name.split("_"))
         if error < SOURCE_RADIUS_THRESHOLD:
-            log(
+            log.info(
                 f"Creating source for event {dateobs} with Localization {localization_name}."
             )
             dateobs_txt = Time(dateobs).isot
@@ -191,7 +191,7 @@ async def post_gcn_source(
                 sa.select(Group).where(Group.name == cfg["misc.public_group_name"])
             )
             if public_group is None:
-                log(
+                log.warning(
                     f"WARNING: Public group {cfg['misc.public_group_name']} not found in the database, cannot post source"
                 )
             else:
@@ -203,7 +203,7 @@ async def post_gcn_source(
                         Source.select(user).where(Source.obj_id == source["id"])
                     )
                     if existing_source is None:
-                        log(
+                        log.info(
                             f"Posting source for event {dateobs} with Localization {localization_name} with id {source['id']}."
                         )
                         if source["origin"] is None:
@@ -211,7 +211,7 @@ async def post_gcn_source(
                         await post_source_async(source, user.id, session)
                         return True
         else:
-            log(
+            log.info(
                 f"Source radius {error:.4f} is larger than threshold {SOURCE_RADIUS_THRESHOLD:.4f}, not creating source for event {dateobs} with Localization {localization_name}."
             )
 
@@ -219,8 +219,8 @@ async def post_gcn_source(
         if not (
             isinstance(e, ValueError) and "could not convert string to float" in str(e)
         ):
-            log(traceback.format_exc())
-            log(
+            log.error(traceback.format_exc())
+            log.error(
                 f"Failed to create source for event {dateobs} with Localization {localization_name}: {str(e)}."
             )
     finally:
@@ -449,7 +449,9 @@ async def post_skymap_from_notice(
         await session.commit()
         localization_id = localization.id
 
-        log(f"Generating tiles/properties/contours for localization {localization.id}")
+        log.info(
+            f"Generating tiles/properties/contours for localization {localization.id}"
+        )
         # The tiles/properties helpers run in a sync executor thread with their
         # own sync session — async caller cannot await them, so always dispatch.
         try:
@@ -479,7 +481,7 @@ async def post_skymap_from_notice(
 
     else:
         localization_id = localization.id
-        log(f"Localization {localization_id} already exists.")
+        log.info(f"Localization {localization_id} already exists.")
 
     return localization_id
 
@@ -812,7 +814,9 @@ async def post_gcnevent_from_dictionary(payload, user_id, session, asynchronous=
         await session.commit()
         localization_id = localization.id
 
-        log(f"Generating tiles/properties/contours for localization {localization_id}")
+        log.info(
+            f"Generating tiles/properties/contours for localization {localization_id}"
+        )
         try:
             loop = asyncio.get_event_loop()
         except Exception:
@@ -2224,7 +2228,7 @@ def add_tiles_and_properties_and_contour(
             sa.select(Localization).where(Localization.id == localization_id)
         )
 
-        log(f"Retrieving skymap properties for localization {localization_id}")
+        log.info(f"Retrieving skymap properties for localization {localization_id}")
         properties_dict, tags_list = get_skymap_properties(localization)
         if properties is not None:
             properties_dict.update(properties)
@@ -2246,7 +2250,7 @@ def add_tiles_and_properties_and_contour(
         ]
         session.add_all(tags)
 
-        log(f"Adding default localization tags for localization {localization_id}")
+        log.info(f"Adding default localization tags for localization {localization_id}")
         gcn_tags = add_default_gcn_tags(user, session, localization=localization)
         if gcn_tags is not None and len(gcn_tags) > 0:
             session.add_all(gcn_tags)
@@ -2268,7 +2272,7 @@ def add_tiles_and_properties_and_contour(
                 lambda: post_notification(request_body, timeout=30),
             )
 
-        log(f"Adding tiles for localization {localization_id}")
+        log.info(f"Adding tiles for localization {localization_id}")
         tiles = [
             LocalizationTile(
                 localization_id=localization_id,
@@ -2284,7 +2288,7 @@ def add_tiles_and_properties_and_contour(
         session.add_all(tiles)
         session.commit()
 
-        log(f"Adding contour for localization {localization_id}")
+        log.info(f"Adding contour for localization {localization_id}")
         localization = get_contour(localization)
         session.add(localization)
         session.commit()
@@ -2303,7 +2307,7 @@ def add_tiles_and_properties_and_contour(
         )
 
         if url is not None:
-            log(f"Fetching and saving raw skymap data to disk {localization_id}")
+            log.info(f"Fetching and saving raw skymap data to disk {localization_id}")
             try:
                 r = requests.get(url, allow_redirects=True, timeout=15)
                 data_to_disk = r.content
@@ -2313,22 +2317,22 @@ def add_tiles_and_properties_and_contour(
                     localization.save_data(localization_name, data_to_disk)
                     session.commit()
             except Exception as e:
-                log(
+                log.info(
                     f"Localization {localization_id} URL {url} failed to download: {str(e)}."
                 )
-        log(
+        log.info(
             f"Generated tiles / properties / contour for localization {localization_id}"
         )
         return
     except ObjectDeletedError:
         # Localization was deleted (e.g. event removed) mid-generation; benign race.
-        log(
+        log.info(
             f"Localization {localization_id} was deleted during contour generation; skipping."
         )
         session.rollback()
     except Exception as e:
         traceback.print_exc()
-        log(
+        log.error(
             f"Unable to generate tiles / properties / contour for localization {localization_id}: {e}"
         )
         session.rollback()
@@ -2402,7 +2406,7 @@ def add_default_gcn_tags(user, session, dateobs=None, localization=None):
             for text in gcn_tags
         ]
     except Exception as e:
-        log(f"Unable to add default GCN tags: {str(e)}")
+        log.error(f"Unable to add default GCN tags: {str(e)}")
         gcn_tags = []
 
     return gcn_tags
@@ -2476,7 +2480,7 @@ async def add_default_gcn_tags_async(user, session, dateobs=None, localization=N
             for text in gcn_tags
         ]
     except Exception as e:
-        log(f"Unable to add default GCN tags: {str(e)}")
+        log.error(f"Unable to add default GCN tags: {str(e)}")
         gcn_tags = []
 
     return gcn_tags
@@ -2499,7 +2503,9 @@ def add_observation_plans(localization_id, user_id, parent_session=None):
         if localization is None:
             # Localization was deleted (e.g. event removed) while this
             # background job ran; nothing to plan for.
-            log(f"Localization {localization_id} no longer exists; skipping obs plans.")
+            log.info(
+                f"Localization {localization_id} no longer exists; skipping obs plans."
+            )
             return
         dateobs = localization.dateobs
         localization_tags = [
@@ -2522,7 +2528,7 @@ def add_observation_plans(localization_id, user_id, parent_session=None):
             GcnEvent.select(user).where(GcnEvent.dateobs == dateobs)
         ).first()
         if not isinstance(event.gcn_notices, list) or len(event.gcn_notices) == 0:
-            log(
+            log.info(
                 f"No GCN notices found for event {event.id}, skipping default observation plan"
             )
             return
@@ -2534,13 +2540,13 @@ def add_observation_plans(localization_id, user_id, parent_session=None):
 
         event_properties = event.properties
         if not isinstance(event_properties, list) or len(event_properties) == 0:
-            log(
+            log.info(
                 f"No GCN properties found for event {event.id}, skipping default observation plan"
             )
             return
         event_properties = sorted(event_properties, key=lambda x: x.created_at)[-1].data
         if not isinstance(event_properties, dict):
-            log(
+            log.info(
                 f"No GCN valid properties found for event {event.id}, skipping default observation plan"
             )
             return
@@ -2604,7 +2610,7 @@ def add_observation_plans(localization_id, user_id, parent_session=None):
                     localization.notice_id is None
                     or notice.id != localization.notice_id
                 ):
-                    log(
+                    log.info(
                         f"Skipping default observation plan {gcn_observation_plan.id} because it does not match the localization notice"
                     )
                     continue
@@ -2651,7 +2657,7 @@ def add_observation_plans(localization_id, user_id, parent_session=None):
                     for prop_filt in filters["gcn_properties"]:
                         prop_split = prop_filt.split(":")
                         if len(prop_split) != 3:
-                            log(
+                            log.info(
                                 f"Invalid propertiesFilter value -- property filter must have 3 values, skipping default observation plan {gcn_observation_plan.id}"
                             )
                             properties_pass = False
@@ -2666,7 +2672,7 @@ def add_observation_plans(localization_id, user_id, parent_session=None):
                         try:
                             value = float(value)
                         except ValueError as e:
-                            log(
+                            log.info(
                                 f"Invalid propertiesFilter value: {e}, skipping default observation plan {gcn_observation_plan.id}"
                             )
                             properties_pass = False
@@ -2674,7 +2680,7 @@ def add_observation_plans(localization_id, user_id, parent_session=None):
 
                         op = prop_split[2].strip()
                         if op not in op_options:
-                            log(
+                            log.info(
                                 f"Invalid operator: {op}, skipping default observation plan {gcn_observation_plan.id}"
                             )
                             properties_pass = False
@@ -2692,7 +2698,7 @@ def add_observation_plans(localization_id, user_id, parent_session=None):
                     and len(filters["localization_properties"]) > 0
                 ):
                     if not isinstance(localization_properties, dict):
-                        log(
+                        log.info(
                             f"Skipping default observation plan {gcn_observation_plan.id} because localization properties are not available"
                         )
                         continue
@@ -2700,7 +2706,7 @@ def add_observation_plans(localization_id, user_id, parent_session=None):
                     for prop_filt in filters["localization_properties"]:
                         prop_split = prop_filt.split(":")
                         if len(prop_split) != 3:
-                            log(
+                            log.info(
                                 f"Invalid propertiesFilter value -- property filter must have 3 values, skipping default observation plan {gcn_observation_plan.id}"
                             )
                             valid_properties = False
@@ -2715,7 +2721,7 @@ def add_observation_plans(localization_id, user_id, parent_session=None):
                         try:
                             value = float(value)
                         except ValueError as e:
-                            log(
+                            log.info(
                                 f"Invalid propertiesFilter value: {e}, skipping default observation plan {gcn_observation_plan.id}"
                             )
                             valid_properties = False
@@ -2723,7 +2729,7 @@ def add_observation_plans(localization_id, user_id, parent_session=None):
 
                         op = prop_split[2].strip()
                         if op not in op_options:
-                            log(
+                            log.info(
                                 f"Invalid operator: {op}, skipping default observation plan {gcn_observation_plan.id}"
                             )
                             valid_properties = False
@@ -2741,7 +2747,7 @@ def add_observation_plans(localization_id, user_id, parent_session=None):
 
             elif gcn_observation_plan.get("auto_send", False):
                 # default plans must have filters defined to use auto_send
-                log(
+                log.info(
                     f"auto_send set to True but no filters, skipping default observation plan {gcn_observation_plan.id}"
                 )
 
@@ -2752,10 +2758,10 @@ def add_observation_plans(localization_id, user_id, parent_session=None):
                 default_plan=True,
                 asynchronous=False,
             )
-        log(f"Triggered observation plans for localization {localization_id}")
+        log.info(f"Triggered observation plans for localization {localization_id}")
     except Exception as e:
         traceback.print_exc()
-        log(
+        log.error(
             f"Unable to trigger observation plans for localization {localization_id}: {e}"
         )
     finally:
@@ -2794,7 +2800,7 @@ def add_tiles_properties_contour_and_obsplan(
         add_observation_plans(localization_id, user_id, session)
     except Exception as e:
         traceback.print_exc()
-        log(
+        log.error(
             f"Unable to generate tiles / properties / observation plans / contour for localization {localization_id}: {e}"
         )
     finally:
@@ -3734,7 +3740,7 @@ def add_gcn_summary(
         session.add(notification)
         session.commit()
 
-        log(f"Successfully generated GCN summary {gcn_summary.id}")
+        log.info(f"Successfully generated GCN summary {gcn_summary.id}")
 
     except Exception as e:
         try:
@@ -3743,7 +3749,7 @@ def add_gcn_summary(
             session.commit()
         except Exception:
             pass
-        log(f"Unable to create GCN summary: {e}")
+        log.error(f"Unable to create GCN summary: {e}")
         raise e
     finally:
         session.close()
@@ -4519,7 +4525,7 @@ def add_gcn_report(
             session.add(notification)
             session.commit()
 
-            log(f"Successfully generated GCN report {gcn_report.id}")
+            log.info(f"Successfully generated GCN report {gcn_report.id}")
         except Exception as e:
             try:
                 session.rollback()
@@ -4528,10 +4534,10 @@ def add_gcn_report(
                 session.commit()
             except Exception:
                 session.rollback()
-            log(f"Unable to update GCN report: {str(e)}")
+            log.error(f"Unable to update GCN report: {str(e)}")
 
     except Exception as e:
-        log(f"Unable to create GCN report: {str(e)}")
+        log.error(f"Unable to create GCN report: {str(e)}")
         raise e
     finally:
         session.close()
@@ -6014,9 +6020,9 @@ def crossmatch_gcn_objects(obj_id, event_ids, user_id, integrated_probability=0.
             payload={"obj_key": obj.internal_key},
         )
 
-        log(f"Generated GCN crossmatch for {obj_id}")
+        log.info(f"Generated GCN crossmatch for {obj_id}")
     except Exception as e:
-        log(f"Unable to generate GCN crossmatch for {obj_id}: {e}")
+        log.error(f"Unable to generate GCN crossmatch for {obj_id}: {e}")
     finally:
         session.close()
         Session.remove()

--- a/skyportal/handlers/api/gcn_gracedb.py
+++ b/skyportal/handlers/api/gcn_gracedb.py
@@ -9,7 +9,7 @@ from tornado.ioloop import IOLoop
 from baselayer.app.access import permissions
 from baselayer.app.env import load_env
 from baselayer.app.flow import Flow
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ...models import CommentOnGCN, DBSession, GcnEvent, Group, User
 from ..base import BaseHandler
@@ -105,9 +105,9 @@ def post_gracedb_data(dateobs, gracedb_id, user_id):
             action_type="skyportal/REFRESH_GCN_EVENT",
             payload={"gcnEvent_dateobs": dateobs},
         )
-        log(f"Posted GraceDB data for {dateobs}")
+        log.info(f"Posted GraceDB data for {dateobs}")
     except Exception as e:
-        log(f"Failed to post GraceDB data for {dateobs}: {str(e)}")
+        log.error(f"Failed to post GraceDB data for {dateobs}: {str(e)}")
     finally:
         session.close()
         Session.remove()

--- a/skyportal/handlers/api/gcn_tach.py
+++ b/skyportal/handlers/api/gcn_tach.py
@@ -10,7 +10,7 @@ from tornado.ioloop import IOLoop
 
 from baselayer.app.access import auth_or_token, permissions
 from baselayer.app.flow import Flow
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ...models import DBSession, GcnEvent, User
 from ..base import BaseHandler
@@ -260,7 +260,7 @@ def post_aliases(dateobs, tach_id, user_id):
             payload={"gcnEvent_dateobs": dateobs},
         )
     except Exception:
-        log(f"Failed to post aliases for {dateobs}")
+        log.error(f"Failed to post aliases for {dateobs}")
     finally:
         session.close()
         Session.remove()

--- a/skyportal/handlers/api/group.py
+++ b/skyportal/handlers/api/group.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import selectinload
 from baselayer.app.access import AccessError, auth_or_token, permissions
 from baselayer.app.env import load_env
 from baselayer.app.models import RoleACL, UserACL, UserRole
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ...models import (
     Filter,
@@ -228,7 +228,7 @@ class GroupHandler(BaseHandler):
                     await session.commit()
                     group["filters"] = filters
                 except AccessError as e:
-                    log(f"Insufficient filter permissions: {e}.")
+                    log.info(f"Insufficient filter permissions: {e}.")
 
                 return self.success(data=group)
 

--- a/skyportal/handlers/api/instrument.py
+++ b/skyportal/handlers/api/instrument.py
@@ -23,7 +23,7 @@ from tornado.ioloop import IOLoop
 
 from baselayer.app.access import auth_or_token, permissions
 from baselayer.app.env import load_env
-from baselayer.log import make_log
+from skyportal.log import make_log
 from skyportal.utils.calculations import get_airmass
 
 from ...enum_types import ALLOWED_BANDPASSES
@@ -343,7 +343,7 @@ class InstrumentHandler(BaseHandler):
                 if not {"ID", "RA", "Dec"}.issubset(field_data):
                     return self.error("ID, RA, and Dec required in field_data.")
 
-                log(f"Started generating fields for instrument {instrument.id}")
+                log.info(f"Started generating fields for instrument {instrument.id}")
                 # run async
                 IOLoop.current().run_in_executor(
                     None,
@@ -1006,7 +1006,7 @@ class InstrumentHandler(BaseHandler):
                     if not {"ID", "RA", "Dec"}.issubset(field_data):
                         return self.error("ID, RA, and Dec required in field_data.")
 
-                log(f"Started generating fields for instrument {instrument.id}")
+                log.info(f"Started generating fields for instrument {instrument.id}")
                 # run async
                 IOLoop.current().run_in_executor(
                     None,
@@ -1111,7 +1111,7 @@ def vaccum_analyze_instrumentfieldtiles():
     This is needed to optimize the query plans for some queries involving instrumentfieldtiles,
     such as querying for an instrument's fields overlap with a GCN event's sky localization.
     """
-    log("Running VACUUM ANALYZE on instrumentfieldtiles table")
+    log.info("Running VACUUM ANALYZE on instrumentfieldtiles table")
     start = time.time()
     with DBSession() as session:
         connection = (
@@ -1121,7 +1121,7 @@ def vaccum_analyze_instrumentfieldtiles():
         )
         connection.execute(sa.text("VACUUM ANALYZE instrumentfieldtiles"))
         connection.close()
-    log(
+    log.info(
         f"Successfully ran VACUUM ANALYZE on instrumentfieldtiles table, in {time.time() - start} seconds"
     )
 
@@ -1420,7 +1420,7 @@ def add_tiles(
             instrument.has_fields = False
         session.commit()
 
-        log(f"Successfully generated fields for instrument {instrument_id}")
+        log.info(f"Successfully generated fields for instrument {instrument_id}")
 
         # PostgreSQL has a tendency of generating really suboptimal query plans
         # for some queries involving instrumentfieldtiles, after inserting new tiles.
@@ -1432,7 +1432,7 @@ def add_tiles(
         # to do so, we need to get the connection from the session
         run_async(vaccum_analyze_instrumentfieldtiles)
     except Exception as e:
-        log(f"Unable to generate fields for instrument {instrument_id}: {e}")
+        log.error(f"Unable to generate fields for instrument {instrument_id}: {e}")
     finally:
         Session.remove()
         return field_ids

--- a/skyportal/handlers/api/internal/altdata_info.py
+++ b/skyportal/handlers/api/internal/altdata_info.py
@@ -3,7 +3,7 @@ import sqlalchemy as sa
 
 from baselayer.app.access import auth_or_token
 from baselayer.app.env import load_env
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ....utils.cache import Cache, dict_to_bytes
 from ...base import BaseHandler
@@ -77,5 +77,5 @@ class AltdataInfoHandler(BaseHandler):
                 return self.success(data=data)
 
         except Exception as e:
-            log(f"Failed to get altdata info: {e}")
+            log.error(f"Failed to get altdata info: {e}")
             return self.error(f"Failed to get altdata info: {e}")

--- a/skyportal/handlers/api/internal/annotations_info.py
+++ b/skyportal/handlers/api/internal/annotations_info.py
@@ -5,7 +5,7 @@ from sqlalchemy import func, literal
 
 from baselayer.app.access import auth_or_token
 from baselayer.app.env import load_env
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ....models import Annotation
 from ....utils.cache import Cache, dict_to_bytes
@@ -93,5 +93,5 @@ class AnnotationsInfoHandler(BaseHandler):
                     return self.success(data=grouped)
 
         except Exception as e:
-            log(f"Failed to get annotations info: {e}")
+            log.error(f"Failed to get annotations info: {e}")
             return self.error(f"Failed to get annotations info: {e}")

--- a/skyportal/handlers/api/internal/log.py
+++ b/skyportal/handlers/api/internal/log.py
@@ -4,7 +4,7 @@ import os
 import tornado.web
 
 from baselayer.app.access import permissions
-from baselayer.log import make_log
+from skyportal.log import make_log
 from skyportal.utils.files import filesize_to_human_readable
 
 from ...base import BaseHandler
@@ -17,7 +17,7 @@ class LogHandler(BaseHandler):
     async def post(self, *ignored_args):
         """Log a frontend error to the server logs, tracking user crash reports."""
         data = self.get_json()
-        log(f"{data['error']}{data['stack']}")
+        log.info(f"{data['error']}{data['stack']}")
         return self.success()
 
     @permissions(["System admin"])

--- a/skyportal/handlers/api/internal/recent_sources.py
+++ b/skyportal/handlers/api/internal/recent_sources.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import selectinload
 
 from baselayer.app.access import auth_or_token
 from baselayer.app.env import load_env
-from baselayer.log import make_log
+from skyportal.log import make_log
 from skyportal.models.group import Group
 
 from ....models import Obj, ObjTag, Source, serialize_obj_tag
@@ -133,7 +133,7 @@ class RecentSourcesHandler(BaseHandler):
                 )
 
                 if s is None or source_entry is None:
-                    log(f"Source with obj_id {obj_id} not found.")
+                    log.info(f"Source with obj_id {obj_id} not found.")
                     continue
 
                 sources.append(

--- a/skyportal/handlers/api/moving_object.py
+++ b/skyportal/handlers/api/moving_object.py
@@ -1,11 +1,10 @@
-import traceback
-
 import arrow
 import sqlalchemy as sa
 from sqlalchemy.orm import joinedload
 
 from baselayer.app.access import auth_or_token
 from baselayer.app.env import load_env
+from skyportal.log import make_log
 
 from ...models import Instrument
 from ...utils.moving_objects import (
@@ -17,6 +16,8 @@ from ...utils.parse import str_to_bool
 from ..base import BaseHandler
 
 _, cfg = load_env()
+
+log = make_log("api/moving_object")
 
 
 class MovingObjectFollowupHandler(BaseHandler):
@@ -193,5 +194,5 @@ class MovingObjectFollowupHandler(BaseHandler):
 
                 return self.success(data=observations)
             except Exception as e:
-                traceback.print_exc()
+                log.exception(f"Error finding observable sequence for {obj_name}")
                 return self.error(f"Error: {e}")

--- a/skyportal/handlers/api/mpc.py
+++ b/skyportal/handlers/api/mpc.py
@@ -12,7 +12,7 @@ from tornado.ioloop import IOLoop
 from baselayer.app.access import auth_or_token
 from baselayer.app.env import load_env
 from baselayer.app.flow import Flow
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ...models import (
     DBSession,
@@ -176,7 +176,7 @@ def query_mpc(obj_id, user_id, url):
     else:
         session = Session(bind=DBSession.session_factory.kw["bind"])
 
-    log(f"Querying MPC for {obj_id}: {url}")
+    log.info(f"Querying MPC for {obj_id}: {url}")
 
     try:
         user = session.get(User, user_id)
@@ -190,17 +190,17 @@ def query_mpc(obj_id, user_id, url):
             responseSplit = response.text.split("(1)")[-1].split(" ")
             mpc_name = list(filter(None, responseSplit))[0]
 
-            log(f"{obj_id}: identified MPC name {mpc_name}")
+            log.info(f"{obj_id}: identified MPC name {mpc_name}")
 
             obj.is_roid = True
             obj.mpc_name = mpc_name
             session.commit()
         elif re.findall("No known minor planets,.*", response.text):
-            log(f"{obj_id}: No known minor planets")
+            log.info(f"{obj_id}: No known minor planets")
             obj.is_roid = False
             session.commit()
         else:
-            log(f"Message from MPC for {obj_id} not parsable: {response.text}")
+            log.info(f"Message from MPC for {obj_id} not parsable: {response.text}")
 
         flow = Flow()
         flow.push(
@@ -210,7 +210,7 @@ def query_mpc(obj_id, user_id, url):
         )
 
     except Exception as e:
-        log(f"Error checking MPC for {obj_id}: {(str(e))}")
+        log.error(f"Error checking MPC for {obj_id}: {(str(e))}")
         session.rollback()
     finally:
         session.close()

--- a/skyportal/handlers/api/observation.py
+++ b/skyportal/handlers/api/observation.py
@@ -29,7 +29,7 @@ from baselayer.app.access import auth_or_token, permissions
 from baselayer.app.custom_exceptions import AccessError
 from baselayer.app.env import load_env
 from baselayer.app.flow import Flow
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ...models import (
     Allocation,
@@ -119,7 +119,7 @@ def add_queued_observations(instrument_id, obstable):
                 )
             ).first()
             if field is None:
-                return log(
+                return log.error(
                     f"Unable to add observations for instrument {instrument_id}: Missing field {field_id}"
                 )
 
@@ -141,11 +141,11 @@ def add_queued_observations(instrument_id, obstable):
         flow = Flow()
         flow.push("*", "skyportal/REFRESH_QUEUED_OBSERVATIONS")
 
-        return log(
+        return log.info(
             f"Successfully added queued observations for instrument {instrument_id}"
         )
     except Exception as e:
-        return log(
+        return log.error(
             f"Unable to add queued observations for instrument {instrument_id}: {e}"
         )
     finally:
@@ -204,7 +204,7 @@ def add_observations(instrument_id, obstable):
             )
             missing = list(set(field_ids) - {f.field_id for f in fields})
             if len(missing) > 0:
-                return log(
+                return log.error(
                     f"Unable to add observations for instrument {instrument_id}: {len(missing)} fields are missing: {missing[:100]}"
                 )
             for field in fields:
@@ -228,7 +228,7 @@ def add_observations(instrument_id, obstable):
             missing.extend(set(observation_ids) - set(observations))
 
         if len(missing) < len(unique_observation_ids):
-            log(
+            log.error(
                 f"Unable to add some observations for instrument {instrument_id}: {len(unique_observation_ids) - len(missing)} observations (out of {len(unique_observation_ids)}) already exist. These will be skipped"
             )
 
@@ -274,16 +274,20 @@ def add_observations(instrument_id, obstable):
                 session.commit()
             except Exception as e:
                 session.rollback()
-                return log(
+                return log.error(
                     f"Unable to add observations for instrument {instrument_id}: {e}"
                 )
 
         flow = Flow()
         flow.push("*", "skyportal/REFRESH_OBSERVATIONS")
 
-        return log(f"Successfully added observations for instrument {instrument_id}")
+        return log.info(
+            f"Successfully added observations for instrument {instrument_id}"
+        )
     except Exception as e:
-        return log(f"Unable to add observations for instrument {instrument_id}: {e}")
+        return log.error(
+            f"Unable to add observations for instrument {instrument_id}: {e}"
+        )
     finally:
         session.close()
         Session.remove()
@@ -573,7 +577,7 @@ async def get_observations(
                 )
                 localization_tiles = localization_tiles_result.all()
                 if stats_logging:
-                    log(
+                    log.info(
                         "STATS: ",
                         f"Number of localization tiles= {len(localization_tiles)}. "
                         f"Runtime= {time.time() - t0:.2f}s. ",
@@ -599,7 +603,7 @@ async def get_observations(
                 field_upper_bounds = np.array([f[1] for f in instrument_field_tuples])
 
                 if stats_logging:
-                    log(
+                    log.info(
                         "STATS: ",
                         f"Number of field tiles= {len(instrument_field_tuples)}. "
                         f"Runtime= {time.time() - t0:.2f}s. ",
@@ -610,7 +614,7 @@ async def get_observations(
                 total_area = sum(t[1] - t[0] for t in merged_tuples)
                 total_area *= ha.constants.PIXEL_AREA
                 if stats_logging:
-                    log(
+                    log.info(
                         "STATS: ",
                         f"len(merged_tuples)= {len(merged_tuples)}, "
                         f"total_area= {total_area:.2f}. "
@@ -657,7 +661,7 @@ async def get_observations(
                 intprob *= ha.constants.PIXEL_AREA
 
                 if stats_logging:
-                    log(
+                    log.info(
                         "STATS: ",
                         f"area= {intarea}, prob= {intprob}. Runtime= {time.time() - t0:.2f}s. ",
                     )
@@ -712,7 +716,7 @@ async def get_observations(
                     intarea = 0.0
 
                 if stats_logging:
-                    log(
+                    log.info(
                         f"STATS: area= {intarea}, prob= {intprob}. Runtime= {time.time() - t0:.2f}s. "
                     )
             else:

--- a/skyportal/handlers/api/observation_plan.py
+++ b/skyportal/handlers/api/observation_plan.py
@@ -62,9 +62,9 @@ from baselayer.app.access import auth_or_token, permissions
 from baselayer.app.custom_exceptions import AccessError
 from baselayer.app.env import load_env
 from baselayer.app.flow import Flow
-from baselayer.log import make_log
 from skyportal.enum_types import ALLOWED_BANDPASSES
 from skyportal.handlers.api.observingrun import post_observing_run
+from skyportal.log import make_log
 from skyportal.utils.calculations import get_rise_set_time, get_target
 from skyportal.utils.observation_plan import (
     convert_plan_to_rubin_format,
@@ -170,7 +170,9 @@ with astropy.utils.data.conf.set_temp("remote_timeout", 2):
             bandwidth = bandpass.maxwave() - bandpass.minwave()
             TREASUREMAP_FILTERS[bandpass_name] = [central_wavelength, bandwidth]
         except Exception as e:
-            log(f"Error adding bandpass {bandpass_name} to treasuremap filters: {e}")
+            log.error(
+                f"Error adding bandpass {bandpass_name} to treasuremap filters: {e}"
+            )
 
 # overwrite the filters for ZTF, as i-band is will otherwise be matched to TESS by treasuremap
 TREASUREMAP_FILTERS["ztfg"] = "g"
@@ -228,12 +230,12 @@ async def send_observation_plan(
             f"Cannot send observation plan with status {observation_plan_request.status}"
         )
     if not observation_plan_request.observation_plans:
-        log(
+        log.info(
             f"No observation plans to send for observation plan {plan_id} (event {observation_plan_request.gcnevent_id}, allocation {observation_plan_request.allocation_id})"
         )
         return
     if not observation_plan_request.observation_plans[0].planned_observations:
-        log(
+        log.info(
             f"No planned observations to send for observation plan {plan_id} (event {observation_plan_request.gcnevent_id}, allocation {observation_plan_request.allocation_id})"
         )
         return
@@ -249,7 +251,7 @@ async def send_observation_plan(
             )
         )
         if existing_obs_plan_requests:
-            log(
+            log.info(
                 f"Skipping auto-send of observation plan {observation_plan_request.id}: plans have already been sent to the instrument in the last 24 hours for event {observation_plan_request.gcnevent_id} and allocation {observation_plan_request.allocation_id}"
             )
             return
@@ -260,20 +262,20 @@ async def send_observation_plan(
             )
         )
         if defaultobsplanrequest is None:
-            log(
+            log.error(
                 f"Cannot find default observation plan request with ID: {default_obsplan_id}, skipping auto send."
             )
             return
 
         filters = defaultobsplanrequest.filters
         if not filters or not isinstance(filters, dict):
-            log(
+            log.info(
                 f"Default observation plan request {default_obsplan_id} has no filters, skipping auto send."
             )
             return
 
         if observation_plan_request.created_at < utcnow_naive() - timedelta(hours=1):
-            log(
+            log.info(
                 f"Default observation plan request {default_obsplan_id} was created more than 1 hour ago, skipping auto send."
             )
             return
@@ -284,7 +286,7 @@ async def send_observation_plan(
                 arrow.get(plan_request_end_date).timestamp()
                 < utcnow_naive().timestamp()
             ):
-                log(
+                log.info(
                     f"Default observation plan request {default_obsplan_id} has an end date in the past, skipping auto send."
                 )
                 return
@@ -298,14 +300,16 @@ async def send_observation_plan(
                     .statistics
                 )
             except Exception as e:
-                log(f"Error getting statistics for observation plan {plan_id}: {e}")
+                log.error(
+                    f"Error getting statistics for observation plan {plan_id}: {e}"
+                )
                 return
 
             properties_pass = True
             for prop_filt in plan_properties:
                 prop_split = prop_filt.split(":")
                 if len(prop_split) != 3:
-                    log(
+                    log.info(
                         f"Invalid propertiesFilter value -- property filter must have 3 values, cannot auto-send default observation plan {default_obsplan_id}"
                     )
                     properties_pass = False
@@ -320,7 +324,7 @@ async def send_observation_plan(
                 try:
                     value = float(value)
                 except ValueError as e:
-                    log(
+                    log.info(
                         f"Invalid propertiesFilter value: {e}, cannot auto-send default observation plan {default_obsplan_id}"
                     )
                     properties_pass = False
@@ -328,7 +332,7 @@ async def send_observation_plan(
 
                 op = prop_split[2].strip()
                 if op not in op_options:
-                    log(
+                    log.info(
                         f"Invalid operator: {op}, skipping default observation plan {default_obsplan_id}"
                     )
                     properties_pass = False
@@ -339,7 +343,7 @@ async def send_observation_plan(
                     break
 
             if not properties_pass:
-                log(
+                log.info(
                     f"Default observation plan request {default_obsplan_id} failed plan properties/statistics filter, skipping auto send."
                 )
                 return
@@ -514,7 +518,7 @@ async def post_survey_efficiency_analysis(
                         if ddec > height:
                             height = ddec
 
-    log(
+    log.info(
         f"Simsurvey analysis in progress for ID {survey_efficiency_analysis.id}. Should be available soon."
     )
 
@@ -3327,12 +3331,12 @@ def observation_simsurvey(
         session.merge(survey_efficiency_analysis)
         session.commit()
 
-        return log(
+        return log.info(
             f"Finished survey efficiency analysis for ID {survey_efficiency_analysis.id}"
         )
 
     except Exception as e:
-        return log(
+        return log.error(
             f"Unable to complete survey efficiency analysis {survey_efficiency_analysis.id}: {e}"
         )
     finally:

--- a/skyportal/handlers/api/observingrun.py
+++ b/skyportal/handlers/api/observingrun.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import selectinload
 from baselayer.app.access import auth_or_token, permissions
 from baselayer.app.flow import Flow
 from baselayer.app.model_util import recursive_to_dict
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ...models import (
     ClassicalAssignment,
@@ -260,7 +260,7 @@ class ObservingRunHandler(BaseHandler):
                 if updated:
                     await session.commit()
             except Exception as e:
-                log(f"Error calculating run_end_utc: {e}")
+                log.error(f"Error calculating run_end_utc: {e}")
 
             runs_list = [run.to_dict() for run in runs]
 

--- a/skyportal/handlers/api/phot_stat.py
+++ b/skyportal/handlers/api/phot_stat.py
@@ -4,7 +4,7 @@ from sqlalchemy import func
 from sqlalchemy.orm import selectinload
 
 from baselayer.app.access import auth_or_token, permissions
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ...models import (
     Classification,

--- a/skyportal/handlers/api/photometric_series.py
+++ b/skyportal/handlers/api/photometric_series.py
@@ -1,6 +1,5 @@
 import os
 import textwrap
-import traceback
 
 import arrow
 import conesearch_alchemy as ca
@@ -451,25 +450,23 @@ def post_photometric_series(json_data, data, attributes_metadata, user, session)
             if v is None:
                 metadata.pop(k)
 
-    except Exception:
-        raise ValueError(f"Problem parsing data/metadata: {traceback.format_exc()}")
+    except Exception as e:
+        raise ValueError(f"Problem parsing data/metadata: {e}") from e
 
     # check all the related DB objects are valid:
     try:
         group_ids = get_group_ids(metadata, user, session)
-    except Exception:
-        raise ValueError(f"Could not parse group IDs: {traceback.format_exc()}")
+    except Exception as e:
+        raise ValueError(f"Could not parse group IDs: {e}") from e
     try:
         stream_ids = get_stream_ids(metadata, user, session)
-    except Exception:
-        raise ValueError(f"Could not parse stream IDs: {traceback.format_exc()}")
+    except Exception as e:
+        raise ValueError(f"Could not parse stream IDs: {e}") from e
 
     try:
         check_objects_exist(metadata, user, session)
-    except Exception:
-        raise ValueError(
-            f"Problems accessing database objects: {traceback.format_exc()}"
-        )
+    except Exception as e:
+        raise ValueError(f"Problems accessing database objects: {e}") from e
 
     try:
         # load the group, stream and owner IDs:
@@ -486,29 +483,27 @@ def post_photometric_series(json_data, data, attributes_metadata, user, session)
         # parse all attributes into correct type
         metadata = verify_metadata(metadata)
 
-    except Exception:
-        raise ValueError(f"Problem parsing data/metadata: {traceback.format_exc()}")
+    except Exception as e:
+        raise ValueError(f"Problem parsing data/metadata: {e}") from e
 
     try:
         individual_enum_checks(metadata)
-    except Exception:
-        raise ValueError(f"Problem parsing metadata: {traceback.format_exc()}")
+    except Exception as e:
+        raise ValueError(f"Problem parsing metadata: {e}") from e
 
     try:
         ps = PhotometricSeries(data, **metadata)
         # allow the config to change the default behavior:
         ps.autodelete = cfg.get("photometric_series_autodelete", True)
 
-    except Exception:
-        raise ValueError(
-            f"Could not create PhotometricSeries object: {traceback.format_exc()}"
-        )
+    except Exception as e:
+        raise ValueError(f"Could not create PhotometricSeries object: {e}") from e
 
     try:
         # make sure we can get the file name:
         full_name, path = ps.make_full_name()
-    except Exception:
-        raise ValueError(f"Errors when making file name: {traceback.format_exc()}")
+    except Exception as e:
+        raise ValueError(f"Errors when making file name: {e}") from e
 
     # make sure the file does not exist:
     if os.path.isfile(full_name):
@@ -550,10 +545,10 @@ def post_photometric_series(json_data, data, attributes_metadata, user, session)
 
         return ps.id
 
-    except Exception:
+    except Exception as e:
         session.rollback()
         ps.delete_data()  # make sure not to leave files behind
-        raise ValueError(f"Could not save photometric series: {traceback.format_exc()}")
+        raise ValueError(f"Could not save photometric series: {e}") from e
 
 
 def update_photometric_series(ps, json_data, data, attributes_metadata, user, session):
@@ -584,8 +579,8 @@ def update_photometric_series(ps, json_data, data, attributes_metadata, user, se
         try:
             verify_data(data)
             inferred_metadata = infer_metadata(data)
-        except Exception:
-            raise ValueError(f"Problem parsing data/metadata: {traceback.format_exc()}")
+        except Exception as e:
+            raise ValueError(f"Problem parsing data/metadata: {e}") from e
 
     prev_filename = ps.filename
 
@@ -600,19 +595,17 @@ def update_photometric_series(ps, json_data, data, attributes_metadata, user, se
     # check all the related DB objects are valid:
     try:
         group_ids = get_group_ids(metadata, user, session)
-    except Exception:
-        raise ValueError(f"Could not parse group IDs: {traceback.format_exc()}")
+    except Exception as e:
+        raise ValueError(f"Could not parse group IDs: {e}") from e
     try:
         stream_ids = get_stream_ids(metadata, user, session)
-    except Exception:
-        raise ValueError(f"Could not parse stream IDs: {traceback.format_exc()}")
+    except Exception as e:
+        raise ValueError(f"Could not parse stream IDs: {e}") from e
 
     try:
         check_objects_exist(metadata, user, session)
-    except Exception:
-        raise ValueError(
-            f"Problems accessing database objects: {traceback.format_exc()}"
-        )
+    except Exception as e:
+        raise ValueError(f"Problems accessing database objects: {e}") from e
 
     try:
         # load the group and stream IDs:
@@ -629,20 +622,20 @@ def update_photometric_series(ps, json_data, data, attributes_metadata, user, se
         # parse all attributes into correct type
         metadata = verify_metadata(metadata)
 
-    except Exception:
-        raise ValueError(f"Problem parsing data/metadata: {traceback.format_exc()}")
+    except Exception as e:
+        raise ValueError(f"Problem parsing data/metadata: {e}") from e
 
     try:
         individual_enum_checks(metadata)
-    except Exception:
-        raise ValueError(f"Problem parsing metadata: {traceback.format_exc()}")
+    except Exception as e:
+        raise ValueError(f"Problem parsing metadata: {e}") from e
 
     # update the underlying data (if given)
     if data is not None:
         try:
             ps.data = data  # also run calc_flux_mag() and calc_stats()
-        except Exception:
-            raise ValueError(f"Could not update data: {traceback.format_exc()}")
+        except Exception as e:
+            raise ValueError(f"Could not update data: {e}") from e
 
     # update the metadata on the PhotometricSeries object
     for k, v in metadata.items():
@@ -657,8 +650,8 @@ def update_photometric_series(ps, json_data, data, attributes_metadata, user, se
     try:
         # make sure we can get the file name:
         full_name, path = ps.make_full_name()
-    except Exception:
-        raise ValueError(f"Errors when making file name: {traceback.format_exc()}")
+    except Exception as e:
+        raise ValueError(f"Errors when making file name: {e}") from e
 
     # make sure the file does not exist:
     if prev_filename != full_name and os.path.isfile(full_name):
@@ -683,19 +676,17 @@ def update_photometric_series(ps, json_data, data, attributes_metadata, user, se
         session.add(ps)
         session.commit()
 
-    except Exception:
+    except Exception as e:
         session.rollback()
         ps.delete_data(temp=True)  # make sure not to leave files behind
-        raise ValueError(f"Could not save photometric series: {traceback.format_exc()}")
+        raise ValueError(f"Could not save photometric series: {e}") from e
 
     # get rid of the old data, regardless of new name
     try:
         if os.path.isfile(prev_filename):
             os.remove(prev_filename)
     except Exception:
-        log.error(
-            f"Could not remove old file {prev_filename}: {traceback.format_exc()}"
-        )
+        log.exception(f"Could not remove old file {prev_filename}")
     ps.move_temp_data()  # make the temp file permanent
 
     return ps.id
@@ -744,17 +735,13 @@ class PhotometricSeriesHandler(BaseHandler):
         if isinstance(data, dict):
             try:
                 data = pd.DataFrame(data)
-            except Exception:
-                return self.error(
-                    f"Could not convert data to a DataFrame. {traceback.format_exc()} "
-                )
+            except Exception as e:
+                return self.error(f"Could not convert data to a DataFrame. {e} ")
         elif isinstance(data, str):
             try:
                 data, attributes_metadata = load_dataframe_from_bytestream(data)
-            except Exception:
-                return self.error(
-                    f"Could not load DataFrame from HDF5 file. {traceback.format_exc()} "
-                )
+            except Exception as e:
+                return self.error(f"Could not load DataFrame from HDF5 file. {e} ")
         else:
             return self.error(
                 "Data must be a dictionary (JSON) or dataframe in HDF5 format. "
@@ -770,6 +757,7 @@ class PhotometricSeriesHandler(BaseHandler):
                     session,
                 )
             except Exception as e:
+                log.exception("Unable to post photometric series")
                 return self.error(f"Unable to post photometric series: {str(e)}")
 
         return self.success(data={"id": photometric_series_id})
@@ -840,17 +828,13 @@ class PhotometricSeriesHandler(BaseHandler):
             if isinstance(data, dict):
                 try:
                     data = pd.DataFrame(data)
-                except Exception:
-                    return self.error(
-                        f"Could not convert data to a DataFrame. {traceback.format_exc()} "
-                    )
+                except Exception as e:
+                    return self.error(f"Could not convert data to a DataFrame. {e} ")
             elif isinstance(data, str):
                 try:
                     data, attributes_metadata = load_dataframe_from_bytestream(data)
-                except Exception:
-                    return self.error(
-                        f"Could not load DataFrame from HDF5 file. {traceback.format_exc()} "
-                    )
+                except Exception as e:
+                    return self.error(f"Could not load DataFrame from HDF5 file. {e} ")
 
             try:
                 photometric_series_id = update_photometric_series(
@@ -862,6 +846,7 @@ class PhotometricSeriesHandler(BaseHandler):
                     session,
                 )
             except Exception as e:
+                log.exception("Unable to update photometric series")
                 return self.error(f"Unable to update photometric series: {str(e)}")
 
             return self.success(data={"id": photometric_series_id})
@@ -1355,9 +1340,10 @@ class PhotometricSeriesHandler(BaseHandler):
 
                 try:
                     output_dict = ps.to_dict(data_format=data_format)
-                except Exception:
+                except Exception as e:
+                    log.exception("Cannot convert photometric series to dictionary")
                     return self.error(
-                        f"Cannot convert photometric series to dictionary: {traceback.format_exc()}"
+                        f"Cannot convert photometric series to dictionary: {e}"
                     )
 
                 return self.success(data=output_dict)
@@ -1481,50 +1467,38 @@ class PhotometricSeriesHandler(BaseHandler):
         if start_after is not None:
             try:
                 start_after_mjd = Time(arrow.get(start_after).datetime).mjd
-            except Exception:
-                return self.error(
-                    f"Cannot parse time {start_after}: {traceback.format_exc()}"
-                )
+            except Exception as e:
+                return self.error(f"Cannot parse time {start_after}: {e}")
             stmt = stmt.where(PhotometricSeries.mjd_first > start_after_mjd)
         if start_before is not None:
             try:
                 start_before_mjd = Time(arrow.get(start_before).datetime).mjd
-            except Exception:
-                return self.error(
-                    f"Cannot parse time {start_before}: {traceback.format_exc()}"
-                )
+            except Exception as e:
+                return self.error(f"Cannot parse time {start_before}: {e}")
             stmt = stmt.where(PhotometricSeries.mjd_first < start_before_mjd)
         if middle_after is not None:
             try:
                 middle_after_mjd = Time(arrow.get(middle_after).datetime).mjd
-            except Exception:
-                return self.error(
-                    f"Cannot parse time {middle_after}: {traceback.format_exc()}"
-                )
+            except Exception as e:
+                return self.error(f"Cannot parse time {middle_after}: {e}")
             stmt = stmt.where(PhotometricSeries.mjd_mid > middle_after_mjd)
         if middle_before is not None:
             try:
                 middle_before_mjd = Time(arrow.get(middle_before).datetime).mjd
-            except Exception:
-                return self.error(
-                    f"Cannot parse time {middle_before}: {traceback.format_exc()}"
-                )
+            except Exception as e:
+                return self.error(f"Cannot parse time {middle_before}: {e}")
             stmt = stmt.where(PhotometricSeries.mjd_mid < middle_before_mjd)
         if end_after is not None:
             try:
                 end_after_mjd = Time(arrow.get(end_after).datetime).mjd
-            except Exception:
-                return self.error(
-                    f"Cannot parse time {end_after}: {traceback.format_exc()}"
-                )
+            except Exception as e:
+                return self.error(f"Cannot parse time {end_after}: {e}")
             stmt = stmt.where(PhotometricSeries.mjd_last > end_after_mjd)
         if end_before is not None:
             try:
                 end_before_mjd = Time(arrow.get(end_before).datetime).mjd
-            except Exception:
-                return self.error(
-                    f"Cannot parse time {end_before}: {traceback.format_exc()}"
-                )
+            except Exception as e:
+                return self.error(f"Cannot parse time {end_before}: {e}")
             stmt = stmt.where(PhotometricSeries.mjd_last < end_before_mjd)
 
         if detected is not None:
@@ -1535,10 +1509,8 @@ class PhotometricSeriesHandler(BaseHandler):
 
             try:
                 detected = bool(detected)
-            except ValueError:
-                return self.error(
-                    f"Cannot parse detected value {detected}: {traceback.format_exc()}"
-                )
+            except ValueError as e:
+                return self.error(f"Cannot parse detected value {detected}: {e}")
             stmt = stmt.where(PhotometricSeries.is_detected.is_(detected))
 
         if exp_time_exact is not None:
@@ -1868,10 +1840,9 @@ class PhotometricSeriesHandler(BaseHandler):
                     "numPerPage": num_per_page,
                     "pageNumber": page_number,
                 }
-            except Exception:
-                return self.error(
-                    f"Could not convert series to dict {traceback.format_exc()}"
-                )
+            except Exception as e:
+                log.exception("Could not convert series to dict")
+                return self.error(f"Could not convert series to dict {e}")
             return self.success(data=results)
 
     @permissions(["Upload data"])

--- a/skyportal/handlers/api/photometric_series.py
+++ b/skyportal/handlers/api/photometric_series.py
@@ -13,7 +13,7 @@ from sqlalchemy.sql.expression import case
 
 from baselayer.app.access import permissions  # , auth_or_token
 from baselayer.app.env import load_env
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ...enum_types import ALLOWED_BANDPASSES
 from ...models.assignment import ClassicalAssignment
@@ -693,7 +693,9 @@ def update_photometric_series(ps, json_data, data, attributes_metadata, user, se
         if os.path.isfile(prev_filename):
             os.remove(prev_filename)
     except Exception:
-        log(f"Could not remove old file {prev_filename}: {traceback.format_exc()}")
+        log.error(
+            f"Could not remove old file {prev_filename}: {traceback.format_exc()}"
+        )
     ps.move_temp_data()  # make the temp file permanent
 
     return ps.id

--- a/skyportal/handlers/api/photometry.py
+++ b/skyportal/handlers/api/photometry.py
@@ -23,7 +23,7 @@ from sqlalchemy.orm import joinedload, load_only, selectinload
 from baselayer.app.access import auth_or_token, permissions
 from baselayer.app.env import load_env
 from baselayer.app.flow import Flow
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ...enum_types import ALLOWED_BANDPASSES, ALLOWED_MAGSYSTEMS
 from ...models import (
@@ -221,7 +221,7 @@ def get_color(bandpass, format="hex"):
     elif 1e5 < wavelength <= 3e5:  # JWST miri and miri-tophat
         bandcolor = rgb2hex(cmap_deep_ir((5.48 - np.log10(wavelength)) / 0.48)[:3])
     else:
-        log(
+        log.info(
             f"{bandpass} with effective wavelength {wavelength} is out of range for color maps, using black"
         )
         bandcolor = "#000000"
@@ -245,7 +245,7 @@ def get_bandpasses_to_colors(bandpasses, colors_type="rgb"):
         try:
             out[bandpass] = get_color(bandpass, colors_type)
         except Exception as e:
-            log(f"Skipping bandpass {bandpass} in color mapping due to error: {e}")
+            log.info(f"Skipping bandpass {bandpass} in color mapping due to error: {e}")
     return out
 
 
@@ -258,7 +258,9 @@ def _safe_effective_wavelength(bandpass):
     try:
         return get_effective_wavelength(bandpass)
     except Exception as e:
-        log(f"Skipping bandpass {bandpass} in wavelength mapping due to error: {e}")
+        log.info(
+            f"Skipping bandpass {bandpass} in wavelength mapping due to error: {e}"
+        )
         return None
 
 
@@ -1514,7 +1516,7 @@ async def add_external_photometry(
         )
 
     username = user.username
-    log(f"Pending request from {username} with {len(df.index)} rows")
+    log.info(f"Pending request from {username} with {len(df.index)} rows")
 
     try:
         if duplicates in ["ignore", "update"]:
@@ -1553,7 +1555,9 @@ async def add_external_photometry(
                         {"photometr_id": duplicate.id, "group_id": gid}
                         for gid in new_group_ids
                     )
-                    log(f"Adding groups {new_group_ids} to photometry {duplicate.id}")
+                    log.info(
+                        f"Adding groups {new_group_ids} to photometry {duplicate.id}"
+                    )
                     updated = True
 
                 # posting to new streams? Same ON CONFLICT handling.
@@ -1564,7 +1568,7 @@ async def add_external_photometry(
                             {"photometr_id": duplicate.id, "stream_id": sid}
                             for sid in stream_ids_update
                         )
-                        log(
+                        log.info(
                             f"Adding streams {stream_ids_update} to photometry {duplicate.id}"
                         )
                         updated = True
@@ -1594,11 +1598,11 @@ async def add_external_photometry(
                 )
 
             if duplicates in ["update"] and len(id_map_no_update_needed) > 0:
-                log(
+                log.info(
                     f"A total of ({len(id_map_no_update_needed)}) duplicate photometry points did not need to be updated: {id_map_no_update_needed.values()}"
                 )
             new_photometry = df.loc[new_photometry_df_idxs]
-            log(
+            log.info(
                 f"Inserting {len(new_photometry.index)} "
                 f"(out of {len(df.index)}) new photometry points"
             )
@@ -1628,19 +1632,19 @@ async def add_external_photometry(
             ids = [id_map[pdidx] for pdidx, _ in df.iterrows()]
 
         if len(new_photometry) > 0:
-            log(
+            log.info(
                 f"Request from {username} with "
                 f"{len(new_photometry.index)} rows complete with upload_id {upload_id}."
             )
         else:
-            log(
+            log.info(
                 f"Request from {username} with "
                 f"{len(new_photometry.index)} rows complete with no new photometry."
             )
         return ids, upload_id
     except Exception as e:
         await session.rollback()
-        log(f"Unable to post photometry: {e}")
+        log.error(f"Unable to post photometry: {e}")
         return None, None
 
 
@@ -1754,7 +1758,7 @@ class PhotometryHandler(BaseHandler):
 
             obj_id = df["obj_id"].unique()[0]
             username = self.associated_user_object.username
-            log(
+            log.info(
                 f"Pending request from {username} for object {obj_id} with {len(df.index)} rows"
             )
 
@@ -1774,7 +1778,7 @@ class PhotometryHandler(BaseHandler):
                     return self.error(str(e))
                 return self.error(traceback.format_exc())
 
-            log(
+            log.info(
                 f"Request from {username} for object {obj_id} with {len(df.index)} rows complete with upload_id {upload_id}"
             )
 
@@ -1890,7 +1894,7 @@ class PhotometryHandler(BaseHandler):
 
             obj_id = df["obj_id"].unique()[0]
             username = self.associated_user_object.username
-            log(
+            log.info(
                 f"Pending request from {username} for object {obj_id} with {len(df.index)} rows"
             )
 
@@ -1935,7 +1939,7 @@ class PhotometryHandler(BaseHandler):
                             {"photometr_id": duplicate.id, "group_id": gid}
                             for gid in new_group_ids
                         )
-                        log(
+                        log.info(
                             f"Adding groups {new_group_ids} to photometry {duplicate.id}"
                         )
 
@@ -1947,7 +1951,7 @@ class PhotometryHandler(BaseHandler):
                                 {"photometr_id": duplicate.id, "stream_id": sid}
                                 for sid in stream_ids_update
                             )
-                            log(
+                            log.info(
                                 f"Adding streams {stream_ids_update} to photometry {duplicate.id}"
                             )
 
@@ -2024,12 +2028,12 @@ class PhotometryHandler(BaseHandler):
 
                 # now safely drop the duplicates:
                 new_photometry = df.loc[new_photometry_df_idxs]
-                log(
+                log.info(
                     f"Inserting {len(new_photometry.index)} "
                     f"(out of {len(df.index)}) new photometry points"
                 )
                 if ignore_flux and overwrite_flux and len(updated_ids) > 0:
-                    log(
+                    log.info(
                         f"A total of {len(updated_ids)} duplicate photometry points (by obj_id, instrument_id, mjd, origin only, ignoring flux/fluxerr) were updated as requested."
                     )
 
@@ -2062,12 +2066,12 @@ class PhotometryHandler(BaseHandler):
                 ids = [id_map[pdidx] for pdidx, _ in df.iterrows()]
 
                 if len(new_photometry) > 0:
-                    log(
+                    log.info(
                         f"Request from {username} for object {obj_id} with "
                         f"{len(new_photometry.index)} rows complete with upload_id {upload_id}."
                     )
                 else:
-                    log(
+                    log.info(
                         f"Request from {username} for object {obj_id} with "
                         f"{len(new_photometry.index)} rows complete with no new photometry."
                     )

--- a/skyportal/handlers/api/photometry.py
+++ b/skyportal/handlers/api/photometry.py
@@ -1,6 +1,5 @@
 import copy
 import json
-import traceback
 import uuid
 from collections import defaultdict
 from io import StringIO
@@ -1776,7 +1775,8 @@ class PhotometryHandler(BaseHandler):
                 await session.rollback()
                 if "The following photometry already exists in the database:" in str(e):
                     return self.error(str(e))
-                return self.error(traceback.format_exc())
+                log.exception("Error posting photometry")
+                return self.error(str(e))
 
             log.info(
                 f"Request from {username} for object {obj_id} with {len(df.index)} rows complete with upload_id {upload_id}"
@@ -2077,9 +2077,10 @@ class PhotometryHandler(BaseHandler):
                     )
                 return self.success(data={"ids": ids})
 
-            except Exception:
+            except Exception as e:
                 await session.rollback()
-                return self.error(traceback.format_exc())
+                log.exception("Error updating photometry")
+                return self.error(str(e))
 
     @auth_or_token
     def get(self, photometry_id=None):

--- a/skyportal/handlers/api/public_pages/public_release.py
+++ b/skyportal/handlers/api/public_pages/public_release.py
@@ -6,7 +6,7 @@ from sqlalchemy import func
 from sqlalchemy.orm import selectinload
 
 from baselayer.app.access import auth_or_token, permissions
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ....models import Group, GroupPublicRelease, PublicRelease, PublicSourcePage
 from ...base import BaseHandler

--- a/skyportal/handlers/api/public_pages/public_source_page.py
+++ b/skyportal/handlers/api/public_pages/public_source_page.py
@@ -9,7 +9,7 @@ from sqlalchemy import not_, or_
 from baselayer.app.access import auth_or_token, permissions
 from baselayer.app.flow import Flow
 from baselayer.app.models import DBSession
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ....enum_types import THUMBNAIL_TYPES
 from ....models import (

--- a/skyportal/handlers/api/recurring_api.py
+++ b/skyportal/handlers/api/recurring_api.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from baselayer.app.access import auth_or_token, permissions
 from baselayer.app.env import load_env
 from baselayer.app.model_util import recursive_to_dict
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ...models import (
     RecurringAPI,

--- a/skyportal/handlers/api/sharing_service/sharing_service.py
+++ b/skyportal/handlers/api/sharing_service/sharing_service.py
@@ -4,7 +4,7 @@ from marshmallow.exceptions import ValidationError
 from sqlalchemy.orm import selectinload
 
 from baselayer.app.access import auth_or_token, permissions
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ....models import (
     Group,

--- a/skyportal/handlers/api/sharing_service/sharing_service_coauthor.py
+++ b/skyportal/handlers/api/sharing_service/sharing_service_coauthor.py
@@ -1,7 +1,7 @@
 from sqlalchemy.orm import selectinload
 
 from baselayer.app.access import permissions
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ....models import SharingService, SharingServiceCoauthor, User
 from ...base import BaseHandler

--- a/skyportal/handlers/api/sharing_service/sharing_service_group.py
+++ b/skyportal/handlers/api/sharing_service/sharing_service_group.py
@@ -2,7 +2,7 @@ import sqlalchemy as sa
 from sqlalchemy.orm import selectinload
 
 from baselayer.app.access import permissions
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ....models import (
     GroupUser,

--- a/skyportal/handlers/api/sharing_service/sharing_service_group_auto_publisher.py
+++ b/skyportal/handlers/api/sharing_service/sharing_service_group_auto_publisher.py
@@ -1,5 +1,5 @@
 from baselayer.app.access import permissions
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ....models import (
     GroupUser,

--- a/skyportal/handlers/api/sharing_service/sharing_service_submission.py
+++ b/skyportal/handlers/api/sharing_service/sharing_service_submission.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import joinedload, undefer
 
 from baselayer.app.access import auth_or_token
 from baselayer.app.env import load_env
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ....models import Obj, SharingService, SharingServiceSubmission
 from ....utils.data_access import (
@@ -209,7 +209,7 @@ class SharingServiceSubmissionHandler(BaseHandler):
             )
             session.add(sharing_service_submission)
             await session.commit()
-            log(
+            log.info(
                 f"Added submission for obj_id {obj.id} (manual submission) with sharing service id {sharing_service.id} for user_id {self.associated_user_object.id}"
             )
 

--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -48,7 +48,7 @@ from baselayer.app.env import load_env
 from baselayer.app.flow import Flow
 from baselayer.app.model_util import recursive_to_dict
 from baselayer.app.models import AsyncVerifiedSession
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ...models import (
     Allocation,
@@ -134,7 +134,7 @@ def confirmed_in_gcn_status_to_str(status):
 
 
 def remove_obj_thumbnails(obj_id):
-    log(f"removing existing public_url thumbnails for {obj_id}")
+    log.info(f"removing existing public_url thumbnails for {obj_id}")
     with DBSession() as session:
         existing_thumbnails = session.scalars(
             sa.select(Thumbnail).where(
@@ -879,7 +879,7 @@ async def post_source_async(data, user_id, session, refresh_source=True):
                             f"member of the group). Using current user "
                             f"{user.id} instead."
                         )
-                        log(f"WARNING: {warning_msg}")
+                        log.warning(f"WARNING: {warning_msg}")
                         warnings.append(warning_msg)
                     else:
                         saver_per_group_id[gid] = group_saver_for_gid.user
@@ -956,7 +956,7 @@ async def post_source_async(data, user_id, session, refresh_source=True):
             )
             existing_sources = existing_sources_result.all()
             if len(existing_sources) > 0:
-                log(
+                log.info(
                     f"Not saving to group {group.id} because there is already a source saved to one or more of the ignore_if_in_group_ids: {ignore_if_in_group_ids[group.id]}"
                 )
                 not_saved_to_group_ids.append(group.id)
@@ -1134,7 +1134,7 @@ def post_source(data, user_id, session, refresh_source=True):
                     )
                     if not group_saver_for_gid:
                         warning_msg = f"Could not save to group {gid} as user {saver_id_per_group_id[gid]} (user is not a member of the group). Using current user {user.id} instead."
-                        log(f"WARNING: {warning_msg}")
+                        log.warning(f"WARNING: {warning_msg}")
                         warnings.append(warning_msg)
                     else:
                         saver_per_group_id[gid] = group_saver_for_gid.user
@@ -1212,7 +1212,7 @@ def post_source(data, user_id, session, refresh_source=True):
                 )
             ).all()
             if len(existing_sources) > 0:
-                log(
+                log.info(
                     f"Not saving to group {group.id} because there is already a source saved to one or more of the ignore_if_in_group_ids: {ignore_if_in_group_ids[group.id]}"
                 )
                 not_saved_to_group_ids.append(group.id)
@@ -2288,7 +2288,7 @@ class SourceHandler(BaseHandler):
                 if query_size >= SIZE_WARNING_THRESHOLD:
                     end = time.time()
                     duration = end - start
-                    log(
+                    log.info(
                         f"User {self.associated_user_object.id} source query returned {query_size} bytes in {duration} seconds"
                     )
 
@@ -2391,7 +2391,7 @@ class SourceHandler(BaseHandler):
             if query_size >= SIZE_WARNING_THRESHOLD:
                 end = time.time()
                 duration = end - start
-                log(
+                log.info(
                     f"User {self.associated_user_object.id} source query returned {query_size} bytes in {duration} seconds"
                 )
             return self.success(data=query_results)
@@ -2878,7 +2878,7 @@ class SourceOffsetsHandler(BaseHandler):
                     used_ztfref,
                 ) = await IOLoop.current().run_in_executor(None, offset_func)
             except ValueError as e:
-                log(f"Error querying for nearby offset stars: {e}")
+                log.error(f"Error querying for nearby offset stars: {e}")
                 traceback.print_exc()
                 return self.error(f"Error querying for nearby offset stars: {e}")
 
@@ -3235,7 +3235,7 @@ class SourceFinderHandler(BaseHandler):
                     return self.error("Source not found", status=404)
 
                 # otherwise, we log the error and return a 500
-                log(f"Error generating finding chart for {obj_id}: {str(e)}")
+                log.error(f"Error generating finding chart for {obj_id}: {str(e)}")
                 traceback.print_exc()
                 return self.error(f"Error generating finding chart: {str(e)}")
 

--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -7,7 +7,6 @@ import json
 import operator  # noqa: F401
 import re
 import time
-import traceback
 from json.decoder import JSONDecodeError
 
 import arrow
@@ -2281,7 +2280,7 @@ class SourceHandler(BaseHandler):
                     # candidate but isn't saved): return a clean 404, no traceback.
                     return self.error(str(e), status=404)
                 except Exception as e:
-                    traceback.print_exc()
+                    log.exception("Cannot retrieve source")
                     return self.error(f"Cannot retrieve source: {str(e)}")
 
                 query_size = sizeof(source_info)
@@ -2384,7 +2383,7 @@ class SourceHandler(BaseHandler):
                 # client errors: return a clean 400 without a server traceback.
                 return self.error(f"Cannot retrieve sources: {str(e)}", status=400)
             except Exception as e:
-                traceback.print_exc()
+                log.exception("Cannot retrieve sources")
                 return self.error(f"Cannot retrieve sources: {str(e)}")
 
             query_size = sizeof(query_results)
@@ -2878,8 +2877,7 @@ class SourceOffsetsHandler(BaseHandler):
                     used_ztfref,
                 ) = await IOLoop.current().run_in_executor(None, offset_func)
             except ValueError as e:
-                log.error(f"Error querying for nearby offset stars: {e}")
-                traceback.print_exc()
+                log.exception("Error querying for nearby offset stars")
                 return self.error(f"Error querying for nearby offset stars: {e}")
 
             starlist_str = "\n".join(
@@ -3235,8 +3233,7 @@ class SourceFinderHandler(BaseHandler):
                     return self.error("Source not found", status=404)
 
                 # otherwise, we log the error and return a 500
-                log.error(f"Error generating finding chart for {obj_id}: {str(e)}")
-                traceback.print_exc()
+                log.exception(f"Error generating finding chart for {obj_id}")
                 return self.error(f"Error generating finding chart: {str(e)}")
 
             await self.send_file(data, filename, output_type=output_type)

--- a/skyportal/handlers/api/source_groups.py
+++ b/skyportal/handlers/api/source_groups.py
@@ -2,7 +2,7 @@ import sqlalchemy as sa
 from pydantic import BaseModel, ConfigDict, Field
 
 from baselayer.app.access import permissions
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ...models import Obj, Source
 from ...utils.asynchronous import run_async

--- a/skyportal/handlers/api/sources.py
+++ b/skyportal/handlers/api/sources.py
@@ -14,7 +14,7 @@ from mocpy import MOC
 from sqlalchemy.sql import and_, bindparam, text
 
 from baselayer.app.env import load_env
-from baselayer.log import make_log
+from skyportal.log import make_log
 from skyportal.models import (
     Allocation,
     Annotation,
@@ -451,7 +451,7 @@ async def get_localization(localization_dateobs, localization_name, session):
             )
 
     endTime = time.time()
-    log_verbose(f"get_localization took {endTime - startTime} seconds")
+    log_verbose.info(f"get_localization took {endTime - startTime} seconds")
 
     return localization_id, localizationtilescls.__tablename__
 
@@ -590,7 +590,7 @@ async def get_sources(
         page_number = int(page_number)
         num_per_page = int(num_per_page)
     except Exception as e:
-        log(f"Invalid pagination arguments: {e}")
+        log.info(f"Invalid pagination arguments: {e}")
         raise ValueError(f"Invalid pagination arguments: {e}")
 
     if page_number < 1:
@@ -1691,8 +1691,8 @@ async def get_sources(
                             .columns(id=sa.String)
                         )
                         if verbose:
-                            log_verbose(f"Params:\n{query_params}")
-                            log_verbose(f"Query:\n{statement}")
+                            log_verbose.info(f"Params:\n{query_params}")
+                            log_verbose.info(f"Query:\n{statement}")
 
                         startTime = time.time()
 
@@ -1701,13 +1701,13 @@ async def get_sources(
 
                         endTime = time.time()
                         if verbose:
-                            log_verbose(
+                            log_verbose.info(
                                 f"1. SUB SAVE SUMMARY Query took {endTime - startTime} seconds, returned {len(all_source_ids)} results."
                             )
 
                     all_source_ids = list(set(all_source_ids))
                     if verbose:
-                        log_verbose(
+                        log_verbose.info(
                             f"1. COMBINING BOTH QUERY RESULTS TOOK {endTime - startTime} seconds, returned {len(all_source_ids)} results."
                         )
                 else:
@@ -1733,8 +1733,8 @@ async def get_sources(
                         text(statement).bindparams(*query_params).columns(id=sa.String)
                     )
                     if verbose:
-                        log_verbose(f"Params:\n{query_params}")
-                        log_verbose(f"Query:\n{statement}")
+                        log_verbose.info(f"Params:\n{query_params}")
+                        log_verbose.info(f"Query:\n{statement}")
 
                     startTime = time.time()
 
@@ -1743,7 +1743,7 @@ async def get_sources(
 
                     endTime = time.time()
                     if verbose:
-                        log_verbose(
+                        log_verbose.info(
                             f"1. MAIN SAVE SUMMARY Query took {endTime - startTime} seconds, returned {len(all_source_ids)} results."
                         )
 
@@ -1788,7 +1788,9 @@ async def get_sources(
 
             endTime = time.time()
             if verbose:
-                log_verbose(f"2. Sources Query took {endTime - startTime} seconds.")
+                log_verbose.info(
+                    f"2. Sources Query took {endTime - startTime} seconds."
+                )
 
             data["sources"] = sources
             return data
@@ -1832,8 +1834,8 @@ async def get_sources(
                             .columns(id=sa.String, most_recent_saved_at=sa.DateTime)
                         )
                         if verbose:
-                            log_verbose(f"Params:\n{query_params}")
-                            log_verbose(f"Query:\n{statement}")
+                            log_verbose.info(f"Params:\n{query_params}")
+                            log_verbose.info(f"Query:\n{statement}")
 
                         startTime = time.time()
 
@@ -1842,7 +1844,7 @@ async def get_sources(
 
                         endTime = time.time()
                         if verbose:
-                            log_verbose(
+                            log_verbose.info(
                                 f"1. SUB MAIN Query took {endTime - startTime} seconds, returned {len(all_obj_ids)} results."
                             )
 
@@ -1959,7 +1961,7 @@ async def get_sources(
                     all_obj_ids = [r[0] for r in results]
 
                     if verbose:
-                        log_verbose(
+                        log_verbose.info(
                             f"1. COMBINING BOTH QUERY RESULTS TOOK {endTime - startTime} seconds, returned {len(all_obj_ids)} results."
                         )
                 else:
@@ -2046,8 +2048,8 @@ async def get_sources(
                         .columns(id=sa.String, most_recent_saved_at=sa.DateTime)
                     )
                     if verbose:
-                        log_verbose(f"Params:\n{query_params}")
-                        log_verbose(f"Query:\n{statement}")
+                        log_verbose.info(f"Params:\n{query_params}")
+                        log_verbose.info(f"Query:\n{statement}")
 
                     startTime = time.time()
 
@@ -2060,7 +2062,7 @@ async def get_sources(
 
                     endTime = time.time()
                     if verbose:
-                        log_verbose(
+                        log_verbose.info(
                             f"1. MAIN Query took {endTime - startTime} seconds, returned {len(all_obj_ids)} results."
                         )
 
@@ -2113,7 +2115,7 @@ async def get_sources(
 
             endTime = time.time()
             if verbose:
-                log_verbose(f"2. Objs Query took {endTime - startTime} seconds.")
+                log_verbose.info(f"2. Objs Query took {endTime - startTime} seconds.")
 
             # SOURCES
             startTime = time.time()
@@ -2128,7 +2130,9 @@ async def get_sources(
 
             endTime = time.time()
             if verbose:
-                log_verbose(f"3. Sources Query took {endTime - startTime} seconds.")
+                log_verbose.info(
+                    f"3. Sources Query took {endTime - startTime} seconds."
+                )
 
             if not remove_nested:
                 # REFORMAT SOURCES (SAVE INFO)
@@ -2175,7 +2179,7 @@ async def get_sources(
 
                 endTime = time.time()
                 if verbose:
-                    log_verbose(
+                    log_verbose.info(
                         f"4. Sources Refomatting took {endTime - startTime} seconds."
                     )
 
@@ -2209,7 +2213,7 @@ async def get_sources(
 
             endTime = time.time()
             if verbose:
-                log_verbose(
+                log_verbose.info(
                     f"5. Various obj computations took {endTime - startTime} seconds."
                 )
 
@@ -2230,7 +2234,7 @@ async def get_sources(
 
                 endTime = time.time()
                 if verbose:
-                    log_verbose(
+                    log_verbose.info(
                         f"6. Thumbnails Query took {endTime - startTime} seconds."
                     )
 
@@ -2252,7 +2256,7 @@ async def get_sources(
 
                 endTime = time.time()
                 if verbose:
-                    log_verbose(
+                    log_verbose.info(
                         f"7. Photstats Query took {endTime - startTime} seconds."
                     )
 
@@ -2282,7 +2286,7 @@ async def get_sources(
 
                 endTime = time.time()
                 if verbose:
-                    log_verbose(
+                    log_verbose.info(
                         f"8. Classifications Query took {endTime - startTime} seconds."
                     )
 
@@ -2305,7 +2309,7 @@ async def get_sources(
 
                 endTime = time.time()
                 if verbose:
-                    log_verbose(
+                    log_verbose.info(
                         f"9. Annotations Query took {endTime - startTime} seconds."
                     )
 
@@ -2351,7 +2355,7 @@ async def get_sources(
 
                 endTime = time.time()
                 if verbose:
-                    log_verbose(
+                    log_verbose.info(
                         f"10. Hosts Query (+offset) took {endTime - startTime} seconds."
                     )
 
@@ -2379,7 +2383,7 @@ async def get_sources(
 
                 endTime = time.time()
                 if verbose:
-                    log_verbose(
+                    log_verbose.info(
                         f"11. Spectrum Exists Query took {endTime - startTime} seconds."
                     )
 
@@ -2412,7 +2416,7 @@ async def get_sources(
 
                 endTime = time.time()
                 if verbose:
-                    log_verbose(
+                    log_verbose.info(
                         f"12. Comment Exists Query took {endTime - startTime} seconds."
                     )
 
@@ -2459,7 +2463,7 @@ async def get_sources(
 
                 endTime = time.time()
                 if verbose:
-                    log_verbose(
+                    log_verbose.info(
                         f"13. Photometry Exists Query took {endTime - startTime} seconds."
                     )
 
@@ -2477,7 +2481,7 @@ async def get_sources(
                     for obj in objs:
                         del obj["annotations"]
                 if verbose:
-                    log_verbose(
+                    log_verbose.info(
                         f"14. Period Exists Query took {endTime - startTime} seconds."
                     )
 
@@ -2505,7 +2509,7 @@ async def get_sources(
 
                 endTime = time.time()
                 if verbose:
-                    log_verbose(
+                    log_verbose.info(
                         f"15. Comments Query took {endTime - startTime} seconds."
                     )
 
@@ -2527,7 +2531,7 @@ async def get_sources(
 
                 endTime = time.time()
                 if verbose:
-                    log_verbose(
+                    log_verbose.info(
                         f"16. Labellers Query took {endTime - startTime} seconds."
                     )
 
@@ -2538,7 +2542,7 @@ async def get_sources(
 
                 endTime = time.time()
                 if verbose:
-                    log_verbose(
+                    log_verbose.info(
                         f"17. Color Mag Query took {endTime - startTime} seconds."
                     )
             if include_tags:
@@ -2579,7 +2583,9 @@ async def get_sources(
 
                 endTime = time.time()
                 if verbose:
-                    log_verbose(f"18. Tags Query took {endTime - startTime} seconds.")
+                    log_verbose.info(
+                        f"18. Tags Query took {endTime - startTime} seconds."
+                    )
 
             data["sources"] = objs
 
@@ -2614,10 +2620,10 @@ async def get_sources(
 
         endMethodTime = time.time()
         if verbose:
-            log_verbose(f"TOTAL took {endMethodTime - startMethodTime} seconds.")
+            log_verbose.info(f"TOTAL took {endMethodTime - startMethodTime} seconds.")
 
         return data
     except Exception as e:
-        log_verbose(str(e))
+        log_verbose.info(str(e))
         await session.rollback()
         raise e

--- a/skyportal/handlers/api/sources_confirmed_in_gcn.py
+++ b/skyportal/handlers/api/sources_confirmed_in_gcn.py
@@ -4,7 +4,7 @@ from sqlalchemy.orm import selectinload
 
 from baselayer.app.access import auth_or_token, permissions
 from baselayer.app.flow import Flow
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ...models import (
     GcnEvent,

--- a/skyportal/handlers/api/spatial_catalog.py
+++ b/skyportal/handlers/api/spatial_catalog.py
@@ -10,7 +10,7 @@ from tornado.ioloop import IOLoop
 
 from baselayer.app.access import auth_or_token, permissions
 from baselayer.app.flow import Flow
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ...models import (
     DBSession,
@@ -32,7 +32,7 @@ MAX_SPATIAL_CATALOG_ENTRIES = 1000
 
 
 def add_catalog(catalog_id, catalog_data):
-    log(f"Generating catalog with ID {catalog_id}")
+    log.info(f"Generating catalog with ID {catalog_id}")
     start = time.time()
 
     if Session.registry.has():
@@ -111,16 +111,16 @@ def add_catalog(catalog_id, catalog_data):
         end = time.time()
         duration = end - start
 
-        log(f"Generated catalog with ID {catalog_id} in {duration} seconds")
+        log.info(f"Generated catalog with ID {catalog_id} in {duration} seconds")
     except Exception as e:
-        log(f"Unable to generate catalog: {e}")
+        log.error(f"Unable to generate catalog: {e}")
     finally:
         session.close()
         Session.remove()
 
 
 def delete_catalog(catalog_id):
-    log(f"Deleting catalog with ID {catalog_id}")
+    log.info(f"Deleting catalog with ID {catalog_id}")
 
     if Session.registry.has():
         session = Session()
@@ -140,9 +140,9 @@ def delete_catalog(catalog_id):
             "skyportal/REFRESH_SPATIAL_CATALOGS",
         )
 
-        log(f"Deleted catalog with ID {catalog_id}")
+        log.info(f"Deleted catalog with ID {catalog_id}")
     except Exception as e:
-        log(f"Unable to delete catalog: {e}")
+        log.error(f"Unable to delete catalog: {e}")
     finally:
         session.close()
         Session.remove()

--- a/skyportal/handlers/api/spectrum.py
+++ b/skyportal/handlers/api/spectrum.py
@@ -17,7 +17,7 @@ from baselayer.app.custom_exceptions import AccessError
 from baselayer.app.env import load_env
 from baselayer.app.flow import Flow
 from baselayer.app.model_util import recursive_to_dict
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ...enum_types import ALLOWED_SPECTRUM_TYPES, default_spectrum_type
 from ...models import (

--- a/skyportal/handlers/api/summary_query.py
+++ b/skyportal/handlers/api/summary_query.py
@@ -7,7 +7,7 @@ from pinecone import Pinecone
 
 from baselayer.app.access import auth_or_token
 from baselayer.app.env import load_env
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ...models import (
     User,
@@ -75,7 +75,7 @@ def search_sources(
             }
             sources.append(source)
         except Exception as e:
-            log(f"Error: {e}")
+            log.error(f"Error: {e}")
             continue
     return sources
 
@@ -94,7 +94,7 @@ if (
     and summarize_embedding_config.get("index_name")
     and summarize_embedding_config.get("index_size")
 ):
-    log("initializing pinecone access...")
+    log.info("initializing pinecone access...")
     pinecone_client = Pinecone(
         api_key=summarize_embedding_config.get("api_key"),
     )
@@ -110,9 +110,11 @@ if (
 else:
     if cfg["database.database"] == "skyportal_test":
         USE_PINECONE = True
-        log("Setting USE_PINECONE=True as it seems like we are in a test environment")
+        log.info(
+            "Setting USE_PINECONE=True as it seems like we are in a test environment"
+        )
     else:
-        log("No valid pinecone configuration found. Please check the config file.")
+        log.info("No valid pinecone configuration found. Please check the config file.")
 
 summary_config = copy.deepcopy(cfg["analysis_services.openai_analysis_service.summary"])
 if summary_config.get("api_key"):

--- a/skyportal/handlers/api/team.py
+++ b/skyportal/handlers/api/team.py
@@ -3,7 +3,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy.orm import selectinload
 
 from baselayer.app.access import auth_or_token, permissions
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ...models import Group, GroupUser, Team
 from ..base import BaseHandler

--- a/skyportal/handlers/api/tns/obj_tns.py
+++ b/skyportal/handlers/api/tns/obj_tns.py
@@ -1,7 +1,7 @@
 from tornado.ioloop import IOLoop
 
 from baselayer.app.access import auth_or_token
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ....models import (
     Obj,

--- a/skyportal/handlers/api/unsourced_finder.py
+++ b/skyportal/handlers/api/unsourced_finder.py
@@ -9,7 +9,7 @@ from tornado.ioloop import IOLoop
 
 from baselayer.app.access import auth_or_token
 from baselayer.app.env import load_env
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ...utils.naive_datetime import utcnow_naive
 from ...utils.offset import (

--- a/skyportal/handlers/api/user.py
+++ b/skyportal/handlers/api/user.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import selectinload
 
 from baselayer.app.access import auth_or_token, permissions
 from baselayer.app.env import load_env
-from baselayer.log import make_log
+from skyportal.log import make_log
 from skyportal.model_util import all_acl_ids, role_acls
 
 from ...models import (
@@ -226,7 +226,7 @@ async def add_user_and_setup_groups(
         await session.flush()
     except Exception as e:
         await session.rollback()
-        log(str(e))
+        log.info(str(e))
         raise e
     return user.id
 

--- a/skyportal/handlers/api/webhook.py
+++ b/skyportal/handlers/api/webhook.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import selectinload
 from baselayer.app import models as baselayer_models
 from baselayer.app.env import load_env
 from baselayer.app.flow import Flow
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ...models import ObjAnalysis
 from ...utils.naive_datetime import utcnow_naive
@@ -60,7 +60,7 @@ class AnalysisWebhookHandler(BaseHandler):
               application/json:
                 schema: Error
         """
-        log(
+        log.info(
             f"Received webhook request for Analysis type={analysis_resource_type} token={token}"
         )
 
@@ -98,7 +98,7 @@ class AnalysisWebhookHandler(BaseHandler):
                 ).total_seconds()
                 await session.commit()
             except Exception as e:
-                log(f"Trouble accessing Analysis with token {token} {e}.")
+                log.info(f"Trouble accessing Analysis with token {token} {e}.")
                 return self.error("Invalid token", status=403)
 
             data = self.get_json()
@@ -111,11 +111,11 @@ class AnalysisWebhookHandler(BaseHandler):
             if len(results.keys()) > 0:
                 analysis._data = results
                 analysis.save_data()
-                log(
+                log.info(
                     f"Saved webhook data at {analysis.filename}. Message: {analysis.status_message}"
                 )
             else:
-                log(
+                log.info(
                     f"Note: empty analysis results for this webhook. Message: {analysis.status_message}"
                 )
 
@@ -149,7 +149,7 @@ class AnalysisWebhookHandler(BaseHandler):
                         summary, analysis.obj, analysis.author
                     )
                     await session.commit()
-                    log("analysis is a summary. Pushing to source.")
+                    log.info("analysis is a summary. Pushing to source.")
                     flow.push(
                         "*",
                         "skyportal/REFRESH_SOURCE",
@@ -163,7 +163,7 @@ class AnalysisWebhookHandler(BaseHandler):
                             payload={"obj_key": analysis.obj.internal_key},
                         )
             except Exception as e:
-                log(f"Error pushing update to source: {e}")
+                log.error(f"Error pushing update to source: {e}")
 
         return self.success(data={"status": "success"})
 

--- a/skyportal/handlers/public/finder.py
+++ b/skyportal/handlers/public/finder.py
@@ -1,5 +1,4 @@
 import io
-import traceback
 
 import numpy as np
 
@@ -69,8 +68,7 @@ class CachedSourceFinderHandler(BaseHandler):
                 return self.error("Source not found", status=404)
 
             # otherwise, we log the error and return a 500
-            log.error(f"Error retrieving cached finding chart: {str(e)}")
-            traceback.print_exc()
+            log.exception("Error retrieving cached finding chart")
             return self.error(f"Error generating finding chart: {str(e)}")
 
         await self.send_file(data, filename, output_type=output_type)

--- a/skyportal/handlers/public/finder.py
+++ b/skyportal/handlers/public/finder.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from baselayer.app.access import auth_or_token
 from baselayer.app.env import load_env
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ...utils.offset import finding_charts_cache
 from ..base import BaseHandler
@@ -69,7 +69,7 @@ class CachedSourceFinderHandler(BaseHandler):
                 return self.error("Source not found", status=404)
 
             # otherwise, we log the error and return a 500
-            log(f"Error retrieving cached finding chart: {str(e)}")
+            log.error(f"Error retrieving cached finding chart: {str(e)}")
             traceback.print_exc()
             return self.error(f"Error generating finding chart: {str(e)}")
 

--- a/skyportal/handlers/public/report.py
+++ b/skyportal/handlers/public/report.py
@@ -3,7 +3,7 @@ import sqlalchemy as sa
 from sqlalchemy.orm import scoped_session, sessionmaker
 
 from baselayer.app.env import load_env
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ...models import DBSession, GcnReport
 from ...utils.cache import Cache

--- a/skyportal/log.py
+++ b/skyportal/log.py
@@ -1,0 +1,38 @@
+"""SkyPortal logging built on the standard library, replacing baselayer.log.
+
+Keeps the `log = make_log(name)` convention, but returns a real
+`logging.Logger` so call sites use `log.info(...)`, `log.error(...)`, etc.
+"""
+
+import logging
+import sys
+
+_configured = False
+
+
+def setup_logging():
+    """Send logging to stdout, once per process (supervisor captures it to log/)."""
+    global _configured
+    if _configured:
+        return
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(
+        logging.Formatter(
+            "[%(asctime)s %(name)s %(levelname)s] %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S",
+        )
+    )
+    root = logging.getLogger()
+    root.addHandler(handler)
+    # Third-party loggers stay at WARNING; app loggers opt in to INFO via make_log
+    root.setLevel(logging.WARNING)
+    logging.captureWarnings(True)
+    _configured = True
+
+
+def make_log(name):
+    """Return an INFO-level logger, configuring logging on first use."""
+    setup_logging()
+    logger = logging.getLogger(name)
+    logger.setLevel(logging.INFO)
+    return logger

--- a/skyportal/models/analysis.py
+++ b/skyportal/models/analysis.py
@@ -30,7 +30,7 @@ from baselayer.app.models import (
     AccessibleIfUserMatches,
     Base,
 )
-from baselayer.log import make_log
+from skyportal.log import make_log
 from skyportal.models import DBSession
 
 from ..enum_types import (
@@ -293,7 +293,7 @@ class AnalysisMixin:
                 data = joblib.load(buf)
                 jsons = json.dumps(data, cls=DictNumpyEncoder)
             except Exception as e:
-                log(f"Error serializing results data: {e}")
+                log.error(f"Error serializing results data: {e}")
                 jsons = "{}"
             return json.loads(jsons)
         else:
@@ -311,7 +311,7 @@ class AnalysisMixin:
             format = plot["format"]
         except Exception as e:
             format = "png"
-            log(f"Warning: missing format in plot, assuming png {e}")
+            log.warning(f"Warning: missing format in plot, assuming png {e}")
 
         buf = io.BytesIO()
         buf.write(base64.b64decode(plot["data"]))
@@ -624,15 +624,15 @@ class DefaultAnalysis(Base):
 
 @event.listens_for(ObjAnalysis, "after_delete")
 def delete_analysis_data_from_disk(mapper, connection, target):
-    log(f"Deleting analysis data for analysis id={target.id}")
+    log.info(f"Deleting analysis data for analysis id={target.id}")
     target.delete_data()
 
 
 @event.listens_for(AnalysisService, "before_delete")
 def delete_assoc_analysis_data_from_disk(mapper, connection, target):
-    log(f"Deleting associated analysis data for analysis_service={target.id}")
+    log.info(f"Deleting associated analysis data for analysis_service={target.id}")
     for analysis in target.obj_analyses:
-        log(f" ... deleting analysis data for analysis id={analysis.id}")
+        log.info(f" ... deleting analysis data for analysis id={analysis.id}")
         analysis.delete_data()
 
 
@@ -705,7 +705,9 @@ def _run_default_analysis(default_analysis_id, author_id, obj_id, notification):
                 session=db_session,
             )
         except Exception as e:
-            log(f"Error creating default analysis with id {default_analysis_id}: {e}")
+            log.error(
+                f"Error creating default analysis with id {default_analysis_id}: {e}"
+            )
             db_session.rollback()
 
 
@@ -713,7 +715,7 @@ def _run_default_analysis(default_analysis_id, author_id, obj_id, notification):
 def create_default_analysis(mapper, connection, target):
     """Trigger default analyses whose source_filter matches a new classification
     (by name + probability), within the per-day limit and a shared group."""
-    log(f"Checking for default analyses for classification {target.id}")
+    log.info(f"Checking for default analyses for classification {target.id}")
 
     @event.listens_for(inspect(target).session, "after_flush", once=True)
     def receive_after_flush(session, context):
@@ -745,7 +747,7 @@ def create_default_analysis(mapper, connection, target):
                     and classification_filter["probability"]
                     <= target_data["probability"]
                 ):
-                    log(
+                    log.info(
                         f"Creating default analysis {default_analysis.analysis_service.name} "
                         f"for classification {target.id}"
                     )
@@ -758,7 +760,9 @@ def create_default_analysis(mapper, connection, target):
                         f"triggered by classification {target_data['classification']}",
                     )
         except Exception as e:
-            log(f"Error creating default analyses on classification {target.id}: {e}")
+            log.error(
+                f"Error creating default analyses on classification {target.id}: {e}"
+            )
 
 
 @event.listens_for(Source, "after_insert")
@@ -781,7 +785,7 @@ def create_default_analysis_on_save(mapper, connection, target):
                 _default_analysis_under_limit(),
             )
             for default_analysis in session.scalars(stmt).all():
-                log(
+                log.info(
                     f"Creating default analysis {default_analysis.analysis_service.name} "
                     f"for source {target_data['obj_id']} saved to group {group_id}"
                 )
@@ -794,4 +798,4 @@ def create_default_analysis_on_save(mapper, connection, target):
                     f"triggered by save to group {group_id}",
                 )
         except Exception as e:
-            log(f"Error creating default analyses on source save: {e}")
+            log.error(f"Error creating default analyses on source save: {e}")

--- a/skyportal/models/comment.py
+++ b/skyportal/models/comment.py
@@ -17,7 +17,7 @@ from baselayer.app.models import (
     AccessibleIfUserMatches,
     Base,
 )
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ..utils.files import delete_file_data, save_file_data
 from .group import accessible_by_groups_members
@@ -298,5 +298,5 @@ class CommentOnShift(Base, CommentMixin):
 @event.listens_for(CommentOnGCN, "after_delete")
 @event.listens_for(CommentOnShift, "after_delete")
 def delete_comment_data_from_disk(mapper, connection, target):
-    log(f"Deleting comment data for comment id={target.id}")
+    log.info(f"Deleting comment data for comment id={target.id}")
     target.delete_data()

--- a/skyportal/models/followup_request.py
+++ b/skyportal/models/followup_request.py
@@ -27,7 +27,7 @@ from baselayer.app.models import (
     join_model,
     public,
 )
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from .allocation import Allocation
 from .classification import Classification

--- a/skyportal/models/instrument.py
+++ b/skyportal/models/instrument.py
@@ -25,8 +25,8 @@ from baselayer.app.models import (
     join_model,
     public,
 )
-from baselayer.log import make_log
 from skyportal import facility_apis
+from skyportal.log import make_log
 
 from ..enum_types import (
     allowed_bandpasses,

--- a/skyportal/models/invitation.py
+++ b/skyportal/models/invitation.py
@@ -9,7 +9,7 @@ from sqlalchemy_utils import EmailType
 from baselayer.app.env import load_env
 from baselayer.app.flow import Flow
 from baselayer.app.models import AccessibleIfUserMatches, Base
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ..app_utils import get_app_base_url
 from ..email_utils import send_email
@@ -66,7 +66,7 @@ def send_user_invite_email(mapper, connection, target):
     link_location = f"{app_base_url}/login/google-oauth2/?invite_token={target.token}"
     if cfg.get("invitations.disable_emailing", False) is True:
         # If email sending is disabled, log the invite link for testing purposes
-        log(
+        log.info(
             f"Invitation created with token {target.token}; invite link: {link_location}"
         )
         if target.invited_by:
@@ -81,7 +81,7 @@ def send_user_invite_email(mapper, connection, target):
                     },
                 )
             except Exception as e:
-                log(f"Failed to send notification: {e}")
+                log.error(f"Failed to send notification: {e}")
     else:
         send_email(
             recipients=[target.user_email],

--- a/skyportal/models/localization.py
+++ b/skyportal/models/localization.py
@@ -29,7 +29,7 @@ from sqlalchemy.sql.ddl import DDL
 
 from baselayer.app.env import load_env
 from baselayer.app.models import AccessibleIfUserMatches, Base
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ..utils.files import delete_file_data, save_file_data
 
@@ -299,7 +299,7 @@ class Localization(Base):
             # reset the filename
             self._localization_path = None
         except Exception:
-            log(
+            log.error(
                 f"Failed to delete localization ID {self.id} file {self._localization_path}"
             )
 
@@ -561,5 +561,5 @@ class LocalizationTag(Base):
 
 @event.listens_for(Localization, "after_delete")
 def delete_localization_data_from_disk(mapper, connection, target):
-    log(f"Deleting localization data for localization id={target.id}")
+    log.info(f"Deleting localization data for localization id={target.id}")
     target.delete_data()

--- a/skyportal/models/obj.py
+++ b/skyportal/models/obj.py
@@ -31,7 +31,7 @@ from baselayer.app.models import (
     public,
     restricted,
 )
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from .candidate import Candidate
 from .cosmo import cosmo
@@ -575,17 +575,19 @@ class Obj(Base, conesearch_alchemy.Point):
             if match:
                 cutout_url = match.group().replace('src="', "https:").replace('"', "")
         except requests.exceptions.HTTPError as http_err:
-            log(f"HTTPError getting thumbnail for {self.id}: {http_err}")
+            log.info(f"HTTPError getting thumbnail for {self.id}: {http_err}")
         except requests.exceptions.Timeout as timeout_err:
-            log(f"Timeout in getting thumbnail for {self.id}: {timeout_err}")
+            log.info(f"Timeout in getting thumbnail for {self.id}: {timeout_err}")
         except requests.exceptions.ChunkedEncodingError as chunk_err:
-            log(
+            log.info(
                 f"Chunked encoding error in getting thumbnail for {self.id}: {chunk_err}"
             )
         except requests.exceptions.RequestException as other_err:
-            log(f"Unexpected error in getting thumbnail for {self.id}: {other_err}")
+            log.info(
+                f"Unexpected error in getting thumbnail for {self.id}: {other_err}"
+            )
         except Exception as e:
-            log(f"Unexpected error in getting thumbnail for {self.id}: {e}")
+            log.info(f"Unexpected error in getting thumbnail for {self.id}: {e}")
         return cutout_url
 
     @property
@@ -628,13 +630,15 @@ class Obj(Base, conesearch_alchemy.Point):
             else:
                 cutout_url = "/static/images/outside_survey.png"
         except requests.exceptions.HTTPError as http_err:
-            log(f"HTTPError getting thumbnail for {self.id}: {http_err}")
+            log.info(f"HTTPError getting thumbnail for {self.id}: {http_err}")
         except requests.exceptions.Timeout as timeout_err:
-            log(f"Timeout in getting thumbnail for {self.id}: {timeout_err}")
+            log.info(f"Timeout in getting thumbnail for {self.id}: {timeout_err}")
         except requests.exceptions.RequestException as other_err:
-            log(f"Unexpected error in getting thumbnail for {self.id}: {other_err}")
+            log.info(
+                f"Unexpected error in getting thumbnail for {self.id}: {other_err}"
+            )
         except Exception as e:
-            log(f"Unexpected error in getting thumbnail for {self.id}: {e}")
+            log.info(f"Unexpected error in getting thumbnail for {self.id}: {e}")
         return cutout_url
 
     @property
@@ -658,7 +662,7 @@ class Obj(Base, conesearch_alchemy.Point):
                 coordinates=coord, radius=1 * u.arcsec, obs_collection="HST"
             )
         except Exception as e:
-            log(f"Error querying HST coverage for {self.id}: {e}")
+            log.error(f"Error querying HST coverage for {self.id}: {e}")
             return None
         if table is None or len(table) == 0:
             return None
@@ -707,7 +711,7 @@ class Obj(Base, conesearch_alchemy.Point):
                 return match.group().replace('href="', "").replace('"', "")
             return None
         except Exception as e:
-            log(f"Error getting Chandra thumbnail for {self.id}: {e}")
+            log.error(f"Error getting Chandra thumbnail for {self.id}: {e}")
             return None
 
     @property
@@ -724,7 +728,7 @@ class Obj(Base, conesearch_alchemy.Point):
                 dataproduct_type="image",
             )
         except Exception as e:
-            log(f"Error querying JWST coverage for {self.id}: {e}")
+            log.error(f"Error querying JWST coverage for {self.id}: {e}")
             return None
         if table is None or len(table) == 0 or "jpegURL" not in table.colnames:
             return None
@@ -949,4 +953,4 @@ def delete_obj_thumbnails_from_disk(mapper, connection, target):
             try:
                 os.remove(file_uri)
             except (FileNotFoundError, OSError) as e:
-                log(f"Error deleting thumbnail file {file_uri}: {e}")
+                log.error(f"Error deleting thumbnail file {file_uri}: {e}")

--- a/skyportal/models/super_obj.py
+++ b/skyportal/models/super_obj.py
@@ -8,7 +8,7 @@ from baselayer.app.env import load_env
 from baselayer.app.models import (
     Base,
 )
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from .obj import Obj
 

--- a/skyportal/models/telescope.py
+++ b/skyportal/models/telescope.py
@@ -19,7 +19,7 @@ from baselayer.app.models import (
     CustomUserAccessControl,
     public,
 )
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ..utils.cache import Cache, dict_to_bytes
 
@@ -123,7 +123,7 @@ class Telescope(Base):
             )
 
         except Exception as e:
-            log(
+            log.info(
                 f'Telescope {self.id} ("{self.name}") cannot calculate an observer: {e}'
             )
             self._observer = None
@@ -171,7 +171,7 @@ class Telescope(Base):
             )
 
         except Exception as e:
-            log(
+            log.info(
                 f'Telescope {self.id} ("{self.name}") cannot calculate an observer: {e}'
             )
             self._observer_timezone = None
@@ -389,7 +389,7 @@ class Telescope(Base):
                 ):
                     return time_info
             except Exception:
-                log(f"Failed to load cached time info for telescope {self.id}")
+                log.error(f"Failed to load cached time info for telescope {self.id}")
 
         is_night_astronomical = False
         try:
@@ -398,7 +398,7 @@ class Telescope(Base):
             if morning is not None and evening is not None:
                 is_night_astronomical = bool(morning.jd < evening.jd)
         except Exception:
-            log(f"Failed to calculate current time for telescope {self.id}")
+            log.error(f"Failed to calculate current time for telescope {self.id}")
             is_night_astronomical = False
             morning = False
             evening = False

--- a/skyportal/models/thumbnail.py
+++ b/skyportal/models/thumbnail.py
@@ -7,7 +7,7 @@ from sqlalchemy import event
 from sqlalchemy.orm import relationship
 
 from baselayer.app.models import AccessibleIfRelatedRowsAreAccessible, Base
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ..enum_types import thumbnail_types
 from ..utils.thumbnail import image_is_grayscale
@@ -86,4 +86,4 @@ def delete_thumbnail_from_disk(mapper, connection, target):
         try:
             os.remove(target.file_uri)
         except (FileNotFoundError, OSError) as e:
-            log(f"Error deleting thumbnail file {target.file_uri}: {e}")
+            log.error(f"Error deleting thumbnail file {target.file_uri}: {e}")

--- a/skyportal/services/test_server/test_api_server.py
+++ b/skyportal/services/test_server/test_api_server.py
@@ -12,7 +12,7 @@ import vcr
 from suds import Client
 
 from baselayer.app.env import load_env
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 
 def get_cache_file_static():
@@ -330,9 +330,9 @@ class TestRouteHandler(tornado.web.RequestHandler):
                 url = real_host + self.request.uri
 
                 if is_soap_action:
-                    log(f"Forwarding SOAP method call {url}")
+                    log.info(f"Forwarding SOAP method call {url}")
                 else:
-                    log(f"Forwarding DELETE call {url}")
+                    log.info(f"Forwarding DELETE call {url}")
 
                 # Convert Tornado HTTPHeaders object to a regular dict
                 headers = {}
@@ -357,7 +357,7 @@ class TestRouteHandler(tornado.web.RequestHandler):
                         headers=header,
                     )
                 else:
-                    log(f"Forwarding DELETE call: {url}")
+                    log.info(f"Forwarding DELETE call: {url}")
                     s = requests.Session()
                     req = requests.Request(
                         "DELETE", url, data=self.request.body, headers=headers
@@ -415,9 +415,9 @@ class TestRouteHandler(tornado.web.RequestHandler):
                 url = real_host + self.request.uri
 
                 if is_soap_action:
-                    log(f"Forwarding SOAP method call {url}")
+                    log.info(f"Forwarding SOAP method call {url}")
                 else:
-                    log(f"Forwarding PUT call {url}")
+                    log.info(f"Forwarding PUT call {url}")
 
                 # Convert Tornado HTTPHeaders object to a regular dict
                 headers = {}
@@ -442,7 +442,7 @@ class TestRouteHandler(tornado.web.RequestHandler):
                         headers=header,
                     )
                 else:
-                    log(f"Forwarding PUT call: {url}")
+                    log.info(f"Forwarding PUT call: {url}")
                     s = requests.Session()
                     req = requests.Request(
                         "PUT", url, data=self.request.body, headers=headers
@@ -504,10 +504,10 @@ class TestRouteHandler(tornado.web.RequestHandler):
                         headers[k] = str(v)
 
                 if is_wsdl is not None:
-                    log(f"Forwarding WSDL call {url}")
+                    log.info(f"Forwarding WSDL call {url}")
                     Client(url=url, headers=headers, cache=None)
                 else:
-                    log(f"Forwarding GET call: {url}")
+                    log.info(f"Forwarding GET call: {url}")
                     if is_ps1:
                         # PS1 request does not need headers
                         requests.get(url)
@@ -601,9 +601,9 @@ class TestRouteHandler(tornado.web.RequestHandler):
                 url = real_host + self.request.uri
 
                 if is_soap_action:
-                    log(f"Forwarding SOAP method call {url}")
+                    log.info(f"Forwarding SOAP method call {url}")
                 else:
-                    log(f"Forwarding POST call {url}")
+                    log.info(f"Forwarding POST call {url}")
 
                 # Convert Tornado HTTPHeaders object to a regular dict
                 headers = {}
@@ -692,5 +692,5 @@ if __name__ == "__main__":
 
         refresh_cache_days = cfg["test_server.refresh_cache_days"]
 
-        log(f"Listening for test HTTP requests on port {port}")
+        log.info(f"Listening for test HTTP requests on port {port}")
         tornado.ioloop.IOLoop.current().start()

--- a/skyportal/services/test_server/test_smtp_server.py
+++ b/skyportal/services/test_server/test_smtp_server.py
@@ -8,7 +8,7 @@ from aiosmtpd.controller import Controller
 from aiosmtpd.smtp import AuthResult
 
 from baselayer.app.env import load_env
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 
 # For SMTP testing
@@ -23,10 +23,10 @@ class CustomSMTPHandler:
         mail_from = envelope.mail_from
         rcpt_tos = envelope.rcpt_tos
         data = envelope.content  # type: bytes
-        log(f"Receiving message from: {peer}")
-        log(f"Message addressed from: {mail_from}")
-        log(f"Message addressed to  : {rcpt_tos}")
-        log(f"Message length        : {len(data)}")
+        log.info(f"Receiving message from: {peer}")
+        log.info(f"Message addressed from: {mail_from}")
+        log.info(f"Message addressed to  : {rcpt_tos}")
+        log.info(f"Message length        : {len(data)}")
         return "250 OK"
 
 
@@ -37,7 +37,7 @@ if __name__ == "__main__":
     if "test_server" in cfg:
         smtp_port = cfg["test_server.smtp_port"]
 
-        log(f"Listening for test SMTP requests on port {smtp_port}")
+        log.info(f"Listening for test SMTP requests on port {smtp_port}")
         # SMTP TLS context
         context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
         cert_file = os.path.join(os.path.dirname(__file__), "cert.pem")
@@ -56,7 +56,7 @@ if __name__ == "__main__":
 
         # On process close, close SMTP sub-process
         def signal_handler(sig, frame):
-            log("Closing SMTP server")
+            log.info("Closing SMTP server")
             controller.stop()
             sys.exit(0)
 

--- a/skyportal/tests/fixtures.py
+++ b/skyportal/tests/fixtures.py
@@ -1071,9 +1071,9 @@ class InvitationFactory(factory.alchemy.SQLAlchemyModelFactory):
     # or the row fails to flush.
     can_save_to_groups = []
     role = factory.LazyFunction(
-        lambda: DBSession()
-        .scalars(sa.select(Role).where(Role.id == "Full user"))
-        .first()
+        lambda: (
+            DBSession().scalars(sa.select(Role).where(Role.id == "Full user")).first()
+        )
     )
     user_email = "user@email.com"
     invited_by = factory.SubFactory(UserFactory)

--- a/skyportal/utils/asynchronous.py
+++ b/skyportal/utils/asynchronous.py
@@ -2,7 +2,7 @@ import asyncio
 import uuid
 
 from baselayer.app.models import session_context_id
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 log = make_log("async")
 
@@ -25,7 +25,7 @@ def run_async(func, *args, **kwargs):
         try:
             func(*args, **kwargs)
         except Exception as e:
-            log(f"Error running async function {func.__name__}: {e}")
+            log.error(f"Error running async function {func.__name__}: {e}")
 
     try:
         event_loop = asyncio.get_event_loop()

--- a/skyportal/utils/cache.py
+++ b/skyportal/utils/cache.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import numpy as np
 
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 log = make_log("cache")
 
@@ -85,7 +85,7 @@ class Cache:
         if not cache_file.exists():
             return None
 
-        log(f"hit [{name}]")
+        log.info(f"hit [{name}]")
         cache_file.touch()  # Make newest in cache
 
         return cache_file
@@ -108,7 +108,7 @@ class Cache:
         with open(fn, "wb") as f:
             f.write(data)
 
-        log(f"save [{name}] to [{os.path.basename(fn)}]")
+        log.info(f"save [{name}] to [{os.path.basename(fn)}]")
 
         self.clean_cache()
 
@@ -130,7 +130,7 @@ class Cache:
         except FileNotFoundError:
             return
 
-        log(f"cleanup [{os.path.basename(fn)}]")
+        log.info(f"cleanup [{os.path.basename(fn)}]")
         self.clean_cache()
 
     def _remove(self, filenames):
@@ -145,7 +145,7 @@ class Cache:
         for f in filenames:
             try:
                 os.remove(f)
-                log(f'cleanup [{os.path.basename(f)}]')
+                log.info(f'cleanup [{os.path.basename(f)}]')
             except FileNotFoundError:
                 pass
         # fmt: on

--- a/skyportal/utils/cosmology.py
+++ b/skyportal/utils/cosmology.py
@@ -2,7 +2,7 @@ from astropy import cosmology
 from astropy import units as u
 
 from baselayer.app.env import load_env
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 log = make_log("cosmology")
 _, cfg = load_env()
@@ -38,15 +38,15 @@ def establish_cosmology(cfg=cfg):
                     Ob0=user_cosmo.get("Ob0", 0.0455),
                 )
         except (KeyError, NameError) as e:
-            log(f"{e}")
-            log("Exception while processing user-defined cosmology")
+            log.info(f"{e}")
+            log.info("Exception while processing user-defined cosmology")
             raise RuntimeError("Error parsing user-defined cosmology")
 
     else:
-        log(f"Invalid user-defined cosmology [{user_cosmo}]")
-        log(f"Try setting it to one of [{cosmology.realizations.available}]")
+        log.info(f"Invalid user-defined cosmology [{user_cosmo}]")
+        log.info(f"Try setting it to one of [{cosmology.realizations.available}]")
         raise RuntimeError("No valid cosmology specified")
 
-    log(f"Using {cosmo} for cosmological calculations")
+    log.info(f"Using {cosmo} for cosmological calculations")
 
     return cosmo

--- a/skyportal/utils/data_access.py
+++ b/skyportal/utils/data_access.py
@@ -2,7 +2,7 @@ import sqlalchemy as sa
 from sqlalchemy.orm import selectinload
 
 from baselayer.app.models import RoleACL, UserACL, UserRole
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ..models import (
     Filter,
@@ -638,11 +638,11 @@ def auto_source_publishing(session, saver, group_id, obj, publish_to):
                     )
                     session.add(submission_request)
                     session.commit()
-                    log(
+                    log.info(
                         f"Added SharingServiceSubmission for obj_id {obj.id}, group {group_id}, sharing_service_id {sharing_service_id}, user_id {saver.id}, services {service_name}"
                     )
             else:
-                log(
+                log.info(
                     "No auto-sharing services associated with this group are selected to auto publish to TNS or Hermes."
                 )
 
@@ -936,11 +936,11 @@ async def auto_source_publishing_async(session, saver, group_id, obj, publish_to
                     )
                     session.add(submission_request)
                     await session.commit()
-                    log(
+                    log.info(
                         f"Added SharingServiceSubmission for obj_id {obj.id}, group {group_id}, sharing_service_id {sharing_service_id}, user_id {saver.id}, services {service_name}"
                     )
             else:
-                log(
+                log.info(
                     "No auto-sharing services associated with this group are selected to auto publish to TNS or Hermes."
                 )
 

--- a/skyportal/utils/extinction.py
+++ b/skyportal/utils/extinction.py
@@ -8,7 +8,7 @@ from astropy.coordinates import SkyCoord
 from dust_extinction.parameter_averages import G23
 from dustmaps.config import config
 
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 config["data_dir"] = "/tmp"
 log = make_log("extinction")
@@ -54,7 +54,7 @@ class _ExtinctionCalculator:
             path = dustmaps.sfd.data_dir()
             path = os.path.join(path, "sfd")
             if not os.path.exists(path):
-                log("No SFD data for dustmaps, downloading it")
+                log.info("No SFD data for dustmaps, downloading it")
                 dustmaps.sfd.fetch()
 
             self._sfd_query = dustmaps.sfd.SFDQuery()
@@ -109,7 +109,7 @@ def calculate_extinction(
         return extinction
 
     except Exception as e:
-        log(f"Could not calculate extinction for {filter_name}: {e}")
+        log.error(f"Could not calculate extinction for {filter_name}: {e}")
         return None
 
 

--- a/skyportal/utils/gitlog.py
+++ b/skyportal/utils/gitlog.py
@@ -1,7 +1,7 @@
 import re
 import subprocess
 
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 log = make_log("gitlog")
 
@@ -98,7 +98,7 @@ def parse_gitlog(gitlog):
 
         m = re.match(log_re, line)
         if m is None:
-            log(f"sysinfo: could not parse gitlog line: `{line}`")
+            log.info(f"sysinfo: could not parse gitlog line: `{line}`")
             continue
 
         log_fields = m.groupdict()

--- a/skyportal/utils/hermes_submission.py
+++ b/skyportal/utils/hermes_submission.py
@@ -4,7 +4,7 @@ import requests
 
 from baselayer.app.env import load_env
 from baselayer.app.flow import Flow
-from baselayer.log import make_log
+from skyportal.log import make_log
 from skyportal.models import Obj
 from skyportal.utils.http import serialize_requests_response
 
@@ -143,14 +143,14 @@ def submit_to_hermes(
             timeout=5.0,
         )
         if response.status_code != 200:
-            log(
+            log.error(
                 f"Failed to publish to topic '{topic}' with status code {response.status_code}: {response.text}"
             )
             status = f"Error: Failed to publish to topic '{topic}' with status code {response.status_code}"
             notif_text = f"Hermes error: Failed to publish to topic '{topic}' with status code {response.status_code}"
         else:
             if testing:
-                log(
+                log.info(
                     f"Successfully submitted {obj_id} to Hermes test topic {topic} for sharing service {sharing_service_id}"
                 )
                 notif_text = (
@@ -158,7 +158,7 @@ def submit_to_hermes(
                 )
                 status = f"Testing mode, submitted to Hermes test topic '{topic}'."
             else:
-                log(
+                log.info(
                     f"Successfully submitted {obj_id} to Hermes with request ID {submission_request_id} for sharing service {sharing_service_id}"
                 )
                 status = f"Successfully submitted {obj_id} to Hermes."
@@ -169,7 +169,7 @@ def submit_to_hermes(
             serialized_response = serialize_requests_response(response)
             submission_request.hermes_response = serialized_response
     except Exception as e:
-        log(str(e))
+        log.info(str(e))
         status = f"Error: {e}"
         notif_text = f"Hermes error: {e}"
 

--- a/skyportal/utils/moving_objects.py
+++ b/skyportal/utils/moving_objects.py
@@ -10,7 +10,7 @@ from astroplan import Observer
 from astropy.coordinates import AltAz, SkyCoord, get_body
 from astropy.time import Time
 
-from baselayer.log import make_log
+from skyportal.log import make_log
 from skyportal.models import (
     InstrumentField,
     InstrumentFieldTile,
@@ -141,7 +141,7 @@ def get_ephemeris(
         try:
             data = np.load(cached_data, allow_pickle=True).item()
         except Exception as e:
-            log(f"Failed to load cached data: {e}")
+            log.error(f"Failed to load cached data: {e}")
             data = None
 
     if cached_data is None or data is None:

--- a/skyportal/utils/notifications.py
+++ b/skyportal/utils/notifications.py
@@ -9,9 +9,9 @@ from astropy.time import Time
 from sqlalchemy.orm import selectinload
 
 from baselayer.app.env import load_env
-from baselayer.log import make_log
 from skyportal.app_utils import get_app_base_url
 from skyportal.email_utils import send_email
+from skyportal.log import make_log
 from skyportal.models import GcnEvent
 from skyportal.models.gcn import SOURCE_RADIUS_THRESHOLD
 from skyportal.utils.calculations import deg2dms, deg2hms, radec2lb
@@ -473,18 +473,18 @@ def post_notification(request_body, timeout=2):
             notifications_microservice_url, json=request_body, timeout=timeout
         )
     except requests.exceptions.ReadTimeout:
-        log(
+        log.info(
             f"Notification request timed out for {request_body['target_class_name']} with ID {request_body['target_id']}"
         )
         return False
     except Exception as e:
-        log(
+        log.info(
             f"Notification request failed for {request_body['target_class_name']} with ID {request_body['target_id']}: {e}"
         )
         return False
 
     if resp.status_code != 200:
-        log(
+        log.info(
             f"Notification request failed for {request_body['target_class_name']} with ID {request_body['target_id']}: {resp.content}"
         )
         return False

--- a/skyportal/utils/observability.py
+++ b/skyportal/utils/observability.py
@@ -1,6 +1,6 @@
 import os
 
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 log = make_log("observability")
 
@@ -34,7 +34,7 @@ def setup_observability(cfg):
         from opentelemetry.sdk.metrics import MeterProvider
         from opentelemetry.sdk.resources import SERVICE_NAME, Resource
     except ImportError:
-        log("OpenTelemetry packages not installed; skipping observability setup")
+        log.info("OpenTelemetry packages not installed; skipping observability setup")
         return False
 
     service_name = cfg.get("observability.service_name", "skyportal")
@@ -48,7 +48,7 @@ def setup_observability(cfg):
 
     TornadoInstrumentor().instrument()
     _instrument_event_loop_lag()
-    log(
+    log.info(
         "OpenTelemetry instrumentation enabled; "
         "Prometheus metrics at /api/internal/metrics"
     )

--- a/skyportal/utils/observation_plan.py
+++ b/skyportal/utils/observation_plan.py
@@ -1,5 +1,4 @@
 import time
-import traceback
 
 import astropy_healpix as ah
 import healpix_alchemy as ha
@@ -903,9 +902,8 @@ def generate_plan(
         log.info(f"Finished plan(s) for ID(s): {','.join(observation_plan_id_strings)}")
 
     except Exception as e:
-        traceback.print_exc()
-        log.error(
-            f"Failed to generate plans for ID(s): {','.join(observation_plan_id_strings)}: {str(e)}."
+        log.exception(
+            f"Failed to generate plans for ID(s): {','.join(observation_plan_id_strings)}."
         )
         session.rollback()
         # mark the request and plan as failed

--- a/skyportal/utils/observation_plan.py
+++ b/skyportal/utils/observation_plan.py
@@ -17,7 +17,7 @@ from sqlalchemy.orm import scoped_session, sessionmaker
 
 from baselayer.app.env import load_env
 from baselayer.app.flow import Flow
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ..handlers.api.galaxy import get_galaxies
 from .cache import Cache, array_to_bytes
@@ -198,7 +198,7 @@ def generate_observation_plan_statistics(
                 .distinct()
             ).all()
             if stats_logging:
-                log(
+                log.info(
                     "STATS: ",
                     f"{len(localization_tiles)} localization tiles in localization "
                     f"{request.localization_id} retrieved in {time.time() - t0:.2f}s. ",
@@ -218,7 +218,7 @@ def generate_observation_plan_statistics(
                 .distinct()
             ).all()
             if stats_logging:
-                log(
+                log.info(
                     f"STATS: {len(instrument_field_tiles)} instrument "
                     f"fields retrieved in {time.time() - t0:.2f}s. "
                 )
@@ -267,7 +267,7 @@ def generate_observation_plan_statistics(
             intprob *= ha.constants.PIXEL_AREA
 
             if stats_logging:
-                log(
+                log.info(
                     "STATS: ",
                     f"intarea= {intarea * (180 / np.pi) ** 2}, "
                     f"intprob= {intprob}. "
@@ -301,7 +301,7 @@ def generate_observation_plan_statistics(
                 intarea = 0.0
             intarea *= (180.0 / np.pi) ** 2
             if stats_logging:
-                log(f"STATS: area= {intarea}. Runtime= {time.time() - t0:.2f}s. ")
+                log.info(f"STATS: area= {intarea}. Runtime= {time.time() - t0:.2f}s. ")
 
             prob = sa.func.sum(
                 localizationtilescls.probdensity
@@ -318,7 +318,7 @@ def generate_observation_plan_statistics(
                 intprob = 0.0
 
             if stats_logging:
-                log(f"STATS: prob= {intprob}. Runtime= {time.time() - t0:.2f}s. ")
+                log.info(f"STATS: prob= {intprob}. Runtime= {time.time() - t0:.2f}s. ")
         else:
             raise ValueError(f"Unknown stats_method: {stats_method}")
 
@@ -364,7 +364,7 @@ def generate_plan(
 
     error = None
     try:
-        log(
+        log.info(
             f"Creating observation plan(s) for ID(s): {','.join(observation_plan_id_strings)}"
         )
 
@@ -377,7 +377,7 @@ def generate_plan(
             requests.append(request)
 
         user = session.get(User, user_id)
-        log(
+        log.info(
             f"Running observation plan(s) for ID(s): {','.join(observation_plan_id_strings)} in session {user._sa_instance_state.session_id}"
         )
         session.user_or_token = user
@@ -584,7 +584,7 @@ def generate_plan(
 
         params = gwemopt.segments.get_telescope_segments(params)
 
-        log(f"Reading skymap for ID(s): {','.join(observation_plan_id_strings)}")
+        log.info(f"Reading skymap for ID(s): {','.join(observation_plan_id_strings)}")
 
         map_struct = {"skymap": request.localization.table}
 
@@ -680,7 +680,7 @@ def generate_plan(
             else:
                 galaxy_sorting = request.payload["galaxy_sorting"]
 
-            log("querying for galaxies in the localization...")
+            log.info("querying for galaxies in the localization...")
             start = time.time()
             galaxies = get_galaxies(
                 session,
@@ -702,9 +702,9 @@ def generate_plan(
             galaxies, probs = zip(
                 *[(g, g["probability"]) for g in galaxies["galaxies"]]
             )
-            log("done querying and reformatting the results")
+            log.info("done querying and reformatting the results")
             end = time.time()
-            log(
+            log.info(
                 f"querying for galaxies took {end - start} seconds: {len(galaxies)} galaxies found"
             )
 
@@ -776,9 +776,11 @@ def generate_plan(
                     field_ids[request.instrument.name] = field_tiles
 
         end = time.time()
-        log(f"Queries took {end - start} seconds")
+        log.info(f"Queries took {end - start} seconds")
 
-        log(f"Retrieving fields for ID(s): {','.join(observation_plan_id_strings)}")
+        log.info(
+            f"Retrieving fields for ID(s): {','.join(observation_plan_id_strings)}"
+        )
 
         if params["tilesType"] == "moc":
             moc_structs = gwemopt.moc.create_moc(
@@ -798,7 +800,9 @@ def generate_plan(
                     params, map_struct, catalog_struct, regions=regions
                 )
 
-        log(f"Creating schedule(s) for ID(s): {','.join(observation_plan_id_strings)}")
+        log.info(
+            f"Creating schedule(s) for ID(s): {','.join(observation_plan_id_strings)}"
+        )
 
         tile_structs, coverage_struct = gwemopt.coverage.timeallocation(
             params, map_struct, tile_structs
@@ -826,7 +830,7 @@ def generate_plan(
                     session=session,
                 )
                 field_ids[idx] = field_id
-        log(
+        log.info(
             f"Writing planned observations to database for ID(s): {','.join(observation_plan_id_strings)}"
         )
 
@@ -858,7 +862,7 @@ def generate_plan(
                 )
             ).first()
             if field is None:
-                return log(f"Missing field {field_id} from list")
+                return log.info(f"Missing field {field_id} from list")
 
             planned_observation = PlannedObservation(
                 obstime=tt.datetime,
@@ -883,7 +887,9 @@ def generate_plan(
 
         session.commit()
 
-        log(f"Generating statistics for ID(s): {','.join(observation_plan_id_strings)}")
+        log.info(
+            f"Generating statistics for ID(s): {','.join(observation_plan_id_strings)}"
+        )
 
         generate_observation_plan_statistics(observation_plan_ids, request_ids, session)
 
@@ -894,11 +900,11 @@ def generate_plan(
             payload={"gcnEvent_dateobs": request.gcnevent.dateobs},
         )
 
-        log(f"Finished plan(s) for ID(s): {','.join(observation_plan_id_strings)}")
+        log.info(f"Finished plan(s) for ID(s): {','.join(observation_plan_id_strings)}")
 
     except Exception as e:
         traceback.print_exc()
-        log(
+        log.error(
             f"Failed to generate plans for ID(s): {','.join(observation_plan_id_strings)}: {str(e)}."
         )
         session.rollback()

--- a/skyportal/utils/offset.py
+++ b/skyportal/utils/offset.py
@@ -29,7 +29,7 @@ from reproject import reproject_adaptive
 from scipy.ndimage import gaussian_filter
 
 from baselayer.app.env import load_env
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from .. import __version__
 from .cache import Cache, dict_to_bytes
@@ -237,15 +237,15 @@ def get_ps1_url(ra, dec, imsize, *args, **kwargs):
         # see models.py for how this URL is constructed
         match = re.search('src="//ps1images.stsci.edu.*?"', response.content.decode())
         if match is None:
-            log(f"PS1 image not found for {ra} {dec}")
+            log.info(f"PS1 image not found for {ra} {dec}")
             return ""
         url = match.group().replace('src="', "http:").replace('"', "")
         url += f"&format=fits&imagename=ps1{ra}{dec:+f}.fits"
     except (requests.exceptions.SSLError, requests.exceptions.ReadTimeout) as e:
-        log(f"Error getting PS1 image URL {str(e)}")
+        log.error(f"Error getting PS1 image URL {str(e)}")
         return ""
     except Exception as e:
-        log(f"Error getting PS1 image URL {e.message}")
+        log.error(f"Error getting PS1 image URL {e.message}")
         return ""
 
     return url
@@ -312,7 +312,9 @@ def get_ztfref_url(ra, dec, imsize, *args, **kwargs):
         quad = f"{c.loc[0, 'qid']}"
         ccd = f"{c.loc[0, 'ccdid']:02d}"
     except KeyError:
-        log(f"Note: ZTF does not have a reference image at the position {ra} {dec}")
+        log.info(
+            f"Note: ZTF does not have a reference image at the position {ra} {dec}"
+        )
         return ""
 
     path_ursa_ref = os.path.join(
@@ -483,7 +485,7 @@ def get_ztfcatalog(
 
     refurl = get_ztfref_url(ra, dec, imsize=5)
     if refurl is None or refurl == "":
-        log("Empty ZTF reference image URL. Returning empty table.")
+        log.info("Empty ZTF reference image URL. Returning empty table.")
         return Table()
 
     # the catalog data is in the same directory as the reference images
@@ -547,7 +549,9 @@ def _calculate_best_position_for_offset_stars(
         Remove positions that are this number of std away from the median
     """
     if not isinstance(photometry, list):
-        log("Warning: No photometry given. Falling back to original source position.")
+        log.warning(
+            "Warning: No photometry given. Falling back to original source position."
+        )
         return fallback
 
     # convert the photometry into a dataframe
@@ -558,7 +562,7 @@ def _calculate_best_position_for_offset_stars(
     try:
         df = df[(df["flux"].notnull()) & (df["fluxerr"].notnull())]
     except KeyError:
-        log(
+        log.info(
             "Photometry does not include fluxes. Falling back to "
             " original source position."
         )
@@ -573,18 +577,18 @@ def _calculate_best_position_for_offset_stars(
         # point)
         med_ra, med_dec = np.nanmedian(df["ra"]), np.nanmedian(df["dec"])
     except (TypeError, AttributeError):
-        log(
+        log.warning(
             "Warning: could not find the median of the positions"
             " from the photometry data associated with this source "
         )
         return fallback
     except Exception as e:
-        log(e)
-        log("Uncaught error in ra, dec determination")
+        log.info(e)
+        log.info("Uncaught error in ra, dec determination")
         return fallback
 
     if np.isnan(med_ra) or np.isnan(med_dec):
-        log(
+        log.warning(
             "Warning: the median of the positions"
             " from the photometry data associated with this source "
             " retured nan, using fallback"
@@ -598,7 +602,7 @@ def _calculate_best_position_for_offset_stars(
         c2 = SkyCoord(fallback[0] * u.deg, fallback[1] * u.deg, frame="icrs")
         sep = c1.separation(c2)
         if np.abs(sep) > max_offset * u.arcsec:
-            log(
+            log.warning(
                 "Warning: calculated source position is too far from the"
                 " fiducial. Falling back to the fiducial "
             )
@@ -623,14 +627,18 @@ def _calculate_best_position_for_offset_stars(
             diff_ra = np.average(df["ra_offset"], weights=1 / df["ra_unc"] ** 2)
             diff_dec = np.average(df["dec_offset"], weights=1 / df["dec_unc"] ** 2)
         else:
-            log(f"Warning: do not recognize {how} as a valid way to weight astrometry")
+            log.warning(
+                f"Warning: do not recognize {how} as a valid way to weight astrometry"
+            )
             return (med_ra, med_dec)
     except ZeroDivisionError as e:
-        log(f"ZeroDivisionError in calculating position with {how}: {e}")
+        log.info(f"ZeroDivisionError in calculating position with {how}: {e}")
         return (med_ra, med_dec)
 
     if not np.isfinite([diff_ra, diff_dec]).all():
-        log(f"Error calculating position correction with {how}: {[diff_ra, diff_dec]}")
+        log.error(
+            f"Error calculating position correction with {how}: {[diff_ra, diff_dec]}"
+        )
         return (med_ra, med_dec)
 
     position = (
@@ -683,12 +691,12 @@ def get_formatted_standards_list(
 
     standard_file = standard_stars.get(standard_type)
     if standard_file is None:
-        log(f"Warning: '{standard_type}' not defined in the config.yaml.")
+        log.warning(f"Warning: '{standard_type}' not defined in the config.yaml.")
         return result
 
     starlist_format = starlist_formats.get(starlist_type)
     if starlist_format is None:
-        log("Warning: Do not recognize this starlist format. Using Keck.")
+        log.warning("Warning: Do not recognize this starlist format. Using Keck.")
         starlist_format = starlist_formats["Keck"]
 
     space = " "
@@ -701,7 +709,7 @@ def get_formatted_standards_list(
 
     df = pd.read_csv(standard_file, comment="#")
     if not {"name", "ra", "dec", "epoch", "comment"}.issubset(set(df.columns.values)):
-        log("Error: Standard star CSV file is missing necessary headers.")
+        log.error("Error: Standard star CSV file is missing necessary headers.")
         return result
 
     tab = SkyCoord(df["ra"], df["dec"], unit=(u.hourangle, u.deg))
@@ -735,7 +743,7 @@ def get_formatted_standards_list(
         df = df[(df["mag"] <= magnitude_range[0]) & (df["mag"] >= magnitude_range[1])]
 
     if len(df) == 0:
-        log("Warning: No standards stars match the filter criteria.")
+        log.warning("Warning: No standards stars match the filter criteria.")
         return result
 
     if return_dataframe:
@@ -914,7 +922,9 @@ def get_nearby_offset_stars(
         try:
             r = g.query(query_string)
         except Exception as e:
-            log(f"Error querying Gaia: {e}. Falling back to ZTFref or empty result.")
+            log.error(
+                f"Error querying Gaia: {e}. Falling back to ZTFref or empty result."
+            )
             r = None
 
     # ...otherwise fall back to ZTFref public sources or return
@@ -966,7 +976,7 @@ def get_nearby_offset_stars(
     if use_ztfref:
         ztfcatalog = get_ztfcatalog(source_ra, source_dec)
         if ztfcatalog is None or len(ztfcatalog) == 0:
-            log(
+            log.warning(
                 "Warning: Could not find the ZTF reference catalog"
                 f" at position {source_ra} {source_dec}"
             )
@@ -979,7 +989,7 @@ def get_nearby_offset_stars(
                 == 0
             ):
                 ztfcatalog = None
-                log(
+                log.warning(
                     "Warning: The ZTF reference catalog is empty near"
                     f" position {source_ra} {source_dec}. This probably means"
                     " that the source is at the edge of the ref catalog."
@@ -1040,7 +1050,7 @@ def get_nearby_offset_stars(
                         )
                         use_original = False
                 except Exception as e:
-                    log(
+                    log.warning(
                         f"Warning: ZTF catalog matching failed... "
                         f"Error: {str(e)} "
                         f"Failed catalog: {str(ztfcatalog)}"
@@ -1092,7 +1102,7 @@ def get_nearby_offset_stars(
 
     starlist_format = starlist_formats.get(starlist_type)
     if starlist_format is None:
-        log("Warning: Do not recognize this starlist format. Using Keck.")
+        log.warning("Warning: Do not recognize this starlist format. Using Keck.")
         starlist_format = starlist_formats["Keck"]
 
     col_sep = starlist_format["col_sep"]
@@ -1299,7 +1309,7 @@ def fits_image(
         )
 
     if url in [None, ""]:
-        log(f"Could not get FITS image for source {image_source}")
+        log.error(f"Could not get FITS image for source {image_source}")
         return None
 
     cache = Cache(cache_dir=cache_dir, max_items=cache_max_items)
@@ -1467,12 +1477,12 @@ def get_finding_chart(
                             f"existing cache was computed with obstime={cached_obstime.iso}, request has obstime={request_time.iso} (max age is {cache_max_age_days} days)"
                         )
                 except Exception as e:
-                    log(f"Could not parse obstime: {e}")
+                    log.error(f"Could not parse obstime: {e}")
                     del finding_charts_cache[cache_key]
                     raise Exception("Could not parse obstime")
                 return value
             except Exception as e:
-                log(f"Failed to load cached finding chart: {e}")
+                log.error(f"Failed to load cached finding chart: {e}")
 
     if (imsize < 2.0) or (imsize > 15):
         return {
@@ -1539,7 +1549,7 @@ def get_finding_chart(
 
         if source_image_parameters[image_source].get("reproject", False):
             # project image to the skeleton WCS solution
-            log("Reprojecting image to requested position and orientation")
+            log.info("Reprojecting image to requested position and orientation")
             im, _ = reproject_adaptive(hdu, wcs, shape_out=(npixels, npixels))
         else:
             wcs = WCS(hdu.header)
@@ -1572,7 +1582,7 @@ def get_finding_chart(
         # and return the results from that call
         if fallback_image_source is not None:
             if fallback_image_source != image_source:
-                log(f"Falling back on image source {fallback_image_source}")
+                log.info(f"Falling back on image source {fallback_image_source}")
                 return get_finding_chart(
                     source_ra,
                     source_dec,
@@ -1843,6 +1853,6 @@ def get_finding_chart(
             finding_charts_cache[cache_key] = dict_to_bytes(data)
         except Exception as e:
             traceback.print_exc()
-            log(f"Failed to cache finding chart: {e}")
+            log.error(f"Failed to cache finding chart: {e}")
 
     return data

--- a/skyportal/utils/offset.py
+++ b/skyportal/utils/offset.py
@@ -3,7 +3,6 @@ import math
 import os
 import re
 import string
-import traceback
 import urllib
 import warnings
 from functools import wraps
@@ -1852,7 +1851,6 @@ def get_finding_chart(
         try:
             finding_charts_cache[cache_key] = dict_to_bytes(data)
         except Exception as e:
-            traceback.print_exc()
-            log.error(f"Failed to cache finding chart: {e}")
+            log.exception("Failed to cache finding chart")
 
     return data

--- a/skyportal/utils/services.py
+++ b/skyportal/utils/services.py
@@ -45,8 +45,8 @@ def check_loaded(*args, **kwargs):
             while True:
                 if is_loaded():
                     break
-                elif kwargs.get("logger") is not None and callable(kwargs["logger"]):
-                    kwargs["logger"]("Waiting for the app to start...")
+                elif kwargs.get("logger") is not None:
+                    kwargs["logger"].info("Waiting for the app to start...")
                 time.sleep(10)
 
             return func(*args, **kwargs)

--- a/skyportal/utils/tap_services/gaia.py
+++ b/skyportal/utils/tap_services/gaia.py
@@ -11,7 +11,7 @@ from requests.adapters import HTTPAdapter
 from requests.exceptions import HTTPError, ReadTimeout
 
 from baselayer.app.env import load_env
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 log = make_log("tap/gaia")
 
@@ -152,20 +152,22 @@ class GaiaQuery:
                         wait_time = min(
                             1 + 2**retry, self.timeout
                         )  # Exponential backoff, capped at timeout
-                        log(
+                        log.info(
                             f"Query attempt {retry + 1} failed on {server_url}, retrying in {wait_time}s: {e}"
                         )
                         time.sleep(wait_time)
                     else:
-                        log(f"All {n_retries + 1} attempts failed on {server_url}: {e}")
+                        log.info(
+                            f"All {n_retries + 1} attempts failed on {server_url}: {e}"
+                        )
                         break  # Move to next server
 
                 except Exception as e:
-                    log(f"Unexpected error on {server_url}: {e}")
+                    log.info(f"Unexpected error on {server_url}: {e}")
                     break  # Move to next server
 
         # If we get here, all servers failed
-        log("All servers failed for the query")
+        log.info("All servers failed for the query")
         return None
 
     # Context manager methods remain the same

--- a/skyportal/utils/thumbnail.py
+++ b/skyportal/utils/thumbnail.py
@@ -1,7 +1,7 @@
 from PIL import Image, ImageStat, UnidentifiedImageError
 
 from baselayer.app.env import load_env
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 _, cfg = load_env()
 

--- a/skyportal/utils/tns.py
+++ b/skyportal/utils/tns.py
@@ -1,7 +1,6 @@
 import json
 import re
 import time
-import traceback
 import urllib
 
 import astropy.units as u
@@ -297,8 +296,7 @@ def get_recent_TNS(api_key, headers, public_timestamp, get_data=True):
         json_response = json.loads(r.text)
         reply = json_response["data"]
     except Exception as e:
-        traceback.print_exc()
-        log.info(f"TNS request failed: {str(e)}.")
+        log.exception("TNS request failed.")
         return []
 
     sources = []

--- a/skyportal/utils/tns.py
+++ b/skyportal/utils/tns.py
@@ -14,7 +14,7 @@ from astropy.time import Time
 from bs4 import BeautifulSoup
 
 from baselayer.app.env import load_env
-from baselayer.log import make_log
+from skyportal.log import make_log
 
 from ..models import Instrument
 from .calculations import great_circle_distance
@@ -246,7 +246,7 @@ def _tns_request(
             content = r.json()
         except Exception:
             content = r.text
-        log(
+        log.info(
             f"TNS request rate limited: {str(content)}.  Waiting {retry_delay} seconds to try again."
         )
         time.sleep(retry_delay)
@@ -291,18 +291,20 @@ def get_recent_TNS(api_key, headers, public_timestamp, get_data=True):
             content = r.json()
         except Exception:
             content = r.text
-        log(f"TNS request failed: {str(content)}.")
+        log.info(f"TNS request failed: {str(content)}.")
         return []
     try:
         json_response = json.loads(r.text)
         reply = json_response["data"]
     except Exception as e:
         traceback.print_exc()
-        log(f"TNS request failed: {str(e)}.")
+        log.info(f"TNS request failed: {str(e)}.")
         return []
 
     sources = []
-    log(f"Found {len(reply)} recent sources from TNS since {str(public_timestamp)}")
+    log.info(
+        f"Found {len(reply)} recent sources from TNS since {str(public_timestamp)}"
+    )
     for i, obj in enumerate(reply):
         if get_data:
             r = _tns_request(
@@ -320,7 +322,9 @@ def get_recent_TNS(api_key, headers, public_timestamp, get_data=True):
                 try:
                     source_data = r.json().get("data", {})
                 except Exception as e:
-                    log(f"Failed to parse TNS response: {str(e)} ({str(r.json())})")
+                    log.error(
+                        f"Failed to parse TNS response: {str(e)} ({str(r.json())})"
+                    )
                     source_data = None
                 if source_data:
                     sources.append(
@@ -331,7 +335,7 @@ def get_recent_TNS(api_key, headers, public_timestamp, get_data=True):
                         }
                     )
             if i % 10 == 0 and get_data:
-                log(f"Fetched data of {i + 1}/{len(reply)} recent TNS sources")
+                log.info(f"Fetched data of {i + 1}/{len(reply)} recent TNS sources")
         else:
             sources.append(
                 {
@@ -414,7 +418,7 @@ def get_IAUname(
     try:
         reply = r.json().get("data", {})
     except Exception as e:
-        log(f"Failed to parse TNS response: {str(e)} ({str(r.json())})")
+        log.error(f"Failed to parse TNS response: {str(e)} ({str(r.json())})")
         reply = []
 
     if reply:
@@ -537,7 +541,7 @@ def get_tns(
 
     resp = requests.post(tns_microservice_url, json=request_body, timeout=timeout)
     if resp.status_code != 200:
-        log(
+        log.info(
             f"TNS request failed for {str(request_body['obj_id'])} by user ID {request_body['user_id']}: {resp.content}"
         )
 

--- a/skyportal/utils/tns_submission.py
+++ b/skyportal/utils/tns_submission.py
@@ -8,8 +8,8 @@ from astropy.time import Time
 
 from baselayer.app.env import load_env
 from baselayer.app.flow import Flow
-from baselayer.log import make_log
 from skyportal.handlers.api.photometry import serialize
+from skyportal.log import make_log
 from skyportal.models import Stream
 from skyportal.utils.http import serialize_requests_response
 from skyportal.utils.parse import is_null
@@ -64,7 +64,7 @@ def apply_existing_tns_report_rules(
 
     # if the sharing service is in test mode, we skip the existing TNS report check
     if sharing_service.testing:
-        log(f"Skipping existing TNS report check for {obj_id} in test mode.")
+        log.info(f"Skipping existing TNS report check for {obj_id} in test mode.")
         return
 
     _, existing_tns_name = get_IAUname(
@@ -285,7 +285,7 @@ def send_tns_report(
     serialized_response = None
 
     if testing:
-        log(
+        log.info(
             f"Sharing service {sharing_service_id} is in testing mode, skipping TNS submission for {obj_id}."
         )
         return "Testing mode, not submitted", None, None
@@ -300,14 +300,14 @@ def send_tns_report(
         if r.status_code != 429:
             break  # If not rate-limited, exit the retry loop
 
-        log(
+        log.info(
             f"{exceeded_rate_message}, waiting {retry_delay} seconds before retrying..."
         )
         time.sleep(retry_delay)
 
     if r.status_code == 200:
         submission_id = r.json()["data"]["report_id"]
-        log(
+        log.info(
             f"Successfully submitted {obj_id} to TNS with request ID {submission_id} for sharing service {sharing_service_id}"
         )
         status = "submitted"
@@ -424,13 +424,13 @@ def submit_to_tns(
         notif_type = "warning"
         notif_text = f"TNS warning: {e}"
         status = f"Error: {e}"
-        log(str(e))
+        log.info(str(e))
 
     except Exception as e:
         notif_type = "error"
         notif_text = f"TNS error: {e}"
         status = f"Error: {e}"
-        log(str(e))
+        log.info(str(e))
 
     try:
         flow = Flow()
@@ -554,7 +554,7 @@ def check_at_report(submission_id, sharing_service):
             if obj_name is None:
                 raise ValueError("Object found and report posted but no name found.")
     except Exception as e:
-        log(f"Error checking report: {e}")
+        log.error(f"Error checking report: {e}")
         raise ValueError(f"Error checking report: {e}")
 
     # for now catching errors from TNS is not implemented, so we just return None for the error


### PR DESCRIPTION
- Root logger sits at WARNING so third-party libraries (SQLAlchemy, urllib3, tornado) can't flood the logs even if they use the builtin logger and app loggers get INFO
- the ~70 `log.error(f"...{traceback.format_exc()}")` sites could become `log.exception(...)` in except blocks and get tracebacks for free for cleaner tracebacks