### PR TITLE
Filter rename: require group admin, add inline rename UI

### DIFF
--- a/skyportal/handlers/api/filter.py
+++ b/skyportal/handlers/api/filter.py
@@ -5,6 +5,7 @@ from baselayer.app.access import auth_or_token, permissions
 
 from ...models import Filter
 from ..base import BaseHandler
+from .group import has_admin_access_for_group
 
 
 class FilterHandler(BaseHandler):
@@ -144,6 +145,14 @@ class FilterHandler(BaseHandler):
             )
             if f is None:
                 return self.error(f"Cannot find a filter with ID: {filter_id}.")
+
+            if not await has_admin_access_for_group(
+                self.associated_user_object, f.group_id, session
+            ):
+                return self.error(
+                    "Insufficient permissions: must be a group admin or system admin to rename a filter.",
+                    status=403,
+                )
 
             data = self.get_json()
             data["id"] = filter_id

--- a/skyportal/tests/api_tests/sources_candidates/test_filters.py
+++ b/skyportal/tests/api_tests/sources_candidates/test_filters.py
@@ -95,3 +95,44 @@ def test_post_filter_with_unauthorized_stream(
         token=manage_groups_token,
     )
     assert status in [401, 500]
+
+
+def test_group_admin_can_rename_filter(group_admin_token, public_filter):
+    status, data = api(
+        "PATCH",
+        f"filters/{public_filter.id}",
+        data={"name": "renamed_by_group_admin"},
+        token=group_admin_token,
+    )
+    assert status == 200
+    assert data["status"] == "success"
+
+    status, data = api("GET", f"filters/{public_filter.id}", token=group_admin_token)
+    assert status == 200
+    assert data["data"]["name"] == "renamed_by_group_admin"
+
+
+def test_non_admin_member_cannot_rename_filter(upload_data_token, public_filter):
+    status, data = api(
+        "PATCH",
+        f"filters/{public_filter.id}",
+        data={"name": "should_be_rejected"},
+        token=upload_data_token,
+    )
+    assert status == 403
+    assert data["status"] == "error"
+
+
+def test_super_admin_can_rename_filter(super_admin_token, public_filter):
+    status, data = api(
+        "PATCH",
+        f"filters/{public_filter.id}",
+        data={"name": "renamed_by_super_admin"},
+        token=super_admin_token,
+    )
+    assert status == 200
+    assert data["status"] == "success"
+
+    status, data = api("GET", f"filters/{public_filter.id}", token=super_admin_token)
+    assert status == 200
+    assert data["data"]["name"] == "renamed_by_super_admin"

--- a/static/js/components/group/GroupFiltersStreams.tsx
+++ b/static/js/components/group/GroupFiltersStreams.tsx
@@ -2,6 +2,9 @@ import { useState } from "react";
 import { Link } from "react-router-dom";
 import { Controller, useForm } from "react-hook-form";
 import DeleteIcon from "@mui/icons-material/Delete";
+import EditIcon from "@mui/icons-material/Edit";
+import CheckIcon from "@mui/icons-material/Check";
+import CloseIcon from "@mui/icons-material/Close";
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
 import ListItemSecondaryAction from "@mui/material/ListItemSecondaryAction";
@@ -37,6 +40,7 @@ import { useAppDispatch } from "../../types/hooks";
 import {
   useAddGroupFilterMutation,
   useDeleteGroupFilterMutation,
+  useUpdateFilterNameMutation,
 } from "../../ducks/filter";
 import { groupApi } from "../../ducks/group";
 import {
@@ -63,11 +67,14 @@ const GroupFiltersStreams = ({
   const [addStreamOpen, setAddStreamOpen] = useState(false);
   const [panelStreamsExpanded, setPanelStreamsExpanded] =
     useState<any>("panel-streams");
+  const [editingFilterId, setEditingFilterId] = useState<any>(null);
+  const [editNameInput, setEditNameInput] = useState("");
   const dispatch = useAppDispatch();
   const { data: streams } = useGetStreamsQuery();
   const [addGroupFilter] = useAddGroupFilterMutation();
   const [deleteGroupFilter] = useDeleteGroupFilterMutation();
   const [addGroupStream] = useAddGroupStreamMutation();
+  const [updateFilterName] = useUpdateFilterNameMutation();
 
   const {
     register,
@@ -131,6 +138,36 @@ const GroupFiltersStreams = ({
     }
   };
 
+  const handleStartRename = (filter: any) => {
+    setEditingFilterId(filter.id);
+    setEditNameInput(filter.name);
+  };
+
+  const handleCancelRename = () => {
+    setEditingFilterId(null);
+    setEditNameInput("");
+  };
+
+  const handleSaveRename = async () => {
+    const trimmed = editNameInput.trim();
+    if (!trimmed) {
+      dispatch(showNotification("Filter name cannot be empty.", "error"));
+      return;
+    }
+    try {
+      await updateFilterName({
+        filter_id: editingFilterId,
+        name: trimmed,
+      }).unwrap();
+      dispatch(showNotification("Filter name updated."));
+      dispatch(groupApi.util.invalidateTags([{ type: "Group", id: group.id }]));
+    } catch {
+      // error notification handled by the base query
+    }
+    setEditingFilterId(null);
+    setEditNameInput("");
+  };
+
   const groupStreamIds = group?.streams?.map((stream: any) => stream.id);
 
   const isStreamIdInStreams = (sid: any) =>
@@ -163,49 +200,100 @@ const GroupFiltersStreams = ({
                   <List component="nav" disablePadding>
                     {group.filters
                       ?.filter((f: any) => f.stream_id === stream.id)
-                      .map((filter: any) => (
-                        <ListItemButton
-                          key={filter.id}
-                          component={Link}
-                          to={`/filter/${filter.id}`}
-                        >
-                          <ListItemText
-                            key={filter.id}
-                            className={classes.nested}
-                            primary={filter.name}
-                          />
-                          {isAdmin(currentUser) && (
+                      .map((filter: any) =>
+                        editingFilterId === filter.id ? (
+                          <ListItem key={filter.id} className={classes.nested}>
+                            <TextField
+                              value={editNameInput}
+                              onChange={(e) => setEditNameInput(e.target.value)}
+                              size="small"
+                              variant="outlined"
+                              slotProps={{
+                                htmlInput: {
+                                  "data-testid": "filter-name-input",
+                                },
+                              }}
+                              onKeyDown={(e) => {
+                                if (e.key === "Enter") handleSaveRename();
+                                if (e.key === "Escape") handleCancelRename();
+                              }}
+                              autoFocus
+                            />
                             <ListItemSecondaryAction>
                               <IconButton
-                                edge="end"
-                                aria-label="delete"
-                                onClick={async () => {
-                                  try {
-                                    await deleteGroupFilter({
-                                      filter_id: filter.id,
-                                    }).unwrap();
-                                    dispatch(
-                                      showNotification(
-                                        "Deleted filter from group",
-                                      ),
-                                    );
-                                  } catch {
-                                    // error notification handled by the base query
-                                  }
-                                  dispatch(
-                                    groupApi.util.invalidateTags([
-                                      { type: "Group", id: group.id },
-                                    ]),
-                                  );
-                                }}
-                                size="large"
+                                size="small"
+                                onClick={handleSaveRename}
+                                aria-label="save filter name"
+                                data-testid="save-filter-name-button"
                               >
-                                <DeleteIcon />
+                                <CheckIcon fontSize="small" />
+                              </IconButton>
+                              <IconButton
+                                size="small"
+                                onClick={handleCancelRename}
+                                aria-label="cancel rename filter"
+                                data-testid="cancel-filter-name-button"
+                              >
+                                <CloseIcon fontSize="small" />
                               </IconButton>
                             </ListItemSecondaryAction>
-                          )}
-                        </ListItemButton>
-                      ))}
+                          </ListItem>
+                        ) : (
+                          <ListItemButton
+                            key={filter.id}
+                            component={Link}
+                            to={`/filter/${filter.id}`}
+                          >
+                            <ListItemText
+                              key={filter.id}
+                              className={classes.nested}
+                              primary={filter.name}
+                            />
+                            {isAdmin(currentUser) && (
+                              <ListItemSecondaryAction>
+                                <IconButton
+                                  edge="end"
+                                  aria-label="rename filter"
+                                  onClick={(e) => {
+                                    e.preventDefault();
+                                    e.stopPropagation();
+                                    handleStartRename(filter);
+                                  }}
+                                  size="large"
+                                >
+                                  <EditIcon />
+                                </IconButton>
+                                <IconButton
+                                  edge="end"
+                                  aria-label="delete"
+                                  onClick={async () => {
+                                    try {
+                                      await deleteGroupFilter({
+                                        filter_id: filter.id,
+                                      }).unwrap();
+                                      dispatch(
+                                        showNotification(
+                                          "Deleted filter from group",
+                                        ),
+                                      );
+                                    } catch {
+                                      // error notification handled by the base query
+                                    }
+                                    dispatch(
+                                      groupApi.util.invalidateTags([
+                                        { type: "Group", id: group.id },
+                                      ]),
+                                    );
+                                  }}
+                                  size="large"
+                                >
+                                  <DeleteIcon />
+                                </IconButton>
+                              </ListItemSecondaryAction>
+                            )}
+                          </ListItemButton>
+                        ),
+                      )}
                   </List>
                 </div>
               ))}

--- a/static/js/ducks/filter.ts
+++ b/static/js/ducks/filter.ts
@@ -21,6 +21,11 @@ export interface DeleteGroupFilterArg {
   filter_id: number | string;
 }
 
+export interface UpdateFilterNameArg {
+  filter_id: number | string;
+  name: string;
+}
+
 export const filterApi = skyportalApi.injectEndpoints({
   endpoints: (build) => ({
     getFilters: build.query<RouteData<"GET /api/filters">, void>({
@@ -51,6 +56,14 @@ export const filterApi = skyportalApi.injectEndpoints({
       }),
       invalidatesTags: ["Filters"],
     }),
+    updateFilterName: build.mutation<unknown, UpdateFilterNameArg>({
+      query: ({ filter_id, name }) => ({
+        url: `api/filters/${filter_id}`,
+        method: "PATCH",
+        body: { name },
+      }),
+      invalidatesTags: ["Filters"],
+    }),
   }),
 });
 
@@ -59,4 +72,5 @@ export const {
   useGetFilterQuery,
   useAddGroupFilterMutation,
   useDeleteGroupFilterMutation,
+  useUpdateFilterNameMutation,
 } = filterApi;


### PR DESCRIPTION
Ported from fritz, where this runs in production.

**Backend:** `PATCH /api/filters/{filter_id}` previously allowed any group member with row-level update access to rename a filter. It is now gated behind group admin / system admin and returns 403 otherwise. Tests cover group admin (allowed), plain member (403), and super admin (allowed).

**Frontend:** on the group page, group admins get an edit icon next to each filter that renames it inline (Enter saves, Escape cancels) via the existing PATCH endpoint.