### PR TITLE
FilterPlugins: type the group prop, render only when group is loaded

### DIFF
--- a/static/js/components/filter/Filter.tsx
+++ b/static/js/components/filter/Filter.tsx
@@ -140,7 +140,7 @@ const Filter = () => {
           </Card>
         </Grid>
         <Grid size={{ sm: 12, md: 12 }}>
-          <FilterPlugins {...({ group } as any)} />
+          {group && <FilterPlugins group={group} />}
         </Grid>
       </Grid>
     </div>

--- a/static/js/components/filter/FilterPlugins.tsx
+++ b/static/js/components/filter/FilterPlugins.tsx
@@ -1,3 +1,7 @@
-const FilterPlugins = () => <></>;
+interface FilterPluginsProps {
+  group?: any;
+}
+
+const FilterPlugins = (_props: FilterPluginsProps) => <></>;
 
 export default FilterPlugins;


### PR DESCRIPTION
The FilterPlugins extension-point stub takes no props, so Filter.tsx passes `group` through an `as any` spread and renders the plugin before the group query has resolved. This declares the prop on the stub, passes it typed, and guards the render on `group`.

Makes life easier for forks that override FilterPlugins (extracted from fritz, which can drop its Filter.tsx override once this lands).