### PR TITLE
[RFC] Boom integration: alert pages (backend + UI)

### DIFF
--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -265,6 +265,10 @@ app:
       component: sharing_service/SharingServiceSubmissionsPage
     - path: "/moving_objects/obsplan"
       component: moving_object/MovingObjectObsPlanPage
+    - path: "/alerts"
+      component: alert/Alerts
+    - path: "/alerts/:survey/:id"
+      component: alert/Alert
 
   sidebar:
     # See https://material-ui.com/components/material-icons/
@@ -1036,3 +1040,12 @@ docs:
       description: Development server
     - url: https://skyportal.io
       description: Production server
+
+# BOOM alert-broker integration.
+# The boom API endpoints and alert pages require a reachable instance.
+boom:
+  protocol: http
+  host: localhost
+  port: 4000
+  username: admin
+  password: adminsecret

--- a/doc/boom_alerts.md
+++ b/doc/boom_alerts.md
@@ -1,0 +1,29 @@
+# BOOM alert pages
+
+With a BOOM alert broker configured (see the `boom` config section), SkyPortal
+gains pages for searching and inspecting raw survey alerts.
+
+## Pages
+
+- `/alerts` — search alerts by object ID or sky position (cone search) for a
+  given survey.
+- `/alerts/:survey/:id` — detail page for one alert: photometry, metadata, and
+  image cutouts. Cutouts arrive as gzipped FITS and are rendered client-side
+  (`static/js/utils/imageProcessing.js`), so no server-side thumbnail
+  generation is involved. From here an alert can be saved as a SkyPortal
+  source, and its photometry copied to an existing source.
+
+Both routes are registered through the config-driven `app.routes` list, so
+deployments that do not use BOOM can omit them.
+
+On the source page, a search menu (mounted via the `SourcePlugins` extension
+point) links to alert searches at the source position.
+
+## API
+
+- `GET /api/boom/surveys/<survey>/alerts` — query a survey's alerts by object
+  ID or position.
+- `GET /api/boom/surveys/<survey>/alerts/cutouts` — fetch alert image cutouts.
+
+The corresponding API tests require a reachable BOOM instance seeded with
+reference data and skip themselves otherwise.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -108,6 +108,7 @@ User Guide
    analysis
    external_services
    extensions
+   boom_alerts
    pages
    thumbnails
 

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "moment": "2.30.1",
     "nouislider": "15.8.1",
     "numeral": "2.0.6",
+    "pako": "2.1.0",
     "papaparse": "5.5.2",
     "path-browserify": "1.0.1",
     "plotly.js-basic-dist": "3.6.0",

--- a/skyportal/app_server.py
+++ b/skyportal/app_server.py
@@ -201,6 +201,10 @@ from skyportal.handlers.api import (
     VizierQueryHandler,
     WeatherHandler,
 )
+from skyportal.handlers.api.boom import (
+    BoomAlertHandler,
+    BoomCutoutHandler,
+)
 from skyportal.handlers.api.internal import (
     AcrossInstrumentsHandler,
     AcrossJointVisibilityHandler,
@@ -270,6 +274,8 @@ skyportal_handlers = [
         AnalysisProductsHandler,
     ),
     (r"/api/assignment(/.*)?", AssignmentHandler),
+    (r"/api/boom/surveys/([0-9A-Za-z-_\.]+)/alerts", BoomAlertHandler),
+    (r"/api/boom/surveys/([0-9A-Za-z-_\.]+)/alerts/cutouts", BoomCutoutHandler),
     (r"/api/candidates_filter", CandidateFilterHandler),
     (r"/api/candidates/scan_reports/([0-9]+)/items(/[0-9]+)?", ScanReportItemHandler),
     (r"/api/candidates/scan_reports", ScanReportHandler),

--- a/skyportal/handlers/api/boom/__init__.py
+++ b/skyportal/handlers/api/boom/__init__.py
@@ -1,0 +1,2 @@
+from .alert import BoomAlertHandler
+from .cutout import BoomCutoutHandler

--- a/skyportal/handlers/api/boom/alert.py
+++ b/skyportal/handlers/api/boom/alert.py
@@ -1,0 +1,233 @@
+import traceback
+
+import requests
+
+from baselayer.app.access import auth_or_token
+from baselayer.log import make_log
+
+from ...base import BaseHandler
+from .utils import boom_available, boom_token, boom_url, convert_large_ints
+
+log = make_log("api/boom/alert")
+
+BOOM_RADIUS_UNIT_MAP = {
+    "deg": "Degrees",
+    "arcmin": "Arcminutes",
+    "arcsec": "Arcseconds",
+}
+
+NO_CUTOUT_PROJECTION = {
+    "cutoutScience": 0,
+    "cutoutTemplate": 0,
+    "cutoutDifference": 0,
+}
+
+
+class BoomAlertHandler(BaseHandler):
+    @auth_or_token
+    @boom_available
+    async def get(self, survey: str):
+        """
+        ---
+        summary: Retrieve alerts from Boom for a given survey
+        description: |
+          Retrieve alerts from Boom by objectId (single or comma-separated list),
+          candid, or sky position (ra/dec/radius/radius_units). Positional queries
+          and objectId filtering can be combined.
+        tags:
+          - alerts
+          - boom
+        parameters:
+          - in: path
+            name: survey
+            required: true
+            schema:
+              type: string
+            description: Survey name (e.g. ZTF, LSST)
+          - in: query
+            name: objectId
+            required: false
+            schema:
+              type: string
+            description: Single objectId or comma-separated list of objectIds
+          - in: query
+            name: candid
+            required: false
+            schema:
+              type: integer
+            description: Alert candid. Can be combined with objectId.
+          - in: query
+            name: ra
+            required: false
+            schema:
+              type: number
+            description: RA in degrees
+          - in: query
+            name: dec
+            required: false
+            schema:
+              type: number
+            description: Declination in degrees
+          - in: query
+            name: radius
+            required: false
+            schema:
+              type: number
+            description: Search radius (capped at 1 deg). Units set by radius_units.
+          - in: query
+            name: radius_units
+            required: false
+            schema:
+              type: string
+              enum: [deg, arcmin, arcsec]
+            description: Units for radius
+        responses:
+          200:
+            description: retrieved alert(s)
+            content:
+              application/json:
+                schema:
+                  allOf:
+                    - $ref: '#/components/schemas/Success'
+                    - type: object
+                      properties:
+                        data:
+                          type: array
+                          items:
+                            type: object
+          400:
+            content:
+              application/json:
+                schema: Error
+        """
+        object_id = self.get_query_argument("objectId", None)
+        candid = self.get_query_argument("candid", None)
+        ra = self.get_query_argument("ra", None)
+        dec = self.get_query_argument("dec", None)
+        radius = self.get_query_argument("radius", None)
+        radius_units = self.get_query_argument("radius_units", None)
+
+        position_tuple = (ra, dec, radius, radius_units)
+
+        if not any((object_id, candid, ra, dec, radius, radius_units)):
+            return self.error(
+                "Missing required parameters: provide objectId, candid, or ra/dec/radius/radius_units."
+            )
+
+        headers = {"Authorization": f"Bearer {boom_token}"}
+        catalog = f"{survey.upper()}_alerts"
+
+        try:
+            if candid is not None:
+                try:
+                    candid = int(candid)
+                except ValueError:
+                    return self.error("`candid` must be an integer.")
+
+                filter_doc = {"candid": candid}
+                if object_id:
+                    filter_doc["objectId"] = object_id
+
+                response = requests.post(
+                    f"{boom_url}/queries/find",
+                    headers=headers,
+                    json={
+                        "catalog_name": catalog,
+                        "filter": filter_doc,
+                        "projection": NO_CUTOUT_PROJECTION,
+                        "max_time_ms": 10000,
+                    },
+                    timeout=15,
+                )
+                if response.status_code != 200:
+                    return self.error(
+                        f"Boom query failed: {response.status_code} {response.text}"
+                    )
+                data = response.json().get("data", [])
+                return self.success(data=convert_large_ints(data))
+
+            if not any(position_tuple):
+                if object_id is None:
+                    return self.error("Missing required parameters.")
+
+                object_ids = [oid.strip() for oid in object_id.split(",")]
+                filter_doc = (
+                    {"objectId": object_ids[0]}
+                    if len(object_ids) == 1
+                    else {"objectId": {"$in": object_ids}}
+                )
+
+                response = requests.post(
+                    f"{boom_url}/queries/find",
+                    headers=headers,
+                    json={
+                        "catalog_name": catalog,
+                        "filter": filter_doc,
+                        "projection": NO_CUTOUT_PROJECTION,
+                        "max_time_ms": 10000,
+                    },
+                    timeout=15,
+                )
+                if response.status_code != 200:
+                    return self.error(
+                        f"Boom query failed: {response.status_code} {response.text}"
+                    )
+                data = response.json().get("data", [])
+                return self.success(data=convert_large_ints(data))
+
+            if not all(position_tuple):
+                missing = [
+                    name
+                    for name, val in zip(
+                        ["ra", "dec", "radius", "radius_units"], position_tuple
+                    )
+                    if val is None
+                ]
+                return self.error(f"Missing positional parameters: {missing}.")
+
+            if radius_units not in BOOM_RADIUS_UNIT_MAP:
+                return self.error(
+                    "Invalid radius_units. Must be one of 'deg', 'arcmin', or 'arcsec'."
+                )
+            try:
+                ra = float(ra)
+                dec = float(dec)
+                radius = float(radius)
+            except ValueError:
+                return self.error("Invalid (non-float) value provided.")
+
+            if (
+                (radius_units == "deg" and radius > 1)
+                or (radius_units == "arcmin" and radius > 60)
+                or (radius_units == "arcsec" and radius > 3600)
+            ):
+                return self.error("Radius must be <= 1.0 deg.")
+
+            response = requests.post(
+                f"{boom_url}/queries/cone_search",
+                headers=headers,
+                json={
+                    "catalog_name": catalog,
+                    "object_coordinates": {"query": [ra, dec]},
+                    "radius": radius,
+                    "unit": BOOM_RADIUS_UNIT_MAP[radius_units],
+                    "max_time_ms": 10000,
+                },
+                timeout=15,
+            )
+            if response.status_code != 200:
+                return self.error(
+                    f"Boom cone search failed: {response.status_code} {response.text}"
+                )
+
+            alert_data = response.json().get("data", {}).get("query", [])
+
+            if object_id is not None:
+                filter_ids = {oid.strip() for oid in object_id.split(",")}
+                alert_data = [a for a in alert_data if a.get("objectId") in filter_ids]
+
+            return self.success(data=convert_large_ints(alert_data))
+
+        except Exception:
+            _err = traceback.format_exc()
+            return self.error(f"failure: {_err}")

--- a/skyportal/handlers/api/boom/cutout.py
+++ b/skyportal/handlers/api/boom/cutout.py
@@ -1,0 +1,393 @@
+import traceback
+
+import requests
+import sqlalchemy as sa
+from astropy.visualization import (
+    AsinhStretch,
+    AsymmetricPercentileInterval,
+    LinearStretch,
+    LogStretch,
+    MinMaxInterval,
+    SqrtStretch,
+    ZScaleInterval,
+)
+
+from baselayer.app.access import auth_or_token, permissions
+from baselayer.log import make_log
+
+from ....models import Obj, Thumbnail
+from ...base import BaseHandler
+from .utils import (
+    add_thumbnails,
+    boom_available,
+    boom_token,
+    boom_url,
+    decode_cutout,
+    orient_cutout,
+    render_cutout_png,
+    thumbnail_types,
+)
+
+log = make_log("api/boom/cutout")
+
+NORMALIZATION_METHODS = {
+    "asymmetric_percentile": lambda: AsymmetricPercentileInterval(
+        lower_percentile=1, upper_percentile=100
+    ),
+    "min_max": MinMaxInterval,
+    "zscale": lambda: ZScaleInterval(n_samples=600, contrast=0.045, krej=2.5),
+}
+
+STRETCHING_METHODS = {
+    "linear": LinearStretch,
+    "log": LogStretch,
+    "asinh": AsinhStretch,
+    "sqrt": SqrtStretch,
+}
+
+KNOWN_CMAPS = {"bone", "gray", "cividis", "viridis", "magma"}
+
+
+class BoomCutoutHandler(BaseHandler):
+    @auth_or_token
+    @boom_available
+    async def get(self, survey: str):
+        """
+        ---
+        summary: Serve Boom alert cutout(s) as JSON (FITS) or PNG
+        description: |
+          When file_format=png (default): renders a single cutout type as a PNG image.
+          The `cutout` parameter is required in this mode.
+
+          When file_format=fits: fetches all three cutouts from Boom
+          and returns the raw payload as JSON (keys: cutoutScience,
+          cutoutTemplate, cutoutDifference). No server-side processing is
+          applied; the caller receives exactly what Boom returned.
+
+        tags:
+          - alerts
+          - boom
+
+        parameters:
+          - in: path
+            name: survey
+            description: "Survey name (e.g. ZTF, LSST)"
+            required: true
+            schema:
+              type: string
+          - in: query
+            name: candid
+            description: "Alert candid. Mutually exclusive with objectId."
+            required: false
+            schema:
+              type: integer
+          - in: query
+            name: objectId
+            description: "Object ID. Mutually exclusive with candid."
+            required: false
+            schema:
+              type: string
+          - in: query
+            name: which
+            description: "Which alert to use when querying by objectId."
+            required: false
+            schema:
+              type: string
+              enum: [first, last, brightest, faintest]
+          - in: query
+            name: file_format
+            description: |
+              fits (default): return raw Boom JSON with all three cutouts.
+              png: render a single cutout as a PNG image (requires `cutout`).
+            required: false
+            default: png
+            schema:
+              type: string
+              enum: [fits, png]
+          - in: query
+            name: cutout
+            description: "PNG mode only: which cutout to render."
+            required: false
+            schema:
+              type: string
+              enum: [science, template, difference]
+          - in: query
+            name: interval
+            description: "PNG mode only: normalisation interval."
+            required: false
+            schema:
+              type: string
+              enum: [min_max, zscale]
+          - in: query
+            name: stretch
+            description: "PNG mode only: stretch function."
+            required: false
+            schema:
+              type: string
+              enum: [linear, log, asinh, sqrt]
+          - in: query
+            name: cmap
+            description: "PNG mode only: colour map."
+            required: false
+            schema:
+              type: string
+              enum: [bone, gray, cividis, viridis, magma]
+
+        responses:
+          '200':
+            description: retrieved cutout(s)
+            content:
+              application/json:
+                schema:
+                  allOf:
+                    - $ref: '#/components/schemas/Success'
+                    - type: object
+                      properties:
+                        data:
+                          type: object
+              image/png:
+                schema:
+                  type: string
+                  format: binary
+          '400':
+            description: retrieval failed
+            content:
+              application/json:
+                schema: Error
+        """
+        try:
+            candid = self.get_query_argument("candid", None)
+            object_id = self.get_query_argument("objectId", None)
+            which = self.get_query_argument("which", "last")
+            file_format = self.get_argument("file_format", "png").lower()
+            cutout = self.get_argument("cutout", None)
+            interval = self.get_argument("interval", default=None)
+            stretch = self.get_argument("stretch", default=None)
+            cmap = self.get_argument("cmap", default=None)
+
+            if candid is None and object_id is None:
+                return self.error("Either `candid` or `objectId` must be provided.")
+            if candid is not None and object_id is not None:
+                return self.error(
+                    "Only one of `candid` or `objectId` should be provided."
+                )
+            if candid is not None:
+                try:
+                    candid = int(candid)
+                except ValueError:
+                    return self.error("`candid` must be an integer.")
+
+            if file_format not in ("fits", "png"):
+                return self.error("`file_format` must be one of ['fits', 'png'].")
+
+            known_which = ["first", "last", "brightest", "faintest"]
+            if which not in known_which:
+                return self.error(f"`which` must be one of {known_which}.")
+
+            params = (
+                {"candid": candid}
+                if candid is not None
+                else {"objectId": object_id, "which": which}
+            )
+
+            headers = {
+                "Accept": "application/json",
+                "Authorization": f"Bearer {boom_token}",
+            }
+
+            response = requests.get(
+                f"{boom_url}/surveys/{survey.upper()}/cutouts",
+                headers=headers,
+                params=params,
+                timeout=10,
+            )
+            if response.status_code != 200:
+                return self.error(
+                    f"Failed to fetch cutout from Boom: {response.status_code} {response.text}"
+                )
+
+            resp_json = response.json()
+            if "data" not in resp_json:
+                return self.error(
+                    "Unexpected response from Boom API (missing 'data' field)."
+                )
+
+            boom_data = resp_json["data"]
+
+            if file_format == "fits":
+                return self.success(data=boom_data)
+
+            # ── PNG mode ─────────────────────────────────────────────────────
+            if cutout is None:
+                return self.error("`cutout` is required when file_format=png.")
+            cutout = cutout.capitalize()
+            if cutout not in ("Science", "Template", "Difference"):
+                return self.error(
+                    "`cutout` must be one of ['science', 'template', 'difference']."
+                )
+
+            cutout_key = f"cutout{cutout}"
+            if cutout_key not in boom_data:
+                return self.error(f"Cutout type '{cutout}' not found in Boom response.")
+
+            data_array, header = decode_cutout(boom_data[cutout_key], survey)
+            data_array = orient_cutout(data_array, survey, header)
+
+            normalizer = NORMALIZATION_METHODS.get(
+                (interval or "asymmetric_percentile").lower(),
+                NORMALIZATION_METHODS["asymmetric_percentile"],
+            )()
+
+            default_stretch = "linear" if cutout == "Difference" else "log"
+            stretcher = STRETCHING_METHODS.get(
+                (stretch or default_stretch).lower(), LogStretch
+            )()
+
+            cmap = cmap.lower() if cmap and cmap.lower() in KNOWN_CMAPS else "bone"
+
+            buff = render_cutout_png(data_array, stretcher, normalizer, cmap)
+            self.set_header("Content-Type", "image/png")
+            self.write(buff.getvalue())
+
+        except Exception:
+            _err = traceback.format_exc()
+            return self.error(f"failure: {_err}")
+
+    @permissions(["Upload data"])
+    @boom_available
+    async def post(self, survey: str):
+        """
+        ---
+        summary: Save or replace cutout thumbnails for an existing source
+        description: |
+          Fetches cutout images from Boom for a given alert (identified by
+          candid or objectId + which) and stores them as thumbnails for the
+          corresponding source in SkyPortal. All existing thumbnails of types
+          new/ref/sub for that source are replaced. Returns an error if the
+          object does not already exist as a source.
+        tags:
+          - alerts
+          - boom
+        parameters:
+          - in: path
+            name: survey
+            required: true
+            schema:
+              type: string
+            description: Survey name (e.g. ZTF, LSST)
+        requestBody:
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - objectId
+                properties:
+                  objectId:
+                    type: string
+                    description: Object ID of the existing source
+                  candid:
+                    type: integer
+                    description: >
+                      Alert candid to use for the cutout. Mutually exclusive
+                      with `which`.
+                  which:
+                    type: string
+                    enum: [first, last, brightest, faintest]
+                    default: last
+                    description: >
+                      When querying by objectId, which alert to use.
+                      Ignored when `candid` is provided.
+                  band:
+                    type: string
+                    description: Optional band filter (e.g. g, r, i for LSST)
+        responses:
+          200:
+            content:
+              application/json:
+                schema:
+                  allOf:
+                    - $ref: '#/components/schemas/Success'
+                    - type: object
+                      properties:
+                        data:
+                          type: object
+          400:
+            content:
+              application/json:
+                schema: Error
+        """
+        data = self.get_json()
+        object_id = data.get("objectId")
+        candid = data.get("candid")
+        which = data.get("which", "last")
+        band = data.get("band")
+
+        if not object_id:
+            return self.error("`objectId` is required.")
+        try:
+            object_id = str(object_id)
+        except ValueError:
+            return self.error("`objectId` must be a string.")
+
+        known_which = ["first", "last", "brightest", "faintest"]
+        if which not in known_which:
+            return self.error(f"`which` must be one of {known_which}.")
+
+        if candid is not None:
+            try:
+                candid = int(candid)
+            except (TypeError, ValueError):
+                return self.error("`candid` must be an integer.")
+
+        params = (
+            {"candid": candid}
+            if candid is not None
+            else {"objectId": object_id, "which": which}
+        )
+        if band is not None:
+            params["band"] = band
+
+        headers = {
+            "Accept": "application/json",
+            "Authorization": f"Bearer {boom_token}",
+        }
+
+        async with self.AsyncSession() as session:
+            obj = await session.scalar(sa.select(Obj).where(Obj.id == object_id))
+            if obj is None:
+                return self.error(
+                    f"Object '{object_id}' not found. Save it as a source first."
+                )
+
+            response = requests.get(
+                f"{boom_url}/surveys/{survey.upper()}/cutouts",
+                headers=headers,
+                params=params,
+                timeout=10,
+            )
+            if response.status_code != 200:
+                return self.error(
+                    f"Failed to fetch cutouts from Boom: "
+                    f"{response.status_code} {response.text}"
+                )
+
+            cutout_data = response.json().get("data", {})
+            cutout_data["objectId"] = object_id
+
+            existing = (
+                await session.scalars(
+                    sa.select(Thumbnail).where(
+                        Thumbnail.obj_id == object_id,
+                        Thumbnail.type.in_([t[1] for t in thumbnail_types]),
+                    )
+                )
+            ).all()
+            for thumb in existing:
+                await session.delete(thumb)
+            await session.flush()
+
+            await add_thumbnails(cutout_data, survey.upper(), session)
+            await session.commit()
+
+        return self.success(data={"objectId": object_id, "survey": survey})

--- a/skyportal/handlers/api/boom/utils.py
+++ b/skyportal/handlers/api/boom/utils.py
@@ -1,0 +1,291 @@
+import base64
+import functools
+import gzip
+import inspect
+import io
+import traceback
+from datetime import datetime, timedelta
+
+import matplotlib.pyplot as plt
+import numpy as np
+import requests
+from astropy.io import fits
+from astropy.visualization import (
+    AsymmetricPercentileInterval,
+    ImageNormalize,
+    LinearStretch,
+    LogStretch,
+)
+from scipy.ndimage import rotate
+
+from baselayer.app.env import load_env
+from baselayer.log import make_log
+
+log = make_log("app/boom-utils")
+
+
+# ── Shared thumbnail helpers ─────────────────────────────────────────────────
+# Imported lazily to avoid a circular-import at module load time (post_thumbnail
+# lives in handlers/api/thumbnail which ultimately imports app models).
+async def _post_thumbnail(thumbnail_dict, user_id, session):
+    from ..thumbnail import post_thumbnail
+
+    await post_thumbnail(thumbnail_dict, user_id=user_id, session=session)
+
+
+thumbnail_types = [
+    ("cutoutScience", "new"),
+    ("cutoutTemplate", "ref"),
+    ("cutoutDifference", "sub"),
+]
+
+
+def decode_cutout(cutout_data, survey):
+    """Decode a raw cutout payload into (data_array, header).
+
+    Handles bytes/list/base64-string input and the survey-specific compression:
+    LSST cutouts are uncompressed FITS; all others are gzip-compressed.
+    """
+    if isinstance(cutout_data, list):
+        cutout_data = bytes(cutout_data)
+    elif isinstance(cutout_data, str):
+        cutout_data = base64.b64decode(cutout_data)
+    if survey.upper() == "LSST":
+        with fits.open(io.BytesIO(cutout_data), ignore_missing_simple=True) as hdu:
+            return np.array(hdu[0].data), dict(hdu[0].header)
+    else:
+        with (
+            gzip.open(io.BytesIO(cutout_data), "rb") as f,
+            fits.open(io.BytesIO(f.read()), ignore_missing_simple=True) as hdu,
+        ):
+            return np.array(hdu[0].data), dict(hdu[0].header)
+
+
+def orient_cutout(data_array, survey, header):
+    """Rotate/flip a cutout array so that North is up and West is right."""
+    if survey.upper() == "ZTF":
+        return np.flipud(data_array)
+    if survey.upper() == "LSST":
+        rotpa = header.get("ROTPA")
+        if rotpa is not None:
+            try:
+                return rotate(
+                    data_array, -rotpa, reshape=True, order=1, mode="constant", cval=0.0
+                )
+            except Exception as e:
+                log(f"Failed to rotate LSST cutout: {e}")
+    return data_array
+
+
+def clean_image_array(img):
+    """Scrub sentinel infinity values and NaNs from a cutout pixel array."""
+    xl = ~np.isnan(img) & (np.abs(img) > 1e20)
+    if img[xl].any():
+        img[xl] = np.nan
+    if np.isnan(img).any():
+        img = np.nan_to_num(img, nan=float(np.nanmean(img.flatten())))
+    return img
+
+
+def render_cutout_png(data_array, stretch, normalizer, cmap="bone"):
+    """Normalize and render a 2D array to a PNG BytesIO buffer.
+
+    `stretch` and `normalizer` are astropy.visualization instances.
+    Returns a seeked-to-start BytesIO containing the PNG bytes.
+    """
+    img = clean_image_array(data_array)
+    norm = ImageNormalize(img, stretch=stretch)
+    img_norm = norm(img)
+    vmin, vmax = normalizer.get_limits(img_norm)
+
+    buff = io.BytesIO()
+    fig, ax = plt.subplots(figsize=(4, 4))
+    fig.subplots_adjust(0, 0, 1, 1)
+    ax.set_axis_off()
+    ax.imshow(img_norm, cmap=cmap, origin="lower", vmin=vmin, vmax=vmax)
+    plt.savefig(buff, dpi=42, format="png")
+    plt.close(fig)
+    buff.seek(0)
+    return buff
+
+
+def make_thumbnail(obj_id, cutout_data, cutout_type, thumbnail_type, survey):
+    data_array, header = decode_cutout(cutout_data, survey)
+    data_array = orient_cutout(data_array, survey, header)
+
+    stretch = LinearStretch() if cutout_type == "cutoutDifference" else LogStretch()
+    normalizer = AsymmetricPercentileInterval(lower_percentile=1, upper_percentile=100)
+    buff = render_cutout_png(data_array, stretch, normalizer, cmap="bone")
+
+    return {
+        "obj_id": obj_id,
+        "data": base64.b64encode(buff.read()).decode("utf-8"),
+        "ttype": thumbnail_type,
+    }
+
+
+async def add_thumbnails(alert, survey, session):
+    for cutout_type, thumbnail_type in thumbnail_types:
+        if cutout_type not in alert:
+            log(f"Cutout key {cutout_type} not found in alert")
+            continue
+        try:
+            thumbnail = make_thumbnail(
+                alert["objectId"],
+                alert[cutout_type],
+                cutout_type,
+                thumbnail_type,
+                survey,
+            )
+        except Exception as e:
+            traceback.print_exc()
+            log(f"Failed to create thumbnail for cutout type {cutout_type}: {e}")
+            continue
+        await _post_thumbnail(thumbnail, user_id=1, session=session)
+
+
+_, cfg = load_env()
+
+
+def get_boom_url():
+    try:
+        ports_to_ignore = [443, 80]
+        return f"{cfg['boom.protocol']}://{cfg['boom.host']}" + (
+            f":{int(cfg['boom.port'])}"
+            if (
+                isinstance(cfg["boom.port"], int)
+                and int(cfg["boom.port"]) not in ports_to_ignore
+            )
+            else ""
+        )
+    except Exception as e:
+        log(f"Error getting Boom URL: {e}")
+        return None
+
+
+def get_boom_credentials():
+    username = cfg.get("boom.username")
+    password = cfg.get("boom.password")
+    if username is None or password is None:
+        log("Boom credentials not found in configuration")
+        return None
+    return {"username": username, "password": password}
+
+
+boom_url = get_boom_url()
+boom_credentials = get_boom_credentials()
+
+
+def get_boom_token():
+    try:
+        if boom_url is None or boom_credentials is None:
+            return None, None
+        auth_url = f"{boom_url}/auth"
+        current_time = datetime.utcnow()
+        auth_response = requests.post(
+            auth_url,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            data=boom_credentials,
+        )
+        auth_response.raise_for_status()
+        data = auth_response.json()
+        token = data["access_token"]
+        expires_at = None
+        if data.get("expires_in"):
+            expires_in = int(data["expires_in"])
+            expires_at = current_time + timedelta(seconds=expires_in)
+        return token, expires_at
+    except Exception as e:
+        log(f"Error getting Boom token: {e}")
+        return None, None
+
+
+boom_token, boom_token_expires_at = get_boom_token()
+
+
+def _refresh_boom_token():
+    global boom_url
+    global boom_credentials
+    if boom_url is None or boom_credentials is None:
+        raise ValueError("Boom is not available")
+    global boom_token
+    global boom_token_expires_at
+    if boom_token is None or (
+        boom_token_expires_at is not None
+        and boom_token_expires_at < datetime.utcnow() + timedelta(seconds=1800)
+    ):
+        boom_token, boom_token_expires_at = get_boom_token()
+    if boom_token is None:
+        raise ValueError("Boom is not available")
+
+
+def boom_available(func):
+    # Preserve the coroutine-ness of async handlers so baselayer's
+    # auth_or_token/permissions decorators take their async path.
+    if inspect.iscoroutinefunction(func):
+
+        @functools.wraps(func)
+        async def async_wrapper(*args, **kwargs):
+            _refresh_boom_token()
+            return await func(*args, **kwargs)
+
+        return async_wrapper
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        _refresh_boom_token()
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+# JavaScript's Number.MAX_SAFE_INTEGER (2^53 - 1)
+MAX_SAFE_INTEGER = 2**53 - 1
+
+
+# def convert_large_ints(obj):
+#     """Recursively convert integers that exceed JS Number.MAX_SAFE_INTEGER to strings.
+
+#     JavaScript cannot represent integers larger than 2^53 - 1 without loss of
+#     precision. This function walks the response tree and converts any
+#     out-of-range integer to its string representation so the browser receives
+#     the exact value.
+#     """
+#     if isinstance(obj, bool):
+#         return obj
+#     if isinstance(obj, int):
+#         if obj > MAX_SAFE_INTEGER or obj < -MAX_SAFE_INTEGER:
+#             return str(obj)
+#         return obj
+#     if isinstance(obj, dict):
+#         return {k: convert_large_ints(v) for k, v in obj.items()}
+#     if isinstance(obj, list):
+#         return [convert_large_ints(item) for item in obj]
+#     return obj
+
+
+# let's take a different approach: we convert to int all key: value where value is a number and where key ends with "id" (case insensitive)
+def convert_large_ints(obj):
+    """Recursively convert numeric values of keys ending with 'id' to strings.
+
+    This function walks the response tree and converts any numeric value of a key
+    that ends with 'id' (case insensitive) to a string. This allows the
+    frontend to receive these values as strings while still preserving precision
+    for large IDs.
+    """
+    if isinstance(obj, bool):
+        return obj
+    if isinstance(obj, dict):
+        new_obj = {}
+        for k, v in obj.items():
+            if isinstance(v, int | float) and k.lower().endswith("id"):
+                try:
+                    new_obj[k] = str(int(v))
+                except ValueError:
+                    new_obj[k] = v
+            else:
+                new_obj[k] = convert_large_ints(v)
+        return new_obj
+    if isinstance(obj, list):
+        return [convert_large_ints(item) for item in obj]
+    return obj

--- a/skyportal/tests/api/boom/conftest.py
+++ b/skyportal/tests/api/boom/conftest.py
@@ -1,0 +1,200 @@
+"""Fixtures for BOOM integration tests.
+
+These fixtures hit the live BOOM API (via SkyPortal's `@boom_available`
+endpoints), so they require a running boom-api-1 service. Any test that
+uses them will fail at fixture setup if BOOM is unreachable.
+"""
+
+import json
+import os
+import uuid
+
+import pytest
+
+from skyportal.tests import api
+
+# Path inside the container written by the workflow's "Inject BOOM seed
+# reference" step. Contains the objectId and candid of the first alert
+# ingested by boom's consumer-ztf, so tests don't need to hard-code a
+# specific OID that may not exist in the current seed dataset.
+# We use /tmp because the skyportal-web-1 container runs as the
+# `skyportal` user, which can't write under /skyportal/persistentdata
+# directly (only its chowned subdirs).
+_BOOM_SEED_FILE = "/tmp/boom_seed.json"
+
+
+def pytest_configure(config):
+    """Register custom markers so pytest doesn't warn about them."""
+    config.addinivalue_line(
+        "markers",
+        "requires_boom_data: test depends on BOOM mongo being seeded "
+        "(skipped automatically when no BOOM seed reference file is found).",
+    )
+
+
+def _load_boom_seed():
+    """Return {objectId, candid} dict from the seed file, or None."""
+    if not os.path.exists(_BOOM_SEED_FILE):
+        return None
+    try:
+        with open(_BOOM_SEED_FILE) as f:
+            payload = json.load(f)
+    except (OSError, ValueError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    if "objectId" not in payload or "candid" not in payload:
+        return None
+    return payload
+
+
+@pytest.fixture(scope="session")
+def boom_seed():
+    """Session-scoped (objectId, candid) for tests that need a real alert.
+
+    Returns None if BOOM wasn't seeded (e.g. running locally without the
+    workflow's seed step). Tests marked `requires_boom_data` will be
+    skipped in that case by `_boom_seed_data_gate`.
+    """
+    return _load_boom_seed()
+
+
+@pytest.fixture
+def boom_seed_oid(boom_seed):
+    if boom_seed is None:
+        pytest.skip("BOOM seed file not present")
+    return boom_seed["objectId"]
+
+
+@pytest.fixture
+def boom_seed_candid(boom_seed):
+    if boom_seed is None:
+        pytest.skip("BOOM seed file not present")
+    return int(boom_seed["candid"])
+
+
+@pytest.fixture
+def boom_seed_ra(boom_seed):
+    if boom_seed is None or boom_seed.get("ra") is None:
+        pytest.skip("BOOM seed ra not present")
+    return float(boom_seed["ra"])
+
+
+@pytest.fixture
+def boom_seed_dec(boom_seed):
+    if boom_seed is None or boom_seed.get("dec") is None:
+        pytest.skip("BOOM seed dec not present")
+    return float(boom_seed["dec"])
+
+
+@pytest.fixture(autouse=True)
+def _boom_seed_data_gate(request):
+    """Skip tests marked `requires_boom_data` when no seed file exists."""
+    if "requires_boom_data" not in request.keywords:
+        return
+    if _load_boom_seed() is None:
+        pytest.skip(
+            f"BOOM seed reference {_BOOM_SEED_FILE} not present; "
+            "the workflow's BOOM-seeding steps must run before these tests."
+        )
+
+
+@pytest.fixture
+def boom_ztf_stream(super_admin_token, public_stream):
+    """Decorate `public_stream` with ZTF_alerts altdata so that BOOM
+    filters can be attached to it. BOOM derives the survey/permissions
+    from `stream.altdata.collection` and `stream.altdata.selector`.
+    """
+    status, data = api(
+        "PATCH",
+        f"streams/{public_stream.id}",
+        data={
+            "name": str(uuid.uuid4()),
+            "altdata": {"collection": "ZTF_alerts", "selector": [1, 2]},
+        },
+        token=super_admin_token,
+    )
+    assert status == 200, data
+    return public_stream
+
+
+@pytest.fixture
+def boom_filter(super_admin_token, boom_ztf_stream, group_with_stream):
+    """A SkyPortal Filter provisioned on the BOOM side.
+
+    Two-step setup, mirroring the frontend:
+      1. POST /filters to create the SkyPortal-side Filter (no altdata).
+      2. POST /boom/filters/{id} which round-trips to BOOM, creates the
+         BOOM filter, and populates Filter.altdata with the BOOM filter_id.
+
+    Yields the SkyPortal Filter ID. Best-effort DELETE on teardown.
+
+    BOOM validates new filters by running their pipeline against the ZTF
+    corpus, so without seed data step 2 returns 400. We skip up-front
+    when no seed reference file is present.
+    """
+    if _load_boom_seed() is None:
+        pytest.skip(
+            f"BOOM seed reference {_BOOM_SEED_FILE} not present; "
+            "skip filter-provisioning tests until boom-mongo is seeded."
+        )
+
+    status, data = api(
+        "POST",
+        "filters",
+        data={
+            "name": str(uuid.uuid4()),
+            "stream_id": boom_ztf_stream.id,
+            "group_id": group_with_stream.id,
+        },
+        token=super_admin_token,
+    )
+    assert status == 200, data
+    filter_id = data["data"]["id"]
+
+    # BOOM rejects pipelines whose last stage isn't a $project that
+    # includes objectId (validation in build_and_test_filter_version).
+    pipeline = [
+        {"$match": {"candidate.drb": {"$gt": 0.5}}},
+        {"$project": {"objectId": 1, "candid": 1, "candidate": 1}},
+    ]
+    status, data = api(
+        "POST",
+        f"boom/filters/{filter_id}",
+        data={
+            "name": f"boom_filter_{filter_id}",
+            "altdata": pipeline,
+            "filters": "v1",
+        },
+        token=super_admin_token,
+    )
+    assert status == 200, data
+
+    yield filter_id
+
+    api("DELETE", f"boom/filters/{filter_id}", token=super_admin_token)
+
+
+@pytest.fixture
+def boom_filter_module_block(super_admin_token):
+    """Insert a sample BOOM filter-module block into the MongoDB store.
+
+    `BoomFilterModulesHandler` exposes no DELETE, so the block leaks; we
+    use a UUID-suffixed name to avoid collisions across test runs.
+    """
+    name = f"test_block_{uuid.uuid4().hex[:8]}"
+    payload = {
+        "elements": "blocks",
+        "data": {
+            "block": {"$match": {"candidate.drb": {"$gt": 0.5}}},
+            "streams": ["ZTF (1, 2)"],
+        },
+    }
+    status, data = api(
+        "POST",
+        f"boom/filter_modules/{name}",
+        data=payload,
+        token=super_admin_token,
+    )
+    assert status == 200, data
+    return name

--- a/skyportal/tests/api/boom/test_boom_alert.py
+++ b/skyportal/tests/api/boom/test_boom_alert.py
@@ -1,0 +1,147 @@
+import pytest
+
+from skyportal.tests import api
+
+SURVEY = "ZTF"
+
+
+def _alerts_url(query: str = "") -> str:
+    base = f"boom/surveys/{SURVEY}/alerts"
+    return f"{base}?{query}" if query else base
+
+
+# ── Happy paths (need a real alert in BOOM mongo) ────────────────────────────
+
+
+@pytest.mark.requires_boom_data
+def test_get_alerts_by_object_id(view_only_token, boom_seed_oid):
+    status, data = api(
+        "GET", _alerts_url(f"objectId={boom_seed_oid}"), token=view_only_token
+    )
+    assert status == 200
+    assert data["status"] == "success"
+    assert isinstance(data["data"], list)
+    assert len(data["data"]) > 0
+    assert all(alert.get("objectId") == boom_seed_oid for alert in data["data"])
+
+
+@pytest.mark.requires_boom_data
+def test_get_alerts_by_object_id_comma_list(view_only_token, boom_seed_oid):
+    status, data = api(
+        "GET",
+        _alerts_url(f"objectId={boom_seed_oid},{boom_seed_oid}"),
+        token=view_only_token,
+    )
+    assert status == 200
+    assert data["status"] == "success"
+    assert isinstance(data["data"], list)
+
+
+@pytest.mark.requires_boom_data
+def test_get_alerts_by_candid(view_only_token, boom_seed_candid):
+    # The handler's filter_doc uses {"candid": X}, but BOOM stores candid
+    # as the document `_id` (and may not duplicate it as a top-level
+    # `candid` field). The query may legitimately return an empty list.
+    # We assert the wire-up — status + response shape — and verify any
+    # returned alert with an `_id`/`candid` matches the seed value.
+    status, data = api(
+        "GET", _alerts_url(f"candid={boom_seed_candid}"), token=view_only_token
+    )
+    assert status == 200
+    assert data["status"] == "success"
+    assert isinstance(data["data"], list)
+    seed = str(boom_seed_candid)
+    for alert in data["data"]:
+        identifier = str(alert.get("_id") or alert.get("candid") or "")
+        if identifier:
+            assert identifier == seed
+
+
+@pytest.mark.requires_boom_data
+def test_get_alerts_by_candid_and_object_id(
+    view_only_token, boom_seed_candid, boom_seed_oid
+):
+    status, data = api(
+        "GET",
+        _alerts_url(f"candid={boom_seed_candid}&objectId={boom_seed_oid}"),
+        token=view_only_token,
+    )
+    assert status == 200
+    assert data["status"] == "success"
+    assert isinstance(data["data"], list)
+
+
+@pytest.mark.requires_boom_data
+def test_get_alerts_by_cone_search(view_only_token, boom_seed_ra, boom_seed_dec):
+    status, data = api(
+        "GET",
+        _alerts_url(
+            f"ra={boom_seed_ra}&dec={boom_seed_dec}&radius=0.5&radius_units=deg"
+        ),
+        token=view_only_token,
+    )
+    assert status == 200
+    assert data["status"] == "success"
+    assert all("objectId" in alert for alert in data["data"])
+
+
+@pytest.mark.requires_boom_data
+def test_get_alerts_cone_plus_object_id_filter(
+    view_only_token, boom_seed_ra, boom_seed_dec, boom_seed_oid
+):
+    status, data = api(
+        "GET",
+        _alerts_url(
+            f"ra={boom_seed_ra}&dec={boom_seed_dec}&radius=0.5&radius_units=deg"
+            f"&objectId={boom_seed_oid}"
+        ),
+        token=view_only_token,
+    )
+    assert status == 200
+    assert data["status"] == "success"
+    assert all(alert.get("objectId") == boom_seed_oid for alert in data["data"])
+
+
+# ── Error paths (independent of seed data) ──────────────────────────────────
+
+
+def test_get_alerts_no_params_errors(view_only_token):
+    status, data = api("GET", _alerts_url(), token=view_only_token)
+    assert status == 400
+    assert data["status"] == "error"
+
+
+def test_get_alerts_invalid_candid_errors(view_only_token):
+    status, data = api("GET", _alerts_url("candid=not_an_int"), token=view_only_token)
+    assert status == 400
+    assert data["status"] == "error"
+
+
+def test_get_alerts_invalid_radius_units_errors(view_only_token):
+    status, data = api(
+        "GET",
+        _alerts_url("ra=108.5&dec=35.8&radius=1&radius_units=parsecs"),
+        token=view_only_token,
+    )
+    assert status == 400
+    assert data["status"] == "error"
+
+
+def test_get_alerts_radius_too_large_errors(view_only_token):
+    status, data = api(
+        "GET",
+        _alerts_url("ra=108.5&dec=35.8&radius=2&radius_units=deg"),
+        token=view_only_token,
+    )
+    assert status == 400
+    assert data["status"] == "error"
+
+
+def test_get_alerts_incomplete_positional_errors(view_only_token):
+    status, data = api(
+        "GET",
+        _alerts_url("ra=108.5&dec=35.8&radius=1"),
+        token=view_only_token,
+    )
+    assert status == 400
+    assert data["status"] == "error"

--- a/skyportal/tests/api/boom/test_boom_cutout.py
+++ b/skyportal/tests/api/boom/test_boom_cutout.py
@@ -1,0 +1,152 @@
+import pytest
+
+from skyportal.tests import api
+
+SURVEY = "ZTF"
+
+# Placeholders used by error-path tests that fail validation *before*
+# hitting BOOM. The actual values don't matter as long as parsing succeeds.
+_PLACEHOLDER_CANDID = 1105522281015015000
+_PLACEHOLDER_OID = "ZTF99zzzzzz"
+
+
+def _cutout_url(query: str) -> str:
+    return f"boom/surveys/{SURVEY}/alerts/cutouts?{query}"
+
+
+# ── Happy paths (need real alert in BOOM mongo) ─────────────────────────────
+
+
+@pytest.mark.requires_boom_data
+def test_get_cutout_fits_by_candid(view_only_token, boom_seed_candid):
+    status, data = api(
+        "GET",
+        _cutout_url(f"candid={boom_seed_candid}&file_format=fits"),
+        token=view_only_token,
+    )
+    assert status == 200
+    assert data["status"] == "success"
+    assert isinstance(data["data"], dict)
+    for key in ("cutoutScience", "cutoutTemplate", "cutoutDifference"):
+        assert key in data["data"]
+
+
+@pytest.mark.requires_boom_data
+def test_get_cutout_fits_by_object_id(view_only_token, boom_seed_oid):
+    status, data = api(
+        "GET",
+        _cutout_url(f"objectId={boom_seed_oid}&which=last&file_format=fits"),
+        token=view_only_token,
+    )
+    assert status == 200
+    assert data["status"] == "success"
+    assert isinstance(data["data"], dict)
+
+
+@pytest.mark.requires_boom_data
+def test_get_cutout_png_all_types(view_only_token, boom_seed_candid):
+    for cutout in ("science", "template", "difference"):
+        response = api(
+            "GET",
+            _cutout_url(f"candid={boom_seed_candid}&file_format=png&cutout={cutout}"),
+            token=view_only_token,
+            raw_response=True,
+        )
+        assert response.status_code == 200
+        assert response.headers.get("Content-Type") == "image/png"
+        assert len(response.content) > 0
+
+
+# ── Error paths (validate before hitting BOOM, no seed needed) ──────────────
+
+
+def test_get_cutout_no_identifier_errors(view_only_token):
+    status, data = api("GET", _cutout_url("file_format=fits"), token=view_only_token)
+    assert status == 400
+    assert data["status"] == "error"
+
+
+def test_get_cutout_both_identifiers_errors(view_only_token):
+    status, data = api(
+        "GET",
+        _cutout_url(
+            f"candid={_PLACEHOLDER_CANDID}&objectId={_PLACEHOLDER_OID}&file_format=fits"
+        ),
+        token=view_only_token,
+    )
+    assert status == 400
+    assert data["status"] == "error"
+
+
+def test_get_cutout_png_without_cutout_param_errors(view_only_token):
+    status, data = api(
+        "GET",
+        _cutout_url(f"candid={_PLACEHOLDER_CANDID}&file_format=png"),
+        token=view_only_token,
+    )
+    assert status == 400
+    assert data["status"] == "error"
+
+
+def test_get_cutout_invalid_cutout_errors(view_only_token):
+    status, data = api(
+        "GET",
+        _cutout_url(f"candid={_PLACEHOLDER_CANDID}&file_format=png&cutout=bogus"),
+        token=view_only_token,
+    )
+    assert status == 400
+    assert data["status"] == "error"
+
+
+def test_get_cutout_invalid_candid_errors(view_only_token):
+    status, data = api(
+        "GET",
+        _cutout_url("candid=not_an_int&file_format=fits"),
+        token=view_only_token,
+    )
+    assert status == 400
+    assert data["status"] == "error"
+
+
+def test_get_cutout_invalid_file_format_errors(view_only_token):
+    status, data = api(
+        "GET",
+        _cutout_url(f"candid={_PLACEHOLDER_CANDID}&file_format=jpeg"),
+        token=view_only_token,
+    )
+    assert status == 400
+    assert data["status"] == "error"
+
+
+def test_get_cutout_invalid_which_errors(view_only_token):
+    status, data = api(
+        "GET",
+        _cutout_url(f"objectId={_PLACEHOLDER_OID}&which=middle&file_format=fits"),
+        token=view_only_token,
+    )
+    assert status == 400
+    assert data["status"] == "error"
+
+
+def test_post_cutout_requires_object_id(upload_data_token):
+    status, data = api(
+        "POST",
+        f"boom/surveys/{SURVEY}/alerts/cutouts",
+        data={},
+        token=upload_data_token,
+    )
+    assert status == 400
+    assert data["status"] == "error"
+
+
+def test_post_cutout_unknown_object_errors(upload_data_token):
+    status, data = api(
+        "POST",
+        f"boom/surveys/{SURVEY}/alerts/cutouts",
+        data={"objectId": _PLACEHOLDER_OID, "which": "last"},
+        token=upload_data_token,
+    )
+    assert status == 400
+    assert data["status"] == "error"
+    # Handler returns "Object 'X' not found. Save it as a source first."
+    assert "not found" in (data.get("message") or "").lower()

--- a/skyportal/tests/frontend/boom/conftest.py
+++ b/skyportal/tests/frontend/boom/conftest.py
@@ -1,0 +1,63 @@
+"""Frontend test fixtures for BOOM integration tests.
+
+These tests use skyportal's session-scoped Playwright `page` fixture (defined in
+skyportal/tests/test_util.py and re-exported via skyportal/tests/conftest.py)
+to drive a headless Firefox against the running fritz/skyportal app.
+
+The seed-file probe is duplicated from the api/boom/conftest.py because
+pytest's conftest discovery doesn't cross sibling test trees — these
+frontend tests are at tests/frontend/boom/, the api ones at tests/api/boom/.
+"""
+
+import json
+import os
+
+import pytest
+
+_BOOM_SEED_FILE = "/tmp/boom_seed.json"
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "requires_boom_data: test depends on BOOM mongo being seeded "
+        "(skipped automatically when no BOOM seed reference file is found).",
+    )
+
+
+def _load_boom_seed():
+    if not os.path.exists(_BOOM_SEED_FILE):
+        return None
+    try:
+        with open(_BOOM_SEED_FILE) as f:
+            payload = json.load(f)
+    except (OSError, ValueError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    if "objectId" not in payload or "candid" not in payload:
+        return None
+    return payload
+
+
+@pytest.fixture(scope="session")
+def boom_seed():
+    return _load_boom_seed()
+
+
+@pytest.fixture
+def boom_seed_oid(boom_seed):
+    if boom_seed is None:
+        pytest.skip("BOOM seed file not present")
+    return boom_seed["objectId"]
+
+
+@pytest.fixture(autouse=True)
+def _boom_seed_data_gate(request):
+    if "requires_boom_data" not in request.keywords:
+        return
+    if _load_boom_seed() is None:
+        pytest.skip(
+            f"BOOM seed reference {_BOOM_SEED_FILE} not present; "
+            "the workflow's BOOM-seeding steps must run before these tests."
+        )

--- a/skyportal/tests/frontend/boom/test_boom_alerts_frontend.py
+++ b/skyportal/tests/frontend/boom/test_boom_alerts_frontend.py
@@ -1,0 +1,169 @@
+"""Smoke tests for the BOOM-backed alerts pages.
+
+These exercise the frontend changes from PR #578 (Migrate Frontend to
+BOOM-based endpoints): the rewritten Alerts.jsx search/list page and
+the new Alert.jsx detail view. We only assert minimal landmarks — that
+the page mounts and shows the survey selector / alert details — so the
+tests remain robust to small UI tweaks while still catching regressions
+like a route disappearing or a duck/reducer wiring change.
+
+Driven with Playwright (the session-scoped `page` fixture from
+skyportal/tests/test_util.py). `expect(...).to_be_visible()` auto-waits and
+`locator.click()` auto-scrolls + retries actionability, which handles MUI
+dialog backdrops and the detail page's async re-renders without the explicit
+stale-element retry loops the old Selenium version needed.
+"""
+
+import time
+
+import pytest
+from playwright.sync_api import expect
+
+from skyportal.tests import api
+
+
+def test_alerts_page_loads(page):
+    """The /alerts route mounts and renders the survey selector."""
+    page.goto("/alerts")
+    # AlertsSearchButton routes here; the page should render a survey
+    # selector (ZTF / LSST). We look for either label via a broad xpath.
+    expect(
+        page.locator(
+            "//*[contains(translate(text(),'ABCDEFGHIJKLMNOPQRSTUVWXYZ',"
+            "'abcdefghijklmnopqrstuvwxyz'),'ztf') or "
+            "contains(translate(text(),'ABCDEFGHIJKLMNOPQRSTUVWXYZ',"
+            "'abcdefghijklmnopqrstuvwxyz'),'lsst')]"
+        )
+        .locator("visible=true")
+        .first
+    ).to_be_visible()
+
+
+def test_alerts_page_search_by_object_id(page):
+    """The /alerts page accepts an objectId query param and renders without
+    a hard crash. We don't require results because BOOM may have no data
+    matching arbitrary OIDs at this stage; the assertion is just that the
+    page mounted (websocket connected, body present)."""
+    page.goto("/alerts?survey=ZTF&objectId=ZTF99zzzzzz")
+    expect(page.locator("//body").first).to_be_visible()
+
+
+@pytest.mark.requires_boom_data
+def test_alert_detail_page_loads(page, boom_seed_oid):
+    """The Alert.jsx detail page renders for an object that BOOM has data
+    for. The component reads its objectId from route.id (Alert.jsx:472);
+    we assert the heading or another landmark containing the OID."""
+    page.goto(f"/alerts/ZTF/{boom_seed_oid}")
+    expect(
+        page.locator(f"//*[contains(text(),'{boom_seed_oid}')]")
+        .locator("visible=true")
+        .first
+    ).to_be_visible()
+
+
+@pytest.mark.requires_boom_data
+def test_alerts_search_results_for_seed_oid(page, boom_seed_oid):
+    """Run the alerts search with the seed objectId and confirm at least
+    one row references it."""
+    page.goto(f"/alerts?survey=ZTF&objectId={boom_seed_oid}")
+    expect(
+        page.locator(f"//*[contains(text(),'{boom_seed_oid}')]")
+        .locator("visible=true")
+        .first
+    ).to_be_visible()
+
+
+@pytest.mark.requires_boom_data
+def test_open_alert_from_table(page, boom_seed_oid):
+    """The main navigation flow: open the alerts search page, click the
+    alert's objectId link in the results table, and verify the Alert.jsx
+    detail page rendered with the SaveAlertButton present. The row link has
+    target='_blank', so it opens a new page in the browser context.
+    """
+    page.goto(f"/alerts?survey=ZTF&objectId={boom_seed_oid}")
+    # Row link uses data-testid={objectId} (Alerts.jsx:502). Wait for it to be
+    # visible before clicking so the search results have finished rendering.
+    row_link = page.locator(f"//*[@data-testid='{boom_seed_oid}']").first
+    expect(row_link).to_be_visible(timeout=30000)
+    with page.context.expect_page() as new_page_info:
+        row_link.click()
+    new_page = new_page_info.value
+    try:
+        # SaveAlertButton has data-testid=saveAlertButton_{alert.id} where
+        # alert.id is the objectId.
+        expect(
+            new_page.locator(
+                f"//*[@data-testid='saveAlertButton_{boom_seed_oid}']"
+            ).first
+        ).to_be_visible(timeout=30000)
+    finally:
+        new_page.close()
+
+
+@pytest.mark.requires_boom_data
+def test_save_alert_as_source(page, boom_seed_oid, public_group, super_admin_token):
+    """Drive the Save-as-Source workflow end-to-end: open the alert
+    detail page, click the SaveAlertButton, check a group in the dialog,
+    and submit. We verify the *outcome* via the API — confirm a Source
+    was created — rather than waiting for a UI notification, because
+    the success toast can dismiss before it's caught. `public_group`
+    ensures there is at least one selectable group in the dialog.
+    """
+    page.goto(f"/alerts/ZTF/{boom_seed_oid}")
+    # Let the detail page settle before interacting; it re-renders several
+    # times as photometry/cutouts load asynchronously. Waiting for the OID
+    # landmark lets the initial data-load churn finish (Playwright re-resolves
+    # the locator on each action, so no manual stale-element retry is needed).
+    expect(
+        page.locator(f"//*[contains(text(),'{boom_seed_oid}')]")
+        .locator("visible=true")
+        .first
+    ).to_be_visible(timeout=30000)
+    # The detail page re-renders several times as photometry/cutouts load, so a
+    # click that lands mid-render can be dropped before the dialog opens. Wait
+    # for the button to settle, then retry the click until the dialog appears.
+    save_button = page.locator(
+        f"//*[@data-testid='saveAlertButton_{boom_seed_oid}']"
+    ).first
+    expect(save_button).to_be_visible(timeout=30000)
+    # Dialog title (SaveAlertButton.jsx:206).
+    dialog_title = page.locator(
+        "//*[contains(text(),'Select one or more groups')]"
+    ).first
+    for _ in range(5):
+        save_button.click()
+        try:
+            expect(dialog_title).to_be_visible(timeout=5000)
+            break
+        except AssertionError:
+            continue
+    else:
+        # Surface a clear failure if the dialog never opened.
+        expect(dialog_title).to_be_visible(timeout=5000)
+    # Click the group's label text rather than the raw checkbox input: the
+    # MUI <input> is visibility:hidden (only the SVG icon shows), so a direct
+    # click misses the hit area / fires an event React Hook Form ignores.
+    # Clicking the label text triggers the native label→input pairing that
+    # RHF's Controller picks up. public_group.name is unique on the page.
+    page.locator(f"//*[contains(text(),'{public_group.name}')]").first.click()
+    # Submit button has name=finalSaveAlertButton{alert.id}.
+    page.locator(f"//button[@name='finalSaveAlertButton{boom_seed_oid}']").first.click()
+
+    # Poll the API for the Source. The full chain we're verifying is:
+    # dialog submit → boom_alert.saveAlertAsSource duck → backend
+    # POST /api/boom/surveys/ZTF/objects/{oid} (BoomObjectHandler.post)
+    # → Obj + Source created.
+    deadline = time.time() + 30
+    last_status = None
+    while time.time() < deadline:
+        last_status, data = api(
+            "GET", f"sources/{boom_seed_oid}", token=super_admin_token
+        )
+        if last_status == 200 and data.get("status") == "success":
+            assert data["data"]["id"] == boom_seed_oid
+            return
+        time.sleep(1)
+    pytest.fail(
+        f"Source {boom_seed_oid} never appeared after submit "
+        f"(last GET /sources status={last_status})"
+    )

--- a/static/js/components/alert/Alert.tsx
+++ b/static/js/components/alert/Alert.tsx
@@ -1,0 +1,918 @@
+import React, { useEffect, useState, useMemo, Suspense } from "react";
+import { useNavigate, Link } from "react-router-dom";
+
+import Button from "@mui/material/Button";
+import { makeStyles } from "tss-react/mui";
+import Grid from "@mui/material/Grid";
+import Accordion from "@mui/material/Accordion";
+import AccordionSummary from "@mui/material/AccordionSummary";
+import AccordionDetails from "@mui/material/AccordionDetails";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import Typography from "@mui/material/Typography";
+import CircularProgress from "@mui/material/CircularProgress";
+import Chip from "@mui/material/Chip";
+import OpenInNewIcon from "@mui/icons-material/OpenInNew";
+import WarningAmberIcon from "@mui/icons-material/WarningAmber";
+import Tooltip from "@mui/material/Tooltip";
+import Paper from "@mui/material/Paper";
+import Switch from "@mui/material/Switch";
+import TextField from "@mui/material/TextField";
+
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableContainer from "@mui/material/TableContainer";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+
+import StyledDataGrid from "../StyledDataGrid";
+import SaveAlertButton from "./SaveAlertButton";
+import ThumbnailList from "../thumbnail/ThumbnailList";
+import SharePage from "../SharePage";
+import withRouter from "../withRouter";
+
+import { ra_to_hours, dec_to_dms } from "../../units";
+
+import {
+  useGetAlertDataQuery,
+  useGetBoomObjectQuery,
+} from "../../ducks/boom_alert";
+import {
+  useCheckSourceMutation,
+  useLazyGetSourceQuery,
+} from "../../ducks/source";
+import { useLazyFetchSourcesQuery } from "../../ducks/sources";
+import { useGetGroupsQuery } from "../../ducks/groups";
+import { bytes2image } from "../../utils/imageProcessing";
+
+// ── Survey inference ──────────────────────────────────────────────────────────
+
+function inferSurvey(objectId: any): string | null {
+  if (!objectId) return null;
+  if (objectId.toUpperCase().startsWith("ZTF")) return "ZTF";
+  if (/^\d{15,}$/.test(objectId)) return "LSST";
+  return null;
+}
+
+// ── Survey-agnostic field accessors ──────────────────────────────────────────
+
+const getCandid = (alert: any) => {
+  return (
+    alert?.diaSourceId ??
+    alert?.candid ??
+    alert?.candidate?.candid ??
+    alert?._id
+  );
+};
+
+const getJd = (alert: any) => alert?.candidate?.jd;
+
+const getRa = (alert: any) =>
+  alert?.candidate?.ra ?? alert?.candidate?.coord_ra;
+const getDec = (alert: any) =>
+  alert?.candidate?.dec ?? alert?.candidate?.coord_dec;
+
+// ── Row builder ───────────────────────────────────────────────────────────────
+
+const buildRow = (alert: any, survey: string | null) => ({
+  candid: getCandid(alert),
+  jd: getJd(alert),
+  band: alert?.candidate?.band,
+  magpsf: alert?.candidate?.magpsf,
+  sigmapsf: alert?.candidate?.sigmapsf,
+  isdiffpos: alert?.candidate?.isdiffpos,
+  drb: survey === "ZTF" ? alert?.candidate?.drb : alert?.candidate?.reliability,
+  snr: alert?.candidate?.snr_psf ?? alert?.candidate?.snr,
+  ...(survey === "ZTF" ? { programid: alert?.candidate?.programid } : {}),
+});
+
+// ── Column definitions ────────────────────────────────────────────────────────
+
+const fmt = (decimals: number) => (params: any) =>
+  params.value != null ? params.value.toFixed(decimals) : "—";
+
+const buildColumns = (survey: string | null): any[] => {
+  const isLSST = survey === "LSST";
+
+  const columns: any[] = [
+    {
+      field: "candid",
+      headerName: isLSST ? "diaSourceId" : "candid",
+      flex: 1,
+      minWidth: 120,
+      filterable: false,
+      sortable: true,
+      sortingOrder: ["desc", "asc"],
+    },
+    {
+      field: "jd",
+      headerName: isLSST ? "MJD" : "JD",
+      flex: 1,
+      minWidth: 100,
+      filterable: false,
+      sortable: true,
+      sortingOrder: ["desc", "asc"],
+      renderCell: fmt(5),
+    },
+    {
+      field: "band",
+      headerName: "band",
+      flex: 1,
+      minWidth: 80,
+      filterable: true,
+      sortable: true,
+    },
+    {
+      field: "magpsf",
+      headerName: "magpsf",
+      flex: 1,
+      minWidth: 90,
+      filterable: false,
+      sortable: true,
+      renderCell: fmt(3),
+    },
+    {
+      field: "sigmapsf",
+      headerName: "sigmapsf",
+      flex: 1,
+      minWidth: 90,
+      filterable: false,
+      sortable: true,
+      renderCell: fmt(3),
+    },
+    {
+      field: "isdiffpos",
+      headerName: "isdiffpos",
+      flex: 1,
+      minWidth: 90,
+      filterable: true,
+      sortable: true,
+      renderCell: (params: any) =>
+        params.value != null ? String(params.value) : "—",
+    },
+    {
+      field: "drb",
+      headerName: isLSST ? "reliability" : "drb",
+      flex: 1,
+      minWidth: 100,
+      filterable: false,
+      sortable: true,
+      sortingOrder: ["desc", "asc"],
+      renderCell: fmt(5),
+    },
+    {
+      field: "snr",
+      headerName: "snr",
+      flex: 1,
+      minWidth: 80,
+      filterable: false,
+      sortable: true,
+      renderCell: fmt(2),
+    },
+  ];
+
+  if (survey === "ZTF") {
+    columns.push({
+      field: "programid",
+      headerName: "programid",
+      flex: 1,
+      minWidth: 100,
+      filterable: true,
+      sortable: true,
+    });
+  }
+
+  return columns;
+};
+
+// ── Photometry plot ───────────────────────────────────────────────────────────
+
+const VegaPlotAlert = React.lazy(() => import("../plot/VegaPlotAlert"));
+
+interface AlertPhotometryPlotProps {
+  objectId: string;
+  jd?: number | null;
+  survey: string;
+}
+
+const AlertPhotometryPlot = ({
+  objectId,
+  jd = null,
+  survey,
+}: AlertPhotometryPlotProps) => {
+  const { data: objectData } = useGetBoomObjectQuery(
+    { survey, id: objectId },
+    { skip: !survey },
+  );
+  const [showUpperLimits, setShowUpperLimits] = useState(true);
+  const [showForcedPhotometry, setShowForcedPhotometry] = useState(true);
+  const [forcedPhotometrySNR, setForcedPhotometrySNR] = useState<any>(3);
+
+  if (!objectData || jd === null) {
+    return <div>Loading photometry...</div>;
+  }
+
+  let photometry: any[] = [];
+  if (typeof objectData === "object") {
+    const detections = (objectData.prv_candidates || []).map((d: any) => ({
+      ...d,
+      origin: "alert",
+    }));
+    const nonDetections = (objectData.prv_nondetections || []).map(
+      (d: any) => ({
+        ...d,
+        magpsf: null,
+        sigmapsf: null,
+        origin: "alert",
+      }),
+    );
+    photometry = detections.concat(nonDetections);
+
+    const fp_hists = showForcedPhotometry
+      ? (objectData.fp_hists || []).map((d: any) => {
+          const point: any = { ...d, origin: "fp" };
+          if (d.snr_psf > forcedPhotometrySNR) {
+            point.magpsf = d.magpsf;
+            point.sigmapsf = d.sigmapsf;
+          } else {
+            point.magpsf = null;
+            point.sigmapsf = null;
+            if (d.magpsf) point.diffmaglim = d.magpsf;
+          }
+          return point;
+        })
+      : [];
+
+    photometry = photometry.concat(fp_hists);
+    if (!showUpperLimits) {
+      photometry = photometry.filter((d: any) => d.magpsf);
+    }
+  }
+
+  if (photometry.length === 0) {
+    return <div>No photometry found</div>;
+  }
+
+  return (
+    <div style={{ width: "100%", height: "90%" }}>
+      <VegaPlotAlert values={photometry} jd={jd} />
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "row",
+          justifyContent: "flex-start",
+          gap: "0.5rem",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "row",
+            alignItems: "center",
+          }}
+        >
+          <Switch
+            checked={showUpperLimits}
+            onChange={() => setShowUpperLimits((v) => !v)}
+            name="showUpperLimits"
+            slotProps={{ input: { "aria-label": "show upper limits" } }}
+          />
+          <div>Upper limits</div>
+        </div>
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "row",
+            alignItems: "center",
+          }}
+        >
+          <Switch
+            checked={showForcedPhotometry}
+            onChange={() => setShowForcedPhotometry((v) => !v)}
+            name="showForcedPhotometry"
+            slotProps={{ input: { "aria-label": "show forced photometry" } }}
+          />
+          <div>Forced photometry</div>
+        </div>
+        <TextField
+          label="SNR Threshold (FP only)"
+          type="number"
+          value={forcedPhotometrySNR}
+          size="small"
+          onChange={(e) => setForcedPhotometrySNR(e.target.value)}
+          slotProps={{ inputLabel: { shrink: true } }}
+        />
+      </div>
+    </div>
+  );
+};
+
+// ── Cross-matches panel ───────────────────────────────────────────────────────
+
+const PRIORITY_COLS = ["_id", "coordinates.distance_arcsec", "ra", "dec"];
+
+const flattenEntry = (entry: any) => {
+  const flat: any = {};
+  Object.entries(entry).forEach(([k, v]) => {
+    if (v !== null && typeof v === "object" && !Array.isArray(v)) {
+      Object.entries(v).forEach(([sk, sv]) => {
+        flat[`${k}.${sk}`] = sv;
+      });
+    } else {
+      flat[k] = v;
+    }
+  });
+  return flat;
+};
+
+const fmtCell = (v: any) => {
+  if (v === null || v === undefined) return "—";
+  if (Array.isArray(v)) return JSON.stringify(v);
+  if (typeof v === "object") return JSON.stringify(v);
+  if (typeof v === "number" && !Number.isInteger(v)) return v.toFixed(5);
+  return String(v);
+};
+
+interface CatalogTableProps {
+  entries: any[];
+}
+
+const CatalogTable = ({ entries }: CatalogTableProps) => {
+  const flat = entries.map(flattenEntry);
+  const allKeys = Array.from(new Set(flat.flatMap((e: any) => Object.keys(e))));
+  const priority = PRIORITY_COLS.filter((c) => allKeys.includes(c));
+  const rest = allKeys.filter((c) => !PRIORITY_COLS.includes(c)).sort();
+  const columns = [...priority, ...rest];
+
+  const cellSx = { padding: "2px 8px", whiteSpace: "nowrap" };
+  return (
+    <TableContainer style={{ overflowX: "auto" }}>
+      <Table size="small" style={{ fontSize: "0.8rem" }}>
+        <TableHead>
+          <TableRow>
+            {columns.map((col) => (
+              <TableCell key={col} sx={{ ...cellSx, fontWeight: 600 }}>
+                {col === "coordinates.distance_arcsec" ? `dist (")` : col}
+              </TableCell>
+            ))}
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {flat.map((row: any, i: number) => (
+            <TableRow key={i} hover>
+              {columns.map((col) => (
+                <TableCell key={col} sx={cellSx}>
+                  {fmtCell(row[col])}
+                </TableCell>
+              ))}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+};
+
+interface CrossMatchesPanelProps {
+  cross_matches: Record<string, any>;
+}
+
+const CrossMatchesPanel = ({ cross_matches }: CrossMatchesPanelProps) => {
+  const allCatalogs = Object.keys(cross_matches).sort();
+  const withMatches = allCatalogs.filter(
+    (k) => Array.isArray(cross_matches[k]) && cross_matches[k].length > 0,
+  );
+  const withoutMatches = allCatalogs.filter(
+    (k) => !Array.isArray(cross_matches[k]) || cross_matches[k].length === 0,
+  );
+
+  if (allCatalogs.length === 0) {
+    return (
+      <Typography variant="body2" style={{ padding: "0.5rem" }}>
+        No cross-matches found.
+      </Typography>
+    );
+  }
+
+  const catalogAccordion = (catalog: string, hasMatches: boolean) => {
+    const entries = cross_matches[catalog];
+    const count = hasMatches ? entries.length : 0;
+    return (
+      <Accordion
+        key={catalog}
+        disableGutters
+        disabled={!hasMatches}
+        defaultExpanded={false}
+        sx={{
+          mb: "0.375rem",
+          "&.Mui-disabled": { backgroundColor: "transparent", opacity: 1 },
+          "&:before": { display: "none" },
+        }}
+      >
+        <AccordionSummary
+          expandIcon={hasMatches ? <ExpandMoreIcon /> : null}
+          style={{ cursor: hasMatches ? "pointer" : "default" }}
+        >
+          <Typography
+            style={{
+              fontWeight: 500,
+              color: hasMatches ? "inherit" : "text.disabled",
+              opacity: hasMatches ? 1 : 0.45,
+              display: "flex",
+              alignItems: "center",
+              gap: "0.4rem",
+            }}
+          >
+            {catalog}
+            <Chip
+              size="small"
+              label={count}
+              color={hasMatches ? "default" : "default"}
+              style={{ opacity: hasMatches ? 1 : 0.45 }}
+            />
+          </Typography>
+        </AccordionSummary>
+        {hasMatches && (
+          <AccordionDetails style={{ padding: "0 0 0.5rem 0" }}>
+            <CatalogTable entries={entries} />
+          </AccordionDetails>
+        )}
+      </Accordion>
+    );
+  };
+
+  const allOrdered = [...withMatches, ...withoutMatches];
+  return (
+    <div>
+      {allOrdered.map((catalog) =>
+        catalogAccordion(catalog, withMatches.includes(catalog)),
+      )}
+    </div>
+  );
+};
+
+// ── Styles ────────────────────────────────────────────────────────────────────
+
+const useStyles = makeStyles()((theme) => ({
+  root: { width: "100%" },
+  itemPadding: { padding: "0.5rem 0 0.5rem 0" },
+  saveAlertButton: { margin: "0.5rem 0 0 0", paddingTop: "0.5rem" },
+  header: { paddingBottom: "0.625rem", color: theme.palette.text.primary },
+  accordionHeading: {
+    fontSize: "1.25rem",
+    fontWeight: theme.typography.fontWeightRegular,
+  },
+  accordionDetails: { width: "100%" },
+  name: {
+    fontSize: "200%",
+    fontWeight: "900",
+    color: "darkgray",
+    display: "inline-block",
+  },
+  alignRight: { display: "inline-block", verticalAlign: "super" },
+  sourceInfo: { display: "flex", flexFlow: "row wrap", alignItems: "center" },
+  position: { fontWeight: "bold", fontSize: "110%" },
+}));
+
+function isString(x: any) {
+  return Object.prototype.toString.call(x) === "[object String]";
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+interface AlertProps {
+  route: any;
+}
+
+const Font: any = "font";
+
+const Alert = ({ route }: AlertProps) => {
+  const objectId = route.id;
+  const survey = inferSurvey(objectId);
+
+  const navigate = useNavigate();
+  const { classes } = useStyles();
+  const [savedSource, setSavedSource] = useState(false);
+  const [fetchedDuplicates, setFetchedDuplicates] = useState(false);
+
+  const [triggerCheckSource] = useCheckSourceMutation();
+  const [triggerGetSource, getSourceResult] = useLazyGetSourceQuery();
+  const [triggerFetchSources, fetchSourcesResult] = useLazyFetchSourcesQuery();
+
+  // RTK Query: read results from the query hooks (no more redux slices).
+  const sources: any = fetchSourcesResult.data;
+  const source: any = getSourceResult.data;
+  const loadedSourceId = getSourceResult.data?.id;
+  const userAccessibleGroups = useGetGroupsQuery().data?.userAccessible ?? [];
+  const userAccessibleGroupIds = useMemo(
+    () => userAccessibleGroups?.map((a: any) => a.id),
+    [userAccessibleGroups],
+  );
+
+  const [candid, setCandid] = useState<any>(null);
+  const [jd, setJd] = useState<any>(null);
+  const [cutoutDataUris, setCutoutDataUris] = useState<any>(null);
+
+  useEffect(() => {
+    if (!objectId || !survey) return;
+    setCutoutDataUris(null);
+    fetch(
+      `/api/boom/surveys/${survey}/alerts/cutouts?objectId=${objectId}&which=brightest&file_format=fits`,
+      { credentials: "include" },
+    )
+      .then((r) => r.json())
+      .then((json) => {
+        if (json.status !== "success" || !json.data) {
+          setCutoutDataUris({});
+          return;
+        }
+        const d = json.data;
+        setCutoutDataUris({
+          new: bytes2image(d.cutoutScience, survey, "science", "bone") ?? null,
+          ref:
+            bytes2image(d.cutoutTemplate, survey, "template", "bone") ?? null,
+          sub:
+            bytes2image(d.cutoutDifference, survey, "difference", "bone") ??
+            null,
+        });
+      })
+      .catch(() => setCutoutDataUris({}));
+  }, [objectId, survey]);
+
+  const [panelXMatchExpanded, setPanelXMatchExpanded] = useState(true);
+  const handlePanelXMatchChange =
+    (panel: any) => (_: any, isExpanded: boolean) =>
+      setPanelXMatchExpanded(isExpanded ? panel : false);
+
+  const { data: alertData, isError: alertError } = useGetAlertDataQuery(
+    { survey: survey as string, id: objectId },
+    { skip: !survey },
+  );
+  const { data: objectData, isError: objectError } = useGetBoomObjectQuery(
+    { survey: survey as string, id: objectId },
+    { skip: !survey },
+  );
+
+  // ── Source existence check ──────────────────────────────────────────────────
+  useEffect(() => {
+    const fetchExistingSource = async () => {
+      const result = await triggerCheckSource({
+        id: objectId,
+        params: { nameOnly: true },
+      });
+      if (
+        result.data?.status === "success" &&
+        result.data?.data?.source_exists === true
+      ) {
+        setSavedSource(true);
+        triggerGetSource(objectId);
+      } else {
+        setSavedSource(false);
+      }
+    };
+    if (objectId !== loadedSourceId) {
+      fetchExistingSource();
+    }
+  }, [objectId]);
+
+  // ── Alert data → default candid/jd + duplicate check ────────────────────────
+  // getAlertData/getBoomObject are fetched by the query hooks above; derive the
+  // default candid/jd (and the duplicate check) once the alerts arrive.
+  useEffect(() => {
+    if (!Array.isArray(alertData) || alertData.length === 0) return;
+
+    const candids = Array.from(new Set(alertData.map((a: any) => getCandid(a))))
+      .filter((c: any) => c != null)
+      .sort();
+    const jds = Array.from(new Set(alertData.map((a: any) => getJd(a))))
+      .filter((j: any) => j != null)
+      .sort();
+
+    if (candids.length === 0) return;
+    setCandid(candids[candids.length - 1]);
+    setJd(jds[jds.length - 1]);
+
+    const lastAlert = alertData.find(
+      (a: any) => getCandid(a) === candids[candids.length - 1],
+    );
+    const ra = getRa(lastAlert);
+    const dec = getDec(lastAlert);
+    if (ra != null && dec != null) {
+      triggerFetchSources({ ra, dec, radius: 2 / 3600 }).then((result: any) => {
+        if (result.data?.["status"] === "success") setFetchedDuplicates(true);
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [alertData]);
+
+  // ── Unknown survey guard ────────────────────────────────────────────────────
+  if (!survey) {
+    return (
+      <div style={{ padding: "1rem" }}>
+        <Typography variant="h5" className={classes.header}>
+          Unknown object format: <b>{objectId}</b>
+        </Typography>
+        <Typography variant="body1">
+          Could not determine the survey from this object ID. Expected a ZTF
+          name (e.g. ZTF21abc...) or an LSST diaObjectId (15+ digit integer).
+        </Typography>
+      </div>
+    );
+  }
+
+  // ── Alert candidate lookup helpers ─────────────────────────────────────────
+  const alertsForObject = Array.isArray(alertData) ? alertData : [];
+
+  const currentAlert = alertsForObject.find(
+    (a: any) => getCandid(a) === candid,
+  );
+
+  const rows = alertsForObject.map((a: any) => buildRow(a, survey));
+  const columns = buildColumns(survey);
+
+  let cross_matches: Record<string, any> = {};
+  if (objectData && !isString(objectData)) {
+    cross_matches = objectData?.cross_matches ?? {};
+  }
+
+  const thumbnails = cutoutDataUris
+    ? [
+        { type: "new", id: 0, public_url: cutoutDataUris.new },
+        { type: "ref", id: 1, public_url: cutoutDataUris.ref },
+        { type: "sub", id: 2, public_url: cutoutDataUris.sub },
+      ]
+    : [];
+
+  // ── Loading / error states ─────────────────────────────────────────────────
+  if (alertData == null && !alertError) {
+    return (
+      <div>
+        <CircularProgress color="secondary" />
+      </div>
+    );
+  }
+  if (alertError || objectError) {
+    return <div>Failed to fetch alert data, please try again later.</div>;
+  }
+  if (alertData?.length === 0) {
+    return (
+      <Typography variant="h5" className={classes.header}>
+        {objectId} not found
+      </Typography>
+    );
+  }
+
+  if (!alertData?.length) {
+    return null;
+  }
+
+  return (
+    <Grid container spacing={2}>
+      {/* ── Header card ─────────────────────────────────────────────────── */}
+      <Grid size={12}>
+        <Paper>
+          <Grid container spacing={0} style={{ paddingBottom: "1rem" }}>
+            {/* Left: metadata, save button */}
+            <Grid size={{ xs: 12, lg: 6 }}>
+              <div
+                style={{
+                  padding: "0.5rem 1rem 0 1rem",
+                  display: "flex",
+                  flexDirection: "column",
+                }}
+              >
+                <div>
+                  <div className={classes.alignRight}>
+                    <SharePage />
+                  </div>
+                  <div className={classes.name}>{objectId}</div>
+                  {objectData?.missing === true && (
+                    <Chip
+                      title="Aux data for this object is temporarily unavailable. Detections were fetched using individual alerts instead."
+                      size="small"
+                      label="Warning: missing aux data"
+                      style={{ backgroundColor: "#E9D502" }}
+                      icon={<WarningAmberIcon />}
+                    />
+                  )}
+                </div>
+
+                {candid !== null && currentAlert && (
+                  <div style={{ display: "flex", flexDirection: "column" }}>
+                    <div>
+                      <b>{survey === "LSST" ? "diaSourceId" : "candid"}:</b>
+                      &nbsp;{candid}
+                    </div>
+                    <div className={classes.sourceInfo}>
+                      <b>Position (J2000):&nbsp;&nbsp;</b>
+                      <span className={classes.position}>
+                        {ra_to_hours(getRa(currentAlert), ":")}
+                        &nbsp;
+                        {dec_to_dms(getDec(currentAlert), ":")}
+                        &nbsp;
+                      </span>
+                    </div>
+                    <div className={classes.sourceInfo}>
+                      <div>
+                        (&alpha;,&delta;= {getRa(currentAlert)}, &nbsp;
+                        {getDec(currentAlert)}
+                        {currentAlert?.coordinates?.b != null && (
+                          <>
+                            ;&nbsp; l,b=
+                            {currentAlert.coordinates?.l?.toFixed(6)}, &nbsp;
+                            {currentAlert.coordinates?.b?.toFixed(6)}
+                          </>
+                        )}
+                        )
+                      </div>
+                    </div>
+                  </div>
+                )}
+
+                {savedSource || loadedSourceId === objectId ? (
+                  <div>
+                    <div className={classes.itemPadding}>
+                      <Chip
+                        size="small"
+                        label="Previously Saved"
+                        clickable
+                        onClick={() => navigate(`/source/${objectId}`)}
+                        onDelete={() =>
+                          window.open(`/source/${objectId}`, "_blank")
+                        }
+                        deleteIcon={<OpenInNewIcon />}
+                        color="primary"
+                      />
+                    </div>
+                    {source?.id === objectId &&
+                      source.groups?.map((group: any) => (
+                        <Tooltip
+                          key={group.id}
+                          title={`Saved at ${group.saved_at} by ${group.saved_by?.username}`}
+                        >
+                          <Chip
+                            label={
+                              group.nickname
+                                ? group.nickname.substring(0, 15)
+                                : group.name.substring(0, 15)
+                            }
+                            size="small"
+                            data-testid={`groupChip_${group.id}`}
+                          />
+                        </Tooltip>
+                      ))}
+                    <div className={classes.itemPadding}>
+                      <div className={classes.saveAlertButton}>
+                        <SaveAlertButton
+                          alert={{
+                            id: objectId,
+                            survey,
+                            candid,
+                            group_ids: userAccessibleGroupIds,
+                          }}
+                          userGroups={userAccessibleGroups}
+                        />
+                      </div>
+                    </div>
+                  </div>
+                ) : (
+                  <div className={classes.itemPadding}>
+                    <Chip size="small" label="NOT SAVED" />
+                    <br />
+                    <div className={classes.saveAlertButton}>
+                      <SaveAlertButton
+                        alert={{
+                          id: objectId,
+                          survey,
+                          candid,
+                          group_ids: userAccessibleGroupIds,
+                        }}
+                        userGroups={userAccessibleGroups}
+                      />
+                    </div>
+                  </div>
+                )}
+
+                {fetchedDuplicates &&
+                  sources?.sources?.length > 0 &&
+                  !(
+                    sources.sources.length === 1 &&
+                    sources.sources[0].id === objectId
+                  ) && (
+                    <div className={classes.sourceInfo}>
+                      <b>
+                        <Font color="#457b9d">Possible duplicate of:</Font>
+                      </b>
+                      &nbsp;
+                      {sources.sources.map(
+                        (dup: any) =>
+                          dup?.id !== objectId && (
+                            <Link
+                              key={dup.id}
+                              to={`/source/${dup.id}`}
+                              role="link"
+                            >
+                              <Button size="small">{dup.id}</Button>
+                            </Link>
+                          ),
+                      )}
+                    </div>
+                  )}
+              </div>
+            </Grid>
+
+            {/* Right: thumbnails + cutout save panel */}
+            <Grid size={{ xs: 12, lg: 6 }}>
+              {candid !== null && (
+                <div
+                  style={{
+                    display: "grid",
+                    gridTemplateColumns: "1fr 1fr 1fr",
+                    gap: "0.5rem",
+                    gridAutoFlow: "row",
+                    padding: "1rem 1rem 0 1rem",
+                  }}
+                >
+                  {cutoutDataUris === null ? (
+                    <CircularProgress size={32} style={{ margin: "auto" }} />
+                  ) : (
+                    <ThumbnailList
+                      ra={getRa(currentAlert)}
+                      dec={getDec(currentAlert)}
+                      thumbnails={thumbnails}
+                      displayTypes={["new", "ref", "sub"]}
+                      useGrid={false}
+                      noMargin
+                      size="100%"
+                      minSize="5rem"
+                      maxSize="24vh"
+                    />
+                  )}
+                </div>
+              )}
+            </Grid>
+          </Grid>
+        </Paper>
+      </Grid>
+
+      {/* ── Photometry plot ──────────────────────────────────────────────── */}
+      <Grid size={12}>
+        <Suspense fallback={<CircularProgress color="secondary" />}>
+          <Paper
+            style={{
+              width: "100%",
+              height: "55vh",
+              padding: "1rem 0.5rem 0.5rem 0.5rem",
+              backgroundColor: "white",
+            }}
+          >
+            <AlertPhotometryPlot objectId={objectId} jd={jd} survey={survey} />
+          </Paper>
+        </Suspense>
+      </Grid>
+
+      {/* ── Alert history table ──────────────────────────────────────────── */}
+      <Grid size={12}>
+        <Paper elevation={1}>
+          <Typography variant="h6" style={{ padding: "0.5rem" }}>
+            Alerts
+          </Typography>
+          <StyledDataGrid
+            autoHeight
+            title="Alerts"
+            rows={rows}
+            columns={columns}
+            getRowId={(row: any) => row.candid}
+            initialState={{
+              sorting: { sortModel: [{ field: "jd", sort: "desc" }] },
+            }}
+            pageSizeOptions={[10, 25, 50, 100]}
+          />
+        </Paper>
+      </Grid>
+
+      {/* ── Cross-matches ────────────────────────────────────────────────── */}
+      <Grid size={12}>
+        <Accordion
+          expanded={panelXMatchExpanded}
+          onChange={handlePanelXMatchChange(true)}
+        >
+          <AccordionSummary
+            expandIcon={<ExpandMoreIcon />}
+            aria-controls="panel-content"
+            id="xmatch-panel-header"
+          >
+            <Typography className={classes.accordionHeading}>
+              Cross-matches
+            </Typography>
+          </AccordionSummary>
+          <AccordionDetails className={classes.accordionDetails}>
+            <CrossMatchesPanel cross_matches={cross_matches} />
+          </AccordionDetails>
+        </Accordion>
+      </Grid>
+    </Grid>
+  );
+};
+
+export default withRouter(Alert);

--- a/static/js/components/alert/Alerts.tsx
+++ b/static/js/components/alert/Alerts.tsx
@@ -1,0 +1,1175 @@
+import { useState, useEffect } from "react";
+import { useSearchParams, Link } from "react-router-dom";
+
+import Card from "@mui/material/Card";
+import CardActions from "@mui/material/CardActions";
+import CardContent from "@mui/material/CardContent";
+
+import TextField from "@mui/material/TextField";
+import InputLabel from "@mui/material/InputLabel";
+import MenuItem from "@mui/material/MenuItem";
+import FormHelperText from "@mui/material/FormHelperText";
+import FormControl from "@mui/material/FormControl";
+import Select from "@mui/material/Select";
+import FormControlLabel from "@mui/material/FormControlLabel";
+import Switch from "@mui/material/Switch";
+import SaveIcon from "@mui/icons-material/Save";
+import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
+import KeyboardArrowRightIcon from "@mui/icons-material/KeyboardArrowRight";
+import IconButton from "@mui/material/IconButton";
+import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import DialogContentText from "@mui/material/DialogContentText";
+import DialogTitle from "@mui/material/DialogTitle";
+import Checkbox from "@mui/material/Checkbox";
+import Chip from "@mui/material/Chip";
+
+import Grid from "@mui/material/Grid";
+
+import { makeStyles } from "tss-react/mui";
+import { useForm, Controller } from "react-hook-form";
+import Paper from "@mui/material/Paper";
+import CircularProgress from "@mui/material/CircularProgress";
+import Tooltip from "@mui/material/Tooltip";
+import Typography from "@mui/material/Typography";
+import {
+  GridToolbarContainer,
+  GridToolbarColumnsButton,
+} from "@mui/x-data-grid";
+
+import { showNotification } from "baselayer/components/Notifications";
+
+import { useAppDispatch } from "../../types/hooks";
+
+import StyledDataGrid from "../StyledDataGrid";
+
+import Button from "../Button";
+import ThumbnailList from "../thumbnail/ThumbnailList";
+import FormValidationError from "../FormValidationError";
+
+import { dms_to_dec, hours_to_ra } from "../../units";
+import { greatCircleDistance } from "../../utils";
+
+import { useSaveAlertAsSourceMutation } from "../../ducks/boom_alert";
+import { useLazyGetAlertsQuery } from "../../ducks/boom_alerts";
+import { useGetGroupsQuery } from "../../ducks/groups";
+import { bytes2image } from "../../utils/imageProcessing";
+
+function isString(x: any) {
+  return Object.prototype.toString.call(x) === "[object String]";
+}
+
+function inferSurvey(objectId: any): string | null {
+  if (!objectId) return null;
+  if (objectId.toUpperCase().startsWith("ZTF")) return "ZTF";
+  // WINTER objectIds are WNTR-prefixed (e.g. WNTR26capcd); BOOM knows the
+  // survey as WINTER, so bridge the two namespaces here.
+  if (objectId.toUpperCase().startsWith("WNTR")) return "WINTER";
+  if (/^\d{15,}$/.test(objectId)) return "LSST";
+  return null;
+}
+
+const useStyles = makeStyles()((theme) => ({
+  root: {
+    margin: 0,
+    padding: 0,
+    width: "100%",
+    "& > *": {
+      margin: 0,
+      padding: 0,
+    },
+  },
+  cardContent: {
+    padding: "0.75rem",
+    paddingBottom: 0,
+  },
+  cardActions: {
+    padding: "0.75rem",
+  },
+  whitish: {
+    color: "#f0f0f0",
+  },
+  visuallyHidden: {
+    border: 0,
+    clip: "rect(0 0 0 0)",
+    height: 1,
+    margin: -1,
+    overflow: "hidden",
+    padding: 0,
+    position: "absolute",
+    top: 20,
+    width: 1,
+  },
+  search_button: {
+    color: "#f0f0f0 !important",
+  },
+  margin_bottom: {
+    "margin-bottom": "2em",
+  },
+  margin_left: {
+    "margin-left": "2em",
+  },
+  image: {
+    padding: theme.spacing(1),
+    textAlign: "center",
+    color: theme.palette.text.secondary,
+  },
+  paper: {
+    padding: theme.spacing(2),
+    textAlign: "center",
+    color: theme.palette.text.secondary,
+  },
+  formControl: {
+    width: "100%",
+  },
+  selectEmpty: {
+    width: "100%",
+  },
+  header: {
+    paddingBottom: "0.625rem",
+  },
+  button: {
+    textTransform: "none",
+  },
+  wrapperRoot: {
+    display: "flex",
+    alignItems: "center",
+  },
+  wrapper: {
+    margin: 0,
+    position: "relative",
+  },
+  buttonProgress: {
+    color: theme.palette.text.secondary,
+    position: "absolute",
+    top: "50%",
+    left: "50%",
+    marginTop: -12,
+    marginLeft: -12,
+  },
+  grid_item_table: {
+    order: 2,
+    [theme.breakpoints.up("lg")]: {
+      order: 1,
+    },
+  },
+  grid_item_search_box: {
+    order: 1,
+    [theme.breakpoints.up("lg")]: {
+      order: 2,
+    },
+  },
+  marginTop: {
+    marginTop: "1em",
+  },
+}));
+
+interface CutoutTripletProps {
+  rowObj: any;
+  survey: string;
+}
+
+const CutoutTriplet = ({ rowObj, survey }: CutoutTripletProps) => {
+  const [dataUris, setDataUris] = useState<any>(null);
+
+  useEffect(() => {
+    const query = rowObj.candid
+      ? `candid=${rowObj.candid}`
+      : `objectId=${rowObj.objectId}&which=last`;
+    fetch(
+      `/api/boom/surveys/${survey}/alerts/cutouts?${query}&file_format=fits`,
+      {
+        credentials: "include",
+      },
+    )
+      .then((r) => r.json())
+      .then((json) => {
+        if (json.status !== "success" || !json.data) {
+          setDataUris({});
+          return;
+        }
+        const d = json.data;
+        setDataUris({
+          new: bytes2image(d.cutoutScience, survey, "science", "bone") ?? null,
+          ref:
+            bytes2image(d.cutoutTemplate, survey, "template", "bone") ?? null,
+          sub:
+            bytes2image(d.cutoutDifference, survey, "difference", "bone") ??
+            null,
+        });
+      })
+      .catch(() => setDataUris({}));
+  }, [rowObj.candid, rowObj.objectId, survey]);
+
+  return dataUris === null ? (
+    <CircularProgress size={32} />
+  ) : (
+    <ThumbnailList
+      thumbnails={[
+        { type: "new", id: 0, public_url: dataUris.new },
+        { type: "ref", id: 1, public_url: dataUris.ref },
+        { type: "sub", id: 2, public_url: dataUris.sub },
+      ]}
+      ra={rowObj.ra}
+      dec={rowObj.dec}
+      displayTypes={["new", "ref", "sub"]}
+    />
+  );
+};
+
+const Alerts = () => {
+  const dispatch = useAppDispatch();
+  const { classes } = useStyles();
+
+  const [searchParams] = useSearchParams();
+
+  const { register, handleSubmit, control, getValues, reset, setValue } =
+    useForm();
+
+  const [
+    triggerGetAlerts,
+    { data: alerts = null, isFetching: queryInProgress },
+  ] = useLazyGetAlertsQuery();
+  const [saveAlertAsSource] = useSaveAlertAsSourceMutation();
+  // RTK Query: groups come from the query hook (no more redux slice).
+  const groups = useGetGroupsQuery().data?.userAccessible ?? [];
+
+  // save alerts to SP in bulk (by objectID)
+  const [selectedSurvey, setSelectedSurvey] = useState("ZTF");
+
+  const [groupByObj, setGroupByObj] = useState(false);
+  const [saveDialogOpen, setSaveDialogOpen] = useState(false);
+  const [rowsToSave, setRowsToSave] = useState<any[]>([]);
+  const [selectedGroups, setSelectedGroups] = useState<any[]>([]);
+  const [saving, setSaving] = useState(false);
+  // Object IDs of the rows currently selected via the DataGrid checkboxes.
+  const [selectedRowIds, setSelectedRowIds] = useState<any[]>([]);
+  // candids of the rows whose cutout-triplet pull-out panel is expanded.
+  const [openedRows, setOpenedRows] = useState<any[]>([]);
+
+  useEffect(() => {
+    const objectId = searchParams.get("objectId");
+    const ra = parseFloat(searchParams.get("ra") as any);
+    const dec = parseFloat(searchParams.get("dec") as any);
+    let radius = parseFloat(searchParams.get("radius") as any);
+    let radius_unit = searchParams.get("radius_unit");
+    const group_by = searchParams.get("group_by_obj");
+    const surveyParam = searchParams.get("survey");
+
+    if (!objectId && (Number.isNaN(ra) || Number.isNaN(dec))) {
+      return;
+    }
+
+    // Explicit survey param takes priority; infer from objectId as fallback
+    const inferredSurvey = inferSurvey(objectId);
+    const survey = surveyParam?.toUpperCase() || inferredSurvey || "ZTF";
+    setSelectedSurvey(survey);
+
+    // Use objectId search only when the objectId belongs to the target survey
+    const objectIdMatchesSurvey = !inferredSurvey || inferredSurvey === survey;
+
+    if (objectId && objectIdMatchesSurvey) {
+      triggerGetAlerts({ survey, object_id: objectId } as any);
+      reset({ object_id: objectId, instrument: survey.toLowerCase() });
+    } else if (!Number.isNaN(ra) && !Number.isNaN(dec)) {
+      if (!["arcsec", "arcmin", "deg", "rad"].includes(radius_unit as any)) {
+        radius_unit = "arcsec";
+      }
+      if (Number.isNaN(radius)) {
+        radius = 3.0;
+      }
+      triggerGetAlerts({
+        survey,
+        ra,
+        dec,
+        radius,
+        radius_unit,
+      } as any);
+      reset({ ra, dec, radius, radius_unit, instrument: survey.toLowerCase() });
+    }
+
+    if ([true, "true", "t", "1", 1].includes(group_by as any)) {
+      setGroupByObj(true);
+    }
+  }, [dispatch, searchParams]);
+
+  const makeRow = (alert: any, survey: string | null) => {
+    const isLSST = survey === "LSST";
+    const isZTF = survey === "ZTF";
+    return {
+      objectId: alert?.objectId,
+      candid: isLSST
+        ? (alert?.diaSourceId ?? alert?.candid ?? alert?._id)
+        : (alert?.candid ?? alert?.candidate?.candid ?? alert?._id),
+      jd: alert?.candidate?.jd,
+      ra: alert?.candidate?.ra ?? alert?.candidate?.coord_ra,
+      dec: alert?.candidate?.dec ?? alert?.candidate?.coord_dec,
+      band: alert?.candidate?.band,
+      magpsf: alert?.candidate?.magpsf,
+      sigmapsf: alert?.candidate?.sigmapsf,
+      isdiffpos: alert?.candidate?.isdiffpos,
+      // Real/bogus-style score: ZTF drb, LSST reliability, WINTER scorr.
+      drb: isLSST
+        ? alert?.candidate?.reliability
+        : isZTF
+          ? alert?.candidate?.drb
+          : alert?.candidate?.scorr,
+      snr: alert?.candidate?.snr_psf,
+      ...(isLSST ? {} : { programid: alert?.candidate?.programid }),
+      // ACAI/BTSbot are ZTF-specific classifiers; other surveys (e.g. WINTER)
+      // don't carry them.
+      ...(isZTF
+        ? {
+            acai_h: alert?.classifications?.acai_h,
+            acai_n: alert?.classifications?.acai_n,
+            acai_o: alert?.classifications?.acai_o,
+            acai_v: alert?.classifications?.acai_v,
+            acai_b: alert?.classifications?.acai_b,
+            btsbot: alert?.classifications?.btsbot,
+          }
+        : {}),
+    };
+  };
+
+  // Infer the survey from what's actually loaded rather than the form state,
+  // so changing the instrument dropdown doesn't corrupt the existing results.
+  const dataSurvey =
+    (alerts?.length > 0 && inferSurvey(alerts[0]?.objectId)) || selectedSurvey;
+
+  let rows: any[] = [];
+
+  if (alerts !== null && !isString(alerts) && Array.isArray(alerts)) {
+    rows = alerts.map((a: any) => makeRow(a, dataSurvey));
+  }
+
+  if (groupByObj === true && rows.length > 0) {
+    // first find the unique objectIds
+    const uniqueObjectIds = Array.from(
+      new Set(rows.map((row: any) => row.objectId)),
+    );
+    // then build the new rows, which only contain the latest alert for each objectId
+    // (highest jd)
+    rows = uniqueObjectIds.map((objectId) => {
+      const alertsForObject = rows.filter(
+        (row: any) => row.objectId === objectId,
+      );
+      const latestAlert = alertsForObject.reduce((a: any, b: any) =>
+        a.jd > b.jd ? a : b,
+      );
+      return latestAlert;
+    });
+    // add the separation between the ra and dec used in the form
+    rows = rows.map((row: any) => {
+      const { ra, dec } = getValues();
+      const separation = greatCircleDistance(ra, dec, row.ra, row.dec);
+      return { ...row, separation };
+    });
+  }
+
+  const handleSaveDialogClose = () => {
+    if (!saving) {
+      setRowsToSave([]);
+      setSaveDialogOpen(false);
+    }
+  };
+
+  const handleSaveDialogOpen = async (objectIds: any[]) => {
+    setRowsToSave(objectIds);
+    setSaveDialogOpen(true);
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    const { instrument } = getValues();
+    const survey = (instrument || "ztf").toUpperCase();
+    const objectIds = rowsToSave;
+    objectIds.forEach((objectId: any) => {
+      const payload = {
+        group_ids: selectedGroups,
+      };
+      saveAlertAsSource({ survey, id: objectId, payload })
+        .unwrap()
+        .then(() => {
+          dispatch(
+            showNotification(
+              `Saved ${objectId} to groups ${selectedGroups.join(", ")}`,
+            ),
+          );
+        })
+        .catch(() => {
+          dispatch(
+            showNotification(
+              `Failed to save ${objectId} to groups ${selectedGroups.join(
+                ", ",
+              )}`,
+              "error",
+            ),
+          );
+        });
+    });
+    setSaving(false);
+    setSaveDialogOpen(false);
+  };
+
+  // DataGrid row id: the candid uniquely identifies an alert (and, in grouped
+  // mode, the single latest alert per objectId). Synthetic detail rows append
+  // "__detail" to their parent's candid.
+  const getRowId = (row: any) =>
+    row.__detail ? `${row.candid}__detail` : row.candid;
+
+  const toggleExpand = (candid: any) =>
+    setOpenedRows((prev) =>
+      prev.includes(candid)
+        ? prev.filter((c: any) => c !== candid)
+        : [...prev, candid],
+    );
+
+  // Map each selectable row id (candid) to its objectId so the bulk-save action
+  // can recover the object ids from the selection model.
+  const objectIdByRowId: Record<string, any> = {};
+  rows.forEach((row: any) => {
+    objectIdByRowId[row.candid] = row.objectId;
+  });
+
+  const isLSST = dataSurvey === "LSST";
+  const isZTF = dataSurvey === "ZTF";
+
+  const compactHeaderClass = "alerts-compact-cell";
+
+  const expandColumn: any = {
+    field: "__expand",
+    headerName: "",
+    width: 56,
+    sortable: false,
+    filterable: false,
+    hideable: false,
+    disableColumnMenu: true,
+    // For a synthetic detail row, span the full width of the grid; otherwise a
+    // single cell holding the expand toggle.
+    colSpan: (_value: any, row: any) => (row.__detail ? 100 : 1),
+    renderCell: (params: any) => {
+      if (params.row.__detail) {
+        const rowObj = params.row.__source;
+        return (
+          <Grid
+            container
+            direction="row"
+            spacing={3}
+            sx={{ justifyContent: "center", alignItems: "center" }}
+            data-testid={`alertRow_${rowObj.candid}`}
+          >
+            <Grid>
+              <CutoutTriplet
+                rowObj={rowObj}
+                survey={inferSurvey(rowObj.objectId) || dataSurvey}
+              />
+            </Grid>
+          </Grid>
+        );
+      }
+      const expanded = openedRows.includes(params.row.candid);
+      return (
+        <IconButton
+          id="expandable-button"
+          size="small"
+          aria-label="expand row"
+          onClick={() => toggleExpand(params.row.candid)}
+        >
+          {expanded ? <KeyboardArrowDownIcon /> : <KeyboardArrowRightIcon />}
+        </IconButton>
+      );
+    },
+  };
+
+  const objectIdColumn: any = {
+    field: "objectId",
+    headerName: "Object ID",
+    flex: 1,
+    minWidth: 130,
+    sortingOrder: ["desc", "asc", null],
+    renderCell: (params: any) => {
+      const value = params.value;
+      return (
+        <Link
+          to={`/alerts/${(
+            inferSurvey(value) || dataSurvey
+          ).toLowerCase()}/${value}`}
+          target="_blank"
+          data-testid={value}
+          rel="noreferrer"
+        >
+          <Button className={classes.button} size="small" variant="contained">
+            {value}
+          </Button>
+        </Link>
+      );
+    },
+  };
+
+  const candidColumn: any = {
+    field: "candid",
+    headerName: dataSurvey === "LSST" ? "diaSourceId" : "candid",
+    flex: 1,
+    minWidth: 120,
+    filterable: false,
+  };
+
+  const positionColumns: any[] = [
+    {
+      field: "ra",
+      headerName: "R.A.",
+      flex: 1,
+      minWidth: 100,
+      filterable: false,
+      renderCell: (params: any) => params.value?.toFixed(5),
+    },
+    {
+      field: "dec",
+      headerName: "Decl.",
+      flex: 1,
+      minWidth: 100,
+      filterable: false,
+      renderCell: (params: any) => params.value?.toFixed(6),
+    },
+  ];
+
+  const separationColumn: any = {
+    field: "separation",
+    headerName: "Separation",
+    flex: 1,
+    minWidth: 110,
+    filterable: false,
+    renderCell: (params: any) =>
+      params.value != null ? `${params.value.toFixed(2)}"` : "",
+  };
+
+  const mlScoreColumn = (field: string, headerName: string): any => ({
+    field,
+    headerName,
+    flex: 1,
+    minWidth: 90,
+    filterable: false,
+    headerClassName: compactHeaderClass,
+    cellClassName: compactHeaderClass,
+    renderCell: (params: any) => params.value?.toFixed(2),
+  });
+
+  const surveyColumns: any[] = [
+    {
+      field: "jd",
+      headerName: isLSST ? "MJD" : "JD",
+      flex: 1,
+      minWidth: 110,
+      filterable: false,
+      sortingOrder: ["desc", "asc", null],
+      renderCell: (params: any) => params.value?.toFixed(5),
+    },
+    ...positionColumns,
+    {
+      field: "band",
+      headerName: "band",
+      flex: 1,
+      minWidth: 80,
+      headerClassName: compactHeaderClass,
+    },
+    {
+      field: "magpsf",
+      headerName: "magpsf",
+      flex: 1,
+      minWidth: 130,
+      filterable: false,
+      cellClassName: "alerts-nowrap-cell",
+      renderCell: (params: any) => {
+        const mag = params.row.magpsf;
+        const sigma = params.row.sigmapsf;
+        if (mag == null) return "—";
+        return sigma != null
+          ? `${mag.toFixed(3)} ± ${sigma.toFixed(3)}`
+          : mag.toFixed(3);
+      },
+    },
+    {
+      field: "snr",
+      headerName: "snr",
+      flex: 1,
+      minWidth: 80,
+      filterable: false,
+      headerClassName: compactHeaderClass,
+      cellClassName: compactHeaderClass,
+      renderCell: (params: any) => params.value?.toFixed(2),
+    },
+    {
+      field: "isdiffpos",
+      headerName: "isdiffpos",
+      flex: 1,
+      minWidth: 100,
+      renderCell: (params: any) =>
+        params.value != null ? String(params.value) : "—",
+    },
+    {
+      field: "drb",
+      headerName: isLSST ? "reliability" : isZTF ? "drb" : "scorr",
+      flex: 1,
+      minWidth: 100,
+      filterable: false,
+      headerClassName: compactHeaderClass,
+      cellClassName: compactHeaderClass,
+      renderCell: (params: any) => params.value?.toFixed(2),
+    },
+    ...(!isLSST
+      ? [
+          {
+            field: "programid",
+            headerName: "programid",
+            flex: 1,
+            minWidth: 100,
+            headerClassName: compactHeaderClass,
+          },
+        ]
+      : []),
+    // ACAI/BTSbot are ZTF-specific classifiers; don't show them for other surveys.
+    ...(isZTF
+      ? [
+          mlScoreColumn("acai_h", "acai_h"),
+          mlScoreColumn("acai_n", "acai_n"),
+          mlScoreColumn("acai_o", "acai_o"),
+          mlScoreColumn("acai_v", "acai_v"),
+          mlScoreColumn("acai_b", "acai_b"),
+          mlScoreColumn("btsbot", "BTSbot"),
+        ]
+      : []),
+  ];
+
+  const columns: any[] = [
+    expandColumn,
+    objectIdColumn,
+    candidColumn,
+    ...surveyColumns,
+  ];
+
+  if (groupByObj) {
+    const { ra, dec, object_id } = getValues();
+    if (ra && dec && !object_id) {
+      // insert separation after the dec column
+      // (index 5: __expand, objectId, candid, jd, ra, dec)
+      columns.splice(6, 0, separationColumn);
+    }
+  }
+
+  // sigmapsf is folded into the magpsf cell, so it is never shown as its own
+  // column (matches the old display:false). candid stays visible as before.
+  const columnVisibilityModel = { sigmapsf: false };
+
+  // Default sort: separation ascending in positional grouped mode, otherwise
+  // most-recent (jd) first.
+  const useSeparationSort =
+    groupByObj && getValues()["ra"] && getValues()["dec"];
+  const sortModel: any[] = [
+    useSeparationSort
+      ? { field: "separation", sort: "asc" }
+      : { field: "jd", sort: "desc" },
+  ];
+
+  // Interleave a synthetic full-width detail row after each expanded alert so
+  // the cutout-triplet pull-out renders inline (DataGrid community edition has
+  // no native master-detail). getRowHeight lets those rows size to content.
+  const displayRows: any[] = [];
+  rows.forEach((row: any) => {
+    displayRows.push(row);
+    if (openedRows.includes(row.candid)) {
+      displayRows.push({ candid: row.candid, __detail: true, __source: row });
+    }
+  });
+
+  const getRowHeight = (params: any) => (params.model.__detail ? "auto" : null);
+
+  const CustomToolbar = () => (
+    <GridToolbarContainer>
+      <GridToolbarColumnsButton />
+      <FormControlLabel
+        control={
+          <Switch
+            checked={groupByObj}
+            onChange={() => setGroupByObj(!groupByObj)}
+            name="groupAlerts"
+            color="primary"
+          />
+        }
+        label="Group by Object ID"
+      />
+      {groupByObj && selectedRowIds.length > 0 && (
+        <Tooltip title="Save selected alerts as sources">
+          <IconButton
+            aria-label="save"
+            data-testid="save-selected-alerts-button"
+            onClick={() => {
+              const objectIds = Array.from(
+                new Set(
+                  selectedRowIds
+                    .map((rowId: any) => objectIdByRowId[rowId])
+                    .filter(Boolean),
+                ),
+              );
+              handleSaveDialogOpen(objectIds);
+            }}
+            size="large"
+          >
+            <SaveIcon />
+          </IconButton>
+        </Tooltip>
+      )}
+    </GridToolbarContainer>
+  );
+
+  const formSubmit = async () => {
+    let { object_id, ra, dec, radius, radius_unit, instrument } = getValues();
+    let survey = (instrument || "ztf").toUpperCase();
+
+    if (object_id?.trim()) {
+      const inferred = inferSurvey(object_id.trim());
+      if (inferred && inferred !== survey) {
+        survey = inferred;
+        setValue("instrument", inferred.toLowerCase());
+        dispatch(
+          showNotification(
+            `Survey changed to ${inferred} based on the object ID format.`,
+            "warning",
+          ),
+        );
+      }
+    }
+
+    setSelectedSurvey(survey);
+    ra = ra?.toString();
+    dec = dec?.toString();
+    radius = radius?.toString();
+
+    if (!object_id?.length && !ra?.length && !dec?.length && !radius?.length) {
+      dispatch(
+        showNotification(
+          `You must either specify an object ID, a position`,
+          "error",
+        ),
+      );
+      return;
+    }
+
+    if (object_id?.length) {
+      object_id = object_id.trim();
+    }
+
+    // check that if positional query is requested then all required data are supplied
+    if (
+      (ra?.length || dec?.length || radius?.length) &&
+      !(ra?.length && dec?.length && radius?.length)
+    ) {
+      dispatch(
+        showNotification(
+          `Positional parameters, if specified, must be all set`,
+          "error",
+        ),
+      );
+    } else {
+      const hadPositionalParams = !!(
+        ra?.length ||
+        dec?.length ||
+        radius?.length
+      );
+      if (ra?.length) {
+        if (
+          ra?.includes(":") ||
+          ra?.includes("h") ||
+          ra?.includes("m") ||
+          ra?.includes("s")
+        ) {
+          ra = ra.replace(/h|m/g, ":").replace(/s/g, "");
+          ra = hours_to_ra(ra);
+        } else {
+          ra = parseFloat(ra);
+        }
+      }
+      if (dec?.length) {
+        if (
+          dec?.includes(":") ||
+          dec?.includes("d") ||
+          dec?.includes("m") ||
+          dec?.includes("s")
+        ) {
+          dec = dec.replace(/d|m/g, ":").replace(/s/g, "");
+          dec = dms_to_dec(dec);
+        } else {
+          dec = parseFloat(dec);
+        }
+      }
+      if (radius_unit === "arcmin") {
+        //convert arcmin to arcsec
+        radius = parseFloat(radius) * 60;
+      } else if (radius_unit === "deg") {
+        //convert deg to arcsec
+        radius = parseFloat(radius) * 3600;
+      } else if (radius_unit === "rad") {
+        //convert rad to arcsec
+        radius = parseFloat(radius) * 206264.80624709636;
+      } else {
+        radius = parseFloat(radius);
+      }
+
+      if (object_id?.length) {
+        if (hadPositionalParams) {
+          dispatch(
+            showNotification(
+              `Object ID specified, ignored positional parameters`,
+              "warning",
+            ),
+          );
+        }
+        ra = null;
+        dec = null;
+        radius = null;
+      } else if (
+        Number.isNaN(parseFloat(ra)) ||
+        Number.isNaN(parseFloat(dec)) ||
+        Number.isNaN(parseFloat(radius))
+      ) {
+        dispatch(showNotification(`Invalid positional parameters`, "error"));
+        return;
+      }
+      if (object_id?.indexOf(",") > -1) {
+        const object_id_split = object_id.split(",");
+        triggerGetAlerts({
+          survey,
+          object_id: object_id_split,
+          ra,
+          dec,
+          radius,
+        } as any);
+      } else {
+        triggerGetAlerts({ survey, object_id, ra, dec, radius } as any);
+      }
+    }
+  };
+
+  return (
+    <>
+      <div>
+        <Grid
+          container
+          direction="row"
+          spacing={1}
+          sx={{ justifyContent: "flex-start", alignItems: "flex-start" }}
+        >
+          <Grid size={{ xs: 12, lg: 10 }} className={classes.grid_item_table}>
+            <Paper elevation={1}>
+              <div className={(classes as any).maindiv}>
+                <div className={(classes as any).accordionDetails}>
+                  <Typography variant="h6" style={{ padding: "0.5rem" }}>
+                    {groupByObj ? "Alerts (grouped by Object ID)" : "Alerts"}
+                  </Typography>
+                  {queryInProgress ? (
+                    <CircularProgress />
+                  ) : (
+                    <StyledDataGrid
+                      autoHeight
+                      rows={displayRows}
+                      columns={columns}
+                      getRowId={getRowId}
+                      getRowHeight={getRowHeight}
+                      columnVisibilityModel={columnVisibilityModel}
+                      sortModel={sortModel}
+                      checkboxSelection={groupByObj}
+                      isRowSelectable={(params: any) => !params.row.__detail}
+                      rowSelectionModel={{
+                        type: "include",
+                        ids: new Set(selectedRowIds),
+                      }}
+                      onRowSelectionModelChange={(model: any) =>
+                        setSelectedRowIds(Array.from(model.ids))
+                      }
+                      // Keep all columns mounted so the detail row's colSpan
+                      // works (column virtualization conflicts with colSpan).
+                      columnBufferPx={3000}
+                      pageSizeOptions={[10, 25, 50, 100]}
+                      initialState={{
+                        pagination: { paginationModel: { pageSize: 10 } },
+                      }}
+                      slots={{ toolbar: CustomToolbar }}
+                      showToolbar
+                      sx={{
+                        "& .alerts-compact-cell": {
+                          padding: "4px 4px 4px 4px",
+                        },
+                        "& .alerts-nowrap-cell": {
+                          whiteSpace: "nowrap",
+                        },
+                      }}
+                    />
+                  )}
+                </div>
+              </div>
+            </Paper>
+          </Grid>
+          <Grid
+            size={{ xs: 12, lg: 2 }}
+            className={classes.grid_item_search_box}
+          >
+            <Card className={classes.root}>
+              <form onSubmit={handleSubmit(formSubmit)}>
+                <CardContent className={classes.cardContent}>
+                  <FormControl required className={classes.selectEmpty}>
+                    <InputLabel
+                      {...({
+                        name: "alert-stream-select-required-label",
+                      } as any)}
+                    >
+                      Instrument
+                    </InputLabel>
+                    <Controller
+                      {...({
+                        labelId: "alert-stream-select-required-label",
+                      } as any)}
+                      name="instrument"
+                      control={control}
+                      rules={{ required: true }}
+                      render={({ field: { onChange, value } }) => (
+                        <Select
+                          value={value || "ztf"}
+                          onChange={(e) => {
+                            onChange(e);
+                          }}
+                          defaultValue="ztf"
+                        >
+                          <MenuItem value="ztf">ZTF</MenuItem>
+                          <MenuItem value="lsst">LSST</MenuItem>
+                          <MenuItem value="winter">WINTER</MenuItem>
+                        </Select>
+                      )}
+                    />
+                    <FormHelperText>Required</FormHelperText>
+                  </FormControl>
+                  <Controller
+                    render={({ field: { onChange, value } }) => (
+                      <TextField
+                        autoFocus
+                        margin="dense"
+                        name="object_id"
+                        label="objectId"
+                        type="text"
+                        fullWidth
+                        inputRef={
+                          register("object_id", {
+                            minLength: 3,
+                            required: false,
+                          }) as any
+                        }
+                        value={value}
+                        onChange={onChange}
+                      />
+                    )}
+                    name="object_id"
+                    control={control}
+                  />
+                  <Controller
+                    render={({ field: { onChange, value } }) => (
+                      <TextField
+                        margin="dense"
+                        name="ra"
+                        label="RA [deg, HH:MM:SS, HHhMMmSSs]"
+                        fullWidth
+                        inputRef={register("ra", { required: false }) as any}
+                        value={value}
+                        onChange={onChange}
+                      />
+                    )}
+                    name="ra"
+                    control={control}
+                  />
+                  <Controller
+                    render={({ field: { onChange, value } }) => (
+                      <TextField
+                        margin="dense"
+                        name="dec"
+                        label="Dec [deg, DD:MM:SS, DDdMMmSSs]"
+                        fullWidth
+                        inputRef={register("dec", { required: false }) as any}
+                        value={value}
+                        onChange={onChange}
+                      />
+                    )}
+                    name="dec"
+                    control={control}
+                  />
+                  <div
+                    style={{
+                      display: "flex",
+                      flexDirection: "row",
+                      justifyContent: "space-between",
+                      gap: "0.5rem",
+                    }}
+                  >
+                    <Controller
+                      render={({ field: { onChange, value } }) => (
+                        <TextField
+                          margin="dense"
+                          name="radius"
+                          label="Radius"
+                          fullWidth
+                          inputRef={
+                            register("radius", { required: false }) as any
+                          }
+                          value={value}
+                          onChange={onChange}
+                        />
+                      )}
+                      name="radius"
+                      control={control}
+                    />
+                    <Controller
+                      {...({
+                        labelId: "radius-unit-select-required-label",
+                      } as any)}
+                      name="radius_unit"
+                      control={control}
+                      rules={{ required: true }}
+                      render={({ field: { onChange, value } }) => (
+                        <Select
+                          value={value}
+                          onChange={onChange}
+                          defaultValue="arcsec"
+                          inputRef={
+                            register("radius_unit", { required: true }) as any
+                          }
+                          {...({ margin: "dense" } as any)}
+                          fullWidth
+                          style={{
+                            height: "3.5rem",
+                            marginTop: "8px",
+                            marginBottom: "4px",
+                          }}
+                        >
+                          <MenuItem value="arcsec">arcsec</MenuItem>
+                          <MenuItem value="arcmin">arcmin</MenuItem>
+                          <MenuItem value="deg">deg</MenuItem>
+                          <MenuItem value="rad">rad</MenuItem>
+                        </Select>
+                      )}
+                    />
+                  </div>
+                </CardContent>
+                <CardActions className={classes.cardActions}>
+                  <div className={classes.wrapperRoot}>
+                    <div className={classes.wrapper}>
+                      <Button
+                        type="submit"
+                        variant="contained"
+                        color="primary"
+                        onClick={() => formSubmit()}
+                        disabled={queryInProgress}
+                      >
+                        Search
+                      </Button>
+                      {queryInProgress && (
+                        <CircularProgress
+                          size={24}
+                          color="secondary"
+                          className={classes.buttonProgress}
+                        />
+                      )}
+                    </div>
+                  </div>
+                </CardActions>
+              </form>
+            </Card>
+          </Grid>
+        </Grid>
+        <Dialog
+          open={saveDialogOpen}
+          onClose={handleSaveDialogClose}
+          aria-labelledby="responsive-dialog-title"
+          maxWidth="md"
+        >
+          <DialogTitle id="responsive-dialog-title">
+            Save Alert(s) as Source(s)
+          </DialogTitle>
+          <DialogContent>
+            <DialogContentText>
+              Save the following alert(s) as source(s) to the selected group(s):
+            </DialogContentText>
+            <div
+              style={{
+                display: "flex",
+                flexDirection: "row",
+                flexWrap: "wrap",
+                width: "100%",
+              }}
+            >
+              {(rowsToSave || []).map((objectId: any) => (
+                <Chip key={objectId} label={`${objectId}`} />
+              ))}
+            </div>
+            <DialogContentText className={classes.marginTop}>
+              Select groups to save new source to:
+            </DialogContentText>
+            {selectedGroups?.length === 0 && (
+              <FormValidationError message="Select at least one group." />
+            )}
+            <div
+              style={{
+                display: "flex",
+                flexDirection: "row",
+                flexWrap: "wrap",
+                width: "100%",
+              }}
+            >
+              {groups.map((group: any) => (
+                <div key={group.id}>
+                  <Checkbox
+                    color="primary"
+                    checked={selectedGroups.includes(group.id)}
+                    onChange={(e) => {
+                      if (e.target.checked) {
+                        setSelectedGroups((prev) => [...prev, group.id]);
+                      } else {
+                        setSelectedGroups(
+                          selectedGroups.filter((g: any) => g !== group.id),
+                        );
+                      }
+                    }}
+                  />
+                  {group.nickname || group.name}
+                </div>
+              ))}
+            </div>
+          </DialogContent>
+          <DialogActions>
+            <Button
+              variant="contained"
+              color="primary"
+              className={classes.search_button}
+              type="submit"
+              data-testid="save-dialog-submit"
+              onClick={() => handleSave()}
+              disabled={
+                selectedGroups?.length === 0 ||
+                rowsToSave?.length === 0 ||
+                saving
+              }
+            >
+              Save
+            </Button>
+            <Button
+              autoFocus
+              onClick={handleSaveDialogClose}
+              color="primary"
+              disabled={saving}
+            >
+              Dismiss
+            </Button>
+          </DialogActions>
+        </Dialog>
+      </div>
+    </>
+  );
+};
+
+export default Alerts;

--- a/static/js/components/alert/AlertsSearchButton.tsx
+++ b/static/js/components/alert/AlertsSearchButton.tsx
@@ -1,0 +1,38 @@
+import { Link } from "react-router-dom";
+
+interface AlertsSearchButtonProps {
+  ra?: number;
+  dec?: number;
+  radius?: number;
+  survey?: string;
+  objectId?: string | null;
+}
+
+const AlertsSearchButton = ({
+  ra,
+  dec,
+  radius = 3,
+  survey = "ZTF",
+  objectId = null,
+}: AlertsSearchButtonProps) => {
+  const params = new URLSearchParams();
+  params.set("survey", survey);
+  params.set("group_by_obj", "true");
+  if (objectId) params.set("objectId", objectId);
+  if (ra != null) {
+    params.set("ra", String(ra));
+    params.set("dec", String(dec));
+    params.set("radius", String(radius));
+  }
+  return (
+    <Link
+      to={`/alerts?${params.toString()}`}
+      target="_blank"
+      style={{ textDecoration: "none", color: "black" }}
+    >
+      {survey} Alerts
+    </Link>
+  );
+};
+
+export default AlertsSearchButton;

--- a/static/js/components/alert/CopyAlertPhotometryDialog.tsx
+++ b/static/js/components/alert/CopyAlertPhotometryDialog.tsx
@@ -1,0 +1,135 @@
+import { useForm, Controller } from "react-hook-form";
+
+import Dialog from "@mui/material/Dialog";
+import DialogContent from "@mui/material/DialogContent";
+import DialogTitle from "@mui/material/DialogTitle";
+import Checkbox from "@mui/material/Checkbox";
+import FormControlLabel from "@mui/material/FormControlLabel";
+
+import { showNotification } from "baselayer/components/Notifications";
+
+import { useAppDispatch } from "../../types/hooks";
+
+import Button from "../Button";
+import FormValidationError from "../FormValidationError";
+
+import { useSaveAlertAsSourceMutation } from "../../ducks/boom_alert";
+import { useGetGroupsQuery } from "../../ducks/groups";
+
+interface CopyAlertPhotometryDialogProps {
+  alert: any;
+  survey: string;
+  duplicate: any;
+  dialogOpen: boolean;
+  closeDialog: (...a: any[]) => void;
+}
+
+const CopyAlertPhotometryDialog = ({
+  alert,
+  survey,
+  duplicate,
+  dialogOpen,
+  closeDialog,
+}: CopyAlertPhotometryDialogProps) => {
+  const dispatch = useAppDispatch();
+  const [saveAlertAsSource] = useSaveAlertAsSourceMutation();
+
+  const { data: groupsData } = useGetGroupsQuery();
+  const groups = groupsData?.userAccessible;
+
+  const {
+    handleSubmit,
+    reset,
+    control,
+    getValues,
+
+    formState: { errors },
+  } = useForm();
+
+  const currentGroupIds = duplicate.groups?.map((g: any) => g.id);
+
+  const savedGroups =
+    groups?.filter((g: any) => currentGroupIds.includes(g.id)) ?? [];
+
+  const validateGroups = () => {
+    const formState: any = getValues();
+    return (
+      formState.groupIds?.length &&
+      formState.groupIds.filter((value: any) => Boolean(value)).length >= 1
+    );
+  };
+
+  const onSubmit = async (data: any) => {
+    const savedGroupIds = savedGroups?.map((g: any) => g.id);
+    const groupIds = savedGroupIds?.filter(
+      (_ID: any, idx: number) => data.groupIds[idx],
+    );
+    data.group_ids = groupIds;
+    data.copyToSource = duplicate.id;
+    try {
+      await saveAlertAsSource({
+        survey,
+        id: alert.objectId,
+        payload: data,
+      }).unwrap();
+      dispatch(
+        showNotification("Source photometry updated successfully", "info"),
+      );
+      reset();
+    } catch {
+      // error notification handled by the base query
+    }
+    closeDialog();
+  };
+
+  return (
+    <>
+      <Dialog open={dialogOpen} onClose={closeDialog} sx={{ "z-index": 99999 }}>
+        <DialogTitle>Copy photometry to selected groups:</DialogTitle>
+        <DialogContent>
+          <form onSubmit={handleSubmit(onSubmit)}>
+            {(errors["inviteGroupIds"] || errors["unsaveGroupIds"]) && (
+              <FormValidationError message="Select at least one group." />
+            )}
+            {!!savedGroups.length && (
+              <>
+                {savedGroups.map((savedGroup: any, idx: number) => (
+                  <FormControlLabel
+                    key={savedGroup.id}
+                    control={
+                      <Controller
+                        render={({ field: { onChange, value } }) => (
+                          <Checkbox
+                            onChange={(event) => onChange(event.target.checked)}
+                            checked={value}
+                            data-testid={`copyGroupCheckbox_${savedGroup.id}`}
+                          />
+                        )}
+                        name={`groupIds[${idx}]`}
+                        control={control}
+                        rules={{ validate: validateGroups }}
+                        defaultValue={false}
+                      />
+                    }
+                    label={savedGroup.name}
+                  />
+                ))}
+              </>
+            )}
+            <div style={{ textAlign: "center" }}>
+              <Button
+                secondary
+                type="submit"
+                name={`copyPhotometryButton_${alert.objectId}`}
+              >
+                Copy Photometry
+              </Button>
+            </div>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+};
+
+export default CopyAlertPhotometryDialog;

--- a/static/js/components/alert/SaveAlertButton.tsx
+++ b/static/js/components/alert/SaveAlertButton.tsx
@@ -1,0 +1,272 @@
+import { useState, useEffect, useRef } from "react";
+import Dialog from "@mui/material/Dialog";
+import DialogContent from "@mui/material/DialogContent";
+import DialogTitle from "@mui/material/DialogTitle";
+import Checkbox from "@mui/material/Checkbox";
+import Button from "@mui/material/Button";
+import ButtonGroup from "@mui/material/ButtonGroup";
+import FormControlLabel from "@mui/material/FormControlLabel";
+import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
+import ClickAwayListener from "@mui/material/ClickAwayListener";
+import Grow from "@mui/material/Grow";
+import Paper from "@mui/material/Paper";
+import Popper from "@mui/material/Popper";
+import MenuItem from "@mui/material/MenuItem";
+import MenuList from "@mui/material/MenuList";
+import { useForm, Controller } from "react-hook-form";
+
+import { showNotification } from "baselayer/components/Notifications";
+
+import { useAppDispatch } from "../../types/hooks";
+
+import FormValidationError from "../FormValidationError";
+
+import { useSaveAlertAsSourceMutation } from "../../ducks/boom_alert";
+import { useLazyGetSourceQuery } from "../../ducks/source";
+import { useGetGroupsQuery } from "../../ducks/groups";
+
+interface SaveAlertButtonProps {
+  alert: any;
+  userGroups: any[];
+}
+
+const SaveAlertButton = ({ alert, userGroups }: SaveAlertButtonProps) => {
+  const [saveAlertAsSource] = useSaveAlertAsSourceMutation();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  // Dialog logic:
+
+  const dispatch = useAppDispatch();
+  const [triggerGetSource, getSourceResult] = useLazyGetSourceQuery();
+  const [dialogOpen, setDialogOpen] = useState(false);
+  // RTK Query: read results from the query hooks (no more redux slices).
+  const source: any = getSourceResult.data;
+  const groups = (useGetGroupsQuery().data?.all ?? []).filter(
+    (g: any) => !g.single_user_group,
+  );
+
+  const currentGroupIds =
+    source?.id === alert.id
+      ? (source?.groups?.map((g: any) => g.id) ?? [])
+      : [];
+  const unsavedGroups = groups?.filter(
+    (g: any) => !currentGroupIds.includes(g.id),
+  );
+
+  const {
+    handleSubmit,
+    reset,
+    control,
+    getValues,
+
+    formState: { errors },
+  } = useForm();
+
+  useEffect(() => {
+    reset({
+      group_ids: [],
+    });
+  }, [reset, userGroups, alert]);
+
+  const handleClickOpenDialog = () => {
+    setDialogOpen(true);
+  };
+
+  const handleCloseDialog = () => {
+    setDialogOpen(false);
+  };
+
+  const validateGroups = () => {
+    const formState: any = getValues();
+    return (
+      formState.group_ids.filter((value: any) => Boolean(value)).length >= 1
+    );
+  };
+
+  const onSubmitGroupSelectSave = async (data: any) => {
+    setIsSubmitting(true);
+    data.id = alert.id;
+    data.survey = alert.survey;
+    const groupIDs = unsavedGroups.map((g: any) => g.id);
+    const selectedGroupIDs = groupIDs.filter(
+      (_ID: any, idx: number) => data.group_ids[idx],
+    );
+
+    data.payload = { candid: alert.candid, group_ids: selectedGroupIDs };
+
+    let result: any;
+    try {
+      result = await saveAlertAsSource(data).unwrap();
+    } catch {
+      setIsSubmitting(false);
+      return;
+    }
+    dispatch(
+      showNotification("Source photometry updated successfully", "info"),
+    );
+    if (result?.used_latest_candid) {
+      dispatch(
+        showNotification(
+          "Note that the latest alert packet was used to post thumbnails, as the provided candid didn't have any.",
+          "warning",
+        ),
+      );
+    }
+    setIsSubmitting(false);
+    setDialogOpen(false);
+    reset();
+    triggerGetSource(alert.id);
+  };
+
+  // Split button logic (largely copied from
+  // https://material-ui.com/components/button-group/#split-button):
+
+  const options = ["Select groups & save as a source"];
+  // const options = ["Select groups & save as a source", "Select filters & save as a candidate"];
+
+  const [splitButtonMenuOpen, setSplitButtonMenuOpen] = useState(false);
+  const anchorRef = useRef<any>(null);
+  const [anchorEl, setAnchorEl] = useState<any>(null);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  useEffect(() => {
+    setAnchorEl(anchorRef.current);
+  }, []);
+
+  const handleClickMainButton = async () => {
+    if (selectedIndex === 0) {
+      handleClickOpenDialog();
+    }
+  };
+
+  const handleMenuItemClick = (_event: any, index: number) => {
+    setSelectedIndex(index);
+    setSplitButtonMenuOpen(false);
+  };
+
+  const handleToggleSplitButtonMenu = () => {
+    setSplitButtonMenuOpen((prevOpen) => !prevOpen);
+  };
+
+  const handleCloseSplitButtonMenu = (event: any) => {
+    if (anchorRef.current && anchorRef.current.contains(event.target)) {
+      return;
+    }
+    setSplitButtonMenuOpen(false);
+  };
+
+  return (
+    <div>
+      <ButtonGroup
+        variant="contained"
+        ref={anchorRef}
+        aria-label="split button"
+      >
+        <Button
+          onClick={handleClickMainButton}
+          name={`initialSaveAlertButton${alert.id}`}
+          data-testid={`saveAlertButton_${alert.id}`}
+          disabled={isSubmitting}
+        >
+          {options[selectedIndex]}
+        </Button>
+        <Button
+          size="small"
+          aria-controls={splitButtonMenuOpen ? "split-button-menu" : undefined}
+          aria-expanded={splitButtonMenuOpen ? "true" : undefined}
+          aria-label="Save as Source"
+          aria-haspopup="menu"
+          name={`saveAlertButtonDropDownArrow${alert.id}`}
+          onClick={handleToggleSplitButtonMenu}
+        >
+          <ArrowDropDownIcon />
+        </Button>
+      </ButtonGroup>
+      <Popper
+        open={splitButtonMenuOpen}
+        anchorEl={anchorEl}
+        role={undefined}
+        transition
+        disablePortal
+        style={{ zIndex: 1000 }}
+      >
+        {({ TransitionProps, placement }) => (
+          <Grow
+            {...TransitionProps}
+            style={{
+              transformOrigin:
+                placement === "bottom" ? "center top" : "center bottom",
+            }}
+          >
+            <Paper>
+              <ClickAwayListener onClickAway={handleCloseSplitButtonMenu}>
+                <MenuList id="split-button-menu">
+                  {options.map((option, index) => (
+                    <MenuItem
+                      key={option}
+                      {...({
+                        name: `buttonMenuOption${alert.id}_${option}`,
+                      } as any)}
+                      selected={index === selectedIndex}
+                      onClick={(event) => handleMenuItemClick(event, index)}
+                    >
+                      {option}
+                    </MenuItem>
+                  ))}
+                </MenuList>
+              </ClickAwayListener>
+            </Paper>
+          </Grow>
+        )}
+      </Popper>
+
+      <Dialog
+        open={dialogOpen}
+        onClose={handleCloseDialog}
+        style={{ position: "fixed" }}
+      >
+        <DialogTitle>Select one or more groups:</DialogTitle>
+        <DialogContent>
+          <form onSubmit={handleSubmit(onSubmitGroupSelectSave)}>
+            {errors["group_ids"] && (
+              <FormValidationError message="Select at least one group." />
+            )}
+            {unsavedGroups.map((unsavedGroup: any, idx: number) => (
+              <FormControlLabel
+                key={unsavedGroup.id}
+                control={
+                  <Controller
+                    name={`group_ids[${idx}]`}
+                    control={control}
+                    rules={{ validate: validateGroups }}
+                    defaultValue={false}
+                    render={({ field: { onChange, value } }) => (
+                      <Checkbox
+                        {...({ color: "primary", type: "checkbox" } as any)}
+                        onChange={(event) => onChange(event.target.checked)}
+                        checked={value}
+                      />
+                    )}
+                  />
+                }
+                label={unsavedGroup.name}
+              />
+            ))}
+            <br />
+            <div style={{ textAlign: "center" }}>
+              <Button
+                variant="contained"
+                type="submit"
+                name={`finalSaveAlertButton${alert.id}`}
+                disabled={isSubmitting}
+              >
+                Save
+              </Button>
+            </div>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+};
+
+export default SaveAlertButton;

--- a/static/js/components/source/SourcePlugins.tsx
+++ b/static/js/components/source/SourcePlugins.tsx
@@ -1,3 +1,51 @@
-const SourcePlugins = () => <></>;
+import React from "react";
+
+import Menu from "@mui/material/Menu";
+import MenuItem from "@mui/material/MenuItem";
+
+import Button from "../Button";
+
+import AlertsSearchButton from "../alert/AlertsSearchButton";
+
+interface SourcePluginsProps {
+  source: any;
+}
+
+const SourcePlugins = ({ source }: SourcePluginsProps) => {
+  const [anchorElArchive, setAnchorElArchive] = React.useState<any>(null);
+  const openArchive = Boolean(anchorElArchive);
+
+  return (
+    <div>
+      <Button
+        aria-controls={openArchive ? "basic-menu" : undefined}
+        aria-haspopup="true"
+        aria-expanded={openArchive ? "true" : undefined}
+        onClick={(e: any) => setAnchorElArchive(e.currentTarget)}
+        primary
+        size="small"
+      >
+        ALERT ARCHIVES
+      </Button>
+      <Menu
+        transitionDuration={50}
+        id="archive-menu"
+        anchorEl={anchorElArchive}
+        open={openArchive}
+        onClose={() => setAnchorElArchive(null)}
+        slotProps={{
+          list: { "aria-labelledby": "basic-button" },
+        }}
+      >
+        <MenuItem>
+          <AlertsSearchButton ra={source.ra} dec={source.dec} survey="ZTF" />
+        </MenuItem>
+        <MenuItem>
+          <AlertsSearchButton ra={source.ra} dec={source.dec} survey="LSST" />
+        </MenuItem>
+      </Menu>
+    </div>
+  );
+};
 
 export default SourcePlugins;

--- a/static/js/ducks/boom_alert.ts
+++ b/static/js/ducks/boom_alert.ts
@@ -1,0 +1,43 @@
+import { skyportalApi } from "../api/skyportalApi";
+
+export interface AlertArg {
+  survey: string;
+  id: string | number;
+}
+
+export interface SaveAlertArg {
+  survey: string;
+  id: string | number;
+  payload: Record<string, any>;
+}
+
+// One BOOM object's alerts + object record + "save as source". RTK Query
+// conversion of the old boom_alert thunks; the per-object keyed slices
+// (boom_alert_data / boom_object_data) are replaced by RTK's per-arg cache, so
+// consumers read the query hook's `data` for the current objectId.
+export const boomAlertApi = skyportalApi.injectEndpoints({
+  endpoints: (build) => ({
+    getAlertData: build.query<any, AlertArg>({
+      query: ({ survey, id }) =>
+        `api/boom/surveys/${survey}/alerts?objectId=${id}`,
+    }),
+    getBoomObject: build.query<any, AlertArg>({
+      query: ({ survey, id }) => `api/boom/surveys/${survey}/objects/${id}`,
+    }),
+    saveAlertAsSource: build.mutation<any, SaveAlertArg>({
+      query: ({ survey, id, payload }) => ({
+        url: `api/boom/surveys/${survey}/objects/${id}`,
+        method: "POST",
+        body: payload,
+      }),
+    }),
+  }),
+});
+
+export const {
+  useGetAlertDataQuery,
+  useLazyGetAlertDataQuery,
+  useGetBoomObjectQuery,
+  useLazyGetBoomObjectQuery,
+  useSaveAlertAsSourceMutation,
+} = boomAlertApi;

--- a/static/js/ducks/boom_alerts.ts
+++ b/static/js/ducks/boom_alerts.ts
@@ -1,0 +1,37 @@
+import { skyportalApi } from "../api/skyportalApi";
+
+export interface FetchAlertsArg {
+  survey: string;
+  object_id?: string | undefined;
+  ra?: number | string | undefined;
+  dec?: number | string | undefined;
+  radius?: number | string | undefined;
+}
+
+// Alerts for a BOOM survey, by objectId and/or cone (ra/dec/radius). RTK Query
+// conversion of the old `fetchAlerts` thunk + "alerts" slice; the component now
+// reads `data`/`isFetching` from the (lazy) query hook instead of the slice.
+export const boomAlertsApi = skyportalApi.injectEndpoints({
+  endpoints: (build) => ({
+    getAlerts: build.query<any, FetchAlertsArg>({
+      query: ({ survey, object_id, ra, dec, radius }) => {
+        const params = new URLSearchParams();
+        if (object_id) {
+          params.set("objectId", object_id);
+        }
+        if (ra && dec && radius) {
+          params.set("ra", String(ra));
+          params.set("dec", String(dec));
+          params.set("radius", String(radius));
+          params.set("radius_units", "arcsec");
+        }
+        const qs = params.toString();
+        return qs
+          ? `api/boom/surveys/${survey}/alerts?${qs}`
+          : `api/boom/surveys/${survey}/alerts`;
+      },
+    }),
+  }),
+});
+
+export const { useGetAlertsQuery, useLazyGetAlertsQuery } = boomAlertsApi;

--- a/static/js/utils/imageProcessing.js
+++ b/static/js/utils/imageProcessing.js
@@ -1,0 +1,523 @@
+import pako from "pako";
+
+const NAXIS1_BYTES = new TextEncoder().encode("NAXIS1  =");
+const NAXIS2_BYTES = new TextEncoder().encode("NAXIS2  =");
+const NAXIS1_BYTES_LEN = NAXIS1_BYTES.length;
+const NAXIS2_BYTES_LEN = NAXIS2_BYTES.length;
+const FITS_HEADER_LEN = 2880;
+const SPACE_BYTES = new TextEncoder().encode(" ");
+const SPACE_BYTE = SPACE_BYTES[0];
+
+function bone(n) {
+  const points = [
+    { index: 0, rgb: [0, 0, 0] },
+    { index: 0.376, rgb: [84, 84, 116] },
+    { index: 0.753, rgb: [169, 200, 200] },
+    { index: 1, rgb: [255, 255, 255] },
+  ];
+
+  const lookup = [];
+  for (let i = 0; i < n; i++) {
+    const x = i / (n - 1);
+    let j = 0;
+    while (points[j + 1].index < x) {
+      j++;
+    }
+    const x0 = points[j].index;
+    const x1 = points[j + 1].index;
+    const y0 = points[j].rgb;
+    const y1 = points[j + 1].rgb;
+    const t = (x - x0) / (x1 - x0);
+    const y = [
+      Math.round(y0[0] + t * (y1[0] - y0[0])),
+      Math.round(y0[1] + t * (y1[1] - y0[1])),
+      Math.round(y0[2] + t * (y1[2] - y0[2])),
+      255,
+    ];
+    lookup.push(y);
+  }
+  return lookup;
+}
+
+const bone_cm = bone(256);
+
+function isEqualArray(a, b) {
+  if (a.length != b.length) {
+    return false;
+  }
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] != b[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function bytesToFloats(data) {
+  const floats = new Float32Array(data.length / 4);
+  for (let i = 0; i < data.length; i += 4) {
+    floats[i / 4] = new DataView(
+      data.buffer,
+      data.byteOffset + i,
+      4,
+    ).getFloat32(0, false);
+  }
+  return floats;
+}
+
+function bytes2imgdata(bytes) {
+  let decompressedCutout;
+  try {
+    const compressedCutoutArray =
+      bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    decompressedCutout = pako.inflate(compressedCutoutArray);
+  } catch (e) {
+    console.warn("Failed to decompress cutout, assuming uncompressed data", e);
+    decompressedCutout =
+      bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+  }
+
+  const subset = decompressedCutout.slice(0, FITS_HEADER_LEN);
+
+  let naxis1_key_start = 0;
+  let naxis1_val_start = 0;
+  let naxis1_val_end = 0;
+
+  for (let i = 0; i < FITS_HEADER_LEN - NAXIS1_BYTES_LEN; i++) {
+    if (isEqualArray(subset.slice(i, i + NAXIS1_BYTES_LEN), NAXIS1_BYTES)) {
+      naxis1_key_start = i;
+      break;
+    }
+  }
+
+  if (naxis1_key_start === 0) {
+    console.error("NAXIS1 key not found in FITS header");
+    return { data: new Float32Array(), naxis1: 0, naxis2: 0, rotpa: null };
+  }
+
+  for (let i = naxis1_key_start + NAXIS1_BYTES_LEN; i < FITS_HEADER_LEN; i++) {
+    if (subset[i] !== SPACE_BYTE) {
+      naxis1_val_start = i;
+      break;
+    }
+  }
+
+  if (naxis1_val_start === 0) {
+    console.error("NAXIS1 value start not found in FITS header");
+    return { data: new Float32Array(), naxis1: 0, naxis2: 0, rotpa: null };
+  }
+
+  for (let i = naxis1_val_start; i < FITS_HEADER_LEN; i++) {
+    if (subset[i] === SPACE_BYTE) {
+      naxis1_val_end = i;
+      break;
+    }
+  }
+
+  const naxis1_val = subset.slice(naxis1_val_start, naxis1_val_end);
+  const naxis1_val_str = new TextDecoder().decode(naxis1_val);
+  const naxis1 = parseInt(naxis1_val_str, 10);
+
+  let naxis2_key_start = naxis1_val_end;
+  let naxis2_val_start = 0;
+  let naxis2_val_end = 0;
+  for (let i = naxis2_key_start; i < FITS_HEADER_LEN - NAXIS2_BYTES_LEN; i++) {
+    if (isEqualArray(subset.slice(i, i + NAXIS2_BYTES_LEN), NAXIS2_BYTES)) {
+      naxis2_key_start = i;
+      break;
+    }
+  }
+  if (naxis2_key_start === 0) {
+    console.error("NAXIS2 key not found in FITS header");
+    return { data: new Float32Array(), naxis1: 0, naxis2: 0, rotpa: null };
+  }
+  for (let i = naxis2_key_start + NAXIS2_BYTES_LEN; i < FITS_HEADER_LEN; i++) {
+    if (subset[i] !== SPACE_BYTE) {
+      naxis2_val_start = i;
+      break;
+    }
+  }
+  if (naxis2_val_start === 0) {
+    console.error("NAXIS2 value start not found in FITS header");
+    return { data: new Float32Array(), naxis1: 0, naxis2: 0, rotpa: null };
+  }
+  for (let i = naxis2_val_start; i < FITS_HEADER_LEN; i++) {
+    if (subset[i] === SPACE_BYTE) {
+      naxis2_val_end = i;
+      break;
+    }
+  }
+
+  const naxis2_val = subset.slice(naxis2_val_start, naxis2_val_end);
+  const naxis2_val_str = new TextDecoder().decode(naxis2_val);
+  const naxis2 = parseInt(naxis2_val_str, 10);
+
+  // We now look for ROTPA   =     40.6698912392206 , if it exists
+  let rotpa_key_start = naxis2_val_end;
+  let rotpa_val_start = 0;
+  let rotpa_val_end = 0;
+  const ROTPA_BYTES = new TextEncoder().encode("ROTPA   =");
+  const ROTPA_BYTES_LEN = ROTPA_BYTES.length;
+  for (let i = rotpa_key_start; i < FITS_HEADER_LEN - ROTPA_BYTES_LEN; i++) {
+    if (isEqualArray(subset.slice(i, i + ROTPA_BYTES_LEN), ROTPA_BYTES)) {
+      rotpa_key_start = i;
+      break;
+    }
+  }
+  if (rotpa_key_start !== 0) {
+    for (let i = rotpa_key_start + ROTPA_BYTES_LEN; i < FITS_HEADER_LEN; i++) {
+      if (subset[i] !== SPACE_BYTE) {
+        rotpa_val_start = i;
+        break;
+      }
+    }
+    if (rotpa_val_start !== 0) {
+      for (let i = rotpa_val_start; i < FITS_HEADER_LEN; i++) {
+        if (subset[i] === SPACE_BYTE || subset[i] === 47 /* '/' */) {
+          rotpa_val_end = i;
+          break;
+        }
+      }
+    }
+  }
+  let rotpa = null;
+  if (rotpa_val_start !== 0 && rotpa_val_end !== 0) {
+    const rotpa_val = subset.slice(rotpa_val_start, rotpa_val_end);
+    const rotpa_val_str = new TextDecoder().decode(rotpa_val);
+    const rotpa_float = parseFloat(rotpa_val_str);
+    rotpa = !isNaN(rotpa_float) ? rotpa_float : null;
+  }
+
+  let data = decompressedCutout.slice(
+    FITS_HEADER_LEN,
+    naxis1 * naxis2 * 4 + FITS_HEADER_LEN,
+  );
+  if (data instanceof Uint8Array) {
+    data = bytesToFloats(data);
+  }
+
+  const NAXIS_STANDARD = Math.max(naxis1, naxis2);
+  const NB_PIXELS = NAXIS_STANDARD * NAXIS_STANDARD;
+
+  const offset1 = Math.ceil((NAXIS_STANDARD - naxis1) / 2.0);
+  const offset2 = Math.ceil((NAXIS_STANDARD - naxis2) / 2.0);
+
+  if (offset1 !== 0 || offset2 !== 0) {
+    const new_image_data = new Float32Array(NB_PIXELS);
+    for (let i = 0; i < naxis2; i++) {
+      for (let j = 0; j < naxis1; j++) {
+        const k = i * naxis1 + j;
+        const k_new = (i + offset2) * NAXIS_STANDARD + (j + offset1);
+        new_image_data[k_new] = data[k];
+      }
+    }
+    data = new_image_data;
+  }
+
+  return { data, naxis1: NAXIS_STANDARD, naxis2: NAXIS_STANDARD, rotpa };
+}
+
+function cleanupImage(image) {
+  const new_img = Array.from(image).map((value) =>
+    Math.abs(value) > 1e20 ? NaN : value,
+  );
+  const filtered = new_img.filter((val) => !isNaN(val));
+  const sorted = filtered.sort((a, b) => a - b);
+  const median = sorted[Math.floor(filtered.length / 2)] ?? 0;
+  return new_img.map((value) => (isNaN(value) ? median : value));
+}
+
+function ensureFinite(image) {
+  return image.map((value) => (isFinite(value) ? value : 0));
+}
+
+function normalizeImage(
+  image,
+  method = "minmax",
+  lower_percentile = 0.01,
+  upper_percentile = 1,
+) {
+  if (method === "minmax") {
+    const max = Math.max(...image);
+    const min = Math.min(...image);
+    const range = max - min;
+    if (range === 0) {
+      return image.map(() => 0.5);
+    }
+    return image.map((value) => (value - min) / range);
+  } else if (method === "asymmetric_percentile") {
+    const sorted = [...image].sort((a, b) => a - b);
+    const lower =
+      lower_percentile > 0
+        ? sorted[Math.floor(lower_percentile * sorted.length)]
+        : 0;
+    const upper =
+      upper_percentile < 1
+        ? sorted[Math.floor(upper_percentile * sorted.length)]
+        : 1;
+    const range = upper - lower;
+    if (range === 0) {
+      return image.map(() => 0.5);
+    }
+    const clipped = image.map((value) =>
+      Math.max(lower, Math.min(upper, value)),
+    );
+    return clipped.map((value) => (value - lower) / range);
+  }
+  throw new Error("Unknown normalization method");
+}
+
+function stretchImage(image, cutoutType, method = null, alpha = 1000.0) {
+  if (method === null) {
+    method = cutoutType === "difference" ? "linear" : "log";
+  }
+  if (method === "linear") {
+    return image;
+  }
+  if (method === "log") {
+    return image.map(
+      (value) => Math.log(alpha * value + 1) / Math.log(alpha + 1),
+    );
+  }
+  if (method === "asinh") {
+    return image.map((value) => Math.asinh(value));
+  }
+  if (method === "sqrt") {
+    return image.map((value) => Math.sqrt(value));
+  }
+  throw new Error("Unknown stretch method");
+}
+
+function applyColorMap(image, colorMap = "gray") {
+  const rgba_image = new Array(image.length);
+  if (colorMap === "gray") {
+    for (let i = 0; i < image.length; i++) {
+      rgba_image[i] = [image[i], image[i], image[i], 255];
+    }
+  } else if (colorMap === "bone") {
+    for (let i = 0; i < image.length; i++) {
+      rgba_image[i] = bone_cm[image[i]];
+    }
+  } else {
+    throw new Error("Invalid color map");
+  }
+  return rgba_image;
+}
+
+export function bytes2image(
+  bytes,
+  survey,
+  type = "science",
+  colorMap = "gray",
+  rotated = true,
+) {
+  let naxis1;
+  let naxis2;
+  let rotpa;
+  let data;
+
+  if (typeof bytes === "string") {
+    const binaryString = atob(bytes);
+    const len = binaryString.length;
+    const byteArray = new Uint8Array(len);
+    for (let i = 0; i < len; i++) {
+      byteArray[i] = binaryString.charCodeAt(i);
+    }
+    const result = bytes2imgdata(byteArray);
+    data = Array.from(result.data);
+    naxis1 = result.naxis1;
+    naxis2 = result.naxis2;
+    rotpa = result.rotpa;
+  } else {
+    if (!bytes) return null;
+    let buf;
+    if (bytes instanceof Uint8Array) {
+      buf = bytes;
+    } else if (bytes instanceof ArrayBuffer) {
+      buf = new Uint8Array(bytes);
+    } else {
+      return null;
+    }
+    const result = bytes2imgdata(buf);
+    data = Array.from(result.data);
+    naxis1 = result.naxis1;
+    naxis2 = result.naxis2;
+    rotpa = result.rotpa;
+  }
+
+  const NAXIS_STANDARD = Math.max(naxis1, naxis2);
+  data = cleanupImage(data);
+  data = normalizeImage(data, "minmax");
+  if (type !== "difference") {
+    const alpha = survey.toLowerCase() === "lsst" ? 10.0 : 1000.0;
+    data = stretchImage(data, type, "log", alpha);
+  }
+  data = normalizeImage(data, "asymmetric_percentile");
+  data = ensureFinite(data);
+  data = data.map((value) =>
+    Math.round(Math.max(0, Math.min(255, value * 255))),
+  );
+
+  let colored = applyColorMap(data, colorMap);
+
+  // if rotpa is defined, rotate the image accordingly. When we rotate, we rotate around the center of the image
+  // and add black pixels for the areas that are outside the original image
+  // if (rotpa !== null) {
+  //   const angleRad = (rotpa * Math.PI) / 180;
+  //   const cosAngle = Math.cos(angleRad);
+  //   const sinAngle = Math.sin(angleRad);
+  //   const centerX = NAXIS_STANDARD / 2;
+  //   const centerY = NAXIS_STANDARD / 2;
+
+  //   const rotatedImage = new Array(NAXIS_STANDARD * NAXIS_STANDARD).fill([0, 0, 0, 255]);
+
+  //   for (let y = 0; y < NAXIS_STANDARD; y++) {
+  //     for (let x = 0; x < NAXIS_STANDARD; x++) {
+  //       const xCentered = x - centerX;
+  //       const yCentered = y - centerY;
+
+  //       const originalX = Math.round(cosAngle * xCentered + sinAngle * yCentered + centerX);
+  //       const originalY = Math.round(-sinAngle * xCentered + cosAngle * yCentered + centerY);
+
+  //       if (originalX >= 0 && originalX < NAXIS_STANDARD && originalY >= 0 && originalY < NAXIS_STANDARD) {
+  //         const originalIndex = originalY * NAXIS_STANDARD + originalX;
+  //         const rotatedIndex = y * NAXIS_STANDARD + x;
+  //         rotatedImage[rotatedIndex] = colored[originalIndex];
+  //       }
+  //     }
+  //   }
+  //   colored.splice(0, colored.length, ...rotatedImage);
+  // }
+  // same as above (rotate if rotpa is defined), but create a new colored array
+  // that is big enough for the rotated image without cropping
+  // so, we want to compute what the new size should be
+  // then we create a new array of that size, and we copy the rotated pixels into it
+  if (rotpa !== null && rotated) {
+    const angleRad = (rotpa * Math.PI) / 180;
+    const cosAngle = Math.cos(angleRad);
+    const sinAngle = Math.sin(angleRad);
+    const centerX = NAXIS_STANDARD / 2;
+    const centerY = NAXIS_STANDARD / 2;
+
+    // compute new image size
+    const corners = [
+      { x: 0 - centerX, y: 0 - centerY },
+      { x: NAXIS_STANDARD - centerX, y: 0 - centerY },
+      { x: 0 - centerX, y: NAXIS_STANDARD - centerY },
+      { x: NAXIS_STANDARD - centerX, y: NAXIS_STANDARD - centerY },
+    ];
+    let minX = Infinity;
+    let maxX = -Infinity;
+    let minY = Infinity;
+    let maxY = -Infinity;
+    for (const corner of corners) {
+      const rotatedX = cosAngle * corner.x + sinAngle * corner.y;
+      const rotatedY = -sinAngle * corner.x + cosAngle * corner.y;
+      minX = Math.min(minX, rotatedX);
+      maxX = Math.max(maxX, rotatedX);
+      minY = Math.min(minY, rotatedY);
+      maxY = Math.max(maxY, rotatedY);
+    }
+    const newWidth = Math.ceil(maxX - minX);
+    const newHeight = Math.ceil(maxY - minY);
+    const newCenterX = newWidth / 2;
+    const newCenterY = newHeight / 2;
+
+    const rotatedImage = Array.from({ length: newWidth * newHeight }, () => [
+      0, 0, 0, 0,
+    ]);
+
+    // Use backward mapping (inverse transform) to avoid gaps
+    for (let newY = 0; newY < newHeight; newY++) {
+      for (let newX = 0; newX < newWidth; newX++) {
+        const xCentered = newX - newCenterX;
+        const yCentered = newY - newCenterY;
+
+        // Apply inverse rotation (clockwise)
+        const originalX = cosAngle * xCentered + sinAngle * yCentered + centerX;
+        const originalY =
+          -sinAngle * xCentered + cosAngle * yCentered + centerY;
+
+        // Use bilinear interpolation for better quality
+        const x0 = Math.floor(originalX);
+        const y0 = Math.floor(originalY);
+        const x1 = x0 + 1;
+        const y1 = y0 + 1;
+
+        if (x0 >= 0 && x1 < NAXIS_STANDARD && y0 >= 0 && y1 < NAXIS_STANDARD) {
+          const dx = originalX - x0;
+          const dy = originalY - y0;
+
+          const p00 = colored[y0 * NAXIS_STANDARD + x0];
+          const p10 = colored[y0 * NAXIS_STANDARD + x1];
+          const p01 = colored[y1 * NAXIS_STANDARD + x0];
+          const p11 = colored[y1 * NAXIS_STANDARD + x1];
+
+          const rotatedIndex = newY * newWidth + newX;
+          rotatedImage[rotatedIndex] = [
+            Math.round(
+              (1 - dx) * (1 - dy) * p00[0] +
+                dx * (1 - dy) * p10[0] +
+                (1 - dx) * dy * p01[0] +
+                dx * dy * p11[0],
+            ),
+            Math.round(
+              (1 - dx) * (1 - dy) * p00[1] +
+                dx * (1 - dy) * p10[1] +
+                (1 - dx) * dy * p01[1] +
+                dx * dy * p11[1],
+            ),
+            Math.round(
+              (1 - dx) * (1 - dy) * p00[2] +
+                dx * (1 - dy) * p10[2] +
+                (1 - dx) * dy * p01[2] +
+                dx * dy * p11[2],
+            ),
+            255,
+          ];
+        }
+      }
+    }
+    colored = rotatedImage;
+    naxis1 = newWidth;
+    naxis2 = newHeight;
+  }
+
+  // also reverse north and south to have north up, if survey is lsst
+  const finalWidth = rotpa !== null ? naxis1 : NAXIS_STANDARD;
+  const finalHeight = rotpa !== null ? naxis2 : NAXIS_STANDARD;
+  if (survey.toLowerCase() === "lsst") {
+    const finalImage = new Array(finalWidth * finalHeight);
+    for (let y = 0; y < finalHeight; y++) {
+      for (let x = 0; x < finalWidth; x++) {
+        const originalIndex = y * finalWidth + x;
+        const flippedIndex = (finalHeight - 1 - y) * finalWidth + x;
+        finalImage[flippedIndex] = colored[originalIndex];
+      }
+    }
+    colored.splice(0, colored.length, ...finalImage);
+  }
+
+  if (typeof document !== "undefined") {
+    const canvas = document.createElement("canvas");
+    canvas.width = finalWidth;
+    canvas.height = finalHeight;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return null;
+    const imageData = ctx.createImageData(finalWidth, finalHeight);
+    for (let i = 0; i < finalHeight; i++) {
+      for (let j = 0; j < finalWidth; j++) {
+        const pixelValue = colored[i * finalWidth + j];
+        const pixelIndex = (i * finalWidth + j) * 4;
+        imageData.data[pixelIndex] = pixelValue[0];
+        imageData.data[pixelIndex + 1] = pixelValue[1];
+        imageData.data[pixelIndex + 2] = pixelValue[2];
+        imageData.data[pixelIndex + 3] = pixelValue[3];
+      }
+    }
+    ctx.putImageData(imageData, 0, 0);
+    return canvas.toDataURL();
+  } else {
+    return null;
+  }
+}


### PR DESCRIPTION
Second vertical slice of upstreaming the fritz boom frontend.

**Backend:** `/api/boom/surveys/<survey>/alerts` and `.../alerts/cutouts` handlers + API tests.
**Frontend:** `/alerts` search page and `/alerts/:survey/:id` detail page (config-driven routes), browser-side FITS cutout rendering (`imageProcessing.js`, adds `pako`), boom alert ducks, and an alert-search menu on the source page via the SourcePlugins extension point.

The CopyAlertPhotometryDialog surfaces alert photometry into skyportal and pairs naturally with the photometry-passthrough backend in #6348.

---
**Shared plumbing note:** this draft and its two siblings each carry `handlers/api/boom/utils.py`, a trimmed `boom/__init__.py`, and the `boom:` config section so they are independently reviewable; whichever merges first owns them and the others rebase. `boom/object.py`, `photometry.py`, and `photometry_cache.py` are deliberately absent — that is the photometry-passthrough surface of #6348. All kowalski-era code paths are stripped pending the kowalski-upstreaming decision.

Draft pending the boom-frontend roadmap discussion; feedback on slicing and config-gating conventions welcome.

**Update:** now also includes the boom alerts frontend smoke tests (`tests/frontend/boom/`) and `doc/boom_alerts.md`.