### PR TITLE
[RFC] Boom integration: archive API (backend + duck)

### DIFF
--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -1036,3 +1036,12 @@ docs:
       description: Development server
     - url: https://skyportal.io
       description: Production server
+
+# BOOM alert-broker integration.
+# The boom API endpoints require a reachable instance.
+boom:
+  protocol: http
+  host: localhost
+  port: 4000
+  username: admin
+  password: adminsecret

--- a/skyportal/app_server.py
+++ b/skyportal/app_server.py
@@ -201,6 +201,10 @@ from skyportal.handlers.api import (
     VizierQueryHandler,
     WeatherHandler,
 )
+from skyportal.handlers.api.boom import (
+    BoomCatalogNamesHandler,
+    BoomCrossMatchHandler,
+)
 from skyportal.handlers.api.internal import (
     AcrossInstrumentsHandler,
     AcrossJointVisibilityHandler,
@@ -270,6 +274,8 @@ skyportal_handlers = [
         AnalysisProductsHandler,
     ),
     (r"/api/assignment(/.*)?", AssignmentHandler),
+    (r"/api/boom/archive/catalogs", BoomCatalogNamesHandler),
+    (r"/api/boom/archive/cross_match", BoomCrossMatchHandler),
     (r"/api/candidates_filter", CandidateFilterHandler),
     (r"/api/candidates/scan_reports/([0-9]+)/items(/[0-9]+)?", ScanReportItemHandler),
     (r"/api/candidates/scan_reports", ScanReportHandler),

--- a/skyportal/handlers/api/boom/__init__.py
+++ b/skyportal/handlers/api/boom/__init__.py
@@ -1,0 +1,1 @@
+from .archive import BoomCatalogNamesHandler, BoomCrossMatchHandler

--- a/skyportal/handlers/api/boom/archive.py
+++ b/skyportal/handlers/api/boom/archive.py
@@ -1,0 +1,272 @@
+import asyncio
+import traceback
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timedelta
+
+import requests
+
+from baselayer.app.access import auth_or_token
+from baselayer.log import make_log
+
+from ...base import BaseHandler
+from .alert import BOOM_RADIUS_UNIT_MAP
+from .utils import boom_available, boom_token, boom_url
+
+log = make_log("api/boom_archive")
+
+# Collections that belong to surveys/alerts, not reference catalogs.
+SURVEY_PREFIXES = ("ZTF_", "LSST_", "PTF_", "PGIR_", "WNTR_")
+
+CATALOGS_TTL = timedelta(hours=1)
+
+_reference_catalogs = None
+_catalogs_fetched_at = None
+
+
+def _fetch_reference_catalogs():
+    """Hit Boom's /catalogs endpoint, strip alert collections, and cache."""
+    global _reference_catalogs, _catalogs_fetched_at
+    if boom_url is None or boom_token is None:
+        return _reference_catalogs
+    try:
+        response = requests.get(
+            f"{boom_url}/catalogs",
+            headers={"Authorization": f"Bearer {boom_token}"},
+            timeout=10,
+        )
+        if response.status_code != 200:
+            log(
+                f"Failed to fetch catalog list from Boom: "
+                f"{response.status_code} {response.text}"
+            )
+            return _reference_catalogs  # return stale list if available
+        all_catalogs = response.json().get("data", [])
+        _reference_catalogs = [
+            str(c["name"])
+            for c in all_catalogs
+            if not any(str(c["name"]).startswith(p) for p in SURVEY_PREFIXES)
+        ]
+        _catalogs_fetched_at = datetime.utcnow()
+        log(f"Cached {len(_reference_catalogs)} Boom reference catalogs.")
+        return _reference_catalogs
+    except Exception as e:
+        log(f"Failed to fetch catalog list from Boom: {e}")
+        return _reference_catalogs
+
+
+def get_reference_catalogs():
+    """Return cached reference catalog list, refreshing if TTL has expired."""
+    if (
+        _reference_catalogs is None
+        or _catalogs_fetched_at is None
+        or datetime.utcnow() - _catalogs_fetched_at > CATALOGS_TTL
+    ):
+        return _fetch_reference_catalogs()
+    return _reference_catalogs
+
+
+# Warm the cache at module load time (best-effort; may be None if Boom is down).
+_fetch_reference_catalogs()
+
+
+def _cone_search_catalog(catalog, ra, dec, radius, unit, token, url):
+    """Run a single cone-search against one Boom catalog. Returns (catalog, results)."""
+    try:
+        response = requests.post(
+            f"{url}/queries/cone_search",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "catalog_name": catalog,
+                "object_coordinates": {"query": [ra, dec]},
+                "radius": radius,
+                "unit": unit,
+                "max_time_ms": 5000,
+            },
+            timeout=10,
+        )
+        if response.status_code != 200:
+            return catalog, []
+        results = response.json().get("data", {}).get("query", [])
+        for source in results:
+            source["_id"] = str(source.get("_id", ""))
+            coords = (
+                source.get("coordinates", {})
+                .get("radec_geojson", {})
+                .get("coordinates", [])
+            )
+            if len(coords) == 2:
+                source["ra"] = coords[0] + 180
+                source["dec"] = coords[1]
+        return catalog, results
+    except Exception as e:
+        log(f"Cone search against {catalog} failed: {e}")
+        return catalog, []
+
+
+class BoomCatalogNamesHandler(BaseHandler):
+    @auth_or_token
+    @boom_available
+    async def get(self):
+        """
+        ---
+        summary: List non-survey catalog names available in Boom
+        description: |
+          Returns the cached list of reference catalog names from Boom
+          (i.e. all catalogs whose names do not start with a known survey
+          prefix such as ZTF_, LSST_, PTF_, PGIR_, or WNTR_).
+          The list is refreshed automatically every hour.
+        tags:
+          - archive
+          - boom
+        responses:
+          200:
+            description: list of catalog names
+            content:
+              application/json:
+                schema:
+                  allOf:
+                    - $ref: '#/components/schemas/Success'
+                    - type: object
+                      properties:
+                        data:
+                          type: array
+                          items:
+                            type: string
+          400:
+            content:
+              application/json:
+                schema: Error
+        """
+        catalogs = get_reference_catalogs()
+        if catalogs is None:
+            return self.error("Could not retrieve catalog list from Boom.")
+        return self.success(data=catalogs)
+
+
+class BoomCrossMatchHandler(BaseHandler):
+    @auth_or_token
+    @boom_available
+    async def get(self):
+        """
+        ---
+        summary: Cross-match a position against all reference catalogs in Boom
+        description: |
+          Retrieves the cached list of non-survey catalogs from Boom (refreshed
+          every hour), then runs a positional cone-search against every reference
+          catalog in parallel.
+        tags:
+          - archive
+          - boom
+        parameters:
+          - in: query
+            name: ra
+            required: true
+            schema:
+              type: number
+            description: RA in degrees (0 ≤ RA < 360)
+          - in: query
+            name: dec
+            required: true
+            schema:
+              type: number
+            description: Declination in degrees (-90 ≤ Dec ≤ 90)
+          - in: query
+            name: radius
+            required: true
+            schema:
+              type: number
+            description: Search radius, capped at 1 deg. Units set by radius_units.
+          - in: query
+            name: radius_units
+            required: true
+            schema:
+              type: string
+              enum: [deg, arcmin, arcsec]
+        responses:
+          200:
+            description: cross-matched sources keyed by catalog name
+            content:
+              application/json:
+                schema:
+                  allOf:
+                    - $ref: '#/components/schemas/Success'
+                    - type: object
+                      properties:
+                        data:
+                          type: object
+          400:
+            content:
+              application/json:
+                schema: Error
+        """
+        ra = self.get_query_argument("ra", None)
+        dec = self.get_query_argument("dec", None)
+        radius = self.get_query_argument("radius", None)
+        radius_units = self.get_query_argument("radius_units", None)
+
+        if not all((ra, dec, radius, radius_units)):
+            missing = [
+                name
+                for name, val in zip(
+                    ["ra", "dec", "radius", "radius_units"],
+                    [ra, dec, radius, radius_units],
+                )
+                if val is None
+            ]
+            return self.error(f"Missing required parameters: {missing}.")
+
+        if radius_units not in BOOM_RADIUS_UNIT_MAP:
+            return self.error(
+                "Invalid radius_units. Must be one of 'deg', 'arcmin', or 'arcsec'."
+            )
+
+        try:
+            ra = float(ra)
+            dec = float(dec)
+            radius = float(radius)
+        except ValueError:
+            return self.error("Invalid (non-float) value provided.")
+
+        if not (0 <= ra < 360):
+            return self.error("Invalid RA value: must be 0 <= RA [deg] < 360.")
+        if not (-90 <= dec <= 90):
+            return self.error("Invalid Dec value: must be -90 <= Dec [deg] <= 90.")
+        if (
+            (radius_units == "deg" and radius > 1)
+            or (radius_units == "arcmin" and radius > 60)
+            or (radius_units == "arcsec" and radius > 3600)
+        ):
+            return self.error("Radius must be <= 1.0 deg.")
+
+        try:
+            catalogs = get_reference_catalogs()
+            if not catalogs:
+                return self.error(
+                    "No reference catalogs available in Boom to cross-match against."
+                )
+
+            unit = BOOM_RADIUS_UNIT_MAP[radius_units]
+            loop = asyncio.get_event_loop()
+            with ThreadPoolExecutor() as pool:
+                futures = [
+                    loop.run_in_executor(
+                        pool,
+                        _cone_search_catalog,
+                        catalog,
+                        ra,
+                        dec,
+                        radius,
+                        unit,
+                        boom_token,
+                        boom_url,
+                    )
+                    for catalog in catalogs
+                ]
+                pairs = await asyncio.gather(*futures)
+
+            data = {catalog: results for catalog, results in pairs if results}
+            return self.success(data=data)
+
+        except Exception:
+            _err = traceback.format_exc()
+            return self.error(f"failure: {_err}")

--- a/skyportal/handlers/api/boom/utils.py
+++ b/skyportal/handlers/api/boom/utils.py
@@ -1,0 +1,291 @@
+import base64
+import functools
+import gzip
+import inspect
+import io
+import traceback
+from datetime import datetime, timedelta
+
+import matplotlib.pyplot as plt
+import numpy as np
+import requests
+from astropy.io import fits
+from astropy.visualization import (
+    AsymmetricPercentileInterval,
+    ImageNormalize,
+    LinearStretch,
+    LogStretch,
+)
+from scipy.ndimage import rotate
+
+from baselayer.app.env import load_env
+from baselayer.log import make_log
+
+log = make_log("app/boom-utils")
+
+
+# ── Shared thumbnail helpers ─────────────────────────────────────────────────
+# Imported lazily to avoid a circular-import at module load time (post_thumbnail
+# lives in handlers/api/thumbnail which ultimately imports app models).
+async def _post_thumbnail(thumbnail_dict, user_id, session):
+    from ..thumbnail import post_thumbnail
+
+    await post_thumbnail(thumbnail_dict, user_id=user_id, session=session)
+
+
+thumbnail_types = [
+    ("cutoutScience", "new"),
+    ("cutoutTemplate", "ref"),
+    ("cutoutDifference", "sub"),
+]
+
+
+def decode_cutout(cutout_data, survey):
+    """Decode a raw cutout payload into (data_array, header).
+
+    Handles bytes/list/base64-string input and the survey-specific compression:
+    LSST cutouts are uncompressed FITS; all others are gzip-compressed.
+    """
+    if isinstance(cutout_data, list):
+        cutout_data = bytes(cutout_data)
+    elif isinstance(cutout_data, str):
+        cutout_data = base64.b64decode(cutout_data)
+    if survey.upper() == "LSST":
+        with fits.open(io.BytesIO(cutout_data), ignore_missing_simple=True) as hdu:
+            return np.array(hdu[0].data), dict(hdu[0].header)
+    else:
+        with (
+            gzip.open(io.BytesIO(cutout_data), "rb") as f,
+            fits.open(io.BytesIO(f.read()), ignore_missing_simple=True) as hdu,
+        ):
+            return np.array(hdu[0].data), dict(hdu[0].header)
+
+
+def orient_cutout(data_array, survey, header):
+    """Rotate/flip a cutout array so that North is up and West is right."""
+    if survey.upper() == "ZTF":
+        return np.flipud(data_array)
+    if survey.upper() == "LSST":
+        rotpa = header.get("ROTPA")
+        if rotpa is not None:
+            try:
+                return rotate(
+                    data_array, -rotpa, reshape=True, order=1, mode="constant", cval=0.0
+                )
+            except Exception as e:
+                log(f"Failed to rotate LSST cutout: {e}")
+    return data_array
+
+
+def clean_image_array(img):
+    """Scrub sentinel infinity values and NaNs from a cutout pixel array."""
+    xl = ~np.isnan(img) & (np.abs(img) > 1e20)
+    if img[xl].any():
+        img[xl] = np.nan
+    if np.isnan(img).any():
+        img = np.nan_to_num(img, nan=float(np.nanmean(img.flatten())))
+    return img
+
+
+def render_cutout_png(data_array, stretch, normalizer, cmap="bone"):
+    """Normalize and render a 2D array to a PNG BytesIO buffer.
+
+    `stretch` and `normalizer` are astropy.visualization instances.
+    Returns a seeked-to-start BytesIO containing the PNG bytes.
+    """
+    img = clean_image_array(data_array)
+    norm = ImageNormalize(img, stretch=stretch)
+    img_norm = norm(img)
+    vmin, vmax = normalizer.get_limits(img_norm)
+
+    buff = io.BytesIO()
+    fig, ax = plt.subplots(figsize=(4, 4))
+    fig.subplots_adjust(0, 0, 1, 1)
+    ax.set_axis_off()
+    ax.imshow(img_norm, cmap=cmap, origin="lower", vmin=vmin, vmax=vmax)
+    plt.savefig(buff, dpi=42, format="png")
+    plt.close(fig)
+    buff.seek(0)
+    return buff
+
+
+def make_thumbnail(obj_id, cutout_data, cutout_type, thumbnail_type, survey):
+    data_array, header = decode_cutout(cutout_data, survey)
+    data_array = orient_cutout(data_array, survey, header)
+
+    stretch = LinearStretch() if cutout_type == "cutoutDifference" else LogStretch()
+    normalizer = AsymmetricPercentileInterval(lower_percentile=1, upper_percentile=100)
+    buff = render_cutout_png(data_array, stretch, normalizer, cmap="bone")
+
+    return {
+        "obj_id": obj_id,
+        "data": base64.b64encode(buff.read()).decode("utf-8"),
+        "ttype": thumbnail_type,
+    }
+
+
+async def add_thumbnails(alert, survey, session):
+    for cutout_type, thumbnail_type in thumbnail_types:
+        if cutout_type not in alert:
+            log(f"Cutout key {cutout_type} not found in alert")
+            continue
+        try:
+            thumbnail = make_thumbnail(
+                alert["objectId"],
+                alert[cutout_type],
+                cutout_type,
+                thumbnail_type,
+                survey,
+            )
+        except Exception as e:
+            traceback.print_exc()
+            log(f"Failed to create thumbnail for cutout type {cutout_type}: {e}")
+            continue
+        await _post_thumbnail(thumbnail, user_id=1, session=session)
+
+
+_, cfg = load_env()
+
+
+def get_boom_url():
+    try:
+        ports_to_ignore = [443, 80]
+        return f"{cfg['boom.protocol']}://{cfg['boom.host']}" + (
+            f":{int(cfg['boom.port'])}"
+            if (
+                isinstance(cfg["boom.port"], int)
+                and int(cfg["boom.port"]) not in ports_to_ignore
+            )
+            else ""
+        )
+    except Exception as e:
+        log(f"Error getting Boom URL: {e}")
+        return None
+
+
+def get_boom_credentials():
+    username = cfg.get("boom.username")
+    password = cfg.get("boom.password")
+    if username is None or password is None:
+        log("Boom credentials not found in configuration")
+        return None
+    return {"username": username, "password": password}
+
+
+boom_url = get_boom_url()
+boom_credentials = get_boom_credentials()
+
+
+def get_boom_token():
+    try:
+        if boom_url is None or boom_credentials is None:
+            return None, None
+        auth_url = f"{boom_url}/auth"
+        current_time = datetime.utcnow()
+        auth_response = requests.post(
+            auth_url,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            data=boom_credentials,
+        )
+        auth_response.raise_for_status()
+        data = auth_response.json()
+        token = data["access_token"]
+        expires_at = None
+        if data.get("expires_in"):
+            expires_in = int(data["expires_in"])
+            expires_at = current_time + timedelta(seconds=expires_in)
+        return token, expires_at
+    except Exception as e:
+        log(f"Error getting Boom token: {e}")
+        return None, None
+
+
+boom_token, boom_token_expires_at = get_boom_token()
+
+
+def _refresh_boom_token():
+    global boom_url
+    global boom_credentials
+    if boom_url is None or boom_credentials is None:
+        raise ValueError("Boom is not available")
+    global boom_token
+    global boom_token_expires_at
+    if boom_token is None or (
+        boom_token_expires_at is not None
+        and boom_token_expires_at < datetime.utcnow() + timedelta(seconds=1800)
+    ):
+        boom_token, boom_token_expires_at = get_boom_token()
+    if boom_token is None:
+        raise ValueError("Boom is not available")
+
+
+def boom_available(func):
+    # Preserve the coroutine-ness of async handlers so baselayer's
+    # auth_or_token/permissions decorators take their async path.
+    if inspect.iscoroutinefunction(func):
+
+        @functools.wraps(func)
+        async def async_wrapper(*args, **kwargs):
+            _refresh_boom_token()
+            return await func(*args, **kwargs)
+
+        return async_wrapper
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        _refresh_boom_token()
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+# JavaScript's Number.MAX_SAFE_INTEGER (2^53 - 1)
+MAX_SAFE_INTEGER = 2**53 - 1
+
+
+# def convert_large_ints(obj):
+#     """Recursively convert integers that exceed JS Number.MAX_SAFE_INTEGER to strings.
+
+#     JavaScript cannot represent integers larger than 2^53 - 1 without loss of
+#     precision. This function walks the response tree and converts any
+#     out-of-range integer to its string representation so the browser receives
+#     the exact value.
+#     """
+#     if isinstance(obj, bool):
+#         return obj
+#     if isinstance(obj, int):
+#         if obj > MAX_SAFE_INTEGER or obj < -MAX_SAFE_INTEGER:
+#             return str(obj)
+#         return obj
+#     if isinstance(obj, dict):
+#         return {k: convert_large_ints(v) for k, v in obj.items()}
+#     if isinstance(obj, list):
+#         return [convert_large_ints(item) for item in obj]
+#     return obj
+
+
+# let's take a different approach: we convert to int all key: value where value is a number and where key ends with "id" (case insensitive)
+def convert_large_ints(obj):
+    """Recursively convert numeric values of keys ending with 'id' to strings.
+
+    This function walks the response tree and converts any numeric value of a key
+    that ends with 'id' (case insensitive) to a string. This allows the
+    frontend to receive these values as strings while still preserving precision
+    for large IDs.
+    """
+    if isinstance(obj, bool):
+        return obj
+    if isinstance(obj, dict):
+        new_obj = {}
+        for k, v in obj.items():
+            if isinstance(v, int | float) and k.lower().endswith("id"):
+                try:
+                    new_obj[k] = str(int(v))
+                except ValueError:
+                    new_obj[k] = v
+            else:
+                new_obj[k] = convert_large_ints(v)
+        return new_obj
+    if isinstance(obj, list):
+        return [convert_large_ints(item) for item in obj]
+    return obj

--- a/skyportal/tests/api/boom/conftest.py
+++ b/skyportal/tests/api/boom/conftest.py
@@ -1,0 +1,200 @@
+"""Fixtures for BOOM integration tests.
+
+These fixtures hit the live BOOM API (via SkyPortal's `@boom_available`
+endpoints), so they require a running boom-api-1 service. Any test that
+uses them will fail at fixture setup if BOOM is unreachable.
+"""
+
+import json
+import os
+import uuid
+
+import pytest
+
+from skyportal.tests import api
+
+# Path inside the container written by the workflow's "Inject BOOM seed
+# reference" step. Contains the objectId and candid of the first alert
+# ingested by boom's consumer-ztf, so tests don't need to hard-code a
+# specific OID that may not exist in the current seed dataset.
+# We use /tmp because the skyportal-web-1 container runs as the
+# `skyportal` user, which can't write under /skyportal/persistentdata
+# directly (only its chowned subdirs).
+_BOOM_SEED_FILE = "/tmp/boom_seed.json"
+
+
+def pytest_configure(config):
+    """Register custom markers so pytest doesn't warn about them."""
+    config.addinivalue_line(
+        "markers",
+        "requires_boom_data: test depends on BOOM mongo being seeded "
+        "(skipped automatically when no BOOM seed reference file is found).",
+    )
+
+
+def _load_boom_seed():
+    """Return {objectId, candid} dict from the seed file, or None."""
+    if not os.path.exists(_BOOM_SEED_FILE):
+        return None
+    try:
+        with open(_BOOM_SEED_FILE) as f:
+            payload = json.load(f)
+    except (OSError, ValueError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    if "objectId" not in payload or "candid" not in payload:
+        return None
+    return payload
+
+
+@pytest.fixture(scope="session")
+def boom_seed():
+    """Session-scoped (objectId, candid) for tests that need a real alert.
+
+    Returns None if BOOM wasn't seeded (e.g. running locally without the
+    workflow's seed step). Tests marked `requires_boom_data` will be
+    skipped in that case by `_boom_seed_data_gate`.
+    """
+    return _load_boom_seed()
+
+
+@pytest.fixture
+def boom_seed_oid(boom_seed):
+    if boom_seed is None:
+        pytest.skip("BOOM seed file not present")
+    return boom_seed["objectId"]
+
+
+@pytest.fixture
+def boom_seed_candid(boom_seed):
+    if boom_seed is None:
+        pytest.skip("BOOM seed file not present")
+    return int(boom_seed["candid"])
+
+
+@pytest.fixture
+def boom_seed_ra(boom_seed):
+    if boom_seed is None or boom_seed.get("ra") is None:
+        pytest.skip("BOOM seed ra not present")
+    return float(boom_seed["ra"])
+
+
+@pytest.fixture
+def boom_seed_dec(boom_seed):
+    if boom_seed is None or boom_seed.get("dec") is None:
+        pytest.skip("BOOM seed dec not present")
+    return float(boom_seed["dec"])
+
+
+@pytest.fixture(autouse=True)
+def _boom_seed_data_gate(request):
+    """Skip tests marked `requires_boom_data` when no seed file exists."""
+    if "requires_boom_data" not in request.keywords:
+        return
+    if _load_boom_seed() is None:
+        pytest.skip(
+            f"BOOM seed reference {_BOOM_SEED_FILE} not present; "
+            "the workflow's BOOM-seeding steps must run before these tests."
+        )
+
+
+@pytest.fixture
+def boom_ztf_stream(super_admin_token, public_stream):
+    """Decorate `public_stream` with ZTF_alerts altdata so that BOOM
+    filters can be attached to it. BOOM derives the survey/permissions
+    from `stream.altdata.collection` and `stream.altdata.selector`.
+    """
+    status, data = api(
+        "PATCH",
+        f"streams/{public_stream.id}",
+        data={
+            "name": str(uuid.uuid4()),
+            "altdata": {"collection": "ZTF_alerts", "selector": [1, 2]},
+        },
+        token=super_admin_token,
+    )
+    assert status == 200, data
+    return public_stream
+
+
+@pytest.fixture
+def boom_filter(super_admin_token, boom_ztf_stream, group_with_stream):
+    """A SkyPortal Filter provisioned on the BOOM side.
+
+    Two-step setup, mirroring the frontend:
+      1. POST /filters to create the SkyPortal-side Filter (no altdata).
+      2. POST /boom/filters/{id} which round-trips to BOOM, creates the
+         BOOM filter, and populates Filter.altdata with the BOOM filter_id.
+
+    Yields the SkyPortal Filter ID. Best-effort DELETE on teardown.
+
+    BOOM validates new filters by running their pipeline against the ZTF
+    corpus, so without seed data step 2 returns 400. We skip up-front
+    when no seed reference file is present.
+    """
+    if _load_boom_seed() is None:
+        pytest.skip(
+            f"BOOM seed reference {_BOOM_SEED_FILE} not present; "
+            "skip filter-provisioning tests until boom-mongo is seeded."
+        )
+
+    status, data = api(
+        "POST",
+        "filters",
+        data={
+            "name": str(uuid.uuid4()),
+            "stream_id": boom_ztf_stream.id,
+            "group_id": group_with_stream.id,
+        },
+        token=super_admin_token,
+    )
+    assert status == 200, data
+    filter_id = data["data"]["id"]
+
+    # BOOM rejects pipelines whose last stage isn't a $project that
+    # includes objectId (validation in build_and_test_filter_version).
+    pipeline = [
+        {"$match": {"candidate.drb": {"$gt": 0.5}}},
+        {"$project": {"objectId": 1, "candid": 1, "candidate": 1}},
+    ]
+    status, data = api(
+        "POST",
+        f"boom/filters/{filter_id}",
+        data={
+            "name": f"boom_filter_{filter_id}",
+            "altdata": pipeline,
+            "filters": "v1",
+        },
+        token=super_admin_token,
+    )
+    assert status == 200, data
+
+    yield filter_id
+
+    api("DELETE", f"boom/filters/{filter_id}", token=super_admin_token)
+
+
+@pytest.fixture
+def boom_filter_module_block(super_admin_token):
+    """Insert a sample BOOM filter-module block into the MongoDB store.
+
+    `BoomFilterModulesHandler` exposes no DELETE, so the block leaks; we
+    use a UUID-suffixed name to avoid collisions across test runs.
+    """
+    name = f"test_block_{uuid.uuid4().hex[:8]}"
+    payload = {
+        "elements": "blocks",
+        "data": {
+            "block": {"$match": {"candidate.drb": {"$gt": 0.5}}},
+            "streams": ["ZTF (1, 2)"],
+        },
+    }
+    status, data = api(
+        "POST",
+        f"boom/filter_modules/{name}",
+        data=payload,
+        token=super_admin_token,
+    )
+    assert status == 200, data
+    return name

--- a/skyportal/tests/api/boom/test_boom_archive.py
+++ b/skyportal/tests/api/boom/test_boom_archive.py
@@ -1,0 +1,96 @@
+import pytest
+
+from skyportal.tests import api
+
+
+def test_get_archive_catalogs(view_only_token):
+    status, data = api("GET", "boom/archive/catalogs", token=view_only_token)
+    assert status == 200
+    assert data["status"] == "success"
+    assert isinstance(data["data"], list)
+    # Reference catalogs only — survey collections must be stripped out.
+    for name in data["data"]:
+        assert not name.startswith(("ZTF_", "LSST_", "PTF_", "PGIR_", "WNTR_"))
+
+
+@pytest.mark.requires_boom_data
+def test_cross_match_happy_path(view_only_token):
+    # The cross-match endpoint fans out over BOOM's reference catalogs.
+    # In CI we seed a `test_catalog` collection with 1000 fake sources
+    # in a 0.01 deg box around (RA=0, Dec=80). The wider search radius
+    # here (1 deg) is generous enough that we should always get matches
+    # given the fake catalog density, while still exercising the real
+    # cone-search code path. Defensive skip kept so the test degrades
+    # gracefully if the catalog seeding step is removed/skipped.
+    status, catalogs_data = api("GET", "boom/archive/catalogs", token=view_only_token)
+    if status != 200 or not catalogs_data.get("data"):
+        pytest.skip("BOOM has no reference catalogs ingested; skipping cross-match")
+
+    ra, dec = 0.005, 80.0  # inside the fake_source_* spread
+    status, data = api(
+        "GET",
+        f"boom/archive/cross_match?ra={ra}&dec={dec}&radius=1&radius_units=deg",
+        token=view_only_token,
+    )
+    assert status == 200
+    assert data["status"] == "success"
+    assert isinstance(data["data"], dict)
+    # The fake catalog should have produced at least one hit.
+    assert "test_catalog" in data["data"]
+    assert len(data["data"]["test_catalog"]) > 0
+
+
+def test_cross_match_missing_params_errors(view_only_token):
+    status, data = api("GET", "boom/archive/cross_match?ra=10", token=view_only_token)
+    assert status == 400
+    assert data["status"] == "error"
+
+
+def test_cross_match_invalid_radius_units_errors(view_only_token):
+    status, data = api(
+        "GET",
+        "boom/archive/cross_match?ra=10&dec=20&radius=1&radius_units=parsecs",
+        token=view_only_token,
+    )
+    assert status == 400
+    assert data["status"] == "error"
+
+
+def test_cross_match_non_float_errors(view_only_token):
+    status, data = api(
+        "GET",
+        "boom/archive/cross_match?ra=abc&dec=20&radius=1&radius_units=arcsec",
+        token=view_only_token,
+    )
+    assert status == 400
+    assert data["status"] == "error"
+
+
+def test_cross_match_ra_out_of_range_errors(view_only_token):
+    status, data = api(
+        "GET",
+        "boom/archive/cross_match?ra=400&dec=20&radius=1&radius_units=arcsec",
+        token=view_only_token,
+    )
+    assert status == 400
+    assert data["status"] == "error"
+
+
+def test_cross_match_dec_out_of_range_errors(view_only_token):
+    status, data = api(
+        "GET",
+        "boom/archive/cross_match?ra=10&dec=120&radius=1&radius_units=arcsec",
+        token=view_only_token,
+    )
+    assert status == 400
+    assert data["status"] == "error"
+
+
+def test_cross_match_radius_too_large_errors(view_only_token):
+    status, data = api(
+        "GET",
+        "boom/archive/cross_match?ra=10&dec=20&radius=2&radius_units=deg",
+        token=view_only_token,
+    )
+    assert status == 400
+    assert data["status"] == "error"

--- a/static/js/ducks/boom_archive.ts
+++ b/static/js/ducks/boom_archive.ts
@@ -1,0 +1,30 @@
+import { skyportalApi } from "../api/skyportalApi";
+
+export interface CrossMatchArg {
+  ra: number | string;
+  dec: number | string;
+  radius: number | string;
+}
+
+// BOOM archive: catalog names + positional cross-matches. RTK Query conversion
+// of the old boom_archive thunks (kept in place — the archive functionality is
+// being moved from kowalski_archive onto BOOM). Endpoint names are BOOM-prefixed
+// where kowalski_archive has an equivalent, to stay unique on the shared api.
+export const boomArchiveApi = skyportalApi.injectEndpoints({
+  endpoints: (build) => ({
+    getBoomCatalogNames: build.query<any, void>({
+      query: () => "api/boom/archive/catalogs",
+    }),
+    getCrossMatches: build.query<any, CrossMatchArg>({
+      query: ({ ra, dec, radius }) =>
+        `api/boom/archive/cross_match?ra=${ra}&dec=${dec}&radius=${radius}&radius_units=arcsec`,
+    }),
+  }),
+});
+
+export const {
+  useGetBoomCatalogNamesQuery,
+  useLazyGetBoomCatalogNamesQuery,
+  useGetCrossMatchesQuery,
+  useLazyGetCrossMatchesQuery,
+} = boomArchiveApi;


### PR DESCRIPTION
Third vertical slice of upstreaming the fritz boom frontend.

**Backend:** `/api/boom/archive/catalogs` and `/api/boom/archive/cross_match` handlers + API tests, plus the RTK Query duck.

Deliberately backend-only: fritz's archive/cross-match UI (Archive page, source-page archive search, centroid-plot cross-match overlays) still talks to the legacy kowalski endpoints and will migrate onto these endpoints as a follow-up once the kowalski question from the roadmap is settled.

---
**Shared plumbing note:** this draft and its two siblings each carry `handlers/api/boom/utils.py`, a trimmed `boom/__init__.py`, and the `boom:` config section so they are independently reviewable; whichever merges first owns them and the others rebase. `boom/object.py`, `photometry.py`, and `photometry_cache.py` are deliberately absent — that is the photometry-passthrough surface of #6348. All kowalski-era code paths are stripped pending the kowalski-upstreaming decision.

Draft pending the boom-frontend roadmap discussion; feedback on slicing and config-gating conventions welcome.