### PR TITLE
use baselayer models for broker ingestion session

### DIFF
--- a/services/broker_ingest/broker_ingest.py
+++ b/services/broker_ingest/broker_ingest.py
@@ -12,10 +12,10 @@ import asyncio
 
 import sqlalchemy as sa
 
+from baselayer.app import models as baselayer_models
 from baselayer.app.env import load_env
 from baselayer.app.models import init_db
 from baselayer.log import make_log
-from skyportal import models
 from skyportal.models import Broker
 
 env, cfg = load_env()
@@ -55,7 +55,10 @@ async def _run_loop():
     running: dict[int, asyncio.Task] = {}
     while True:
         try:
-            async with models.async_plain_session_factory() as session:
+            # Resolve on the baselayer module at call time: init_db() rebinds the
+            # global there, but skyportal.models star-imported it as None at import
+            # time and keeps that stale binding.
+            async with baselayer_models.async_plain_session_factory() as session:
                 wanted = await _active_ingestion_brokers(session)
         except Exception as e:
             log(f"failed to list brokers: {e}")

--- a/skyportal/broker_apis/fink.py
+++ b/skyportal/broker_apis/fink.py
@@ -348,13 +348,15 @@ class FINKBROKER(BrokerAPI):
                 "Fink ingestion requires altdata['fink']['servers'] "
                 "(Kafka bootstrap servers)."
             )
-        # Fink authenticates with SASL SCRAM-SHA-512 over sasl_plaintext.
         config = {
             "bootstrap.servers": servers,
             "group.id": fink.get("group_id", f"skyportal-broker-{broker.id}"),
             "auto.offset.reset": fink.get("auto_offset_reset", "earliest"),
         }
-        if fink.get("username"):
+        # Fink's public livestream is passwordless (fink-client sends no SASL when
+        # `password` is null); only enable SASL SCRAM when a password is actually
+        # configured, else an empty password fails the auth handshake.
+        if fink.get("username") and fink.get("password"):
             config.update(
                 {
                     "security.protocol": "sasl_plaintext",


### PR DESCRIPTION
This PR enables the use of baselayer models for broker ingestion session