### PR TITLE
use single GET helper function

### DIFF
--- a/static/js/API.ts
+++ b/static/js/API.ts
@@ -148,6 +148,27 @@ export const filterOutEmptyValues = (
   return filteredParams;
 };
 
+/**
+ * Encode an object as a URL query string (no leading "?"), skipping null,
+ * undefined, "" and empty arrays. Use this everywhere query params are built so
+ * the encoding/skipping rules stay consistent across ducks.
+ */
+export const buildQueryString = (params: Record<string, unknown>): string => {
+  const search = new URLSearchParams();
+  Object.entries(params ?? {}).forEach(([key, value]) => {
+    if (
+      value === null ||
+      value === undefined ||
+      value === "" ||
+      (Array.isArray(value) && value.length === 0)
+    ) {
+      return;
+    }
+    search.append(key, String(value));
+  });
+  return search.toString();
+};
+
 function GET<T = unknown>(
   endpoint: string,
   actionType?: string,
@@ -156,14 +177,9 @@ function GET<T = unknown>(
 ): ApiThunk<T> {
   let url = endpoint;
   if (queryParams) {
-    const filteredQueryParams = filterOutEmptyValues(
-      queryParams,
-      true,
-      removeFalse,
+    const queryString = buildQueryString(
+      filterOutEmptyValues(queryParams, true, removeFalse),
     );
-    const queryString = new URLSearchParams(
-      filteredQueryParams as Record<string, string>,
-    ).toString();
     url += `?${queryString}`;
   }
   return API<T>(url, actionType, "GET");

--- a/static/js/ducks/allocations.ts
+++ b/static/js/ducks/allocations.ts
@@ -10,6 +10,7 @@
  * The old websocket `REFRESH_ALLOCATIONS` handler refetched all three lists;
  * here we invalidate the "Allocation" tag so any active variant refetches.
  */
+import { buildQueryString } from "../API";
 import { skyportalApi } from "../api/skyportalApi";
 import { invalidateOnMessage } from "../api/wsInvalidation";
 import type { RouteData } from "../types/routeSchemaMap";
@@ -20,17 +21,7 @@ const buildAllocationUrl = (params?: AllocationQueryParams): string => {
   if (!params || Object.keys(params).length === 0) {
     return "api/allocation";
   }
-  const filtered: Record<string, string> = {};
-  Object.entries(params).forEach(([key, value]) => {
-    if (value === undefined || value === null || value === "") {
-      return;
-    }
-    if (Array.isArray(value) && value.length === 0) {
-      return;
-    }
-    filtered[key] = String(value);
-  });
-  const queryString = new URLSearchParams(filtered).toString();
+  const queryString = buildQueryString(params);
   return queryString ? `api/allocation?${queryString}` : "api/allocation";
 };
 

--- a/static/js/ducks/analysis_services.ts
+++ b/static/js/ducks/analysis_services.ts
@@ -7,6 +7,7 @@
  * `REFRESH_ANALYSIS_SERVICES` message is bridged to cache invalidation via
  * `invalidateOnMessage`.
  */
+import { buildQueryString } from "../API";
 import { skyportalApi } from "../api/skyportalApi";
 import { invalidateOnMessage } from "../api/wsInvalidation";
 import type { RouteData } from "../types/routeSchemaMap";
@@ -23,9 +24,7 @@ export const analysisServicesApi = skyportalApi.injectEndpoints({
       Record<string, unknown> | void
     >({
       query: (params) => {
-        const queryString = new URLSearchParams(
-          (params as Record<string, string>) ?? {},
-        ).toString();
+        const queryString = buildQueryString(params ?? {});
         return queryString
           ? `api/analysis_service?${queryString}`
           : "api/analysis_service";

--- a/static/js/ducks/brokers.ts
+++ b/static/js/ducks/brokers.ts
@@ -2,6 +2,7 @@
  * Alert brokers: list configured brokers and query their alerts through the
  * generic `/api/brokers` API (dispatched server-side to the broker's provider).
  */
+import { buildQueryString } from "../API";
 import { skyportalApi } from "../api/skyportalApi";
 
 export interface Broker {
@@ -21,13 +22,7 @@ export interface BrokerAlertQuery {
 }
 
 const buildQuery = (params: BrokerAlertQuery["params"]) => {
-  const search = new URLSearchParams();
-  Object.entries(params).forEach(([k, v]) => {
-    if (v !== undefined && v !== "") {
-      search.append(k, String(v));
-    }
-  });
-  const qs = search.toString();
+  const qs = buildQueryString(params);
   return qs ? `?${qs}` : "";
 };
 

--- a/static/js/ducks/candidate/candidates.ts
+++ b/static/js/ducks/candidate/candidates.ts
@@ -25,7 +25,7 @@
  */
 import messageHandler from "baselayer/MessageHandler";
 
-import { filterOutEmptyValues } from "../../API";
+import { buildQueryString, filterOutEmptyValues } from "../../API";
 import { skyportalApi } from "../../api/skyportalApi";
 import { candidateApi } from "./candidate";
 import store from "../../store";
@@ -70,9 +70,7 @@ export const candidatesApi = skyportalApi.injectEndpoints({
         const cleaned = { ...filterParams };
         delete cleaned["_searchCount"];
         const filtered = filterOutEmptyValues(cleaned);
-        const queryString = new URLSearchParams(
-          filtered as Record<string, string>,
-        ).toString();
+        const queryString = buildQueryString(filtered);
         return `api/candidates?${queryString}`;
       },
       // All pages of one filter/query share a single cache entry. The scanning

--- a/static/js/ducks/candidate/scan_reports.ts
+++ b/static/js/ducks/candidate/scan_reports.ts
@@ -6,6 +6,7 @@
  * the `ScanReport` tag so the list refetches. The websocket
  * `REFRESH_SCAN_REPORTS` message is bridged to cache invalidation.
  */
+import { buildQueryString } from "../../API";
 import { skyportalApi } from "../../api/skyportalApi";
 import { invalidateOnMessage } from "../../api/wsInvalidation";
 import type { RouteData } from "../../types/routeSchemaMap";
@@ -17,7 +18,7 @@ export const scanReportsApi = skyportalApi.injectEndpoints({
       Record<string, any> | undefined
     >({
       query: (params) => {
-        const queryString = new URLSearchParams(params ?? {}).toString();
+        const queryString = buildQueryString(params ?? {});
         return queryString
           ? `api/candidates/scan_reports?${queryString}`
           : "api/candidates/scan_reports";

--- a/static/js/ducks/default_survey_efficiencies.ts
+++ b/static/js/ducks/default_survey_efficiencies.ts
@@ -5,6 +5,7 @@
  * Websocket-driven invalidation refetches the list; mutations submit/delete a
  * default survey efficiency.
  */
+import { buildQueryString } from "../API";
 import { skyportalApi } from "../api/skyportalApi";
 import { invalidateOnMessage } from "../api/wsInvalidation";
 import type { RouteData } from "../types/routeSchemaMap";
@@ -16,9 +17,7 @@ export const defaultSurveyEfficienciesApi = skyportalApi.injectEndpoints({
       Record<string, unknown> | void
     >({
       query: (filterParams) => {
-        const params = new URLSearchParams(
-          (filterParams as Record<string, string>) ?? {},
-        ).toString();
+        const params = buildQueryString(filterParams ?? {});
         return params
           ? `api/default_survey_efficiency?${params}`
           : "api/default_survey_efficiency";

--- a/static/js/ducks/earthquake.ts
+++ b/static/js/ducks/earthquake.ts
@@ -12,6 +12,7 @@
  * The websocket `REFRESH_EARTHQUAKE` / `REFRESH_EARTHQUAKES` messages are
  * bridged to cache invalidation via `invalidateOnMessage`.
  */
+import { buildQueryString } from "../API";
 import { skyportalApi } from "../api/skyportalApi";
 import { invalidateOnMessage } from "../api/wsInvalidation";
 import type { RouteData } from "../types/routeSchemaMap";
@@ -53,9 +54,7 @@ export const earthquakeApi = skyportalApi.injectEndpoints({
       Record<string, unknown> | void
     >({
       query: (params) => {
-        const search = new URLSearchParams(
-          (params as Record<string, string>) ?? {},
-        ).toString();
+        const search = buildQueryString(params ?? {});
         return search ? `api/earthquake?${search}` : "api/earthquake";
       },
       providesTags: ["Earthquakes"],

--- a/static/js/ducks/earthquakeStatuses.ts
+++ b/static/js/ducks/earthquakeStatuses.ts
@@ -9,6 +9,7 @@
  * `FETCH_EARTHQUAKE_STATUSES` message arrived, unconditionally. The RTK Query
  * equivalent invalidates the `EarthquakeStatus` tag so any active query refetches.
  */
+import { buildQueryString } from "../API";
 import { skyportalApi } from "../api/skyportalApi";
 import { invalidateOnMessage } from "../api/wsInvalidation";
 
@@ -25,9 +26,7 @@ export const earthquakeStatusesApi = skyportalApi.injectEndpoints({
       EarthquakeStatusesArg | void
     >({
       query: (filterParams) => {
-        const params = new URLSearchParams(
-          (filterParams as Record<string, string>) ?? {},
-        ).toString();
+        const params = buildQueryString(filterParams ?? {});
         return params
           ? `api/earthquake/status?${params}`
           : "api/earthquake/status";

--- a/static/js/ducks/followup_requests.ts
+++ b/static/js/ducks/followup_requests.ts
@@ -13,7 +13,7 @@
 import * as API from "../API";
 import { skyportalApi } from "../api/skyportalApi";
 import { invalidateOnMessage } from "../api/wsInvalidation";
-import { filterOutEmptyValues } from "../API";
+import { buildQueryString, filterOutEmptyValues } from "../API";
 import type { RouteData } from "../types/routeSchemaMap";
 
 type FollowupRequestsArg = Record<string, any> | void;
@@ -24,9 +24,7 @@ const buildFollowupRequestsUrl = (params: Record<string, any>): string => {
     withDefaults["numPerPage"] = 10;
   }
   const filtered = filterOutEmptyValues(withDefaults);
-  const queryString = new URLSearchParams(
-    filtered as Record<string, string>,
-  ).toString();
+  const queryString = buildQueryString(filtered);
   return queryString
     ? `api/followup_request?${queryString}`
     : "api/followup_request";

--- a/static/js/ducks/galaxies.ts
+++ b/static/js/ducks/galaxies.ts
@@ -10,18 +10,9 @@
  * invalidation, preserving the old guard that only refetched when the
  * currently-loaded GCN event matched the pushed event.
  */
+import { buildQueryString } from "../API";
 import { skyportalApi } from "../api/skyportalApi";
 import { invalidateOnMessage } from "../api/wsInvalidation";
-
-const buildQueryString = (params: Record<string, unknown>): string =>
-  new URLSearchParams(
-    Object.entries(params).reduce<Record<string, string>>((acc, [k, v]) => {
-      if (v !== undefined && v !== null) {
-        acc[k] = String(v);
-      }
-      return acc;
-    }, {}),
-  ).toString();
 
 interface GcnEventGalaxiesArg {
   dateobs: string;

--- a/static/js/ducks/gcnEvents.ts
+++ b/static/js/ducks/gcnEvents.ts
@@ -10,6 +10,7 @@
  * The websocket `REFRESH_GCN_EVENTS` message is bridged to cache invalidation
  * via `invalidateOnMessage`.
  */
+import { buildQueryString } from "../API";
 import { skyportalApi } from "../api/skyportalApi";
 import { invalidateOnMessage } from "../api/wsInvalidation";
 
@@ -24,19 +25,7 @@ export interface GcnEventsResult {
  * values to mirror the old `API.GET` `filterOutEmptyValues` behaviour.
  */
 const buildGcnEventsQuery = (filterParams: Record<string, any>): string => {
-  const search = new URLSearchParams();
-  Object.entries(filterParams).forEach(([key, value]) => {
-    if (
-      value === null ||
-      value === undefined ||
-      value === "" ||
-      (Array.isArray(value) && value.length === 0)
-    ) {
-      return;
-    }
-    search.append(key, String(value));
-  });
-  const queryString = search.toString();
+  const queryString = buildQueryString(filterParams);
   return `api/gcn_event${queryString ? `?${queryString}` : ""}`;
 };
 

--- a/static/js/ducks/gcnProperties.ts
+++ b/static/js/ducks/gcnProperties.ts
@@ -7,6 +7,7 @@
  * `invalidateOnMessage`; the old handler ignored the payload and always
  * refreshed, so we unconditionally invalidate the `GcnProperties` tag.
  */
+import { buildQueryString } from "../API";
 import { skyportalApi } from "../api/skyportalApi";
 import { invalidateOnMessage } from "../api/wsInvalidation";
 import type { RouteData } from "../types/routeSchemaMap";
@@ -22,9 +23,9 @@ export const gcnPropertiesApi = skyportalApi.injectEndpoints({
       FetchGcnPropertiesArgs | void
     >({
       query: (filterParams) => {
-        const params = new URLSearchParams(
+        const params = buildQueryString(
           (filterParams as Record<string, string>) ?? {},
-        ).toString();
+        );
         return `api/gcn_event/properties${params ? `?${params}` : ""}`;
       },
       providesTags: ["GcnProperties"],

--- a/static/js/ducks/gcnTags.ts
+++ b/static/js/ducks/gcnTags.ts
@@ -4,6 +4,7 @@
  * RTK Query conversion of the old `FETCH_GCN_TAGS` duck. Websocket-driven
  * invalidation refetches the tag list; mutations post/delete a tag on an event.
  */
+import { buildQueryString } from "../API";
 import { skyportalApi } from "../api/skyportalApi";
 import { invalidateOnMessage } from "../api/wsInvalidation";
 
@@ -21,9 +22,9 @@ export const gcnTagsApi = skyportalApi.injectEndpoints({
   endpoints: (build) => ({
     getGcnTags: build.query<string[], Record<string, unknown> | void>({
       query: (filterParams) => {
-        const params = new URLSearchParams(
+        const params = buildQueryString(
           (filterParams as Record<string, string>) ?? {},
-        ).toString();
+        );
         return params ? `api/gcn_event/tags?${params}` : "api/gcn_event/tags";
       },
       providesTags: ["GcnTags"],

--- a/static/js/ducks/invitations.ts
+++ b/static/js/ducks/invitations.ts
@@ -10,6 +10,7 @@
  * Invite/update/delete are mutations that invalidate the `Invitations` tag so
  * the active list query refetches. This duck has no websocket refresh.
  */
+import { buildQueryString as toQueryString } from "../API";
 import { skyportalApi } from "../api/skyportalApi";
 
 export interface InvitationsParams {
@@ -28,13 +29,7 @@ export interface InvitationsResult {
 }
 
 const buildQueryString = (params: InvitationsParams): string => {
-  const search = new URLSearchParams();
-  Object.entries(params).forEach(([key, value]) => {
-    if (value !== undefined && value !== null && value !== "") {
-      search.append(key, String(value));
-    }
-  });
-  const qs = search.toString();
+  const qs = toQueryString(params);
   return qs ? `?${qs}` : "";
 };
 

--- a/static/js/ducks/localizationTags.ts
+++ b/static/js/ducks/localizationTags.ts
@@ -5,6 +5,7 @@
  * is injected into the central `skyportalApi`; the websocket refresh message is
  * bridged to cache invalidation via `invalidateOnMessage`.
  */
+import { buildQueryString } from "../API";
 import { skyportalApi } from "../api/skyportalApi";
 import { invalidateOnMessage } from "../api/wsInvalidation";
 
@@ -21,9 +22,7 @@ export const localizationTagsApi = skyportalApi.injectEndpoints({
       LocalizationTagsArg | void
     >({
       query: (filterParams) => {
-        const params = new URLSearchParams(
-          (filterParams as Record<string, string>) || {},
-        ).toString();
+        const params = buildQueryString(filterParams || {});
         return params
           ? `api/localization/tags?${params}`
           : "api/localization/tags";

--- a/static/js/ducks/observations.ts
+++ b/static/js/ducks/observations.ts
@@ -19,6 +19,7 @@ import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import relativeTime from "dayjs/plugin/relativeTime";
 
+import { buildQueryString as toQueryString } from "../API";
 import { skyportalApi } from "../api/skyportalApi";
 import { invalidateOnMessage } from "../api/wsInvalidation";
 import type { RouteData } from "../types/routeSchemaMap";
@@ -38,15 +39,7 @@ dayjs.extend(utc);
 type FilterParams = Record<string, unknown>;
 
 const buildQueryString = (filterParams: FilterParams): string => {
-  const params = new URLSearchParams(
-    Object.fromEntries(
-      Object.entries(filterParams)
-        // Drop empty values: String(undefined) would send "instrumentName=undefined",
-        // which the backend tries to resolve as an instrument and 500s.
-        .filter(([, v]) => v !== undefined && v !== null && v !== "")
-        .map(([key, value]) => [key, String(value)]),
-    ),
-  ).toString();
+  const params = toQueryString(filterParams);
   return params ? `api/observation?${params}` : "api/observation";
 };
 
@@ -158,14 +151,7 @@ export const observationsApi = skyportalApi.injectEndpoints({
       RequestAPIQueuedObservationsArg
     >({
       query: ({ id, data }) => {
-        const params = new URLSearchParams(
-          Object.fromEntries(
-            Object.entries(data ?? {}).map(([key, value]) => [
-              key,
-              String(value),
-            ]),
-          ),
-        ).toString();
+        const params = toQueryString(data ?? {});
         return params
           ? `api/observation/external_api/${id}?${params}`
           : `api/observation/external_api/${id}`;

--- a/static/js/ducks/queued_observations.ts
+++ b/static/js/ducks/queued_observations.ts
@@ -26,6 +26,7 @@ import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import relativeTime from "dayjs/plugin/relativeTime";
 
+import { buildQueryString as buildQuery } from "../API";
 import { skyportalApi } from "../api/skyportalApi";
 import { invalidateOnMessage } from "../api/wsInvalidation";
 import type { components } from "../types/api";
@@ -37,11 +38,7 @@ dayjs.extend(utc);
 type FilterParams = Record<string, unknown>;
 
 const buildQueryString = (filterParams: FilterParams): string => {
-  const params = new URLSearchParams(
-    Object.fromEntries(
-      Object.entries(filterParams).map(([key, value]) => [key, String(value)]),
-    ),
-  ).toString();
+  const params = buildQuery(filterParams);
   return params ? `api/observation?${params}` : "api/observation";
 };
 
@@ -145,11 +142,7 @@ export const queuedObservationsApi = skyportalApi.injectEndpoints({
       RequestAPIQueuesArg
     >({
       query: ({ id, data = { queuesOnly: true } }) => {
-        const params = new URLSearchParams(
-          Object.fromEntries(
-            Object.entries(data).map(([key, value]) => [key, String(value)]),
-          ),
-        ).toString();
+        const params = buildQuery(data);
         return params
           ? `api/observation/external_api/${id}?${params}`
           : `api/observation/external_api/${id}`;

--- a/static/js/ducks/shifts.ts
+++ b/static/js/ducks/shifts.ts
@@ -11,6 +11,7 @@
  * The websocket `REFRESH_SHIFT` / `REFRESH_SHIFTS` messages are bridged to cache
  * invalidation via `invalidateOnMessage`.
  */
+import { buildQueryString } from "../API";
 import { skyportalApi } from "../api/skyportalApi";
 import { invalidateOnMessage } from "../api/wsInvalidation";
 import type { RouteData } from "../types/routeSchemaMap";
@@ -77,9 +78,7 @@ export const shiftsApi = skyportalApi.injectEndpoints({
       Record<string, unknown> | void
     >({
       query: (params) => {
-        const search = new URLSearchParams(
-          (params as Record<string, string>) ?? {},
-        ).toString();
+        const search = buildQueryString(params ?? {});
         return search ? `api/shifts?${search}` : "api/shifts";
       },
       transformResponse: (data: RouteData<"GET /api/shifts">) =>
@@ -89,10 +88,10 @@ export const shiftsApi = skyportalApi.injectEndpoints({
     getShiftsSummary: build.query<any, ShiftSummaryArg>({
       query: ({ shiftID, startDate, endDate }) => {
         if (startDate && endDate) {
-          const search = new URLSearchParams({
+          const search = buildQueryString({
             startDate,
             endDate,
-          }).toString();
+          });
           return `api/shifts/summary?${search}`;
         }
         if (shiftID) {

--- a/static/js/ducks/skymap_triggers.ts
+++ b/static/js/ducks/skymap_triggers.ts
@@ -6,6 +6,7 @@
  * trigger payload for an allocation; post/delete are mutations that invalidate
  * the `Localizations`/`Observations` tags so dependent listings refetch.
  */
+import { buildQueryString as buildQuery } from "../API";
 import { skyportalApi } from "../api/skyportalApi";
 import type { RouteData } from "../types/routeSchemaMap";
 
@@ -37,7 +38,7 @@ const buildQueryString = (params: Record<string, unknown>): string => {
       filtered[key] = String(value);
     }
   });
-  const queryString = new URLSearchParams(filtered).toString();
+  const queryString = buildQuery(filtered);
   return queryString ? `?${queryString}` : "";
 };
 

--- a/static/js/ducks/source.ts
+++ b/static/js/ducks/source.ts
@@ -16,6 +16,7 @@
  * messages are bridged to cache invalidation via `invalidateOnMessage`, so only
  * the active (currently-loaded) source's queries refetch.
  */
+import { buildQueryString } from "../API";
 import { skyportalApi } from "../api/skyportalApi";
 import { invalidateOnMessage, findCachedQueryArg } from "../api/wsInvalidation";
 import type { RouteData } from "../types/routeSchemaMap";
@@ -86,9 +87,7 @@ export const sourceApi = skyportalApi.injectEndpoints({
       number | string
     >({
       query: (id) => {
-        const queryString = new URLSearchParams(
-          sourceIncludeParams as unknown as Record<string, string>,
-        ).toString();
+        const queryString = buildQueryString(sourceIncludeParams);
         return `api/sources/${id}?${queryString}`;
       },
       // Provides both the broad "Source" tag (so the existing mutations, which

--- a/static/js/ducks/sources.ts
+++ b/static/js/ducks/sources.ts
@@ -15,7 +15,7 @@ import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import relativeTime from "dayjs/plugin/relativeTime";
 
-import { filterOutEmptyValues } from "../API";
+import { buildQueryString, filterOutEmptyValues } from "../API";
 import { skyportalApi } from "../api/skyportalApi";
 import { findCachedQueryArg, invalidateOnMessage } from "../api/wsInvalidation";
 
@@ -52,9 +52,7 @@ const addFilterParamDefaults = (filterParams: FilterParams): FilterParams => {
 /** Build a `/api/sources?...` URL from a filterParams object. */
 const buildSourcesUrl = (params: FilterParams, removeFalse = true): string => {
   const filtered = filterOutEmptyValues(params, true, removeFalse);
-  const queryString = new URLSearchParams(
-    filtered as Record<string, string>,
-  ).toString();
+  const queryString = buildQueryString(filtered);
   return `/api/sources?${queryString}`;
 };
 

--- a/static/js/ducks/sourcesingcn.ts
+++ b/static/js/ducks/sourcesingcn.ts
@@ -6,6 +6,7 @@
  * submit/patch/delete the confirmation status of a single source and invalidate
  * the `SourceInGcn` tag so the list refetches.
  */
+import { buildQueryString } from "../API";
 import { skyportalApi } from "../api/skyportalApi";
 import type { RouteData } from "../types/routeSchemaMap";
 
@@ -38,20 +39,7 @@ export const sourcesInGcnApi = skyportalApi.injectEndpoints({
       FetchSourcesInGcnArg
     >({
       query: ({ dateobs, ...filterParams }) => {
-        const cleaned: Record<string, string> = {};
-        Object.entries(filterParams).forEach(([key, value]) => {
-          if (value === undefined || value === null) {
-            return;
-          }
-          if (Array.isArray(value)) {
-            if (value.length > 0) {
-              cleaned[key] = value.join(",");
-            }
-          } else {
-            cleaned[key] = String(value);
-          }
-        });
-        const params = new URLSearchParams(cleaned).toString();
+        const params = buildQueryString(filterParams);
         return params
           ? `api/sources_in_gcn/${dateobs}?${params}`
           : `api/sources_in_gcn/${dateobs}`;

--- a/static/js/ducks/spatialCatalogs.ts
+++ b/static/js/ducks/spatialCatalogs.ts
@@ -12,6 +12,7 @@
  * when the pushed id matches a catalog that is currently cached) to cache
  * invalidation.
  */
+import { buildQueryString } from "../API";
 import { skyportalApi } from "../api/skyportalApi";
 import { invalidateOnMessage } from "../api/wsInvalidation";
 import type { RouteData } from "../types/routeSchemaMap";
@@ -23,9 +24,7 @@ export const spatialCatalogsApi = skyportalApi.injectEndpoints({
       Record<string, unknown> | void
     >({
       query: (filterParams) => {
-        const params = new URLSearchParams(
-          (filterParams as Record<string, string>) ?? {},
-        ).toString();
+        const params = buildQueryString(filterParams ?? {});
         return params ? `api/spatial_catalog?${params}` : "api/spatial_catalog";
       },
       providesTags: ["SpatialCatalogs"],

--- a/static/js/ducks/users.ts
+++ b/static/js/ducks/users.ts
@@ -9,6 +9,7 @@
  * The websocket `FETCH_USERS` message is bridged to cache invalidation via
  * `invalidateOnMessage`.
  */
+import { buildQueryString } from "../API";
 import { skyportalApi } from "../api/skyportalApi";
 import { invalidateOnMessage } from "../api/wsInvalidation";
 import type { RouteData } from "../types/routeSchemaMap";
@@ -28,9 +29,9 @@ export const usersApi = skyportalApi.injectEndpoints({
   endpoints: (build) => ({
     getUsers: build.query<UsersResult, Record<string, any> | void>({
       query: (filterParams) => {
-        const params = new URLSearchParams(
-          filterParams as Record<string, string> | undefined,
-        ).toString();
+        const params = buildQueryString(
+          (filterParams as Record<string, string>) ?? {},
+        );
         return `api/user${params ? `?${params}` : ""}`;
       },
       providesTags: ["User"],

--- a/static/js/ducks/users_management.ts
+++ b/static/js/ducks/users_management.ts
@@ -10,6 +10,7 @@
  * invalidation via `invalidateOnMessage`, so the active query refetches with
  * whatever params it currently holds.
  */
+import { buildQueryString as toQueryString } from "../API";
 import { skyportalApi } from "../api/skyportalApi";
 import { invalidateOnMessage } from "../api/wsInvalidation";
 
@@ -37,13 +38,7 @@ export interface UsersManagementResult {
 }
 
 const buildQueryString = (params: UsersManagementParams): string => {
-  const search = new URLSearchParams();
-  Object.entries(params).forEach(([key, value]) => {
-    if (value !== undefined && value !== null && value !== "") {
-      search.append(key, String(value));
-    }
-  });
-  const qs = search.toString();
+  const qs = toQueryString(params);
   return qs ? `?${qs}` : "";
 };
 


### PR DESCRIPTION
This PR unifies the GET with params across APIs.