### PR TITLE
Add timeouts to collection-time server availability checks in test_offset_util

### DIFF
--- a/skyportal/tests/tools/test_offset_util.py
+++ b/skyportal/tests/tools/test_offset_util.py
@@ -191,11 +191,13 @@ ztfref_url = get_ztfref_url(123.0, 33.3, 2)
 run_ztfref_test = True
 try:
     if ztfref_url != "":
-        r = requests.get(ztfref_url)
+        # bound the check: this runs at collection time, and an unreachable
+        # server would otherwise hang the whole pytest run
+        r = requests.get(ztfref_url, timeout=(6.05, 20))
         r.raise_for_status()
     else:
         run_ztfref_test = False
-except (HTTPError, TimeoutError, ConnectionError, MissingSchema) as e:
+except (HTTPError, Timeout, ConnectionError, MissingSchema) as e:
     run_ztfref_test = False
     print(e)
 
@@ -243,7 +245,7 @@ desi_url = (
 # check to see if the DESI server is up. If not, do not run test.
 run_desi_test = True
 try:
-    r = requests.get(desi_url)
+    r = requests.get(desi_url, timeout=(6.05, 20))
     r.raise_for_status()
 except (HTTPError, Timeout, ConnectionError) as e:
     run_desi_test = False


### PR DESCRIPTION
## Why

The `api_and_utils_pt4` CI job takes ~27 minutes while its tests only sum to ~5.4 minutes (per the JUnit XML). The raw job log shows an 18.3-minute silent gap during pytest collection: `test_offset_util.py` makes module-level `requests.get()` calls with no timeout to check whether the DESI (legacysurvey.org) and ZTF/IRSA servers are up, and legacysurvey.org is unreachable from GitHub runners — so every run hangs there until the OS TCP stack gives up. (Example: run 30014403012, `pt4` gap from 14:22 to 14:40 between the pytest `plugins:` line and `collected 233 items`.)

## What

- Add `timeout=(6.05, 20)` to both availability checks — the same connect/read timeouts `skyportal.utils.offset.get_url` already uses.
- Catch requests' `Timeout` instead of builtin `TimeoutError` in the ZTF check, so a read timeout marks the tests as skipped rather than erroring collection of the whole module.