### PR TITLE
Pydantic-typed endpoint validation + OpenAPI docs (prototype on annotation POST)

### DIFF
--- a/skyportal/handlers/api/annotation.py
+++ b/skyportal/handlers/api/annotation.py
@@ -1,8 +1,8 @@
-import re
 import time
-from collections.abc import Mapping
+from typing import Any
 
 from marshmallow.exceptions import ValidationError
+from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import selectinload
 
@@ -22,6 +22,34 @@ from ...utils.sizeof import SIZE_WARNING_THRESHOLD, sizeof
 from ..base import BaseHandler
 
 log = make_log("api/annotation")
+
+
+class AnnotationPostBody(BaseModel):
+    """Request body for posting an annotation."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    origin: str = Field(
+        pattern=r"^\w+",
+        description="String describing the source of this information. "
+        "Only one Annotation per origin is allowed, although each Annotation "
+        "can have multiple fields. To add/change data, use the update method "
+        "instead of trying to post another Annotation from this origin. "
+        "Origin must be a non-empty string starting with an alphanumeric "
+        "character or underscore (it must match the regex: /^\\w+/).",
+    )
+    data: dict[str, Any] = Field(description="Annotation data as {key: value} pairs.")
+    group_ids: list[int] | None = Field(
+        default=None,
+        description="List of group IDs corresponding to which groups should be "
+        "able to view annotation. Defaults to all of requesting user's groups.",
+    )
+
+
+class AnnotationPostResponse(BaseModel):
+    """Data payload returned when posting an annotation."""
+
+    annotation_id: int = Field(description="New annotation ID")
 
 
 def _coerce_resource_id(associated_resource_type, resource_id):
@@ -218,7 +246,13 @@ class AnnotationHandler(BaseHandler):
             return self.success(data=query_output)
 
     @permissions(["Annotate"])
-    async def post(self, associated_resource_type: str, resource_id: str):
+    async def post(
+        self,
+        associated_resource_type: str,
+        resource_id: str,
+        *,
+        body: AnnotationPostBody = None,
+    ) -> AnnotationPostResponse:
         """
         ---
         summary: Post an annotation
@@ -244,73 +278,14 @@ class AnnotationHandler(BaseHandler):
                This would be a string for an object ID,
                or an integer for other data types,
                e.g., a spectrum.
-        requestBody:
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  origin:
-                     type: string
-                     description: |
-                        String describing the source of this information.
-                        Only one Annotation per origin is allowed, although
-                        each Annotation can have multiple fields.
-                        To add/change data, use the update method instead
-                        of trying to post another Annotation from this origin.
-                        Origin must be a non-empty string starting with an
-                        alphanumeric character or underscore.
-                        (it must match the regex: /^\\w+/)
-
-                  data:
-                    type: object
-                  group_ids:
-                    type: array
-                    items:
-                      type: integer
-                    description: |
-                      List of group IDs corresponding to which groups should be
-                      able to view annotation. Defaults to all of requesting user's
-                      groups.
-
-                required:
-                  - origin
-                  - data
-        responses:
-          200:
-            content:
-              application/json:
-                schema:
-                  allOf:
-                    - $ref: '#/components/schemas/Success'
-                    - type: object
-                      properties:
-                        data:
-                          type: object
-                          properties:
-                            annotation_id:
-                              type: integer
-                              description: New annotation ID
         """
-        data = self.get_json()
-        origin = data.get("origin")
-
-        if origin is None:
-            return self.error("origin must be specified")
-
-        if not re.search(r"^\w+", origin):
-            return self.error("Input `origin` must begin with alphanumeric/underscore")
-
-        annotation_data = data.get("data")
-
-        group_ids = data.pop("group_ids", None)
-        if not group_ids:
-            group_ids = [g.id for g in self.current_user.accessible_groups]
-
-        if not isinstance(annotation_data, Mapping):
-            return self.error(
-                "Invalid data: the annotation data must be an object with at least one {key: value} pair"
-            )
+        body = self.parse_body(AnnotationPostBody)
+        origin = body.origin
+        annotation_data = body.data
+        group_ids = body.group_ids or [
+            g.id for g in self.current_user.accessible_groups
+        ]
+        data = {"origin": origin, "data": annotation_data}
 
         async with self.AsyncSession() as session:
             author_id = self.associated_user_object.id

--- a/skyportal/handlers/base.py
+++ b/skyportal/handlers/base.py
@@ -4,12 +4,15 @@ import types
 import typing
 from math import ceil
 
+from pydantic import ValidationError as PydanticValidationError
 from tornado.gen import sleep
 from tornado.iostream import StreamClosedError
+from tornado.web import Finish
 
 from baselayer.app.handlers.base import BaseHandler as BaselayerHandler
 
 from .. import __version__
+from ..utils.api_validate import format_validation_errors
 
 HANDLER_METHODS = ("get", "post", "put", "patch", "delete")
 
@@ -56,6 +59,10 @@ def install_path_param_validation(cls):
         validators = []
         for i, p in enumerate(params):
             if p.annotation is inspect.Parameter.empty:
+                continue
+            # keyword-only params (e.g. pydantic body models documenting the
+            # endpoint for spec_from_handlers) are not path parameters
+            if p.kind is inspect.Parameter.KEYWORD_ONLY:
                 continue
             cast_fn, allow_none = resolve_cast(p.annotation)
             if cast_fn is None or cast_fn is str:
@@ -139,6 +146,18 @@ class BaseHandler(BaselayerHandler):
         if hasattr(self.current_user, "username"):
             return self.current_user
         return self.current_user.created_by
+
+    def parse_body(self, model):
+        """Validate the JSON request body against a pydantic model.
+
+        Returns the parsed model instance; on failure writes the standard 400
+        error response and raises tornado.web.Finish to abort the handler.
+        """
+        try:
+            return model.model_validate(self.get_json())
+        except PydanticValidationError as e:
+            self.error(f"Invalid/missing parameters: {format_validation_errors(e)}")
+            raise Finish() from None
 
     def success(self, *args, **kwargs):
         super().success(*args, **kwargs, extra={"version": __version__})

--- a/skyportal/openapi.py
+++ b/skyportal/openapi.py
@@ -7,6 +7,11 @@ from tornado.routing import URLSpec
 
 from . import __version__
 from .models import schema
+from .utils.api_validate import (
+    body_model_from,
+    register_pydantic_schema,
+    response_model_from,
+)
 
 HTTP_METHODS = ("head", "get", "post", "put", "patch", "delete", "options")
 
@@ -114,9 +119,16 @@ def spec_from_handlers(handlers, exclude_internal=True, metadata=None):
             path_parameters = path_template.count("{}")
 
             spec = yaml_utils.load_yaml_from_docstring(method.__doc__)
-            parameters = list(inspect.signature(method).parameters.keys())[1:]
-            # remove parameters called "ignored_args"
-            parameters = [param for param in parameters if param != "ignored_args"]
+            # keyword-only parameters (e.g. validated request bodies) and
+            # "ignored_args" are not path parameters
+            parameters = [
+                name
+                for name, param in list(inspect.signature(method).parameters.items())[
+                    1:
+                ]
+                if name != "ignored_args"
+                and param.kind is not inspect.Parameter.KEYWORD_ONLY
+            ]
             parameters = [f"{{{param}}}" for param in parameters]
             parameters = parameters + (path_parameters - len(parameters)) * [
                 "",
@@ -133,6 +145,42 @@ def spec_from_handlers(handlers, exclude_internal=True, metadata=None):
                     f"<b>Permission(s) required:</b> <em>{', '.join(method.__permissions__)} (or System admin)</em><br><br>"
                     + spec.get("description", "")
                 )
+
+            # pydantic models in the method's type hints (keyword-only body
+            # param, return annotation) override any hand-written docstring
+            # sections, so docs match validation
+            body_model = body_model_from(method)
+            if body_model is not None:
+                spec["requestBody"] = {
+                    "required": True,
+                    "content": {
+                        "application/json": {
+                            "schema": register_pydantic_schema(openapi_spec, body_model)
+                        }
+                    },
+                }
+
+            response_model = response_model_from(method)
+            if response_model is not None:
+                spec.setdefault("responses", {})["200"] = {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "allOf": [
+                                    {"$ref": "#/components/schemas/Success"},
+                                    {
+                                        "type": "object",
+                                        "properties": {
+                                            "data": register_pydantic_schema(
+                                                openapi_spec, response_model
+                                            )
+                                        },
+                                    },
+                                ]
+                            }
+                        }
+                    }
+                }
 
             multiple_spec = spec.pop("multiple", {})
             single_spec = spec.pop("single", {})

--- a/skyportal/tests/api_tests/sources_candidates/test_annotations.py
+++ b/skyportal/tests/api_tests/sources_candidates/test_annotations.py
@@ -16,7 +16,7 @@ def test_post_without_origin_fails(annotation_token, public_source, public_group
     )
 
     assert status in [400]
-    assert "origin must be specified" in data["message"]
+    assert "origin: Field required" in data["message"]
 
     # this should not work, since "origin" is empty
     status, data = api(
@@ -31,7 +31,7 @@ def test_post_without_origin_fails(annotation_token, public_source, public_group
     )
 
     assert status == 400
-    assert "Input `origin` must begin with alphanumeric/underscore" in data["message"]
+    assert "origin: String should match pattern" in data["message"]
 
 
 def test_post_same_origin_fails(annotation_token, public_source, public_group):
@@ -341,10 +341,7 @@ def test_cannot_add_annotation_without_data(
         token=annotation_token,
     )
     assert status == 400
-    assert (
-        "Invalid data: the annotation data must be an object with at least one {key: value} pair"
-        in data["message"]
-    )
+    assert "data: Field required" in data["message"]
 
 
 def test_post_invalid_data(annotation_token, public_source, public_group):
@@ -361,4 +358,4 @@ def test_post_invalid_data(annotation_token, public_source, public_group):
     )
 
     assert status == 400
-    assert "Invalid data" in data["message"]
+    assert "data: Input should be a valid dictionary" in data["message"]

--- a/skyportal/tests/api_tests/sources_candidates/test_candidates.py
+++ b/skyportal/tests/api_tests/sources_candidates/test_candidates.py
@@ -274,7 +274,6 @@ def test_candidate_list_sorting_basic(
         "POST",
         f"sources/{public_candidate.id}/annotations",
         data={
-            "obj_id": public_candidate.id,
             "origin": origin,
             "data": {"numeric_field": 1},
         },
@@ -286,7 +285,6 @@ def test_candidate_list_sorting_basic(
         "POST",
         f"sources/{public_candidate2.id}/annotations",
         data={
-            "obj_id": public_candidate2.id,
             "origin": origin,
             "data": {"numeric_field": 2},
         },
@@ -319,7 +317,6 @@ def test_candidate_list_sorting_different_origins(
         "POST",
         f"sources/{public_candidate.id}/annotations",
         data={
-            "obj_id": public_candidate.id,
             "origin": origin,
             "data": {"numeric_field": 1},
         },
@@ -331,7 +328,6 @@ def test_candidate_list_sorting_different_origins(
         "POST",
         f"sources/{public_candidate2.id}/annotations",
         data={
-            "obj_id": public_candidate2.id,
             "origin": origin2,
             "data": {"numeric_field": 2},
         },
@@ -370,7 +366,6 @@ def test_candidate_list_sorting_hidden_group(
         "POST",
         f"sources/{public_candidate_two_groups.id}/annotations",
         data={
-            "obj_id": public_candidate_two_groups.id,
             "origin": f"{public_group2.id}",
             "data": {"numeric_field": 1},
             "group_ids": [public_group2.id],
@@ -384,7 +379,6 @@ def test_candidate_list_sorting_hidden_group(
         "POST",
         f"sources/{public_candidate2.id}/annotations",
         data={
-            "obj_id": public_candidate2.id,
             "origin": f"{public_group2.id}",
             "data": {"numeric_field": 2},
         },
@@ -418,7 +412,6 @@ def test_candidate_list_sorting_null_value(
         "POST",
         f"sources/{public_candidate.id}/annotations",
         data={
-            "obj_id": public_candidate.id,
             "origin": origin,
             "data": {"numeric_field": 1},
         },
@@ -430,7 +423,6 @@ def test_candidate_list_sorting_null_value(
         "POST",
         f"sources/{public_candidate2.id}/annotations",
         data={
-            "obj_id": public_candidate2.id,
             "origin": origin,
             "data": {"some_other_field": 2},
         },
@@ -464,7 +456,6 @@ def test_candidate_list_filtering_numeric(
         "POST",
         f"sources/{public_candidate.id}/annotations",
         data={
-            "obj_id": public_candidate.id,
             "origin": origin,
             "data": {"numeric_field": 1},
         },
@@ -476,7 +467,6 @@ def test_candidate_list_filtering_numeric(
         "POST",
         f"sources/{public_candidate2.id}/annotations",
         data={
-            "obj_id": public_candidate2.id,
             "origin": origin,
             "data": {"numeric_field": 2},
         },
@@ -507,7 +497,6 @@ def test_candidate_list_filtering_boolean(
         "POST",
         f"sources/{public_candidate.id}/annotations",
         data={
-            "obj_id": public_candidate.id,
             "origin": origin,
             "data": {"bool_field": True},
         },
@@ -519,7 +508,6 @@ def test_candidate_list_filtering_boolean(
         "POST",
         f"sources/{public_candidate2.id}/annotations",
         data={
-            "obj_id": public_candidate2.id,
             "origin": origin,
             "data": {"bool_field": False},
         },
@@ -550,7 +538,6 @@ def test_candidate_list_filtering_string(
         "POST",
         f"sources/{public_candidate.id}/annotations",
         data={
-            "obj_id": public_candidate.id,
             "origin": origin,
             "data": {"string_field": "a"},
         },
@@ -562,7 +549,6 @@ def test_candidate_list_filtering_string(
         "POST",
         f"sources/{public_candidate2.id}/annotations",
         data={
-            "obj_id": public_candidate2.id,
             "origin": origin,
             "data": {"string_field": "b"},
         },
@@ -760,7 +746,7 @@ def test_exclude_by_outdated_annotations(
     status, data = api(
         "POST",
         f"sources/{public_candidate.id}/annotations",
-        data={"obj_id": public_candidate.id, "origin": origin, "data": {"value1": 1}},
+        data={"origin": origin, "data": {"value1": 1}},
         token=annotation_token,
     )
     assert status == 200

--- a/skyportal/tests/api_tests/spectra_misc/test_annotations_on_photometry.py
+++ b/skyportal/tests/api_tests/spectra_misc/test_annotations_on_photometry.py
@@ -30,13 +30,12 @@ def test_add_and_retrieve_annotation_group_id(
         "POST",
         f"photometry/{photometry_id}/annotations",
         data={
-            "photometry_id": photometry_id,
             "data": {"offset_from_host_galaxy": 1.5},
             "group_ids": [public_group.id],
         },
         token=annotation_token,
     )
-    assert_api_fail(status, data, 400, "origin must be specified")
+    assert_api_fail(status, data, 400, "origin: Field required")
 
     # this should not work, since "origin" is empty
     status, data = api(
@@ -51,7 +50,7 @@ def test_add_and_retrieve_annotation_group_id(
     )
 
     assert status in [400, 401]
-    assert "Input `origin` must begin with alphanumeric/underscore" in data["message"]
+    assert "origin: String should match pattern" in data["message"]
 
     # first time adding an annotation to this object from Kowalski
     status, data = api(
@@ -129,7 +128,6 @@ def test_add_and_retrieve_annotation_group_access(
         f"photometry/{photometry_id}/annotations",
         data={
             "origin": "IPAC",
-            "photometry_id": photometry_id,
             "data": {"distance_from_host": 7.4},
             "group_ids": [public_group2.id],
         },
@@ -161,7 +159,6 @@ def test_add_and_retrieve_annotation_group_access(
         f"photometry/{photometry_id}/annotations",
         data={
             "origin": "kowalski",
-            "photometry_id": photometry_id,
             "data": {"ACAI_class": "type Ia"},
             "group_ids": [public_group.id, public_group2.id],
         },
@@ -212,7 +209,6 @@ def test_add_and_retrieve_annotation_group_access(
         f"photometry/{photometry_id}/annotations",
         data={
             "origin": "kowalski",
-            "photometry_id": photometry_id,
             "data": {"ACAI_class": "type Ia"},
             "group_ids": [public_group2.id],
         },

--- a/skyportal/tests/api_tests/spectra_misc/test_annotations_on_spectrum.py
+++ b/skyportal/tests/api_tests/spectra_misc/test_annotations_on_spectrum.py
@@ -27,14 +27,13 @@ def test_add_and_retrieve_annotation_group_id(
         "POST",
         f"spectra/{spectrum_id}/annotations",
         data={
-            "spectrum_id": spectrum_id,
             "data": {"offset_from_host_galaxy": 1.5},
             "group_ids": [public_group.id],
         },
         token=annotation_token,
     )
     assert status in [400]
-    assert "origin must be specified" in data["message"]
+    assert "origin: Field required" in data["message"]
 
     # this should not work, since "origin" is empty
     status, data = api(
@@ -49,7 +48,7 @@ def test_add_and_retrieve_annotation_group_id(
     )
 
     assert status in [400, 401]
-    assert "Input `origin` must begin with alphanumeric/underscore" in data["message"]
+    assert "origin: String should match pattern" in data["message"]
 
     # first time adding an annotation to this object from Kowalski
     status, data = api(
@@ -123,7 +122,6 @@ def test_add_and_retrieve_annotation_group_access(
         f"spectra/{spectrum_id}/annotations",
         data={
             "origin": "IPAC",
-            "spectrum_id": spectrum_id,
             "data": {"distance_from_host": 7.4},
             "group_ids": [public_group2.id],
         },
@@ -155,7 +153,6 @@ def test_add_and_retrieve_annotation_group_access(
         f"spectra/{spectrum_id}/annotations",
         data={
             "origin": "kowalski",
-            "spectrum_id": spectrum_id,
             "data": {"ACAI_class": "type Ia"},
             "group_ids": [public_group.id, public_group2.id],
         },
@@ -202,7 +199,6 @@ def test_add_and_retrieve_annotation_group_access(
         f"spectra/{spectrum_id}/annotations",
         data={
             "origin": "kowalski",
-            "spectrum_id": spectrum_id,
             "data": {"ACAI_class": "type Ia"},
             "group_ids": [public_group2.id],
         },

--- a/skyportal/tests/api_tests/spectra_misc/test_color_mag.py
+++ b/skyportal/tests/api_tests/spectra_misc/test_color_mag.py
@@ -6,7 +6,6 @@ def test_post_retrieve_color_mag_data(annotation_token, user, public_source):
         "POST",
         f"sources/{public_source.id}/annotations",
         data={
-            "obj_id": public_source.id,
             "origin": "gaiadr3.gaia_source",
             "data": {
                 "Mag_G": 15.1,
@@ -123,7 +122,6 @@ def test_change_color_mag_keys(annotation_token, user, public_source):
         "POST",
         f"sources/{public_source.id}/annotations",
         data={
-            "obj_id": public_source.id,
             "origin": "gaiadr3.gaia_source",
             "data": {"MagG": 15.1, "MagBp": 16.1, "MagRp": 14.0, "Plx": 20},
         },
@@ -199,7 +197,6 @@ def test_add_multiple_color_mag_annotations(annotation_token, user, public_sourc
         "POST",
         f"sources/{public_source.id}/annotations",
         data={
-            "obj_id": public_source.id,
             "origin": "gaiadr1.gaia_source",
             "data": {"MagG": 15.1, "MagBp": 16.1, "MagRp": 14.0, "Plx": 20},
         },
@@ -221,7 +218,6 @@ def test_add_multiple_color_mag_annotations(annotation_token, user, public_sourc
         "POST",
         f"sources/{public_source.id}/annotations",
         data={
-            "obj_id": public_source.id,
             "origin": "gaiadr2.gaia_source",
             "data": {"MagG": 15.2, "MagBp": 16.2, "MagRp": 14.0, "Plx": 20},
         },
@@ -234,7 +230,6 @@ def test_add_multiple_color_mag_annotations(annotation_token, user, public_sourc
         "POST",
         f"sources/{public_source.id}/annotations",
         data={
-            "obj_id": public_source.id,
             "origin": "gaiadr3.gaia_source",
             "data": {"MagG": 15.3, "MagBp": 16.3, "MagRp": 14.0, "Plx": 5},
         },

--- a/skyportal/tests/frontend/sources_and_observingruns_etc/test_scanning_page.py
+++ b/skyportal/tests/frontend/sources_and_observingruns_etc/test_scanning_page.py
@@ -390,7 +390,6 @@ def test_submit_annotations_sorting(
         "POST",
         f"sources/{public_candidate.id}/annotations",
         data={
-            "obj_id": public_candidate.id,
             "origin": origin,
             "data": {"numeric_field": 1},
         },
@@ -401,7 +400,6 @@ def test_submit_annotations_sorting(
         "POST",
         f"sources/{public_candidate2.id}/annotations",
         data={
-            "obj_id": public_candidate2.id,
             "origin": origin,
             "data": {"numeric_field": 2},
         },
@@ -588,7 +586,6 @@ def test_candidate_annotations_search(
         "POST",
         f"sources/{public_candidate.id}/annotations",
         data={
-            "obj_id": public_candidate.id,
             "origin": origin,
             "data": {"alphafield": 1, "betafield": 2},
         },
@@ -892,7 +889,6 @@ def test_add_scanning_profile(
         "POST",
         f"sources/{public_source.id}/annotations",
         data={
-            "obj_id": public_source.id,
             "origin": "kowalski",
             "data": {"offset_from_host_galaxy": 1.5},
             "group_ids": [public_group.id],

--- a/skyportal/tests/frontend/sources_and_observingruns_etc/test_source_list.py
+++ b/skyportal/tests/frontend/sources_and_observingruns_etc/test_source_list.py
@@ -342,7 +342,6 @@ def test_hr_diagram(page, user, public_group, upload_data_token, annotation_toke
         "POST",
         f"sources/{source_id}/annotations",
         data={
-            "obj_id": source_id,
             "origin": "gaiadr3.gaia_source",
             "data": {"Mag_G": 11.3, "Mag_Bp": 11.8, "Mag_Rp": 11.0, "Plx": 20},
         },

--- a/skyportal/tests/frontend/sources_and_observingruns_etc/test_sources.py
+++ b/skyportal/tests/frontend/sources_and_observingruns_etc/test_sources.py
@@ -568,7 +568,6 @@ def test_source_hr_diagram(page, user, public_source, annotation_token, tmp_path
         "POST",
         f"sources/{public_source.id}/annotations",
         data={
-            "obj_id": public_source.id,
             "origin": "gaiadr3.gaia_source",
             "data": {"Mag_G": 11.3, "Mag_Bp": 12.8, "Mag_Rp": 11.0, "Plx": 20},
         },

--- a/skyportal/utils/api_validate.py
+++ b/skyportal/utils/api_validate.py
@@ -1,0 +1,95 @@
+"""Pydantic-based request validation for API handlers.
+
+Annotate a keyword-only handler parameter with a pydantic model (and
+optionally the return type with a response model); `spec_from_handlers` reads
+these hints to document the endpoint. At runtime the handler validates
+explicitly with `BaseHandler.parse_body`, which 400s with field-level errors:
+
+    class MyBody(BaseModel):
+        name: str
+
+    @permissions(["..."])
+    async def post(self, obj_id: str, *, body: MyBody = None) -> MyResponse:
+        body = self.parse_body(MyBody)
+"""
+
+import inspect
+import types
+import typing
+
+from pydantic import BaseModel
+
+REF_TEMPLATE = "#/components/schemas/{model}"
+
+
+def model_from_annotation(annotation):
+    """Extract a pydantic model class from an annotation, unwrapping `X | None`."""
+    if inspect.isclass(annotation) and issubclass(annotation, BaseModel):
+        return annotation
+    if typing.get_origin(annotation) in (typing.Union, types.UnionType):
+        for arg in typing.get_args(annotation):
+            if inspect.isclass(arg) and issubclass(arg, BaseModel):
+                return arg
+    return None
+
+
+def body_model_from(method):
+    """Pydantic model annotating a keyword-only parameter of `method`, or None.
+
+    `inspect.signature` follows `__wrapped__`, so this sees through
+    `@permissions` and the path-parameter validation wrapper.
+    """
+    for param in inspect.signature(method).parameters.values():
+        if param.kind is inspect.Parameter.KEYWORD_ONLY:
+            model = model_from_annotation(param.annotation)
+            if model is not None:
+                return model
+    return None
+
+
+def response_model_from(method):
+    """Pydantic model in the return annotation of `method`, or None."""
+    return model_from_annotation(inspect.signature(method).return_annotation)
+
+
+def format_validation_errors(exc):
+    """Render a pydantic ValidationError as a compact one-line message."""
+    return "; ".join(
+        f"{'.'.join(str(loc) for loc in error['loc']) or 'body'}: {error['msg']}"
+        for error in exc.errors()
+    )
+
+
+def _to_openapi_30(node):
+    """Convert pydantic's JSON Schema (2020-12) to OpenAPI 3.0: replace
+    `anyOf: [X, {type: null}]` with `X` + `nullable: true`."""
+    if isinstance(node, list):
+        return [_to_openapi_30(item) for item in node]
+    if not isinstance(node, dict):
+        return node
+    node = {key: _to_openapi_30(value) for key, value in node.items()}
+    any_of = node.get("anyOf")
+    if any_of and {"type": "null"} in any_of:
+        rest = [subschema for subschema in any_of if subschema != {"type": "null"}]
+        del node["anyOf"]
+        if len(rest) == 1:
+            node.update(rest[0])
+        else:
+            node["anyOf"] = rest
+        node["nullable"] = True
+    return node
+
+
+def register_pydantic_schema(spec, model):
+    """Register a pydantic model (and any nested models) as OpenAPI components
+    on an APISpec; return a `$ref` to the model's component."""
+    schema = model.model_json_schema(ref_template=REF_TEMPLATE)
+    for name, subschema in schema.pop("$defs", {}).items():
+        _register_component(spec, name, _to_openapi_30(subschema))
+    _register_component(spec, model.__name__, _to_openapi_30(schema))
+    return {"$ref": REF_TEMPLATE.format(model=model.__name__)}
+
+
+def _register_component(spec, name, schema):
+    if name not in spec.components.schemas:
+        spec.components.schema(name, component=schema)

--- a/static/js/components/plot/PhotometryPlot.tsx
+++ b/static/js/components/plot/PhotometryPlot.tsx
@@ -214,13 +214,12 @@ const PeriodAnnotationDialog = ({
 
   const submitPeriodAnnotation = async ({ formData }: { formData: any }) => {
     const periodData = {
-      obj_id,
       origin: formData.origin,
       data: {
         period:
           formData.period / (periodUnitDividers[formData.periodUnitValue] ?? 1),
       },
-      groups: formData.groupIDs,
+      group_ids: formData.groupIDs,
     };
     addAnnotation({ sourceID: obj_id, formData: periodData })
       .unwrap()

--- a/static/js/types/api.ts
+++ b/static/js/types/api.ts
@@ -17701,28 +17701,9 @@ export interface paths {
                 };
                 cookie?: never;
             };
-            requestBody?: {
+            requestBody: {
                 content: {
-                    "application/json": {
-                        /**
-                         * @description String describing the source of this information.
-                         *     Only one Annotation per origin is allowed, although
-                         *     each Annotation can have multiple fields.
-                         *     To add/change data, use the update method instead
-                         *     of trying to post another Annotation from this origin.
-                         *     Origin must be a non-empty string starting with an
-                         *     alphanumeric character or underscore.
-                         *     (it must match the regex: /^\w+/)
-                         */
-                        origin: string;
-                        data: Record<string, never>;
-                        /**
-                         * @description List of group IDs corresponding to which groups should be
-                         *     able to view annotation. Defaults to all of requesting user's
-                         *     groups.
-                         */
-                        group_ids?: number[];
-                    };
+                    "application/json": components["schemas"]["AnnotationPostBody"];
                 };
             };
             responses: {
@@ -17732,10 +17713,7 @@ export interface paths {
                     };
                     content: {
                         "application/json": components["schemas"]["Success"] & {
-                            data?: {
-                                /** @description New annotation ID */
-                                annotation_id?: number;
-                            };
+                            data?: components["schemas"]["AnnotationPostResponse"];
                         };
                     };
                 };
@@ -38246,6 +38224,41 @@ export interface components {
             localization_id: number;
             /** @description Integrated probability within skymap. */
             integrated_probability?: number;
+        };
+        /**
+         * AnnotationPostBody
+         * @description Request body for posting an annotation.
+         */
+        AnnotationPostBody: {
+            /**
+             * Origin
+             * @description String describing the source of this information. Only one Annotation per origin is allowed, although each Annotation can have multiple fields. To add/change data, use the update method instead of trying to post another Annotation from this origin. Origin must be a non-empty string starting with an alphanumeric character or underscore (it must match the regex: /^\w+/).
+             */
+            origin: string;
+            /**
+             * Data
+             * @description Annotation data as {key: value} pairs.
+             */
+            data: {
+                [key: string]: unknown;
+            };
+            /**
+             * Group Ids
+             * @description List of group IDs corresponding to which groups should be able to view annotation. Defaults to all of requesting user's groups.
+             * @default null
+             */
+            group_ids: number[] | null;
+        };
+        /**
+         * AnnotationPostResponse
+         * @description Data payload returned when posting an annotation.
+         */
+        AnnotationPostResponse: {
+            /**
+             * Annotation Id
+             * @description New annotation ID
+             */
+            annotation_id: number;
         };
         SpatialCatalogASCIIFileHandlerPost: {
             /** @description Spatial catalog name. */

--- a/static/js/types/routeSchemaMap.ts
+++ b/static/js/types/routeSchemaMap.ts
@@ -171,6 +171,7 @@ export const ROUTE_SCHEMA_MAP = {
   "POST /api/spectra/synthphot/{spectrum_id}": { schema: "Spectrum" as const, list: false },
   "POST /api/spectrum/parse/ascii": { schema: "SpectrumNoID" as const, list: false },
   "POST /api/summary_query": { schema: "Obj" as const, list: true },
+  "POST /api/{associated_resource_type}/{resource_id}/annotations": { schema: "AnnotationPostResponse" as const, list: false },
   "PUT /api/followup_request/prioritization": { schema: "FollowupRequest" as const, list: false },
   "PUT /api/followup_request/{followup_request_id}/comment": { schema: "FollowupRequest" as const, list: false },
   "PUT /api/followup_request/{request_id}": { schema: "FollowupRequest" as const, list: false },


### PR DESCRIPTION
Handlers call body = self.parse_body(Model) (new BaseHandler helper:
400 with field-level errors, aborts via tornado Finish), and
spec_from_handlers reads the same models from the method's type hints
(keyword-only body param annotation, return annotation) to generate
requestBody/response docs, so docs cannot drift from validation.

Pilot: annotation POST. Request models use extra="forbid", which
surfaced a real bug: PhotometryPlot sent group selection as 'groups'
(backend expects 'group_ids'), silently ignoring the chosen groups.
