### PR TITLE
Run model/permission CI shards without booting the app stack

### DIFF
--- a/.github/workflows/test_models.yaml
+++ b/.github/workflows/test_models.yaml
@@ -142,12 +142,6 @@ jobs:
 
           bun pm ls || true
 
-      - name: Refresh SkyPortal dependencies for tested version
-        run: |
-          export PYTHONPATH=$PYTHONPATH:$(pwd)
-          export NPM_CONFIG_LEGACY_PEER_DEPS="true"
-          make dependencies
-
       # Lint the diff once (on shard 0), not once per shard.
       - name: Formatting and linting checks
         if: matrix.shard == 0 && github.ref != 'refs/heads/main'
@@ -161,18 +155,19 @@ jobs:
       # The model/permission tests build their own fixtures, so they don't need
       # the demo-data load (that smoke test still runs in test_migrations.yaml).
       # Each job runs only its PERM_SHARD slice of the parametrized CASES.
+      #
+      # The suite is pure ORM (fixtures write straight to the DB; nothing
+      # calls the API), so bootstrap the test DB with initial_setup.py and run
+      # pytest directly instead of paying the full app/microservice launch of
+      # test_frontend.py in every shard.
       - name: Run model/permission tests (shard ${{ matrix.shard }}/${{ env.N_SHARDS }})
         run: |
           source .venv/bin/activate
+          PYTHONPATH=. python skyportal/initial_setup.py --config=test_config.yaml
+          mkdir -p test-results
           PERM_SHARD="${{ matrix.shard }}/${{ env.N_SHARDS }}" PYTHONPATH=. \
-            python baselayer/tools/test_frontend.py --xml 'skyportal/tests/models'
-
-      - name: Upload logs
-        uses: actions/upload-artifact@v4
-        if: ${{ always() }}
-        with:
-          name: logs-model-logic-${{ matrix.shard }}
-          path: log
+            python -m pytest -s -v --junitxml=test-results/junit.xml \
+            --randomly-seed=1 skyportal/tests/models
 
       - name: Upload test post-mortem reports
         uses: actions/upload-artifact@v4

--- a/skyportal/initial_setup.py
+++ b/skyportal/initial_setup.py
@@ -82,8 +82,16 @@ if __name__ == "__main__":
     for model in Base.metadata.tables:
         print("    -", model)
 
+    # Mirror the boot-time seeding in app_server.make_app so a DB set up here
+    # is usable without ever starting the app (e.g. the model-permission CI).
+    with status("Refreshing enums"):
+        model_util.refresh_enums()
+
     with status("Creating permissions"):
         model_util.setup_permissions()
+
+    with status("Provisioning sitewide public group"):
+        model_util.provision_public_group()
 
     if adminuser != "":
         with status(f"Creating super admin ({adminuser})"):


### PR DESCRIPTION
## Why

After #6380, the Model Logic workflow (~16–18 min) is the slowest CI on PRs. Its suite (`skyportal/tests/models`) is pure ORM — every fixture used by the permission matrix writes straight to the DB. Yet each of the 6 shards launches the entire app stack via `test_frontend.py` (tornado app, nginx, rspack bundle, ~20 microservices), costing ~2.5 min per shard on the 2-vCPU runner. This cuts compute without adding jobs.