### PR TITLE
Replace blind sleeps with polling in async API tests

### DIFF
--- a/skyportal/tests/api_tests/groups_users_analysis/test_observation_plan.py
+++ b/skyportal/tests/api_tests/groups_users_analysis/test_observation_plan.py
@@ -73,12 +73,10 @@ def test_observation_plan_tiling(super_admin_token, public_group, gcn_GW190814):
         assert status == 200
         assert data["status"] == "success"
 
-    # wait for the observation plans to finish, we added some patience later, but we know that it takes at least 30 seconds
-    time.sleep(10)
-
+    # the plans take ~30 s to process; the retry loop below waits for them
     n_retries = 0
     request_ids = []
-    while n_retries < 10:
+    while n_retries < 12:
         try:
             status, data = api(
                 "GET",
@@ -150,7 +148,7 @@ def test_observation_plan_tiling(super_admin_token, public_group, gcn_GW190814):
             n_retries += 1
             time.sleep(5)
 
-    assert n_retries < 10
+    assert n_retries < 12
     assert len(request_ids) == len(requests_data)
 
     # exercise the (async) delete path: DELETE each request and verify it is gone
@@ -245,11 +243,9 @@ def test_observation_plan_combined(super_admin_token, public_group, gcn_GW190814
     assert status == 200, data
     assert data["status"] == "success"
 
-    time.sleep(10)
-
     n_retries = 0
     request_ids = []
-    while n_retries < 10:
+    while n_retries < 12:
         try:
             status, data = api(
                 "GET",
@@ -282,7 +278,7 @@ def test_observation_plan_combined(super_admin_token, public_group, gcn_GW190814
             n_retries += 1
             time.sleep(5)
 
-    assert n_retries < 10
+    assert n_retries < 12
     assert len(request_ids) == len(observation_plans)
 
     # exercise the (async) delete path on the combined requests
@@ -401,11 +397,9 @@ def test_observation_plan_galaxy(
         assert status == 200
         assert data["status"] == "success"
 
-    # wait for the observation plans to finish, we added some patience later, but we know that it takes at least 30 seconds
-    time.sleep(10)
-
+    # the plans take ~30 s to process; the retry loop below waits for them
     n_retries = 0
-    while n_retries < 10:
+    while n_retries < 12:
         try:
             status, data = api(
                 "GET",
@@ -463,6 +457,6 @@ def test_observation_plan_galaxy(
             n_retries = n_retries + 1
             time.sleep(5)
 
-    assert n_retries < 10
+    assert n_retries < 12
 
     remove_telescope_and_instrument(telescope_id, instrument_id, super_admin_token)

--- a/skyportal/tests/api_tests/photometry_followup/test_default_observation_plan.py
+++ b/skyportal/tests/api_tests/photometry_followup/test_default_observation_plan.py
@@ -149,10 +149,8 @@ def test_default_observation_plan_tiling(super_admin_token, public_group):
     assert n_times_2 < 25
 
     # wait for the plans to be processed
-    time.sleep(10)
-
     n_retries = 0
-    while n_retries < 10:
+    while n_retries < 12:
         try:
             # now we want to see if any observation plans were created
             status, data = api(
@@ -172,7 +170,7 @@ def test_default_observation_plan_tiling(super_admin_token, public_group):
             n_retries += 1
             time.sleep(5)
 
-    assert n_retries < 10
+    assert n_retries < 12
 
     status, data = api(
         "DELETE",

--- a/skyportal/tests/api_tests/photometry_followup/test_observation.py
+++ b/skyportal/tests/api_tests/photometry_followup/test_observation.py
@@ -33,10 +33,7 @@ def test_observation(super_admin_token, gcn_GW190425):
     assert status == 200
     assert data["status"] == "success"
 
-    # wait for the executed observations to populate
-    time.sleep(15)
-
-    data = {
+    params = {
         "telescopeName": telescope_name,
         "instrumentName": instrument_name,
         "startDate": "2019-04-25 08:18:05",
@@ -48,11 +45,23 @@ def test_observation(super_admin_token, gcn_GW190425):
         "numPerPage": 1000,
     }
 
-    status, data = api("GET", "observation", params=data, token=super_admin_token)
+    # wait for the executed observations to populate
+    nretries = 0
+    observations_loaded = False
+    while not observations_loaded and nretries < 10:
+        try:
+            status, data = api(
+                "GET", "observation", params=params, token=super_admin_token
+            )
+            assert status == 200
+            data = data["data"]
+            assert len(data["observations"]) == 10
+            observations_loaded = True
+        except AssertionError:
+            nretries = nretries + 1
+            time.sleep(2)
 
-    assert status == 200
-    data = data["data"]
-    assert len(data["observations"]) == 10
+    assert observations_loaded
     assert np.isclose(data["probability"], 2.582514047833091e-05)
     assert any(
         d["obstime"] == "2019-04-25T08:18:18.002909" and d["observation_id"] == 84434604

--- a/skyportal/tests/api_tests/spectra_misc/test_recurring_api.py
+++ b/skyportal/tests/api_tests/spectra_misc/test_recurring_api.py
@@ -63,7 +63,7 @@ def test_post_and_verify_recurring_api(
 
     endpoint = f"sources/{obj_id}"
     n_retries = 0
-    while n_retries < 10:
+    while n_retries < 75:
         status, data = api(
             "GET",
             endpoint,
@@ -71,7 +71,7 @@ def test_post_and_verify_recurring_api(
         )
         if data["status"] == "success":
             break
-        time.sleep(15)
+        time.sleep(2)
         n_retries += 1
-    assert n_retries < 10
+    assert n_retries < 75
     assert status == 200


### PR DESCRIPTION
## Why

Several API tests wait for asynchronous queue processing (observation ingestion, observation plans, recurring APIs) with fixed `time.sleep()` calls. A fixed sleep costs its full duration on every run even when the queue finishes in 1–2 s