### PR TITLE
Pydantic-typed request bodies for filter endpoints

### DIFF
--- a/skyportal/handlers/api/filter.py
+++ b/skyportal/handlers/api/filter.py
@@ -1,10 +1,54 @@
-from marshmallow.exceptions import ValidationError
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy.orm import joinedload
 
 from baselayer.app.access import auth_or_token, permissions
 
 from ...models import Filter
 from ..base import BaseHandler
+
+
+class FilterPostBody(BaseModel):
+    """Request body for creating a filter."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(description="Filter name.")
+    stream_id: int = Field(description="ID of the Filter's Stream.")
+    group_id: int = Field(description="ID of the Filter's Group.")
+    altdata: dict[str, Any] | None = Field(
+        default=None,
+        description="Arbitrary additional JSON data associated with the Filter.",
+    )
+
+
+class FilterPostResponse(BaseModel):
+    """Data payload returned when creating a filter."""
+
+    id: int = Field(description="New filter ID")
+
+
+class FilterPatchBody(BaseModel):
+    """Request body for updating a filter."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str | None = Field(default=None, description="Filter name.")
+    altdata: dict[str, Any] | None = Field(
+        default=None,
+        description="Arbitrary additional JSON data associated with the Filter.",
+    )
+    group_id: int | None = Field(
+        default=None,
+        description="ID of the Filter's Group. Cannot be changed; accepted "
+        "only if it matches the current value.",
+    )
+    stream_id: int | None = Field(
+        default=None,
+        description="ID of the Filter's Stream. Cannot be changed; accepted "
+        "only if it matches the current value.",
+    )
 
 
 class FilterHandler(BaseHandler):
@@ -64,48 +108,28 @@ class FilterHandler(BaseHandler):
             return self.success(data=list_result.all())
 
     @permissions(["Upload data"])
-    async def post(self):
+    async def post(self, *, body: FilterPostBody = None) -> FilterPostResponse:
         """
         ---
         summary: Create a new filter
         description: POST a new filter.
         tags:
           - filters
-        requestBody:
-          content:
-            application/json:
-              schema: FilterNoID
-        responses:
-          200:
-            content:
-              application/json:
-                schema:
-                  allOf:
-                    - $ref: '#/components/schemas/Success'
-                    - type: object
-                      properties:
-                        data:
-                          type: object
-                          properties:
-                            id:
-                              type: integer
-                              description: New filter ID
         """
-        data = self.get_json()
+        body = self.parse_body(FilterPostBody)
         async with self.AsyncSession() as session:
-            schema = Filter.__schema__()
-            try:
-                fil = schema.load(data)
-            except ValidationError as e:
-                return self.error(
-                    f"Invalid/missing parameters: {e.normalized_messages()}"
-                )
+            fil = Filter(
+                name=body.name,
+                stream_id=body.stream_id,
+                group_id=body.group_id,
+                altdata=body.altdata,
+            )
             session.add(fil)
             await session.commit()
             return self.success(data={"id": fil.id})
 
     @permissions(["Upload data"])
-    async def patch(self, filter_id: int):
+    async def patch(self, filter_id: int, *, body: FilterPatchBody = None):
         """
         ---
         summary: Update a filter
@@ -118,10 +142,6 @@ class FilterHandler(BaseHandler):
             required: True
             schema:
               type: integer
-        requestBody:
-          content:
-            application/json:
-              schema: FilterNoID
         responses:
           200:
             content:
@@ -132,6 +152,7 @@ class FilterHandler(BaseHandler):
               application/json:
                 schema: Error
         """
+        body = self.parse_body(FilterPatchBody)
         try:
             filter_id = int(filter_id)
         except (TypeError, ValueError):
@@ -145,22 +166,15 @@ class FilterHandler(BaseHandler):
             if f is None:
                 return self.error(f"Cannot find a filter with ID: {filter_id}.")
 
-            data = self.get_json()
-            data["id"] = filter_id
-
-            schema = Filter.__schema__()
-            try:
-                fil = schema.load(data, partial=True)
-            except ValidationError as e:
-                return self.error(
-                    f"Invalid/missing parameters: {e.normalized_messages()}"
-                )
-
-            if fil.group_id != f.group_id or fil.stream_id != f.stream_id:
+            if (body.group_id is not None and body.group_id != f.group_id) or (
+                body.stream_id is not None and body.stream_id != f.stream_id
+            ):
                 return self.error("Cannot update group_id or stream_id.")
 
-            for k in data:
-                setattr(f, k, data[k])
+            if body.name is not None:
+                f.name = body.name
+            if body.altdata is not None:
+                f.altdata = body.altdata
 
             await session.commit()
             return self.success()

--- a/static/js/types/api.ts
+++ b/static/js/types/api.ts
@@ -4615,9 +4615,9 @@ export interface paths {
                 };
                 cookie?: never;
             };
-            requestBody?: {
+            requestBody: {
                 content: {
-                    "application/json": components["schemas"]["FilterNoID"];
+                    "application/json": components["schemas"]["FilterPatchBody"];
                 };
             };
             responses: {
@@ -4691,9 +4691,9 @@ export interface paths {
                 path?: never;
                 cookie?: never;
             };
-            requestBody?: {
+            requestBody: {
                 content: {
-                    "application/json": components["schemas"]["FilterNoID"];
+                    "application/json": components["schemas"]["FilterPostBody"];
                 };
             };
             responses: {
@@ -4703,10 +4703,7 @@ export interface paths {
                     };
                     content: {
                         "application/json": components["schemas"]["Success"] & {
-                            data?: {
-                                /** @description New filter ID */
-                                id?: number;
-                            };
+                            data?: components["schemas"]["FilterPostResponse"];
                         };
                     };
                 };
@@ -38119,6 +38116,78 @@ export interface components {
             };
             /** @description Default observation plan request ID. */
             default_observationplan_request_id: number;
+        };
+        /**
+         * FilterPostBody
+         * @description Request body for creating a filter.
+         */
+        FilterPostBody: {
+            /**
+             * Name
+             * @description Filter name.
+             */
+            name: string;
+            /**
+             * Stream Id
+             * @description ID of the Filter's Stream.
+             */
+            stream_id: number;
+            /**
+             * Group Id
+             * @description ID of the Filter's Group.
+             */
+            group_id: number;
+            /**
+             * Altdata
+             * @description Arbitrary additional JSON data associated with the Filter.
+             * @default null
+             */
+            altdata: {
+                [key: string]: unknown;
+            } | null;
+        };
+        /**
+         * FilterPostResponse
+         * @description Data payload returned when creating a filter.
+         */
+        FilterPostResponse: {
+            /**
+             * Id
+             * @description New filter ID
+             */
+            id: number;
+        };
+        /**
+         * FilterPatchBody
+         * @description Request body for updating a filter.
+         */
+        FilterPatchBody: {
+            /**
+             * Name
+             * @description Filter name.
+             * @default null
+             */
+            name: string | null;
+            /**
+             * Altdata
+             * @description Arbitrary additional JSON data associated with the Filter.
+             * @default null
+             */
+            altdata: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * Group Id
+             * @description ID of the Filter's Group. Cannot be changed; accepted only if it matches the current value.
+             * @default null
+             */
+            group_id: number | null;
+            /**
+             * Stream Id
+             * @description ID of the Filter's Stream. Cannot be changed; accepted only if it matches the current value.
+             * @default null
+             */
+            stream_id: number | null;
         };
         GalaxyASCIIFileHandlerPost: {
             /** @description Galaxy catalog name. */

--- a/static/js/types/routeSchemaMap.ts
+++ b/static/js/types/routeSchemaMap.ts
@@ -153,6 +153,7 @@ export const ROUTE_SCHEMA_MAP = {
   "POST /api/candidates/scan_reports": { schema: "ScanReport" as const, list: false },
   "POST /api/earthquake/{earthquake_id}/mmadetector/{mma_detector_id}/measurements": { schema: "EarthquakeMeasured" as const, list: false },
   "POST /api/earthquake/{earthquake_id}/mmadetector/{mma_detector_id}/predictions": { schema: "EarthquakePrediction" as const, list: false },
+  "POST /api/filters": { schema: "FilterPostResponse" as const, list: false },
   "POST /api/galaxy_catalog/ascii": { schema: "Galaxy" as const, list: true },
   "POST /api/groups/{group_id}/usersFromGroups": { schema: "GroupUser" as const, list: false },
   "POST /api/objtag": { schema: "ObjTag" as const, list: false },


### PR DESCRIPTION
Continues the typed-endpoint migration started in #6382, converting `FilterHandler` POST and PATCH to the `parse_body` pattern.

- `FilterPostBody` / `FilterPatchBody` (`extra="forbid"`) replace the marshmallow `Filter.__schema__().load(...)` calls, with explicit `name`/`stream_id`/`group_id`/`altdata` fields instead of the opaque `FilterNoID` docstring reference; POST gains a typed `FilterPostResponse` (`{id}`).
- PATCH keeps the old semantics: `group_id`/`stream_id` are rejected with "Cannot update group_id or stream_id." unless they match the current values (the marshmallow ModelSchema PK-merge made same-value no-ops pass before), and only `name`/`altdata` are applied.
- Client sweep: the RTK mutations in `static/js/ducks/filter.ts` send `{name, group_id, stream_id}` / `{name}`, and all test call sites (test_filters.py, test_groups.py, test_scanning_page.py) match; `public_filter` fixtures use `FilterFactory` directly. No client changes were needed.
- `static/js/types/api.ts` and `routeSchemaMap.ts` regenerated.