### PR TITLE
merge all xmatches catalogs and add DESI_DR1 & LS_DR10_PHOTOZ

### DIFF
--- a/static/js/constants/crossmatch.js
+++ b/static/js/constants/crossmatch.js
@@ -608,28 +608,123 @@ const LSPSC = {
   default: null,
 };
 
-export const ztf_crossmatch_fields = {
-  name: "cross_matches",
-  type: {
-    type: "array",
-    items: {
+const DESI_DR1 = {
+  name: "DESI_DR1",
+  type: [
+    "null",
+    {
       type: "record",
-      name: "CrossMatch",
+      name: "DESI_DR1Match",
       fields: [
-        Gaia_DR3,
-        milliquas_v8,
-        NED,
-        TWOMASS_PSC,
-        GALEX,
-        VSX,
-        CatWISE2020,
-        TNS,
+        {
+          name: "_id",
+          type: "double",
+        },
+        {
+          name: "ra",
+          type: "double",
+        },
+        {
+          name: "dec",
+          type: "double",
+        },
+        {
+          name: "survey",
+          type: "string",
+        },
+        {
+          name: "program",
+          type: "string",
+        },
+        {
+          name: "z",
+          type: "double",
+        },
+        {
+          name: "zerr",
+          type: "double",
+        },
+        {
+          name: "zwarn",
+          type: "int",
+        },
+        {
+          name: "chi2",
+          type: "double",
+        },
+        {
+          name: "deltachi2",
+          type: "double",
+        },
+        {
+          name: "spectype",
+          type: "string",
+        },
+        {
+          name: "zcat_nspec",
+          type: "int",
+        },
+        {
+          name: "distance_arcsec",
+          type: "float",
+        },
       ],
     },
-  },
+  ],
+  default: null,
 };
 
-export const lsst_crossmatch_fields = {
+const LS_DR10_PHOTOZ = {
+  name: "LS_DR10_PHOTOZ",
+  type: [
+    "null",
+    {
+      type: "record",
+      name: "LS_DR10_PHOTOZMatch",
+      fields: [
+        {
+          name: "_id",
+          type: "double",
+        },
+        {
+          name: "ra",
+          type: "double",
+        },
+        {
+          name: "dec",
+          type: "double",
+        },
+        {
+          name: "ra_err",
+          type: "double",
+        },
+        {
+          name: "dec_err",
+          type: "double",
+        },
+        {
+          name: "z_phot",
+          type: "double",
+        },
+        {
+          name: "z_phot_err",
+          type: "double",
+        },
+        {
+          name: "photo_z_type",
+          type: "string",
+        },
+        {
+          name: "distance_arcsec",
+          type: "float",
+        },
+      ],
+    },
+  ],
+  default: null,
+};
+
+export const crossmatch_fields = {
   name: "cross_matches",
   type: {
     type: "array",
@@ -646,6 +741,8 @@ export const lsst_crossmatch_fields = {
         VSX,
         CatWISE2020,
         TNS,
+        DESI_DR1,
+        LS_DR10_PHOTOZ,
       ],
     },
   },

--- a/static/js/ducks/boom_filter_modules.ts
+++ b/static/js/ducks/boom_filter_modules.ts
@@ -11,24 +11,16 @@
 import { skyportalApi } from "../api/skyportalApi";
 import { brokerFilterBase } from "./brokerFilterTarget";
 import { useBoomFilterVersion } from "./boom_filter";
-import {
-  ztf_crossmatch_fields,
-  lsst_crossmatch_fields,
-} from "../constants/crossmatch";
+import { crossmatch_fields } from "../constants/crossmatch";
 
-// Append survey-specific cross-match fields to a fetched schema.
+// Append the cross-match fields (same catalogs for every survey) to a fetched schema.
 const patchSchema = (schema: any) => {
   if (!schema) return schema;
 
   const patchedSchema = JSON.parse(JSON.stringify(schema));
 
   if (patchedSchema.fields) {
-    if (patchedSchema.name.includes("Ztf")) {
-      patchedSchema.fields.push(ztf_crossmatch_fields);
-    }
-    if (patchedSchema.name.includes("Lsst")) {
-      patchedSchema.fields.push(lsst_crossmatch_fields);
-    }
+    patchedSchema.fields.push(crossmatch_fields);
   }
 
   return patchedSchema;


### PR DESCRIPTION
Adding DESI_DR1 & LS_DR10_PHOTOZ to the list of visible catalogs on the filter building UI. 

Each survey was using its own set of crossmatching catalogs. This PR also merges these different sets into one set of corssmatching catalogs used by all currently supported surveys. (Side note, those catalogs schemas are currently being hardcoded. It would nice to expose their schemas in BOOM.)