### PR TITLE
fix nested annotations

### DIFF
--- a/data/db_demo.yaml
+++ b/data/db_demo.yaml
@@ -1345,38 +1345,33 @@ sources/ZTF18aabcvnq/comments:
     text: "You're a star! <3"
 
 sources/ZTF21aaqjmps/annotations:
-  - obj_id: ZTF21aaqjmps
-    origin: "Program A"
+  - origin: "Program A"
     data:
       numeric_field: 0.11235813
       some_boolean: true
       class: "SNe II"
 
 sources/ZTF18aabcvnq/annotations:
-  - obj_id: ZTF18aabcvnq
-    origin: "Program b"
+  - origin: "Program b"
     data:
       numeric_field: 0.213471118
       some_boolean: false
       class: "varstar"
 
 sources/ZTFe028h94k/annotations:
-  - obj_id: ZTFe028h94k
-    origin: "Program B"
+  - origin: "Program B"
     data:
       period: 0.5281475
     group_ids:
       - =program_B
-  - obj_id: ZTFe028h94k
-    origin: "ZVM"
+  - origin: "ZVM"
     data:
       period: 0.5281217208459
     group_ids:
       - =program_B
 
 sources/ZTFrlh6cyjh/annotations:
-  - obj_id: ZTFrlh6cyjh
-    origin: "ZVM"
+  - origin: "ZVM"
     data:
       period: 1.107332
     group_ids:

--- a/static/js/contexts/UnifiedBuilderContext.tsx
+++ b/static/js/contexts/UnifiedBuilderContext.tsx
@@ -138,8 +138,13 @@ export const UnifiedBuilderProvider = ({
         );
 
         if (arithVar) {
-          // Arithmetic variable - scan its expression for variable references
-          // that need to be materialized
+          // Arithmetic variable - it must be included itself so its schema-field
+          // dependencies get marked "used" and survive the $project stage(s)
+          // (see mongoPipelineBuilder.js's additionalFieldsToProject handling).
+          annotationFieldsSet.add(f.fieldName);
+
+          // Also scan its expression for variable references that need to be
+          // materialized
           if (arithVar.variable) {
             const expression = arithVar.variable.includes("=")
               ? arithVar.variable.split("=")[1].trim()


### PR DESCRIPTION
Some nested annotations on the filter building UI were not properly projected all the way to the last project stage so they were showing up as null on the annotations table on the source page.