### PR TITLE
Pydantic-typed request body for user role endpoint

### DIFF
--- a/skyportal/handlers/api/roles.py
+++ b/skyportal/handlers/api/roles.py
@@ -1,9 +1,20 @@
+from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy.orm import selectinload
 
 from baselayer.app.access import auth_or_token, permissions
 
 from ...models import Role, User, UserRole
 from ..base import BaseHandler
+
+
+class UserRolePostBody(BaseModel):
+    """Request body for granting roles to a user."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    roleIds: list[str] = Field(
+        description="Array of Role IDs (strings) to be granted to user"
+    )
 
 
 class RoleHandler(BaseHandler):
@@ -47,7 +58,7 @@ class RoleHandler(BaseHandler):
 
 class UserRoleHandler(BaseHandler):
     @permissions(["Manage users"])
-    async def post(self, user_id: int, *ignored_args):
+    async def post(self, user_id: int, *ignored_args, body: UserRolePostBody = None):
         """
         ---
         summary: Grant new Role(s) to a user
@@ -60,35 +71,14 @@ class UserRoleHandler(BaseHandler):
             required: true
             schema:
               type: integer
-        requestBody:
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  roleIds:
-                    type: array
-                    items:
-                      type: string
-                    description: Array of Role IDs (strings) to be granted to user
-                required:
-                  - roleIds
         responses:
           200:
             content:
               application/json:
                 schema: Success
         """
-        data = self.get_json()
-        new_role_ids = data.get("roleIds")
-        if new_role_ids is None:
-            return self.error("Missing required parameter roleIds")
-        if not isinstance(new_role_ids, list) or not all(
-            isinstance(role_id, str) for role_id in new_role_ids
-        ):
-            return self.error(
-                "Improperly formatted parameter roleIds; must be an array of strings."
-            )
+        body = self.parse_body(UserRolePostBody)
+        new_role_ids = body.roleIds
 
         async with self.AsyncSession() as session:
             user = await session.scalar(

--- a/static/js/types/api.ts
+++ b/static/js/types/api.ts
@@ -22300,12 +22300,9 @@ export interface paths {
                 };
                 cookie?: never;
             };
-            requestBody?: {
+            requestBody: {
                 content: {
-                    "application/json": {
-                        /** @description Array of Role IDs (strings) to be granted to user */
-                        roleIds: string[];
-                    };
+                    "application/json": components["schemas"]["UserRolePostBody"];
                 };
             };
             responses: {
@@ -38709,6 +38706,17 @@ export interface components {
              * @description Array of ACL IDs (strings) to be granted to user
              */
             aclIds: string[];
+        };
+        /**
+         * UserRolePostBody
+         * @description Request body for granting roles to a user.
+         */
+        UserRolePostBody: {
+            /**
+             * Roleids
+             * @description Array of Role IDs (strings) to be granted to user
+             */
+            roleIds: string[];
         };
     };
     responses: never;


### PR DESCRIPTION
Continues the typed-endpoint migration (#6382, #6392–#6394, #6397), converting `UserRoleHandler` POST (`/api/user/{user_id}/roles`) to the `parse_body` pattern.

- `UserRolePostBody` (`roleIds: list[str]`, `extra="forbid"`) replaces the hand-rolled presence/shape checks; the invalid-role-id check (which lists the offending ids) stays in the handler.
- Client sweep: `static/js/ducks/roles.ts` (used by `UserManagement.tsx`) and all test_roles.py call sites already send exactly `{roleIds}`; the shape-error test asserts only the 400 status, so no client changes were needed.
- `static/js/types/api.ts` regenerated.