### PR TITLE
Pydantic-typed request body for data sharing endpoint

### DIFF
--- a/skyportal/handlers/api/sharing.py
+++ b/skyportal/handlers/api/sharing.py
@@ -1,3 +1,4 @@
+from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy.orm import selectinload
 
 from baselayer.app.access import permissions
@@ -6,9 +7,31 @@ from ...models import Group, Photometry, Spectrum
 from ..base import BaseHandler
 
 
+class SharingPostBody(BaseModel):
+    """Request body for sharing data with additional groups/users."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    groupIDs: list[int] = Field(
+        min_length=1,
+        description="List of IDs of groups data will be shared with. To share "
+        "data with a single user, specify their single user group ID here.",
+    )
+    photometryIDs: list[int] | None = Field(
+        default=None,
+        description="IDs of the photometry data to be shared. If `spectrumIDs` "
+        "is not provided, this is required.",
+    )
+    spectrumIDs: list[int] | None = Field(
+        default=None,
+        description="IDs of the spectra to be shared. If `photometryIDs` is "
+        "not provided, this is required.",
+    )
+
+
 class SharingHandler(BaseHandler):
     @permissions(["Upload data"])
-    async def post(self):
+    async def post(self, *, body: SharingPostBody = None):
         """
         ---
         summary: Share data with additional groups/users
@@ -17,46 +40,16 @@ class SharingHandler(BaseHandler):
           - data sharing
           - photometry
           - spectra
-        requestBody:
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  photometryIDs:
-                    type: array
-                    items:
-                      type: integer
-                    description: |
-                      IDs of the photometry data to be shared. If `spectrumIDs` is not
-                      provided, this is required.
-                  spectrumIDs:
-                    type: array
-                    items:
-                      type: integer
-                    description: IDs of the spectra to be shared. If `photometryIDs` is
-                      not provided, this is required.
-                  groupIDs:
-                    type: array
-                    items:
-                      type: integer
-                    description: |
-                      List of IDs of groups data will be shared with. To share data with
-                      a single user, specify their single user group ID here.
-                required:
-                  - groupIDs
         responses:
           200:
             content:
               application/json:
                 schema: Success
         """
-        data = self.get_json()
-        group_ids = data.get("groupIDs", None)
-        if group_ids is None or group_ids == []:
-            return self.error("Missing required `groupIDs` field.")
-        phot_ids = data.get("photometryIDs", [])
-        spec_ids = data.get("spectrumIDs", [])
+        body = self.parse_body(SharingPostBody)
+        group_ids = body.groupIDs
+        phot_ids = body.photometryIDs or []
+        spec_ids = body.spectrumIDs or []
         if not phot_ids and not spec_ids:
             return self.error(
                 "One of either `photometryIDs` or `spectrumIDs` must be provided."

--- a/static/js/types/api.ts
+++ b/static/js/types/api.ts
@@ -15047,22 +15047,9 @@ export interface paths {
                 path?: never;
                 cookie?: never;
             };
-            requestBody?: {
+            requestBody: {
                 content: {
-                    "application/json": {
-                        /**
-                         * @description IDs of the photometry data to be shared. If `spectrumIDs` is not
-                         *     provided, this is required.
-                         */
-                        photometryIDs?: number[];
-                        /** @description IDs of the spectra to be shared. If `photometryIDs` is not provided, this is required. */
-                        spectrumIDs?: number[];
-                        /**
-                         * @description List of IDs of groups data will be shared with. To share data with
-                         *     a single user, specify their single user group ID here.
-                         */
-                        groupIDs: number[];
-                    };
+                    "application/json": components["schemas"]["SharingPostBody"];
                 };
             };
             responses: {
@@ -38311,6 +38298,29 @@ export interface components {
              * @default null
              */
             group_ids: number[] | null;
+        };
+        /**
+         * SharingPostBody
+         * @description Request body for sharing data with additional groups/users.
+         */
+        SharingPostBody: {
+            /**
+             * Groupids
+             * @description List of IDs of groups data will be shared with. To share data with a single user, specify their single user group ID here.
+             */
+            groupIDs: number[];
+            /**
+             * Photometryids
+             * @description IDs of the photometry data to be shared. If `spectrumIDs` is not provided, this is required.
+             * @default null
+             */
+            photometryIDs: number[] | null;
+            /**
+             * Spectrumids
+             * @description IDs of the spectra to be shared. If `photometryIDs` is not provided, this is required.
+             * @default null
+             */
+            spectrumIDs: number[] | null;
         };
         /**
          * RecurringAPIPostBody


### PR DESCRIPTION
Continues the typed-endpoint migration (#6382, #6392–#6394, #6397–#6398), converting `SharingHandler` POST (`/api/sharing`) to the `parse_body` pattern.

- `SharingPostBody` (`extra="forbid"`) types `groupIDs` (required, `min_length=1`, matching the old empty-list rejection) and optional `photometryIDs`/`spectrumIDs`; the cross-field "one of either photometryIDs or spectrumIDs" check stays in the handler with its original message.
- Client sweep: `shareData` in `static/js/ducks/source.ts` (used by `ShareDataForm.tsx`) sends exactly `{groupIDs, photometryIDs, spectrumIDs}`, and the test_sharing.py call sites match; error assertions there target handler-level messages that are unchanged.
- `static/js/types/api.ts` regenerated.