### PR TITLE
Pydantic-typed request bodies for source groups endpoints

### DIFF
--- a/skyportal/handlers/api/source_groups.py
+++ b/skyportal/handlers/api/source_groups.py
@@ -1,4 +1,5 @@
 import sqlalchemy as sa
+from pydantic import BaseModel, ConfigDict, Field
 
 from baselayer.app.access import permissions
 from baselayer.log import make_log
@@ -12,53 +13,60 @@ from ..base import BaseHandler
 log = make_log("api/source_groups")
 
 
+class SourceGroupsPostBody(BaseModel):
+    """Request body for saving/unsaving a source to/from groups."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    objId: str = Field(description="ID of the object in question.")
+    inviteGroupIds: list[int] = Field(
+        default_factory=list,
+        description="List of group IDs to save or invite to save specified source.",
+    )
+    unsaveGroupIds: list[int] = Field(
+        default_factory=list,
+        description="List of group IDs from which specified source is to be unsaved.",
+    )
+
+
+class SourceGroupsPatchBody(BaseModel):
+    """Request body for updating a Source table row."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    groupID: int = Field(description="ID of the group whose Source row to update.")
+    active: bool = Field(description="Whether the source is saved to the group.")
+    requested: bool = Field(
+        description="Whether the source is requested to be saved to the group."
+    )
+
+
 class SourceGroupsHandler(BaseHandler):
     @permissions(["Upload data"])
-    async def post(self):
+    async def post(self, *, body: SourceGroupsPostBody = None):
         """
         ---
         summary: Save or unsave sources to/from groups
         description: Save or request group(s) to save source, and optionally unsave from group(s).
         tags:
           - sources
-        requestBody:
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  objId:
-                    type: string
-                    description: ID of the object in question.
-                  inviteGroupIds:
-                    type: array
-                    items:
-                      type: integer
-                    description: |
-                      List of group IDs to save or invite to save specified source.
-                  unsaveGroupIds:
-                    type: array
-                    items:
-                      type: integer
-                    description: |
-                      List of group IDs from which specified source is to be unsaved.
-                required:
-                  - objId
-                anyOf:
-                  - required:
-                    - inviteGroupIds
-                  - required:
-                    - unsaveGroupIds
         responses:
           200:
             content:
               application/json:
                 schema: Success
         """
-        data = self.get_json()
-        obj_id = data.get("objId")
-        if obj_id is None:
-            return self.error("Missing required parameter: objId")
+        body = self.parse_body(SourceGroupsPostBody)
+        obj_id = body.objId
+        # pydantic coerces string ids to int here — clients (and old code
+        # paths) sometimes send these as strings, which then crashes the
+        # Source.group_id comparison against an integer column.
+        save_or_invite_group_ids = body.inviteGroupIds
+        unsave_group_ids = body.unsaveGroupIds
+        if not save_or_invite_group_ids and not unsave_group_ids:
+            return self.error(
+                "Missing required parameter: one of either unsaveGroupIds or inviteGroupIds must be provided"
+            )
 
         async with self.AsyncSession() as session:
             obj = await session.scalar(
@@ -66,22 +74,6 @@ class SourceGroupsHandler(BaseHandler):
             )
             if not obj:
                 return self.error(f"Obj {obj_id} not found", status=404)
-            # Coerce to int up front — clients (and old code paths) sometimes
-            # send these as strings, which then crashes the Source.group_id
-            # comparison against an integer column with a ProgrammingError.
-            try:
-                save_or_invite_group_ids = [
-                    int(g) for g in data.get("inviteGroupIds", [])
-                ]
-                unsave_group_ids = [int(g) for g in data.get("unsaveGroupIds", [])]
-            except (TypeError, ValueError):
-                return self.error(
-                    "inviteGroupIds and unsaveGroupIds must be lists of integers"
-                )
-            if not save_or_invite_group_ids and not unsave_group_ids:
-                return self.error(
-                    "Missing required parameter: one of either unsaveGroupIds or inviteGroupIds must be provided"
-                )
 
             saved_to_group_ids = []
             for save_or_invite_group_id in save_or_invite_group_ids:
@@ -165,7 +157,9 @@ class SourceGroupsHandler(BaseHandler):
             return self.success()
 
     @permissions(["Upload data"])
-    async def patch(self, obj_id: str, *ignored_args):
+    async def patch(
+        self, obj_id: str, *ignored_args, body: SourceGroupsPatchBody = None
+    ):
         """
         ---
         summary: Update a Source table row
@@ -178,38 +172,16 @@ class SourceGroupsHandler(BaseHandler):
             required: true
             schema:
               type: integer
-        requestBody:
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  groupID:
-                    type: integer
-                  active:
-                    type: boolean
-                  requested:
-                    type: boolean
-                required:
-                  - groupID
-                  - active
-                  - requested
         responses:
           200:
             content:
               application/json:
                 schema: Success
         """
-        data = self.get_json()
-        group_id = data.get("groupID")
-        if group_id is None:
-            return self.error("Missing required parameter: groupID")
-        try:
-            group_id = int(group_id)
-        except (TypeError, ValueError):
-            return self.error("groupID must be an integer")
-        active = data.get("active")
-        requested = data.get("requested")
+        body = self.parse_body(SourceGroupsPatchBody)
+        group_id = body.groupID
+        active = body.active
+        requested = body.requested
 
         async with self.AsyncSession() as session:
             obj = await session.scalar(

--- a/static/js/types/api.ts
+++ b/static/js/types/api.ts
@@ -18571,16 +18571,9 @@ export interface paths {
                 path?: never;
                 cookie?: never;
             };
-            requestBody?: {
+            requestBody: {
                 content: {
-                    "application/json": {
-                        /** @description ID of the object in question. */
-                        objId: string;
-                        /** @description List of group IDs to save or invite to save specified source. */
-                        inviteGroupIds?: number[];
-                        /** @description List of group IDs from which specified source is to be unsaved. */
-                        unsaveGroupIds?: number[];
-                    } | unknown | unknown;
+                    "application/json": components["schemas"]["SourceGroupsPostBody"];
                 };
             };
             responses: {
@@ -18626,13 +18619,9 @@ export interface paths {
                 };
                 cookie?: never;
             };
-            requestBody?: {
+            requestBody: {
                 content: {
-                    "application/json": {
-                        groupID: number;
-                        active: boolean;
-                        requested: boolean;
-                    };
+                    "application/json": components["schemas"]["SourceGroupsPatchBody"];
                 };
             };
             responses: {
@@ -38374,6 +38363,48 @@ export interface components {
              * @description New annotation ID
              */
             annotation_id: number;
+        };
+        /**
+         * SourceGroupsPostBody
+         * @description Request body for saving/unsaving a source to/from groups.
+         */
+        SourceGroupsPostBody: {
+            /**
+             * Objid
+             * @description ID of the object in question.
+             */
+            objId: string;
+            /**
+             * Invitegroupids
+             * @description List of group IDs to save or invite to save specified source.
+             */
+            inviteGroupIds?: number[];
+            /**
+             * Unsavegroupids
+             * @description List of group IDs from which specified source is to be unsaved.
+             */
+            unsaveGroupIds?: number[];
+        };
+        /**
+         * SourceGroupsPatchBody
+         * @description Request body for updating a Source table row.
+         */
+        SourceGroupsPatchBody: {
+            /**
+             * Groupid
+             * @description ID of the group whose Source row to update.
+             */
+            groupID: number;
+            /**
+             * Active
+             * @description Whether the source is saved to the group.
+             */
+            active: boolean;
+            /**
+             * Requested
+             * @description Whether the source is requested to be saved to the group.
+             */
+            requested: boolean;
         };
         SpatialCatalogASCIIFileHandlerPost: {
             /** @description Spatial catalog name. */


### PR DESCRIPTION
Continues the typed-endpoint migration (#6382 and follow-ups), converting `SourceGroupsHandler` POST and PATCH to the `parse_body` pattern.

- `SourceGroupsPostBody` (`objId` + `inviteGroupIds`/`unsaveGroupIds`, `extra="forbid"`) replaces the hand-rolled checks; pydantic's lax int coercion takes over the explicit string→int cast that was added for clients sending string ids. The "one of either" cross-field check stays in the handler with its original message.
- `SourceGroupsPatchBody` types `groupID`/`active`/`requested` as required, matching the documented contract (the old code silently tolerated a missing `active`, which would have crashed on commit).
- Client sweep: `updateSourceGroups` (used by `EditSourceGroups.tsx` and `SaveCandidateGroupsDialog.tsx`) and `acceptSaveRequest`/`declineSaveRequest` in `static/js/ducks/source.ts` send exactly these keys, as do all test call sites.
- `static/js/types/api.ts` regenerated.