### PR TITLE
Pydantic-typed request body for recurring API endpoint

### DIFF
--- a/skyportal/handlers/api/recurring_api.py
+++ b/skyportal/handlers/api/recurring_api.py
@@ -2,6 +2,7 @@ import json
 
 import arrow
 from marshmallow.exceptions import ValidationError
+from pydantic import BaseModel, ConfigDict, Field
 
 from baselayer.app.access import auth_or_token, permissions
 from baselayer.app.env import load_env
@@ -21,90 +22,63 @@ ALLOWED_RECURRING_API_METHODS = ["POST", "GET"]
 MAX_RETRIES = 10
 
 
+class RecurringAPIPostBody(BaseModel):
+    """Request body for creating a recurring API."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    endpoint: str = Field(description="Endpoint of the API call.")
+    method: str = Field(description="HTTP method of the API call.")
+    next_call: str = Field(description="Time of the next API call.")
+    call_delay: float = Field(description="Delay until next API call in days.")
+    payload: str = Field(description="JSON string with the payload of the API call.")
+    number_of_retries: int | None = Field(
+        default=None,
+        le=MAX_RETRIES,
+        description="Number of retries before service is deactivated.",
+    )
+
+
+class RecurringAPIPostResponse(BaseModel):
+    """Data payload returned when creating a recurring API."""
+
+    id: int = Field(description="New RecurringAPI ID")
+
+
 class RecurringAPIHandler(BaseHandler):
     """Handler for recurring APIs."""
 
     @permissions(["Manage Recurring APIs"])
-    async def post(self):
+    async def post(
+        self, *, body: RecurringAPIPostBody = None
+    ) -> RecurringAPIPostResponse:
         """
         ---
         summary: Create a new Recurring API
         description: POST a new Recurring APIs.
         tags:
           - recurring apis
-        requestBody:
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  endpoint:
-                    type: string
-                    description: Endpoint of the API call.
-                  method:
-                    type: string
-                    description: HTTP method of the API call.
-                  next_call:
-                    type: datetime
-                    description: Time of the next API call.
-                  call_delay:
-                    type: number
-                    description: Delay until next API call in days.
-                  number_of_retries:
-                    type: integer
-                    description: Number of retries before service is deactivated.
-                  payload:
-                    type: object
-                    description: Payload of the API call.
-                required:
-                  - endpoint
-                  - method
-                  - next_call
-                  - call_delay
-                  - payload
-        responses:
-          200:
-            content:
-              application/json:
-                schema:
-                  allOf:
-                    - $ref: '#/components/schemas/Success'
-                    - type: object
-                      properties:
-                        data:
-                          type: object
-                          properties:
-                            id:
-                              type: integer
-                              description: New RecurringAPI ID
         """
-        data = self.get_json()
+        body = self.parse_body(RecurringAPIPostBody)
+        data = body.model_dump(exclude_none=True)
 
         try:
             data["next_call"] = str(
-                arrow.get(data.get("next_call")).datetime.replace(tzinfo=None)
+                arrow.get(body.next_call).datetime.replace(tzinfo=None)
             )
         except arrow.ParserError:
+            return self.error(f"Invalid input for parameter next_call:{body.next_call}")
+
+        data["method"] = body.method.upper()
+        if data["method"] not in ALLOWED_RECURRING_API_METHODS:
             return self.error(
-                f"Invalid input for parameter next_call:{data.get('next_call')}"
+                f"method must be in {','.join(ALLOWED_RECURRING_API_METHODS)}"
             )
 
-        if "method" in data:
-            data["method"] = data["method"].upper()
-            if not data["method"] in ALLOWED_RECURRING_API_METHODS:
-                return self.error(
-                    'method must be in {",".join(ALLOWED_RECURRING_API_METHODS)}'
-                )
-
-        if "number_of_retries" in data:
-            if data["number_of_retries"] > MAX_RETRIES:
-                return self.error(f"number_of_retries must be <= {MAX_RETRIES}")
-
-        if "payload" in data:
-            try:
-                json.loads(data["payload"])
-            except json.JSONDecodeError:
-                return self.error("payload must be a valid JSON string")
+        try:
+            json.loads(body.payload)
+        except json.JSONDecodeError:
+            return self.error("payload must be a valid JSON string")
 
         async with self.AsyncSession() as session:
             schema = RecurringAPI.__schema__()

--- a/static/js/types/api.ts
+++ b/static/js/types/api.ts
@@ -15716,22 +15716,9 @@ export interface paths {
                 path?: never;
                 cookie?: never;
             };
-            requestBody?: {
+            requestBody: {
                 content: {
-                    "application/json": {
-                        /** @description Endpoint of the API call. */
-                        endpoint: string;
-                        /** @description HTTP method of the API call. */
-                        method: string;
-                        /** @description Time of the next API call. */
-                        next_call: Record<string, never>;
-                        /** @description Delay until next API call in days. */
-                        call_delay: number;
-                        /** @description Number of retries before service is deactivated. */
-                        number_of_retries?: number;
-                        /** @description Payload of the API call. */
-                        payload: Record<string, never>;
-                    };
+                    "application/json": components["schemas"]["RecurringAPIPostBody"];
                 };
             };
             responses: {
@@ -15741,10 +15728,7 @@ export interface paths {
                     };
                     content: {
                         "application/json": components["schemas"]["Success"] & {
-                            data?: {
-                                /** @description New RecurringAPI ID */
-                                id?: number;
-                            };
+                            data?: components["schemas"]["RecurringAPIPostResponse"];
                         };
                     };
                 };
@@ -38348,6 +38332,54 @@ export interface components {
              * @default null
              */
             group_ids: number[] | null;
+        };
+        /**
+         * RecurringAPIPostBody
+         * @description Request body for creating a recurring API.
+         */
+        RecurringAPIPostBody: {
+            /**
+             * Endpoint
+             * @description Endpoint of the API call.
+             */
+            endpoint: string;
+            /**
+             * Method
+             * @description HTTP method of the API call.
+             */
+            method: string;
+            /**
+             * Next Call
+             * @description Time of the next API call.
+             */
+            next_call: string;
+            /**
+             * Call Delay
+             * @description Delay until next API call in days.
+             */
+            call_delay: number;
+            /**
+             * Payload
+             * @description JSON string with the payload of the API call.
+             */
+            payload: string;
+            /**
+             * Number Of Retries
+             * @description Number of retries before service is deactivated.
+             * @default null
+             */
+            number_of_retries: number | null;
+        };
+        /**
+         * RecurringAPIPostResponse
+         * @description Data payload returned when creating a recurring API.
+         */
+        RecurringAPIPostResponse: {
+            /**
+             * Id
+             * @description New RecurringAPI ID
+             */
+            id: number;
         };
         SkymapQueueAPIHandlerPost: {
             /** @description Followup request allocation ID. */

--- a/static/js/types/routeSchemaMap.ts
+++ b/static/js/types/routeSchemaMap.ts
@@ -163,6 +163,7 @@ export const ROUTE_SCHEMA_MAP = {
   "POST /api/observation/ascii": { schema: "ExecutedObservation" as const, list: true },
   "POST /api/observation/external_api": { schema: "ExecutedObservation" as const, list: true },
   "POST /api/observation_plan/{observation_plan_request_id}/queue": { schema: "ObservationPlanRequest" as const, list: false },
+  "POST /api/recurring_api": { schema: "RecurringAPIPostResponse" as const, list: false },
   "POST /api/sharing_service/submission": { schema: "SharingServiceSubmission" as const, list: false },
   "POST /api/sharing_service/{sharing_service_id}/coauthor/{user_id}": { schema: "SharingServiceCoauthor" as const, list: false },
   "POST /api/sharing_service/{sharing_service_id}/group/{group_id}/auto_publisher/{user_id}": { schema: "SharingServiceGroupAutoPublisher" as const, list: false },


### PR DESCRIPTION
Continues the typed-endpoint migration (#6382 and follow-ups), converting `RecurringAPIHandler` POST to the `parse_body` pattern.

- `RecurringAPIPostBody` (`extra="forbid"`) types the five required fields plus optional `number_of_retries` (`le=10`, replacing the manual cap check). The old docstring documented `payload` as an object, but the handler (and the only client) require a JSON **string** — the model now documents the real contract. The arrow `next_call` parse and the `payload must be a valid JSON string` check (exact message asserted in tests) stay in the handler, and the marshmallow load is kept for datetime construction.
- `method` is now required (it always was per the docstring and the RecurringAPI model; the old `if "method" in data` guard just deferred the failure to marshmallow). Also fixes the method-rejection message, which was missing its f-string prefix and printed the literal template.
- Client sweep: `NewRecurringAPI.tsx` (via `ducks/recurring_apis.ts`) sends exactly `{endpoint, method, next_call, call_delay, payload}`; the single test call site matches.
- `static/js/types/api.ts` and `routeSchemaMap.ts` regenerated.