### PR TITLE
Pydantic-typed request bodies for invitation endpoints

### DIFF
--- a/skyportal/handlers/api/invitations.py
+++ b/skyportal/handlers/api/invitations.py
@@ -4,6 +4,7 @@ import uuid
 import arrow
 import python_http_client.exceptions
 import sqlalchemy as sa
+from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import func
 from sqlalchemy.orm import selectinload
 
@@ -26,90 +27,94 @@ from ..base import BaseHandler
 _, cfg = load_env()
 
 
+class InvitationPostBody(BaseModel):
+    """Request body for inviting a new user."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    userEmail: str = Field(description="Email address to send the invitation to.")
+    groupIDs: list[int] = Field(
+        description="List of IDs of groups invited user will be added to. If "
+        "`streamIDs` is not provided, invited user will be given accesss to "
+        "all streams associated with the groups specified by this field."
+    )
+    role: str = Field(
+        default="Full user",
+        description="The role the new user will have in the system. "
+        'If provided, must be one of either "Full user" or "View only". '
+        'Defaults to "Full user".',
+    )
+    streamIDs: list[int] | None = Field(
+        default=None,
+        description="List of IDs of streams invited user will be given access "
+        "to. If not provided, user will be granted access to all streams "
+        "associated with the groups specified by `groupIDs`.",
+    )
+    groupAdmin: list[bool] | None = Field(
+        default=None,
+        description="List of booleans indicating whether user should be "
+        "granted admin status for respective specified group(s). Defaults to "
+        "all false.",
+    )
+    canSave: list[bool] | None = Field(
+        default=None,
+        description="List of booleans indicating whether user should be able "
+        "to save sources to respective specified group(s). Defaults to all "
+        "true.",
+    )
+    userExpirationDate: str | None = Field(
+        default=None,
+        description="Arrow-parseable date string (e.g. 2020-01-01). Set a "
+        "user's expiration date, after which the user's account will be "
+        "deactivated and will be unable to access the application.",
+    )
+
+
+class InvitationPostResponse(BaseModel):
+    """Data payload returned when creating an invitation."""
+
+    id: int = Field(description="New invitation ID")
+
+
+class InvitationPatchBody(BaseModel):
+    """Request body for updating a pending invitation."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    groupIDs: list[int] | None = Field(
+        default=None, description="List of IDs of groups the user is invited to."
+    )
+    streamIDs: list[int] | None = Field(
+        default=None,
+        description="List of IDs of streams invited user will be given access to.",
+    )
+    role: str | None = Field(
+        default=None, description="The role the new user will have in the system."
+    )
+    userExpirationDate: str | None = Field(
+        default=None,
+        description="Arrow-parseable date string (e.g. 2020-01-01). Set a "
+        "user's expiration date, after which the user's account will be "
+        "deactivated and will be unable to access the application.",
+    )
+
+
 class InvitationHandler(BaseHandler):
     @permissions(["Manage users"])
-    async def post(self):
+    async def post(self, *, body: InvitationPostBody = None) -> InvitationPostResponse:
         """
         ---
         summary: Invite a new user
         description: Invite a new user
         tags:
           - invitations
-        requestBody:
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  userEmail:
-                    type: string
-                  role:
-                    type: string
-                    description: |
-                      The role the new user will have in the system.
-                      If provided, must be one of either "Full user" or "View only".
-                      Defaults to "Full user".
-                  streamIDs:
-                    type: array
-                    items:
-                      type: integer
-                    description: |
-                      List of IDs of streams invited user will be given access to. If
-                      not provided, user will be granted access to all streams associated
-                      with the groups specified by `groupIDs`.
-                  groupIDs:
-                    type: array
-                    items:
-                      type: integer
-                    description: |
-                      List of IDs of groups invited user will be added to. If `streamIDs`
-                      is not provided, invited user will be given accesss to all streams
-                      associated with the groups specified by this field.
-                  groupAdmin:
-                    type: array
-                    items:
-                      type: boolean
-                    description: |
-                      List of booleans indicating whether user should be granted admin
-                      status for respective specified group(s). Defaults to all false.
-                  canSave:
-                    type: array
-                    items:
-                      type: boolean
-                    description: |
-                      List of booleans indicating whether user should be able to save
-                      sources to respective specified group(s). Defaults to all true.
-                  userExpirationDate:
-                    type: string
-                    description: |
-                      Arrow-parseable date string (e.g. 2020-01-01). Set a user's expiration
-                      date, after which the user's account will be deactivated and will be unable
-                      to access the application.
-                required:
-                  - userEmail
-                  - groupIDs
-        responses:
-          200:
-            content:
-              application/json:
-                schema:
-                  allOf:
-                    - $ref: '#/components/schemas/Success'
-                    - type: object
-                      properties:
-                        data:
-                          type: object
-                          properties:
-                            id:
-                              type: string
-                              description: New invitation ID
         """
         if not cfg["invitations.enabled"]:
             return self.error("Invitations are not enabled in current deployment.")
-        data = self.get_json()
+        body = self.parse_body(InvitationPostBody)
 
         async with self.AsyncSession() as session:
-            role_id = data.get("role", "Full user")
+            role_id = body.role
             if role_id not in ["Full user", "View only"]:
                 return self.error(
                     f"Unsupported value provided for parameter `role`: {role_id}. "
@@ -119,19 +124,11 @@ class InvitationHandler(BaseHandler):
                 Role.select(self.current_user).where(Role.id == role_id)
             )
 
-            if data.get("userEmail") in [None, "", "None", "null"]:
+            if body.userEmail in ["", "None", "null"]:
                 return self.error("Missing required parameter `userEmail`")
-            user_email = data["userEmail"].strip()
+            user_email = body.userEmail.strip()
 
-            if data.get("groupIDs") is None:
-                return self.error("Missing required parameter `groupIDs`")
-            try:
-                group_ids = [int(gid) for gid in data["groupIDs"]]
-            except ValueError:
-                return self.error(
-                    "Invalid value provided for `groupIDs`; unable to parse "
-                    "all list items to integers."
-                )
+            group_ids = body.groupIDs
             groups_result = await session.scalars(
                 Group.select(self.current_user)
                 .options(selectinload(Group.streams))
@@ -144,14 +141,8 @@ class InvitationHandler(BaseHandler):
                     f"{set(group_ids).difference({g.id for g in groups})}"
                 )
 
-            if data.get("streamIDs") not in [None, "", "null", "None"]:
-                try:
-                    stream_ids = [int(sid) for sid in data["streamIDs"]]
-                except ValueError:
-                    return self.error(
-                        "Invalid value provided for `streamIDs`; unable to parse "
-                        "all list items to integers."
-                    )
+            if body.streamIDs is not None:
+                stream_ids = body.streamIDs
 
                 streams_result = await session.scalars(
                     Stream.select(self.current_user).where(Stream.id.in_(stream_ids))
@@ -180,19 +171,15 @@ class InvitationHandler(BaseHandler):
                     .where(GroupStream.group_id.in_(group_ids))
                 )
                 streams = streams_result.all()
-            admin_for_groups = data.get("groupAdmin", [False] * len(groups))
-            if not all(isinstance(admin, bool) for admin in admin_for_groups):
-                return self.error(
-                    "Invalid value provided for `groupAdmin` parameter: "
-                    "all elements must be booleans"
-                )
-            can_save = data.get("canSave", [True] * len(groups))
-            if not all(isinstance(can_save_el, bool) for can_save_el in can_save):
-                return self.error(
-                    "Invalid value provided for `canSave` parameter: "
-                    "all elements must be booleans"
-                )
-            user_expiration_date = data.get("userExpirationDate")
+            admin_for_groups = (
+                body.groupAdmin
+                if body.groupAdmin is not None
+                else [False] * len(groups)
+            )
+            can_save = (
+                body.canSave if body.canSave is not None else [True] * len(groups)
+            )
+            user_expiration_date = body.userExpirationDate
             if user_expiration_date is not None:
                 try:
                     user_expiration_date = arrow.get(user_expiration_date).datetime
@@ -365,42 +352,20 @@ class InvitationHandler(BaseHandler):
             return self.success(data=info)
 
     @permissions(["Manage users"])
-    async def patch(self, invitation_id: int):
+    async def patch(self, invitation_id: int, *, body: InvitationPatchBody = None):
         """
         ---
         summary: Update a pending invitation
         description: Update a pending invitation
         tags:
           - invitations
-        requestBody:
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  groupIDs:
-                    type: array
-                    items:
-                      type: integer
-                  streamIDs:
-                    type: array
-                    items:
-                      type: integer
-                  role:
-                    type: string
-                  userExpirationDate:
-                    type: string
-                    description: |
-                      Arrow-parseable date string (e.g. 2020-01-01). Set a user's expiration
-                      date, after which the user's account will be deactivated and will be unable
-                      to access the application.
         responses:
           200:
             content:
               application/json:
                 schema: Success
         """
-        data = self.get_json()
+        body = self.parse_body(InvitationPatchBody)
         async with self.AsyncSession() as session:
             invitation = await session.scalar(
                 Invitation.select(session.user_or_token, mode="update")
@@ -415,10 +380,10 @@ class InvitationHandler(BaseHandler):
                     "Insufficient permissions: Only the invitor may update an invitation."
                 )
 
-            group_ids = data.get("groupIDs")
-            stream_ids = data.get("streamIDs")
-            role_id = data.get("role")
-            user_expiration_date = data.get("userExpirationDate")
+            group_ids = body.groupIDs
+            stream_ids = body.streamIDs
+            role_id = body.role
+            user_expiration_date = body.userExpirationDate
             if (
                 group_ids is None
                 and stream_ids is None
@@ -429,8 +394,6 @@ class InvitationHandler(BaseHandler):
                     "At least one of `groupIDs`, `streamIDs`, `role`, or `userExpirationDate` is required."
                 )
             if group_ids is not None:
-                group_ids = [int(gid) for gid in group_ids]
-
                 groups_result = await session.scalars(
                     Group.select(self.current_user)
                     .options(selectinload(Group.streams))
@@ -451,7 +414,6 @@ class InvitationHandler(BaseHandler):
                 )
                 groups = groups_result.all()
             if stream_ids is not None:
-                stream_ids = [int(sid) for sid in stream_ids]
                 streams_result = await session.scalars(
                     Stream.select(self.current_user).where(Stream.id.in_(stream_ids))
                 )

--- a/static/js/types/api.ts
+++ b/static/js/types/api.ts
@@ -11552,45 +11552,9 @@ export interface paths {
                 path?: never;
                 cookie?: never;
             };
-            requestBody?: {
+            requestBody: {
                 content: {
-                    "application/json": {
-                        userEmail: string;
-                        /**
-                         * @description The role the new user will have in the system.
-                         *     If provided, must be one of either "Full user" or "View only".
-                         *     Defaults to "Full user".
-                         */
-                        role?: string;
-                        /**
-                         * @description List of IDs of streams invited user will be given access to. If
-                         *     not provided, user will be granted access to all streams associated
-                         *     with the groups specified by `groupIDs`.
-                         */
-                        streamIDs?: number[];
-                        /**
-                         * @description List of IDs of groups invited user will be added to. If `streamIDs`
-                         *     is not provided, invited user will be given accesss to all streams
-                         *     associated with the groups specified by this field.
-                         */
-                        groupIDs: number[];
-                        /**
-                         * @description List of booleans indicating whether user should be granted admin
-                         *     status for respective specified group(s). Defaults to all false.
-                         */
-                        groupAdmin?: boolean[];
-                        /**
-                         * @description List of booleans indicating whether user should be able to save
-                         *     sources to respective specified group(s). Defaults to all true.
-                         */
-                        canSave?: boolean[];
-                        /**
-                         * @description Arrow-parseable date string (e.g. 2020-01-01). Set a user's expiration
-                         *     date, after which the user's account will be deactivated and will be unable
-                         *     to access the application.
-                         */
-                        userExpirationDate?: string;
-                    };
+                    "application/json": components["schemas"]["InvitationPostBody"];
                 };
             };
             responses: {
@@ -11600,10 +11564,7 @@ export interface paths {
                     };
                     content: {
                         "application/json": components["schemas"]["Success"] & {
-                            data?: {
-                                /** @description New invitation ID */
-                                id?: string;
-                            };
+                            data?: components["schemas"]["InvitationPostResponse"];
                         };
                     };
                 };
@@ -11663,19 +11624,9 @@ export interface paths {
                 path?: never;
                 cookie?: never;
             };
-            requestBody?: {
+            requestBody: {
                 content: {
-                    "application/json": {
-                        groupIDs?: number[];
-                        streamIDs?: number[];
-                        role?: string;
-                        /**
-                         * @description Arrow-parseable date string (e.g. 2020-01-01). Set a user's expiration
-                         *     date, after which the user's account will be deactivated and will be unable
-                         *     to access the application.
-                         */
-                        userExpirationDate?: string;
-                    };
+                    "application/json": components["schemas"]["InvitationPatchBody"];
                 };
             };
             responses: {
@@ -38168,6 +38119,93 @@ export interface components {
              * @enum {string}
              */
             status: "pending" | "accepted" | "declined";
+        };
+        /**
+         * InvitationPostBody
+         * @description Request body for inviting a new user.
+         */
+        InvitationPostBody: {
+            /**
+             * Useremail
+             * @description Email address to send the invitation to.
+             */
+            userEmail: string;
+            /**
+             * Groupids
+             * @description List of IDs of groups invited user will be added to. If `streamIDs` is not provided, invited user will be given accesss to all streams associated with the groups specified by this field.
+             */
+            groupIDs: number[];
+            /**
+             * Role
+             * @description The role the new user will have in the system. If provided, must be one of either "Full user" or "View only". Defaults to "Full user".
+             * @default Full user
+             */
+            role: string;
+            /**
+             * Streamids
+             * @description List of IDs of streams invited user will be given access to. If not provided, user will be granted access to all streams associated with the groups specified by `groupIDs`.
+             * @default null
+             */
+            streamIDs: number[] | null;
+            /**
+             * Groupadmin
+             * @description List of booleans indicating whether user should be granted admin status for respective specified group(s). Defaults to all false.
+             * @default null
+             */
+            groupAdmin: boolean[] | null;
+            /**
+             * Cansave
+             * @description List of booleans indicating whether user should be able to save sources to respective specified group(s). Defaults to all true.
+             * @default null
+             */
+            canSave: boolean[] | null;
+            /**
+             * Userexpirationdate
+             * @description Arrow-parseable date string (e.g. 2020-01-01). Set a user's expiration date, after which the user's account will be deactivated and will be unable to access the application.
+             * @default null
+             */
+            userExpirationDate: string | null;
+        };
+        /**
+         * InvitationPostResponse
+         * @description Data payload returned when creating an invitation.
+         */
+        InvitationPostResponse: {
+            /**
+             * Id
+             * @description New invitation ID
+             */
+            id: number;
+        };
+        /**
+         * InvitationPatchBody
+         * @description Request body for updating a pending invitation.
+         */
+        InvitationPatchBody: {
+            /**
+             * Groupids
+             * @description List of IDs of groups the user is invited to.
+             * @default null
+             */
+            groupIDs: number[] | null;
+            /**
+             * Streamids
+             * @description List of IDs of streams invited user will be given access to.
+             * @default null
+             */
+            streamIDs: number[] | null;
+            /**
+             * Role
+             * @description The role the new user will have in the system.
+             * @default null
+             */
+            role: string | null;
+            /**
+             * Userexpirationdate
+             * @description Arrow-parseable date string (e.g. 2020-01-01). Set a user's expiration date, after which the user's account will be deactivated and will be unable to access the application.
+             * @default null
+             */
+            userExpirationDate: string | null;
         };
         ObservationHandlerPost: {
             /** @description The telescope name associated with the fields */

--- a/static/js/types/routeSchemaMap.ts
+++ b/static/js/types/routeSchemaMap.ts
@@ -156,6 +156,7 @@ export const ROUTE_SCHEMA_MAP = {
   "POST /api/galaxy_catalog/ascii": { schema: "Galaxy" as const, list: true },
   "POST /api/group_admission_requests": { schema: "GroupAdmissionRequestPostResponse" as const, list: false },
   "POST /api/groups/{group_id}/usersFromGroups": { schema: "GroupUser" as const, list: false },
+  "POST /api/invitations": { schema: "InvitationPostResponse" as const, list: false },
   "POST /api/listing": { schema: "ListingPostResponse" as const, list: false },
   "POST /api/objtag": { schema: "ObjTag" as const, list: false },
   "POST /api/objtagoption": { schema: "ObjTagOption" as const, list: false },


### PR DESCRIPTION
Continues the typed-endpoint migration (#6382 and follow-ups), converting `InvitationHandler` POST and PATCH to the `parse_body` pattern.

- `InvitationPostBody` (`extra="forbid"`) types `userEmail`/`groupIDs` (required) plus `role`, `streamIDs`, `groupAdmin`, `canSave`, `userExpirationDate`. `streamIDs: list[int] | None` accepts the explicit `null` the invite form sends; the old string sentinels ("", "null", "None") for it are gone, but the same sentinels for `userEmail` are kept as a handler check. The role allowlist, arrow date parse, group/stream coverage checks, and length check stay in the handler with their messages. POST gains a typed `{id}` response (the old docstring claimed the id was a string; it's an integer).
- `InvitationPatchBody` is all-optional; the "At least one of ..." check (asserted in tests, including via body-less PATCH calls) stays in the handler.
- Client sweep: `InviteNewUserForm.tsx` and `UserInvitations.tsx` (via `ducks/invitations.ts`) send exactly these keys; all test call sites match.
- `static/js/types/api.ts` and `routeSchemaMap.ts` regenerated.