### PR TITLE
Pydantic-typed request bodies for instrument log endpoints

### DIFF
--- a/skyportal/handlers/api/instrument_log.py
+++ b/skyportal/handlers/api/instrument_log.py
@@ -1,8 +1,10 @@
 import json
+from typing import Any
 
 import arrow
 import astropy.units as u
 from astropy.time import Time, TimeDelta
+from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy.orm import selectinload, undefer
 
 from baselayer.app.access import auth_or_token, permissions
@@ -13,9 +15,45 @@ from ...utils.naive_datetime import utcnow_naive
 from ..base import BaseHandler
 
 
+class InstrumentLogPostBody(BaseModel):
+    """Request body for posting instrument logs."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    start_date: str = Field(
+        description="Arrow-parseable date string (e.g. 2020-01-01)."
+    )
+    end_date: str = Field(description="Arrow-parseable date string (e.g. 2020-01-01).")
+    log: str | dict[str, Any] = Field(
+        description="Nested JSON containing the log messages, or a parsable "
+        "string of log lines."
+    )
+
+
+class InstrumentLogPostResponse(BaseModel):
+    """Data payload returned when posting instrument logs."""
+
+    id: int = Field(description="The id of the InstrumentLog")
+
+
+class InstrumentStatusPutBody(BaseModel):
+    """Request body for updating an instrument's status."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: str | dict[str, Any] | None = Field(
+        default=None,
+        description="The status of the instrument, as a JSON object or a "
+        "JSON-encoded string. When empty or omitted, the status is instead "
+        "refreshed from the instrument's remote API.",
+    )
+
+
 class InstrumentLogHandler(BaseHandler):
     @auth_or_token
-    async def post(self, instrument_id: int):
+    async def post(
+        self, instrument_id: int, *, body: InstrumentLogPostBody = None
+    ) -> InstrumentLogPostResponse:
         """
         ---
         summary: Add instrument logs
@@ -29,78 +67,26 @@ class InstrumentLogHandler(BaseHandler):
             schema:
               type: integer
             description: The instrument ID to post logs for
-        requestBody:
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  start_date:
-                    type: string
-                    description: |
-                      Arrow-parseable date string (e.g. 2020-01-01).
-                  end_date:
-                    type: string
-                    description: |
-                      Arrow-parseable date string (e.g. 2020-01-01).
-                  logs:
-                    type: object
-                    description: |
-                       Nested JSON containing the log messages.
-                required:
-                  - start_date
-                  - end_date
-                  - logs
-        responses:
-          200:
-            content:
-              application/json:
-                schema:
-                  allOf:
-                    - $ref: '#/components/schemas/Success'
-                    - type: object
-                      properties:
-                        data:
-                          type: object
-                          properties:
-                            id:
-                              type: integer
-                              description: The id of the InstrumentLog
-          400:
-            content:
-              application/json:
-                schema: Error
         """
+        body = self.parse_body(InstrumentLogPostBody)
         try:
             instrument_id_int = int(instrument_id)
         except (TypeError, ValueError):
             return self.error(f"Invalid instrument_id: {instrument_id}")
 
-        data = self.get_json()
-        start_date = data.get("start_date")
-        if start_date is None:
-            return self.error("date is required")
         try:
-            start_date = arrow.get(start_date).naive
+            start_date = arrow.get(body.start_date).naive
         except Exception as e:
             return self.error(f"Invalid start_date: {str(e)}")
 
-        end_date = data.get("end_date")
-        if end_date is None:
-            return self.error("date is required")
         try:
-            end_date = arrow.get(end_date).naive
+            end_date = arrow.get(body.end_date).naive
         except Exception as e:
             return self.error(f"Invalid end_date: {str(e)}")
 
-        logs = data.get("log")
-        if logs is None:
-            return self.error("log is required")
-
+        logs = body.log
         if isinstance(logs, str):
             logs = read_logs(logs)
-        elif not isinstance(logs, dict):
-            return self.error("log must be either dictionary or parsable string")
 
         async with self.AsyncSession() as session:
             instrument = await session.scalar(
@@ -269,7 +255,7 @@ class InstrumentLogExternalAPIHandler(BaseHandler):
 
 class InstrumentStatusHandler(BaseHandler):
     @permissions(["Upload data"])
-    async def put(self, instrument_id: int):
+    async def put(self, instrument_id: int, *, body: InstrumentStatusPutBody = None):
         """
         ---
         summary: Update instrument status
@@ -283,18 +269,6 @@ class InstrumentStatusHandler(BaseHandler):
             schema:
               type: integer
             description: The instrument ID to update the status for
-        requestBody:
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  status:
-                    type: string
-                    description: |
-                      The status of the instrument
-                required:
-                  - status
         responses:
           200:
             content:
@@ -305,14 +279,14 @@ class InstrumentStatusHandler(BaseHandler):
               application/json:
                 schema: Error
         """
+        body = self.parse_body(InstrumentStatusPutBody)
         try:
             instrument_id_int = int(instrument_id)
         except (TypeError, ValueError):
             return self.error(f"Invalid instrument_id: {instrument_id}")
 
-        data = self.get_json()
-        status = data.get("status", None)
-        if status in [None, "", {}, []]:
+        status = body.status
+        if status in [None, "", {}]:
             async with self.AsyncSession() as session:
                 instrument = await session.scalar(
                     Instrument.select(session.user_or_token, mode="update").where(

--- a/static/js/types/api.ts
+++ b/static/js/types/api.ts
@@ -11006,16 +11006,9 @@ export interface paths {
                 };
                 cookie?: never;
             };
-            requestBody?: {
+            requestBody: {
                 content: {
-                    "application/json": {
-                        /** @description Arrow-parseable date string (e.g. 2020-01-01). */
-                        start_date: string;
-                        /** @description Arrow-parseable date string (e.g. 2020-01-01). */
-                        end_date: string;
-                        /** @description Nested JSON containing the log messages. */
-                        logs: Record<string, never>;
-                    };
+                    "application/json": components["schemas"]["InstrumentLogPostBody"];
                 };
             };
             responses: {
@@ -11025,19 +11018,8 @@ export interface paths {
                     };
                     content: {
                         "application/json": components["schemas"]["Success"] & {
-                            data?: {
-                                /** @description The id of the InstrumentLog */
-                                id?: number;
-                            };
+                            data?: components["schemas"]["InstrumentLogPostResponse"];
                         };
-                    };
-                };
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
                     };
                 };
             };
@@ -11130,12 +11112,9 @@ export interface paths {
                 };
                 cookie?: never;
             };
-            requestBody?: {
+            requestBody: {
                 content: {
-                    "application/json": {
-                        /** @description The status of the instrument */
-                        status: string;
-                    };
+                    "application/json": components["schemas"]["InstrumentStatusPutBody"];
                 };
             };
             responses: {
@@ -38108,6 +38087,54 @@ export interface components {
              * @enum {string}
              */
             status: "pending" | "accepted" | "declined";
+        };
+        /**
+         * InstrumentLogPostBody
+         * @description Request body for posting instrument logs.
+         */
+        InstrumentLogPostBody: {
+            /**
+             * Start Date
+             * @description Arrow-parseable date string (e.g. 2020-01-01).
+             */
+            start_date: string;
+            /**
+             * End Date
+             * @description Arrow-parseable date string (e.g. 2020-01-01).
+             */
+            end_date: string;
+            /**
+             * Log
+             * @description Nested JSON containing the log messages, or a parsable string of log lines.
+             */
+            log: string | {
+                [key: string]: unknown;
+            };
+        };
+        /**
+         * InstrumentLogPostResponse
+         * @description Data payload returned when posting instrument logs.
+         */
+        InstrumentLogPostResponse: {
+            /**
+             * Id
+             * @description The id of the InstrumentLog
+             */
+            id: number;
+        };
+        /**
+         * InstrumentStatusPutBody
+         * @description Request body for updating an instrument's status.
+         */
+        InstrumentStatusPutBody: {
+            /**
+             * Status
+             * @description The status of the instrument, as a JSON object or a JSON-encoded string. When empty or omitted, the status is instead refreshed from the instrument's remote API.
+             * @default null
+             */
+            status: (string | {
+                [key: string]: unknown;
+            }) | null;
         };
         /**
          * InvitationPostBody

--- a/static/js/types/routeSchemaMap.ts
+++ b/static/js/types/routeSchemaMap.ts
@@ -156,6 +156,7 @@ export const ROUTE_SCHEMA_MAP = {
   "POST /api/galaxy_catalog/ascii": { schema: "Galaxy" as const, list: true },
   "POST /api/group_admission_requests": { schema: "GroupAdmissionRequestPostResponse" as const, list: false },
   "POST /api/groups/{group_id}/usersFromGroups": { schema: "GroupUser" as const, list: false },
+  "POST /api/instrument/{instrument_id}/log": { schema: "InstrumentLogPostResponse" as const, list: false },
   "POST /api/invitations": { schema: "InvitationPostResponse" as const, list: false },
   "POST /api/listing": { schema: "ListingPostResponse" as const, list: false },
   "POST /api/objtag": { schema: "ObjTag" as const, list: false },


### PR DESCRIPTION
Continues the typed-endpoint migration (#6382 and follow-ups), converting `InstrumentLogHandler` POST and `InstrumentStatusHandler` PUT to the `parse_body` pattern.

- `InstrumentLogPostBody` documents the real wire contract: the field is `log` (a dict or a parsable log string), not the `logs` object the old docstring claimed, and `start_date`/`end_date` are required strings (arrow parsing and `read_logs` handling stay in the handler). POST gains a typed `{id}` response.
- `InstrumentStatusPutBody` makes `status` optional (`str | dict | null`): the frontend's refresh button PUTs with no body at all, which routes to the remote-API refresh branch, while a non-empty JSON string/object sets the status directly — the old docstring called it a required string, which matched neither path.
- Client sweep: `updateInstrumentStatus` in `static/js/ducks/instrument.ts` sends no body; nothing else in the frontend, tests, or services posts to these routes (they're external-API-facing).
- `static/js/types/api.ts` and `routeSchemaMap.ts` regenerated.