### PR TITLE
Pydantic-typed request bodies for thumbnail endpoints

### DIFF
--- a/skyportal/handlers/api/thumbnail.py
+++ b/skyportal/handlers/api/thumbnail.py
@@ -5,8 +5,8 @@ import os
 from pathlib import Path
 
 import sqlalchemy as sa
-from marshmallow.exceptions import ValidationError
 from PIL import Image, UnidentifiedImageError
+from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import func
 from sqlalchemy.exc import StatementError
 
@@ -14,6 +14,50 @@ from baselayer.app.access import auth_or_token, permissions
 
 from ...models import Obj, Thumbnail, User
 from ..base import BaseHandler
+
+
+class ThumbnailPostBody(BaseModel):
+    """Request body for uploading a thumbnail."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    obj_id: str = Field(description="ID of object associated with thumbnails.")
+    data: str = Field(
+        description="base64-encoded PNG image file contents. Image size must "
+        "be between 16px and 500px on a side."
+    )
+    ttype: str = Field(
+        description="Thumbnail type. Must be one of 'new', 'ref', 'sub', "
+        "'sdss', 'dr8', 'new_gz', 'ref_gz', 'sub_gz'"
+    )
+
+
+class ThumbnailPostResponse(BaseModel):
+    """Data payload returned when uploading a thumbnail."""
+
+    id: int = Field(description="New thumbnail ID")
+
+
+class ThumbnailPutBody(BaseModel):
+    """Request body for updating a thumbnail."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    obj_id: str | None = Field(default=None, description="ID of the thumbnail's obj.")
+    type: str | None = Field(
+        default=None, description="Thumbnail type (e.g., ref, new, sub, ls, ps1, ...)"
+    )
+    file_uri: str | None = Field(
+        default=None,
+        description="Path of the Thumbnail on the machine running SkyPortal.",
+    )
+    public_url: str | None = Field(
+        default=None, description="Publically accessible URL of the thumbnail."
+    )
+    origin: str | None = Field(default=None, description="Origin of the Thumbnail.")
+    is_grayscale: bool | None = Field(
+        default=None, description="Whether the thumbnail is (mostly) grayscale."
+    )
 
 
 async def post_thumbnail(data, user_id, session):
@@ -84,60 +128,20 @@ async def post_thumbnail(data, user_id, session):
 
 class ThumbnailHandler(BaseHandler):
     @permissions(["Upload data"])
-    async def post(self):
+    async def post(self, *, body: ThumbnailPostBody = None) -> ThumbnailPostResponse:
         """
         ---
         summary: Upload thumbnails
         description: Upload thumbnails
         tags:
           - thumbnails
-        requestBody:
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  obj_id:
-                    type: string
-                    description: ID of object associated with thumbnails.
-                  data:
-                    type: string
-                    format: byte
-                    description: base64-encoded PNG image file contents. Image size must be between 16px and 500px on a side.
-                  ttype:
-                    type: string
-                    description: Thumbnail type. Must be one of 'new', 'ref', 'sub', 'sdss', 'dr8', 'new_gz', 'ref_gz', 'sub_gz'
-                required:
-                  - data
-                  - ttype
-        responses:
-          200:
-            content:
-              application/json:
-                schema:
-                  allOf:
-                    - $ref: '#/components/schemas/Success'
-                    - type: object
-                      properties:
-                        data:
-                          type: object
-                          properties:
-                            id:
-                              type: integer
-                              description: New thumbnail ID
-          400:
-            content:
-              application/json:
-                schema: Error
         """
-        data = self.get_json()
-        if "obj_id" not in data:
-            return self.error("Missing required parameter: obj_id")
+        body = self.parse_body(ThumbnailPostBody)
 
         async with self.AsyncSession() as session:
             try:
                 thumbnail_id = await post_thumbnail(
-                    data, self.associated_user_object.id, session
+                    body.model_dump(), self.associated_user_object.id, session
                 )
             except Exception as e:
                 return self.error(f"Thumbnail failed to post: {str(e)}")
@@ -178,7 +182,7 @@ class ThumbnailHandler(BaseHandler):
             return self.success(data=t)
 
     @permissions(["Manage sources"])
-    async def put(self, thumbnail_id: int):
+    async def put(self, thumbnail_id: int, *, body: ThumbnailPutBody = None):
         """
         ---
         summary: Update a thumbnail
@@ -191,26 +195,17 @@ class ThumbnailHandler(BaseHandler):
             required: true
             schema:
               type: integer
-        requestBody:
-          content:
-            application/json:
-              schema: ThumbnailNoID
         responses:
           200:
             content:
               application/json:
-                schema:
-                  allOf:
-                    - $ref: '#/components/schemas/Success'
-                    - type: object
-                      properties:
-                        data:
-                          $ref: '#/components/schemas/Thumbnail'
+                schema: Success
           400:
             content:
               application/json:
                 schema: Error
         """
+        body = self.parse_body(ThumbnailPutBody)
         async with self.AsyncSession() as session:
             t = await session.scalar(
                 Thumbnail.select(session.user_or_token, mode="update").where(
@@ -220,19 +215,8 @@ class ThumbnailHandler(BaseHandler):
             if t is None:
                 return self.error(f"Cannot find Thumbnail with ID: {thumbnail_id}")
 
-            data = self.get_json()
-            data["id"] = thumbnail_id
-
-            schema = Thumbnail.__schema__()
-            try:
-                schema.load(data, partial=True)
-            except ValidationError as e:
-                return self.error(
-                    f"Invalid/missing parameters: {e.normalized_messages()}"
-                )
-
-            for k in data:
-                setattr(t, k, data[k])
+            for field in body.model_fields_set:
+                setattr(t, field, getattr(body, field))
 
             await session.commit()
             return self.success()

--- a/static/js/types/api.ts
+++ b/static/js/types/api.ts
@@ -21066,9 +21066,9 @@ export interface paths {
                 };
                 cookie?: never;
             };
-            requestBody?: {
+            requestBody: {
                 content: {
-                    "application/json": components["schemas"]["ThumbnailNoID"];
+                    "application/json": components["schemas"]["ThumbnailPutBody"];
                 };
             };
             responses: {
@@ -21077,9 +21077,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["Success"] & {
-                            data?: components["schemas"]["Thumbnail"];
-                        };
+                        "application/json": components["schemas"]["Success"];
                     };
                 };
                 400: {
@@ -21151,19 +21149,9 @@ export interface paths {
                 path?: never;
                 cookie?: never;
             };
-            requestBody?: {
+            requestBody: {
                 content: {
-                    "application/json": {
-                        /** @description ID of object associated with thumbnails. */
-                        obj_id?: string;
-                        /**
-                         * Format: byte
-                         * @description base64-encoded PNG image file contents. Image size must be between 16px and 500px on a side.
-                         */
-                        data: string;
-                        /** @description Thumbnail type. Must be one of 'new', 'ref', 'sub', 'sdss', 'dr8', 'new_gz', 'ref_gz', 'sub_gz' */
-                        ttype: string;
-                    };
+                    "application/json": components["schemas"]["ThumbnailPostBody"];
                 };
             };
             responses: {
@@ -21173,19 +21161,8 @@ export interface paths {
                     };
                     content: {
                         "application/json": components["schemas"]["Success"] & {
-                            data?: {
-                                /** @description New thumbnail ID */
-                                id?: number;
-                            };
+                            data?: components["schemas"]["ThumbnailPostResponse"];
                         };
-                    };
-                };
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
                     };
                 };
             };
@@ -38941,6 +38918,80 @@ export interface components {
              * @default null
              */
             fixed_location: boolean | null;
+        };
+        /**
+         * ThumbnailPostBody
+         * @description Request body for uploading a thumbnail.
+         */
+        ThumbnailPostBody: {
+            /**
+             * Obj Id
+             * @description ID of object associated with thumbnails.
+             */
+            obj_id: string;
+            /**
+             * Data
+             * @description base64-encoded PNG image file contents. Image size must be between 16px and 500px on a side.
+             */
+            data: string;
+            /**
+             * Ttype
+             * @description Thumbnail type. Must be one of 'new', 'ref', 'sub', 'sdss', 'dr8', 'new_gz', 'ref_gz', 'sub_gz'
+             */
+            ttype: string;
+        };
+        /**
+         * ThumbnailPostResponse
+         * @description Data payload returned when uploading a thumbnail.
+         */
+        ThumbnailPostResponse: {
+            /**
+             * Id
+             * @description New thumbnail ID
+             */
+            id: number;
+        };
+        /**
+         * ThumbnailPutBody
+         * @description Request body for updating a thumbnail.
+         */
+        ThumbnailPutBody: {
+            /**
+             * Obj Id
+             * @description ID of the thumbnail's obj.
+             * @default null
+             */
+            obj_id: string | null;
+            /**
+             * Type
+             * @description Thumbnail type (e.g., ref, new, sub, ls, ps1, ...)
+             * @default null
+             */
+            type: string | null;
+            /**
+             * File Uri
+             * @description Path of the Thumbnail on the machine running SkyPortal.
+             * @default null
+             */
+            file_uri: string | null;
+            /**
+             * Public Url
+             * @description Publically accessible URL of the thumbnail.
+             * @default null
+             */
+            public_url: string | null;
+            /**
+             * Origin
+             * @description Origin of the Thumbnail.
+             * @default null
+             */
+            origin: string | null;
+            /**
+             * Is Grayscale
+             * @description Whether the thumbnail is (mostly) grayscale.
+             * @default null
+             */
+            is_grayscale: boolean | null;
         };
         /**
          * UserACLPostBody

--- a/static/js/types/routeSchemaMap.ts
+++ b/static/js/types/routeSchemaMap.ts
@@ -180,6 +180,7 @@ export const ROUTE_SCHEMA_MAP = {
   "POST /api/taxonomy": { schema: "TaxonomyPostResponse" as const, list: false },
   "POST /api/teams": { schema: "TeamPostResponse" as const, list: false },
   "POST /api/telescope": { schema: "TelescopePostResponse" as const, list: false },
+  "POST /api/thumbnail": { schema: "ThumbnailPostResponse" as const, list: false },
   "POST /api/{associated_resource_type}/{resource_id}/annotations": { schema: "AnnotationPostResponse" as const, list: false },
   "PUT /api/followup_request/prioritization": { schema: "FollowupRequest" as const, list: false },
   "PUT /api/followup_request/{followup_request_id}/comment": { schema: "FollowupRequest" as const, list: false },
@@ -191,7 +192,6 @@ export const ROUTE_SCHEMA_MAP = {
   "PUT /api/spectra/{spectrum_id}": { schema: "Spectrum" as const, list: false },
   "PUT /api/spectrum/{spectrum_id}": { schema: "Spectrum" as const, list: false },
   "PUT /api/teams/{team_id}": { schema: "TeamPutResponse" as const, list: false },
-  "PUT /api/thumbnail/{thumbnail_id}": { schema: "Thumbnail" as const, list: false },
   "PUT /api/{associated_resource_type}/{resource_id}/comments": { schema: "Comment" as const, list: false },
   "PUT /api/{associated_resource_type}/{resource_id}/comments/{comment_id}": { schema: "Comment" as const, list: false },
 } satisfies Record<string, { schema: SchemaName; list: boolean; wrapper?: string }>;


### PR DESCRIPTION
Continues the typed-endpoint migration (#6382 and follow-ups), converting `ThumbnailHandler` POST and PUT to the `parse_body` pattern.

- `ThumbnailPostBody` requires `obj_id`/`data`/`ttype` — the old docstring marked only `data`/`ttype` required, but the handler rejected a missing `obj_id` anyway. The image-level validation (PNG-only, size bounds, ttype enum) stays in `post_thumbnail`, whose exact messages are asserted in tests. POST gains a typed `{id}` response.
- `ThumbnailPutBody` replaces the opaque `ThumbnailNoID` marshmallow reference with the model's actual columns, applied via `model_fields_set` (preserving the partial-update semantics); its documented 200 response is corrected to plain `Success` (the handler never returned the thumbnail).
- Client sweep: no frontend or service mutates thumbnails through these routes (thumbnails are posted by external brokers); all test call sites send exactly `{obj_id, data, ttype}`. The maintenance `ThumbnailPathHandler` PATCH/DELETE are untouched (optional bodies).
- `static/js/types/api.ts` and `routeSchemaMap.ts` regenerated.