### PR TITLE
Pydantic-typed request body for annotation update endpoint

### DIFF
--- a/skyportal/handlers/api/annotation.py
+++ b/skyportal/handlers/api/annotation.py
@@ -52,6 +52,25 @@ class AnnotationPostResponse(BaseModel):
     annotation_id: int = Field(description="New annotation ID")
 
 
+class AnnotationPutBody(BaseModel):
+    """Request body for updating an annotation."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    data: dict[str, Any] | None = Field(
+        default=None, description="Annotation data as {key: value} pairs."
+    )
+    origin: str | None = Field(
+        default=None,
+        description="String describing the source of this information.",
+    )
+    group_ids: list[int] | None = Field(
+        default=None,
+        description="List of group IDs corresponding to which groups should "
+        "be able to view the annotation.",
+    )
+
+
 def _coerce_resource_id(associated_resource_type, resource_id):
     """Cast the resource_id from the URL path to the appropriate type for the
     target column. obj_id is a string; spectrum_id and photometry_id are
@@ -413,7 +432,12 @@ class AnnotationHandler(BaseHandler):
 
     @permissions(["Annotate"])
     async def put(
-        self, associated_resource_type: str, resource_id: str, annotation_id: int
+        self,
+        associated_resource_type: str,
+        resource_id: str,
+        annotation_id: int,
+        *,
+        body: AnnotationPutBody = None,
     ):
         """
         ---
@@ -444,21 +468,6 @@ class AnnotationHandler(BaseHandler):
             required: true
             schema:
               type: integer
-        requestBody:
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/AnnotationNoID'
-                  - type: object
-                    properties:
-                      group_ids:
-                        type: array
-                        items:
-                          type: integer
-                        description: |
-                          List of group IDs corresponding to which groups should be
-                          able to view the annotation.
         responses:
           200:
             content:
@@ -469,6 +478,7 @@ class AnnotationHandler(BaseHandler):
               application/json:
                 schema: Error
         """
+        body = self.parse_body(AnnotationPutBody)
 
         try:
             annotation_id = int(annotation_id)
@@ -478,7 +488,6 @@ class AnnotationHandler(BaseHandler):
         associated_resource = self.get_associated_resource(associated_resource_type)
 
         async with self.AsyncSession() as session:
-            schema = associated_resource["class"].__schema__()
             a = await session.scalar(
                 associated_resource["class"]
                 .select(self.current_user, mode="update")
@@ -490,22 +499,13 @@ class AnnotationHandler(BaseHandler):
                     "Could not find any accessible annotations.", status=403
                 )
 
-            data = self.get_json()
-            group_ids = data.pop("group_ids", None)
-            data["id"] = annotation_id
+            group_ids = body.group_ids
 
-            try:
-                schema.load(data, partial=True)
-            except ValidationError as e:
-                return self.error(
-                    f"Invalid/missing parameters: {e.normalized_messages()}"
-                )
+            if body.data is not None:
+                a.data = body.data
 
-            if "data" in data:
-                a.data = data["data"]
-
-            if "origin" in data:
-                a.origin = data["origin"]
+            if body.origin is not None:
+                a.origin = body.origin
 
             if group_ids is not None:
                 groups_result = await session.scalars(

--- a/skyportal/tests/api_tests/spectra_misc/test_color_mag.py
+++ b/skyportal/tests/api_tests/spectra_misc/test_color_mag.py
@@ -36,7 +36,6 @@ def test_post_retrieve_color_mag_data(annotation_token, user, public_source):
         "PUT",
         f"sources/{public_source.id}/annotations/{annotation_id}",
         data={
-            "obj_id": public_source.id,
             "origin": "gaiadr3.gaia_source",
             "data": {
                 "Mag_G": 15.1,
@@ -64,7 +63,6 @@ def test_post_retrieve_color_mag_data(annotation_token, user, public_source):
         "PUT",
         f"sources/{public_source.id}/annotations/{annotation_id}",
         data={
-            "obj_id": public_source.id,
             "origin": "gaiadr3.gaia_source",
             "data": {
                 "Mag_G": 15.1,
@@ -144,7 +142,6 @@ def test_change_color_mag_keys(annotation_token, user, public_source):
         "PUT",
         f"sources/{public_source.id}/annotations/{annotation_id}",
         data={
-            "obj_id": public_source.id,
             "origin": "gaiadr3.gaia_source",
             "data": {"mag_g": 15.1, "mag_bp": 16.1, "mag_rp": 14.0, "plx": 20},
         },
@@ -166,7 +163,6 @@ def test_change_color_mag_keys(annotation_token, user, public_source):
         "PUT",
         f"sources/{public_source.id}/annotations/{annotation_id}",
         data={
-            "obj_id": public_source.id,
             "origin": "wise_colors",
             "data": {"mag4.6": 15.1, "Mag_3.3": 16.1, "Mag_12": 14.0, "plx": 20},
         },

--- a/static/js/types/api.ts
+++ b/static/js/types/api.ts
@@ -17495,15 +17495,9 @@ export interface paths {
                 };
                 cookie?: never;
             };
-            requestBody?: {
+            requestBody: {
                 content: {
-                    "application/json": components["schemas"]["AnnotationNoID"] & {
-                        /**
-                         * @description List of group IDs corresponding to which groups should be
-                         *     able to view the annotation.
-                         */
-                        group_ids?: number[];
-                    };
+                    "application/json": components["schemas"]["AnnotationPutBody"];
                 };
             };
             responses: {
@@ -17683,15 +17677,9 @@ export interface paths {
                 };
                 cookie?: never;
             };
-            requestBody?: {
+            requestBody: {
                 content: {
-                    "application/json": components["schemas"]["AnnotationNoID"] & {
-                        /**
-                         * @description List of group IDs corresponding to which groups should be
-                         *     able to view the annotation.
-                         */
-                        group_ids?: number[];
-                    };
+                    "application/json": components["schemas"]["AnnotationPutBody"];
                 };
             };
             responses: {
@@ -38424,6 +38412,32 @@ export interface components {
              * @description New annotation ID
              */
             annotation_id: number;
+        };
+        /**
+         * AnnotationPutBody
+         * @description Request body for updating an annotation.
+         */
+        AnnotationPutBody: {
+            /**
+             * Data
+             * @description Annotation data as {key: value} pairs.
+             * @default null
+             */
+            data: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * Origin
+             * @description String describing the source of this information.
+             * @default null
+             */
+            origin: string | null;
+            /**
+             * Group Ids
+             * @description List of group IDs corresponding to which groups should be able to view the annotation.
+             * @default null
+             */
+            group_ids: number[] | null;
         };
         /**
          * SourceGroupsPostBody


### PR DESCRIPTION
Completes `annotation.py`'s migration to the `parse_body` pattern: the pilot (#6382) covered POST; this converts `AnnotationHandler` PUT.

- `AnnotationPutBody` (`data`/`origin`/`group_ids`, all optional, `extra="forbid"`) replaces the marshmallow PK-merge partial load; the apply-if-provided semantics are unchanged.
- Test sweep: four PUT call sites in `test_color_mag.py` sent a redundant `obj_id` in the body (it's already in the URL path, and the handler never read it) — removed, since `extra="forbid"` now rejects it. The other PUT call sites (`test_annotations.py`, `test_annotations_on_spectrum.py`, `test_annotations_on_photometry.py`) already send exactly `{data, group_ids}`. No frontend edits annotations via this route.
- `static/js/types/api.ts` regenerated.