### PR TITLE
Pydantic-typed request bodies for telescope endpoints

### DIFF
--- a/skyportal/handlers/api/telescope.py
+++ b/skyportal/handlers/api/telescope.py
@@ -1,5 +1,5 @@
 from astropy.time import Time
-from marshmallow.exceptions import ValidationError
+from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy.orm import selectinload
 
 from baselayer.app.access import auth_or_token, permissions
@@ -8,78 +8,100 @@ from ...models import Allocation, AllocationUser, Instrument, Telescope
 from ..base import BaseHandler
 
 
+class TelescopePostBody(BaseModel):
+    """Request body for creating a telescope."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(
+        description="Unabbreviated facility name (e.g., Palomar 200-inch "
+        "Hale Telescope)."
+    )
+    nickname: str = Field(description="Abbreviated facility name (e.g., P200).")
+    diameter: float = Field(description="Diameter in meters.")
+    lat: float | None = Field(default=None, description="Latitude in deg.")
+    lon: float | None = Field(default=None, description="Longitude in deg.")
+    elevation: float | None = Field(default=None, description="Elevation in meters.")
+    skycam_link: str | None = Field(
+        default=None, description="Link to the telescope's sky camera."
+    )
+    weather_link: str | None = Field(
+        default=None, description="Link to the preferred weather site."
+    )
+    robotic: bool = Field(default=False, description="Is this telescope robotic?")
+    fixed_location: bool | None = Field(
+        default=None,
+        description="Does this telescope have a fixed location (lon, lat, "
+        "elev)? Defaults to true.",
+    )
+
+
+class TelescopePostResponse(BaseModel):
+    """Data payload returned when creating a telescope."""
+
+    id: int = Field(description="New telescope ID")
+
+
+class TelescopePutBody(BaseModel):
+    """Request body for updating a telescope."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str | None = Field(
+        default=None,
+        description="Unabbreviated facility name (e.g., Palomar 200-inch "
+        "Hale Telescope).",
+    )
+    nickname: str | None = Field(
+        default=None, description="Abbreviated facility name (e.g., P200)."
+    )
+    diameter: float | None = Field(default=None, description="Diameter in meters.")
+    lat: float | None = Field(default=None, description="Latitude in deg.")
+    lon: float | None = Field(default=None, description="Longitude in deg.")
+    elevation: float | None = Field(default=None, description="Elevation in meters.")
+    skycam_link: str | None = Field(
+        default=None, description="Link to the telescope's sky camera."
+    )
+    weather_link: str | None = Field(
+        default=None, description="Link to the preferred weather site."
+    )
+    robotic: bool | None = Field(default=None, description="Is this telescope robotic?")
+    fixed_location: bool | None = Field(
+        default=None,
+        description="Does this telescope have a fixed location (lon, lat, elev)?",
+    )
+
+
 class TelescopeHandler(BaseHandler):
     @auth_or_token
-    async def post(self):
+    async def post(self, *, body: TelescopePostBody = None) -> TelescopePostResponse:
         """
         ---
         summary: Create a telescope
         description: Create telescopes
         tags:
           - telescopes
-        requestBody:
-          content:
-            application/json:
-              schema: TelescopeNoID
-        responses:
-          200:
-            content:
-              application/json:
-                schema:
-                  allOf:
-                    - $ref: '#/components/schemas/Success'
-                    - type: object
-                      properties:
-                        data:
-                          type: object
-                          properties:
-                            id:
-                              type: integer
-                              description: New telescope ID
-          400:
-            content:
-              application/json:
-                schema: Error
         """
-        data = self.get_json()
+        body = self.parse_body(TelescopePostBody)
 
         async with self.AsyncSession() as session:
-            schema = Telescope.__schema__()
             # check if the telescope has a fixed location
-            if "fixed_location" in data:
-                if data["fixed_location"]:
-                    if (
-                        "lat" not in data
-                        or "lon" not in data
-                        or "elevation" not in data
-                    ):
-                        return self.error(
-                            "Missing latitude, longitude, or elevation; required if the telescope is fixed"
-                        )
-                    elif (
-                        not isinstance(data["lat"], int | float)
-                        or not isinstance(data["lon"], int | float)
-                        or not isinstance(data["elevation"], int | float)
-                    ):
-                        return self.error(
-                            "Latitude, longitude, and elevation must all be numbers"
-                        )
-                    elif (
-                        data["lat"] < -90
-                        or data["lat"] > 90
-                        or data["lon"] < -180
-                        or data["lon"] > 180
-                        or data["elevation"] < 0
-                    ):
-                        return self.error(
-                            "Latitude must be between -90 and 90, longitude between -180 and 180, and elevation must be positive"
-                        )
-            try:
-                telescope = schema.load(data)
-            except ValidationError as e:
-                return self.error(
-                    f"Invalid/missing parameters: {e.normalized_messages()}"
-                )
+            if body.fixed_location:
+                if body.lat is None or body.lon is None or body.elevation is None:
+                    return self.error(
+                        "Missing latitude, longitude, or elevation; required if the telescope is fixed"
+                    )
+                elif (
+                    body.lat < -90
+                    or body.lat > 90
+                    or body.lon < -180
+                    or body.lon > 180
+                    or body.elevation < 0
+                ):
+                    return self.error(
+                        "Latitude must be between -90 and 90, longitude between -180 and 180, and elevation must be positive"
+                    )
+            telescope = Telescope(**body.model_dump(exclude_unset=True))
             session.add(telescope)
             await session.commit()
 
@@ -235,7 +257,7 @@ class TelescopeHandler(BaseHandler):
             return self.success(data=telescopes)
 
     @permissions(["Manage telescopes"])
-    async def put(self, telescope_id: int):
+    async def put(self, telescope_id: int, *, body: TelescopePutBody = None):
         """
         ---
         summary: Update a telescope
@@ -248,10 +270,6 @@ class TelescopeHandler(BaseHandler):
             required: true
             schema:
               type: integer
-        requestBody:
-          content:
-            application/json:
-              schema: TelescopeNoID
         responses:
           200:
             content:
@@ -262,19 +280,7 @@ class TelescopeHandler(BaseHandler):
               application/json:
                 schema: Error
         """
-        keys_to_update = [
-            "name",
-            "nickname",
-            "lat",
-            "lon",
-            "elevation",
-            "diameter",
-            "skycam_link",
-            "weather_link",
-            "robotic",
-            "fixed_location",
-        ]
-        data = {k: v for k, v in self.get_json().items() if k in keys_to_update}
+        body = self.parse_body(TelescopePutBody)
 
         async with self.AsyncSession() as session:
             telescope = await session.scalar(
@@ -285,16 +291,9 @@ class TelescopeHandler(BaseHandler):
             if telescope is None:
                 return self.error("Invalid telescope ID.")
 
-            schema = Telescope.__schema__()
-            try:
-                schema.load(data, partial=True)
-            except ValidationError as e:
-                return self.error(
-                    f"Invalid/missing parameters: {e.normalized_messages()}"
-                )
-
             changed = []
-            for key, value in data.items():
+            for key in body.model_fields_set:
+                value = getattr(body, key)
                 if getattr(telescope, key) != value:
                     setattr(telescope, key, value)
                     changed.append(key)

--- a/static/js/ducks/telescopes.ts
+++ b/static/js/ducks/telescopes.ts
@@ -39,10 +39,27 @@ export const telescopesApi = skyportalApi.injectEndpoints({
       unknown,
       { id: number | string; data: Record<string, any> }
     >({
+      // The edit form seeds its state from the full telescope object; only
+      // send the fields the endpoint accepts.
       query: ({ id, data }) => ({
         url: `api/telescope/${id}`,
         method: "PUT",
-        body: data,
+        body: Object.fromEntries(
+          [
+            "name",
+            "nickname",
+            "lat",
+            "lon",
+            "elevation",
+            "diameter",
+            "skycam_link",
+            "weather_link",
+            "robotic",
+            "fixed_location",
+          ]
+            .filter((key) => key in data)
+            .map((key) => [key, data[key]]),
+        ),
       }),
       invalidatesTags: ["Telescope"],
     }),

--- a/static/js/types/api.ts
+++ b/static/js/types/api.ts
@@ -20914,9 +20914,9 @@ export interface paths {
                 };
                 cookie?: never;
             };
-            requestBody?: {
+            requestBody: {
                 content: {
-                    "application/json": components["schemas"]["TelescopeNoID"];
+                    "application/json": components["schemas"]["TelescopePutBody"];
                 };
             };
             responses: {
@@ -21038,9 +21038,9 @@ export interface paths {
                 path?: never;
                 cookie?: never;
             };
-            requestBody?: {
+            requestBody: {
                 content: {
-                    "application/json": components["schemas"]["TelescopeNoID"];
+                    "application/json": components["schemas"]["TelescopePostBody"];
                 };
             };
             responses: {
@@ -21050,19 +21050,8 @@ export interface paths {
                     };
                     content: {
                         "application/json": components["schemas"]["Success"] & {
-                            data?: {
-                                /** @description New telescope ID */
-                                id?: number;
-                            };
+                            data?: components["schemas"]["TelescopePostResponse"];
                         };
-                    };
-                };
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
                     };
                 };
             };
@@ -38774,6 +38763,146 @@ export interface components {
              * @description Updated team ID
              */
             id: number;
+        };
+        /**
+         * TelescopePostBody
+         * @description Request body for creating a telescope.
+         */
+        TelescopePostBody: {
+            /**
+             * Name
+             * @description Unabbreviated facility name (e.g., Palomar 200-inch Hale Telescope).
+             */
+            name: string;
+            /**
+             * Nickname
+             * @description Abbreviated facility name (e.g., P200).
+             */
+            nickname: string;
+            /**
+             * Diameter
+             * @description Diameter in meters.
+             */
+            diameter: number;
+            /**
+             * Lat
+             * @description Latitude in deg.
+             * @default null
+             */
+            lat: number | null;
+            /**
+             * Lon
+             * @description Longitude in deg.
+             * @default null
+             */
+            lon: number | null;
+            /**
+             * Elevation
+             * @description Elevation in meters.
+             * @default null
+             */
+            elevation: number | null;
+            /**
+             * Skycam Link
+             * @description Link to the telescope's sky camera.
+             * @default null
+             */
+            skycam_link: string | null;
+            /**
+             * Weather Link
+             * @description Link to the preferred weather site.
+             * @default null
+             */
+            weather_link: string | null;
+            /**
+             * Robotic
+             * @description Is this telescope robotic?
+             * @default false
+             */
+            robotic: boolean;
+            /**
+             * Fixed Location
+             * @description Does this telescope have a fixed location (lon, lat, elev)? Defaults to true.
+             * @default null
+             */
+            fixed_location: boolean | null;
+        };
+        /**
+         * TelescopePostResponse
+         * @description Data payload returned when creating a telescope.
+         */
+        TelescopePostResponse: {
+            /**
+             * Id
+             * @description New telescope ID
+             */
+            id: number;
+        };
+        /**
+         * TelescopePutBody
+         * @description Request body for updating a telescope.
+         */
+        TelescopePutBody: {
+            /**
+             * Name
+             * @description Unabbreviated facility name (e.g., Palomar 200-inch Hale Telescope).
+             * @default null
+             */
+            name: string | null;
+            /**
+             * Nickname
+             * @description Abbreviated facility name (e.g., P200).
+             * @default null
+             */
+            nickname: string | null;
+            /**
+             * Diameter
+             * @description Diameter in meters.
+             * @default null
+             */
+            diameter: number | null;
+            /**
+             * Lat
+             * @description Latitude in deg.
+             * @default null
+             */
+            lat: number | null;
+            /**
+             * Lon
+             * @description Longitude in deg.
+             * @default null
+             */
+            lon: number | null;
+            /**
+             * Elevation
+             * @description Elevation in meters.
+             * @default null
+             */
+            elevation: number | null;
+            /**
+             * Skycam Link
+             * @description Link to the telescope's sky camera.
+             * @default null
+             */
+            skycam_link: string | null;
+            /**
+             * Weather Link
+             * @description Link to the preferred weather site.
+             * @default null
+             */
+            weather_link: string | null;
+            /**
+             * Robotic
+             * @description Is this telescope robotic?
+             * @default null
+             */
+            robotic: boolean | null;
+            /**
+             * Fixed Location
+             * @description Does this telescope have a fixed location (lon, lat, elev)?
+             * @default null
+             */
+            fixed_location: boolean | null;
         };
         /**
          * UserACLPostBody

--- a/static/js/types/routeSchemaMap.ts
+++ b/static/js/types/routeSchemaMap.ts
@@ -178,6 +178,7 @@ export const ROUTE_SCHEMA_MAP = {
   "POST /api/summary_query": { schema: "Obj" as const, list: true },
   "POST /api/taxonomy": { schema: "TaxonomyPostResponse" as const, list: false },
   "POST /api/teams": { schema: "TeamPostResponse" as const, list: false },
+  "POST /api/telescope": { schema: "TelescopePostResponse" as const, list: false },
   "POST /api/{associated_resource_type}/{resource_id}/annotations": { schema: "AnnotationPostResponse" as const, list: false },
   "PUT /api/followup_request/prioritization": { schema: "FollowupRequest" as const, list: false },
   "PUT /api/followup_request/{followup_request_id}/comment": { schema: "FollowupRequest" as const, list: false },


### PR DESCRIPTION
Continues the typed-endpoint migration (#6382 and follow-ups), converting `TelescopeHandler` POST and PUT to the `parse_body` pattern.

- `TelescopePostBody`/`TelescopePutBody` (`extra="forbid"`) replace the marshmallow `TelescopeNoID` loads with the model's ten settable columns. The fixed-location cross-field checks (lat/lon/elevation required and range-bounded) keep their handler messages; POST constructs via `model_dump(exclude_unset=True)` so DB defaults (e.g. `fixed_location` → true) still apply to omitted fields, and PUT keeps its changed-fields tracking ("Nothing to update") via `model_fields_set`.
- Client fix: the edit dialog in `TelescopeTable.tsx` seeds its form from the full telescope object (including `id`, `allocations`, and computed fields), which the old PUT silently filtered server-side — `updateTelescope` in `static/js/ducks/telescopes.ts` now sends only the accepted keys. (The form keeps the full object locally, which its name-collision validation relies on.)
- Sweep: all test call sites and the `data/telescopes.yaml` / `db_demo.yaml` seed payloads use exactly the modeled keys (`=id` loader aliases are stripped before POSTing).
- `static/js/types/api.ts` and `routeSchemaMap.ts` regenerated.