### PR TITLE
Pydantic-typed request bodies for token endpoints

### DIFF
--- a/skyportal/handlers/api/internal/token.py
+++ b/skyportal/handlers/api/internal/token.py
@@ -1,4 +1,4 @@
-from marshmallow.exceptions import ValidationError
+from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy.orm import selectinload
 
 from baselayer.app.access import auth_or_token
@@ -8,37 +8,52 @@ from ....models import ACL, Token, User
 from ...base import BaseHandler
 
 
+class TokenPostBody(BaseModel):
+    """Request body for creating a new API token."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(description="Name of the token")
+    acls: list[str] = Field(description="List of ACL IDs to grant the token")
+    user_id: int | None = Field(
+        default=None,
+        description="ID of the user to create the token for; defaults to the requesting user",
+    )
+
+
+class TokenPostResponse(BaseModel):
+    """ID of the newly created token."""
+
+    token_id: str = Field(description="Token ID")
+
+
+class TokenPutBody(BaseModel):
+    """Request body for updating a token."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str | None = Field(default=None, description="New name of the token")
+    acls: list[str] | None = Field(
+        default=None, description="New list of ACL IDs for the token"
+    )
+    user_id: int | None = Field(
+        default=None,
+        description="ID of the user whose permissions the new ACLs are checked against; defaults to the requesting user",
+    )
+
+
 class TokenHandler(BaseHandler):
     @auth_or_token
-    async def post(self):
+    async def post(self, *, body: TokenPostBody = None) -> TokenPostResponse:
         """
         ---
         description: Generate new token (limit 1 per user)
-        requestBody:
-          content:
-            application/json:
-              schema: Token
-        responses:
-          200:
-            content:
-              application/json:
-                schema:
-                  allOf:
-                    - $ref: '#/components/schemas/Success'
-                    - type: object
-                      properties:
-                        data:
-                          type: object
-                          properties:
-                            token_id:
-                              type: string
-                              description: Token ID
         """
-        data = self.get_json()
+        body = self.parse_body(TokenPostBody)
 
         async with self.AsyncSession() as session:
-            if "user_id" in data:
-                user_id = data["user_id"]
+            if body.user_id is not None:
+                user_id = body.user_id
                 user = await session.scalar(
                     User.select(session.user_or_token)
                     .options(
@@ -51,7 +66,7 @@ class TokenHandler(BaseHandler):
                 user = self.associated_user_object
                 user_id = user.id
 
-            token_acls = set(data["acls"])
+            token_acls = set(body.acls)
             if not all(acl_id in user.permissions for acl_id in token_acls):
                 return self.error(
                     "User has attempted to grant token ACLs they do not have "
@@ -68,7 +83,7 @@ class TokenHandler(BaseHandler):
                     "You have reached the maximum number of tokens "
                     "allowed for your account type."
                 )
-            token_name = data["name"]
+            token_name = body.name
             existing_name = await session.scalar(
                 Token.select(session.user_or_token).where(Token.name == token_name)
             )
@@ -148,7 +163,7 @@ class TokenHandler(BaseHandler):
             return self.success(data=result.all())
 
     @auth_or_token
-    async def put(self, token_id: str):
+    async def put(self, token_id: str, *, body: TokenPutBody = None):
         """
         ---
         description: Update token
@@ -160,10 +175,6 @@ class TokenHandler(BaseHandler):
             required: true
             schema:
               type: integer
-        requestBody:
-          content:
-            application/json:
-              schema: Token
         responses:
           200:
             content:
@@ -174,6 +185,7 @@ class TokenHandler(BaseHandler):
               application/json:
                 schema: Error
         """
+        body = self.parse_body(TokenPutBody)
 
         async with self.AsyncSession() as session:
             try:
@@ -189,11 +201,8 @@ class TokenHandler(BaseHandler):
                         "permissions to update it."
                     )
 
-                data = self.get_json()
-                data["id"] = token_id
-
-                if "user_id" in data:
-                    user_id = data["user_id"]
+                if body.user_id is not None:
+                    user_id = body.user_id
                     user = await session.scalar(
                         User.select(session.user_or_token)
                         .options(
@@ -206,18 +215,11 @@ class TokenHandler(BaseHandler):
                     user = self.associated_user_object
                     user_id = user.id
 
-                schema = Token.__schema__()
-                try:
-                    schema.load(data, partial=True)
-                except ValidationError as e:
-                    return self.error(
-                        f"Invalid/missing parameters: {e.normalized_messages()}"
-                    )
-                if "name" in data:
-                    token.name = data["name"]
+                if body.name is not None:
+                    token.name = body.name
 
-                if "acls" in data:
-                    token_acls = set(data["acls"])
+                if body.acls is not None:
+                    token_acls = set(body.acls)
                     if not all(acl_id in user.permissions for acl_id in token_acls):
                         return self.error(
                             "User has attempted to grant token ACLs they do not have "


### PR DESCRIPTION
Continues the typed-endpoint migration (#6382 and follow-ups), converting `TokenHandler` POST and PUT to the `parse_body` pattern.

- `TokenPostBody` requires `name` and `acls`, with optional `user_id` (defaults to the requesting user); POST gains a typed `{token_id}` response. `TokenPutBody` makes all three optional, replacing the marshmallow `partial=True` load — the `name`/`acls` presence checks move to `is not None`, and the ACL ownership/validity checks stay in the handler with their original messages.
- The route is `/api/internal/`, so it is excluded from the OpenAPI spec — no `api.ts`/`routeSchemaMap.ts` changes (verified the regenerated output is unchanged); the win here is runtime validation and `extra="forbid"`.
- Client sweep: `createToken` sends `{name, acls}` (NewTokenForm), `updateToken` sends `{acls}` (UpdateTokenACLs); no backend/service callers. Test payloads in `test_token.py` send `{name, acls, user_id}` — all within the models.