### PR TITLE
Fix classification test broken by taxonomy body validation

### DIFF
--- a/skyportal/tests/api_tests/sources_candidates/test_classifications.py
+++ b/skyportal/tests/api_tests/sources_candidates/test_classifications.py
@@ -14,7 +14,6 @@ def test_add_bad_classification(
         data={
             "name": "test taxonomy" + str(uuid.uuid4()),
             "hierarchy": taxonomy,
-            "origin": "SCoPe",
             "group_ids": [public_group.id],
             "provenance": f"tdtax_{__version__}",
             "version": __version__,


### PR DESCRIPTION
test_add_bad_classification has been failing on CI since #6405: its taxonomy setup POST includes an `origin` key, but `Taxonomy` has no such column (only `Classification` does). The old handler silently discarded the key; `TaxonomyPostBody` uses `extra="forbid"` and now returns 400, failing the test at the `assert status == 200` setup step.