### PR TITLE
Pydantic-typed request bodies for public release endpoints

### DIFF
--- a/skyportal/handlers/api/public_pages/public_release.py
+++ b/skyportal/handlers/api/public_pages/public_release.py
@@ -1,7 +1,9 @@
 import operator  # noqa: F401
 import re
+from typing import Any
 
 import sqlalchemy as sa
+from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import func
 from sqlalchemy.orm import selectinload
 
@@ -12,6 +14,62 @@ from ....models import Group, GroupPublicRelease, PublicRelease, PublicSourcePag
 from ...base import BaseHandler
 
 log = make_log("api/public_release")
+
+
+class PublicReleasePostBody(BaseModel):
+    """Request body for creating a public release."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str | None = Field(default=None, description="Name of the release")
+    link_name: str | None = Field(
+        default=None,
+        description="URL-safe name identifying the release in its public URL",
+    )
+    group_ids: list[int] | None = Field(
+        default=None, description="IDs of the groups that can manage this release"
+    )
+    description: str = Field(default="", description="Description of the release")
+    is_visible: bool = Field(
+        default=True, description="Whether the release is publicly visible"
+    )
+    auto_publish_enabled: bool = Field(
+        default=False,
+        description="Whether sources saved to the release's groups are "
+        "automatically published",
+    )
+    options: dict[str, Any] = Field(
+        default_factory=dict, description="Options for the sources in this release"
+    )
+
+
+class PublicReleasePostResponse(BaseModel):
+    """ID of the newly created public release."""
+
+    id: int = Field(description="Public release ID")
+
+
+class PublicReleasePatchBody(BaseModel):
+    """Request body for updating a public release."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str | None = Field(default=None, description="Name of the release")
+    group_ids: list[int] | None = Field(
+        default=None, description="IDs of the groups that can manage this release"
+    )
+    description: str = Field(default="", description="Description of the release")
+    is_visible: bool = Field(
+        default=True, description="Whether the release is publicly visible"
+    )
+    auto_publish_enabled: bool = Field(
+        default=False,
+        description="Whether sources saved to the release's groups are "
+        "automatically published",
+    )
+    options: dict[str, Any] = Field(
+        default_factory=dict, description="Options for the sources in this release"
+    )
 
 
 async def process_link_name_validation(session, link_name, release_id):
@@ -39,7 +97,9 @@ async def process_link_name_validation(session, link_name, release_id):
 
 class PublicReleaseHandler(BaseHandler):
     @permissions(["Manage sources"])
-    async def post(self):
+    async def post(
+        self, *, body: PublicReleasePostBody = None
+    ) -> PublicReleasePostResponse:
         """
         ---
           summary: Create a new public release
@@ -47,46 +107,17 @@ class PublicReleaseHandler(BaseHandler):
             Create a new public release
           tags:
             - public
-          requestBody:
-            content:
-              application/json:
-                schema:
-                  type: object
-                  properties:
-                    name:
-                      type: string
-                    link_name:
-                      type: string
-                    group_ids:
-                      type: array
-                      items:
-                        type: integer
-                    description:
-                      type: string
-                    options:
-                      type: object
-                    is_visible:
-                      type: boolean
-          responses:
-            200:
-              content:
-                application/json:
-                  schema: Success
-            400:
-              content:
-                application/json:
-                  schema: Error
         """
-        data = self.get_json()
-        if data is None or data == {}:
+        body = self.parse_body(PublicReleasePostBody)
+        if not body.model_fields_set:
             return self.error("No data provided")
-        name = data.get("name")
+        name = body.name
         if name is None or name == "":
             return self.error("Name is required")
-        link_name = data.get("link_name")
+        link_name = body.link_name
         if link_name is None or link_name == "":
             return self.error("Link name is required")
-        group_ids = data.get("group_ids")
+        group_ids = body.group_ids
         if group_ids is None or len(group_ids) == 0:
             return self.error("Specify at least one group")
 
@@ -113,10 +144,10 @@ class PublicReleaseHandler(BaseHandler):
             public_release = PublicRelease(
                 name=name,
                 link_name=link_name,
-                description=data.get("description", ""),
-                is_visible=data.get("is_visible", True),
-                auto_publish_enabled=data.get("auto_publish_enabled", False),
-                options=data.get("options", {}),
+                description=body.description,
+                is_visible=body.is_visible,
+                auto_publish_enabled=body.auto_publish_enabled,
+                options=body.options,
                 groups=groups,
             )
             session.add(public_release)
@@ -125,7 +156,7 @@ class PublicReleaseHandler(BaseHandler):
             return self.success(data={"id": public_release.id})
 
     @permissions(["Manage sources"])
-    async def patch(self, release_id: int):
+    async def patch(self, release_id: int, *, body: PublicReleasePatchBody = None):
         """
         ---
         summary: Update a public release
@@ -138,24 +169,6 @@ class PublicReleaseHandler(BaseHandler):
             required: true
             schema:
               type: integer
-        requestBody:
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  name:
-                    type: string
-                  group_ids:
-                    type: array
-                    items:
-                      type: integer
-                  description:
-                    type: string
-                  options:
-                    type: object
-                  is_visible:
-                    type: boolean
         responses:
           200:
             content:
@@ -166,13 +179,13 @@ class PublicReleaseHandler(BaseHandler):
               application/json:
                 schema: Error
         """
-        data = self.get_json()
-        if data is None or data == {}:
+        body = self.parse_body(PublicReleasePatchBody)
+        if not body.model_fields_set:
             return self.error("No data provided")
-        name = data.get("name")
+        name = body.name
         if name is None or name == "":
             return self.error("Name is required")
-        group_ids = data.get("group_ids")
+        group_ids = body.group_ids
         if group_ids is None or len(group_ids) == 0:
             return self.error("Specify at least one group")
 
@@ -206,20 +219,20 @@ class PublicReleaseHandler(BaseHandler):
             if not groups:
                 return self.error("Invalid groups")
 
+            # like the old code, an omitted is_visible clears the cache (the
+            # check defaulted to False) but leaves the release visible (the
+            # assignment defaulted to True)
             if (
-                data.get("is_visible", False) is False
-                and public_release.is_visible is True
-            ):
+                "is_visible" not in body.model_fields_set or body.is_visible is False
+            ) and public_release.is_visible is True:
                 for source_page in public_release.source_pages:
                     source_page.remove_from_cache()
 
             public_release.name = name
-            public_release.auto_publish_enabled = data.get(
-                "auto_publish_enabled", False
-            )
-            public_release.description = data.get("description", "")
-            public_release.is_visible = data.get("is_visible", True)
-            public_release.options = data.get("options", {})
+            public_release.auto_publish_enabled = body.auto_publish_enabled
+            public_release.description = body.description
+            public_release.is_visible = body.is_visible
+            public_release.options = body.options
             public_release.groups = groups
             await session.commit()
 

--- a/skyportal/tests/api_tests/photometry_followup/test_public_release.py
+++ b/skyportal/tests/api_tests/photometry_followup/test_public_release.py
@@ -30,7 +30,7 @@ def test_create_release(
         data={"false_data": "false"},
         token=manage_sources_token,
     )
-    assert_api_fail(status, data, 400, "Name is required")
+    assert_api_fail(status, data, 400, "false_data: Extra inputs are not permitted")
 
     status, data = api(
         "POST",
@@ -158,7 +158,7 @@ def test_update_release(
         data={"false_data": "false"},
         token=manage_sources_token,
     )
-    assert_api_fail(status, data, 400, "Name is required")
+    assert_api_fail(status, data, 400, "false_data: Extra inputs are not permitted")
 
     status, data = api(
         "PATCH",
@@ -210,6 +210,7 @@ def test_update_release(
     assert release["auto_publish_enabled"] is True
     assert release["link_name"] == link_name
 
+    # link_name is immutable: the PATCH body rejects it outright
     status, data = api(
         "PATCH",
         f"public_pages/release/{release_id}",
@@ -220,7 +221,7 @@ def test_update_release(
         },
         token=manage_sources_token,
     )
-    assert_api(status, data)
+    assert_api_fail(status, data, 400, "link_name: Extra inputs are not permitted")
 
     status, data = api("GET", "public_pages/release", token=manage_sources_token)
     assert_api(status, data)

--- a/static/js/ducks/public_pages/public_release.ts
+++ b/static/js/ducks/public_pages/public_release.ts
@@ -43,10 +43,29 @@ export const publicReleaseApi = skyportalApi.injectEndpoints({
       unknown,
       { releaseId: number; payload: PublicRelease }
     >({
-      query: ({ releaseId, payload }) => ({
+      // The edit form seeds its state from the full fetched release; send only
+      // the keys the PATCH endpoint accepts (link_name is immutable).
+      query: ({
+        releaseId,
+        payload: {
+          name,
+          description,
+          group_ids,
+          options,
+          is_visible,
+          auto_publish_enabled,
+        },
+      }) => ({
         url: `api/public_pages/release/${releaseId}`,
         method: "PATCH",
-        body: payload,
+        body: {
+          name,
+          description,
+          group_ids,
+          options,
+          is_visible,
+          auto_publish_enabled,
+        },
       }),
       invalidatesTags: ["PublicRelease"],
     }),

--- a/static/js/types/api.ts
+++ b/static/js/types/api.ts
@@ -22796,16 +22796,9 @@ export interface paths {
                 path?: never;
                 cookie?: never;
             };
-            requestBody?: {
+            requestBody: {
                 content: {
-                    "application/json": {
-                        name?: string;
-                        link_name?: string;
-                        group_ids?: number[];
-                        description?: string;
-                        options?: Record<string, never>;
-                        is_visible?: boolean;
-                    };
+                    "application/json": components["schemas"]["PublicReleasePostBody"];
                 };
             };
             responses: {
@@ -22814,15 +22807,9 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["Success"];
-                    };
-                };
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
+                        "application/json": components["schemas"]["Success"] & {
+                            data?: components["schemas"]["PublicReleasePostResponse"];
+                        };
                     };
                 };
             };
@@ -22891,15 +22878,9 @@ export interface paths {
                 };
                 cookie?: never;
             };
-            requestBody?: {
+            requestBody: {
                 content: {
-                    "application/json": {
-                        name?: string;
-                        group_ids?: number[];
-                        description?: string;
-                        options?: Record<string, never>;
-                        is_visible?: boolean;
-                    };
+                    "application/json": components["schemas"]["PublicReleasePatchBody"];
                 };
             };
             responses: {
@@ -39066,6 +39047,109 @@ export interface components {
              * @description Array of Role IDs (strings) to be granted to user
              */
             roleIds: string[];
+        };
+        /**
+         * PublicReleasePostBody
+         * @description Request body for creating a public release.
+         */
+        PublicReleasePostBody: {
+            /**
+             * Name
+             * @description Name of the release
+             * @default null
+             */
+            name: string | null;
+            /**
+             * Link Name
+             * @description URL-safe name identifying the release in its public URL
+             * @default null
+             */
+            link_name: string | null;
+            /**
+             * Group Ids
+             * @description IDs of the groups that can manage this release
+             * @default null
+             */
+            group_ids: number[] | null;
+            /**
+             * Description
+             * @description Description of the release
+             * @default
+             */
+            description: string;
+            /**
+             * Is Visible
+             * @description Whether the release is publicly visible
+             * @default true
+             */
+            is_visible: boolean;
+            /**
+             * Auto Publish Enabled
+             * @description Whether sources saved to the release's groups are automatically published
+             * @default false
+             */
+            auto_publish_enabled: boolean;
+            /**
+             * Options
+             * @description Options for the sources in this release
+             */
+            options?: {
+                [key: string]: unknown;
+            };
+        };
+        /**
+         * PublicReleasePostResponse
+         * @description ID of the newly created public release.
+         */
+        PublicReleasePostResponse: {
+            /**
+             * Id
+             * @description Public release ID
+             */
+            id: number;
+        };
+        /**
+         * PublicReleasePatchBody
+         * @description Request body for updating a public release.
+         */
+        PublicReleasePatchBody: {
+            /**
+             * Name
+             * @description Name of the release
+             * @default null
+             */
+            name: string | null;
+            /**
+             * Group Ids
+             * @description IDs of the groups that can manage this release
+             * @default null
+             */
+            group_ids: number[] | null;
+            /**
+             * Description
+             * @description Description of the release
+             * @default
+             */
+            description: string;
+            /**
+             * Is Visible
+             * @description Whether the release is publicly visible
+             * @default true
+             */
+            is_visible: boolean;
+            /**
+             * Auto Publish Enabled
+             * @description Whether sources saved to the release's groups are automatically published
+             * @default false
+             */
+            auto_publish_enabled: boolean;
+            /**
+             * Options
+             * @description Options for the sources in this release
+             */
+            options?: {
+                [key: string]: unknown;
+            };
         };
     };
     responses: never;

--- a/static/js/types/routeSchemaMap.ts
+++ b/static/js/types/routeSchemaMap.ts
@@ -164,6 +164,7 @@ export const ROUTE_SCHEMA_MAP = {
   "POST /api/observation/ascii": { schema: "ExecutedObservation" as const, list: true },
   "POST /api/observation/external_api": { schema: "ExecutedObservation" as const, list: true },
   "POST /api/observation_plan/{observation_plan_request_id}/queue": { schema: "ObservationPlanRequest" as const, list: false },
+  "POST /api/public_pages/release": { schema: "PublicReleasePostResponse" as const, list: false },
   "POST /api/recurring_api": { schema: "RecurringAPIPostResponse" as const, list: false },
   "POST /api/sharing_service/submission": { schema: "SharingServiceSubmission" as const, list: false },
   "POST /api/sharing_service/{sharing_service_id}/coauthor/{user_id}": { schema: "SharingServiceCoauthor" as const, list: false },


### PR DESCRIPTION
Continues the typed-endpoint migration (#6382 and follow-ups), converting `PublicReleaseHandler` POST and PATCH to the `parse_body` pattern.

- `PublicReleasePostBody`/`PublicReleasePatchBody` keep all fields optional and leave the handler checks in place ("No data provided" via `model_fields_set`, "Name is required", "Link name is required", "Specify at least one group", link-name regex) because the tests assert those exact messages; pydantic adds shape validation and `extra="forbid"`. The models also document `auto_publish_enabled`, which the old docstring omitted, and POST gains a typed `{id}` response.
- The PATCH model deliberately has no `link_name`: the old handler silently ignored it (link names are immutable). With `extra="forbid"` that's now an explicit 400 — the test that verified silent-ignore now asserts the rejection.
- PATCH quirk preserved with a comment: the old cache-invalidation check read `is_visible` with a `False` default while the assignment used `True`, so an omitted `is_visible` cleared the page cache but left the release visible; replicated via `model_fields_set`.
- Client fix in `public_release.ts`: the edit form seeds its state from the full fetched release, so PATCH sent `id`/`link_name`/`created_at`/etc. The duck now picks only the accepted keys (same pattern as the telescopes duck fix in #6412).
- `static/js/types/api.ts` and `routeSchemaMap.ts` regenerated.