### PR TITLE
Pydantic-typed request body for frontend error log endpoint

### DIFF
--- a/skyportal/handlers/api/internal/log.py
+++ b/skyportal/handlers/api/internal/log.py
@@ -2,6 +2,7 @@ import datetime
 import os
 
 import tornado.web
+from pydantic import BaseModel, ConfigDict, Field
 
 from baselayer.app.access import permissions
 from baselayer.log import make_log
@@ -12,12 +13,23 @@ from ...base import BaseHandler
 log = make_log("js")
 
 
+class LogPostBody(BaseModel):
+    """Request body for logging a frontend error."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    error: str = Field(description="Error message to log")
+    stack: str | None = Field(
+        default=None, description="Component stack trace of the error"
+    )
+
+
 class LogHandler(BaseHandler):
     @tornado.web.authenticated
-    async def post(self, *ignored_args):
+    async def post(self, *ignored_args, body: LogPostBody = None):
         """Log a frontend error to the server logs, tracking user crash reports."""
-        data = self.get_json()
-        log(f"{data['error']}{data['stack']}")
+        body = self.parse_body(LogPostBody)
+        log(f"{body.error}{body.stack}")
         return self.success()
 
     @permissions(["System admin"])


### PR DESCRIPTION
Continues the typed-endpoint migration (#6382 and follow-ups), converting `LogHandler` POST (the frontend crash reporter) to the `parse_body` pattern.

- `LogPostBody` requires `error` and makes `stack` optional: the old code indexed `data['stack']` directly, so a crash report without a stack raised a KeyError and the report was lost as a 500; now it still logs (with `None` in place of the stack).
- Client sweep: the only caller is `ErrorBoundary.tsx`, which sends `{error, stack}`; no tests or services hit this route. The route is `/api/internal/`, so it's excluded from the OpenAPI spec — no `api.ts`/`routeSchemaMap.ts` changes (verified no drift).