### PR TITLE
Skip the frontend bundle build in API-only CI jobs

### DIFF
--- a/.github/workflows/test_api_and_frontend.yaml
+++ b/.github/workflows/test_api_and_frontend.yaml
@@ -174,6 +174,7 @@ jobs:
           sed -i 's/proxy_read_timeout 60s/proxy_read_timeout 120s/g' baselayer/services/nginx/nginx.conf.template
 
       - name: Build the test frontend bundle in production mode
+        if: ${{ startsWith(matrix.test_subset, 'frontend_') }}
         run: |
           # The rspack service builds a dev bundle in debug mode (which the test
           # harness uses): ~4-5x larger and slower to parse+execute, which makes
@@ -185,14 +186,15 @@ jobs:
       - name: Save dependency caches
         uses: ./.github/actions/cache-dependencies-save
 
-      # Per-folder microservice trim: each frontend folder only exercises a
+      # Per-folder service trim: each frontend folder only exercises a
       # subset of the queues, so disable the unused ones to free CPU/RAM on the
       # 2-vCPU runner. analysis services -> only data_products_and_analysis (pt6);
       # observation_plan_queue/facility_queue -> only the GCN/follow-up (pt2) and
       # observation (pt5) folders; notification_queue -> only the source- and
       # notification-test folders (pt1, pt5). (gcn_service is off everywhere.)
-      - name: Trim unused microservices for this frontend subset
-        if: ${{ startsWith(matrix.test_subset, 'frontend_') }}
+      # The API/external subsets never load the frontend, so they also disable
+      # rspack: no bundle build, and test_frontend.py skips its bundle check.
+      - name: Trim unused services for this test subset
         env:
           TEST_SUBSET: ${{ matrix.test_subset }}
         run: |
@@ -200,6 +202,12 @@ jobs:
           import os
 
           EXTRA = {
+              "api_and_utils_pt1": ["rspack"],
+              "api_and_utils_pt2": ["rspack"],
+              "api_and_utils_pt3": ["rspack"],
+              "api_and_utils_pt4": ["rspack"],
+              "external_pt1": ["rspack"],
+              "external_pt2": ["rspack"],
               "frontend_pt1": ["sn_analysis_service", "openai_analysis_service", "observation_plan_queue"],
               "frontend_pt2": ["sn_analysis_service", "openai_analysis_service"],
               "frontend_pt3": ["sn_analysis_service", "openai_analysis_service", "observation_plan_queue", "facility_queue", "notification_queue"],

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "baselayer"]
 	path = baselayer
-	url = https://github.com/cesium-ml/baselayer.git
-	branch = main
+	# TEMPORARY: points at the fork for cesium-ml/baselayer#446 (bundle check
+	# skip); revert to cesium-ml/baselayer.git and re-pin once that merges.
+	url = https://github.com/leonitousconforti/baselayer.git
+	branch = test-frontend-optional-bundle
 [submodule "skyportal-data"]
 	path = skyportal-data
 	url = https://github.com/skyportal/skyportal-data.git


### PR DESCRIPTION
## Why

The six `api_and_utils_*`/`external_*` matrix jobs never load the frontend, but each one still runs the rspack production bundle build and waits on it before pytest can start — `test_frontend.py`'s readiness check requires `static/build/main*.bundle.js` unconditionally. That's ~1–1.5 min per job (including the critical-path `api_and_utils_pt2` and `external_pt1`), and the build competes for CPU with early tests on the 2-vCPU runners.

## What

- Extend the existing per-subset service trim to the API/external subsets, disabling `rspack` for them (frontend subsets are unchanged).
- Gate the "build production bundle" sed patch to frontend subsets.

## Depends on

cesium-ml/baselayer#446

## Impact

~1–1.5 min off each of the six API/external jobs (~6–9 runner-min per push), including the workflow's critical-path job.