### PR TITLE
source table column picking

### DIFF
--- a/skyportal/tests/frontend/sources_and_observingruns_etc/test_source_table_columns.py
+++ b/skyportal/tests/frontend/sources_and_observingruns_etc/test_source_table_columns.py
@@ -11,13 +11,16 @@ from skyportal.tests import api
 
 
 def _reveal_column(page, search_text):
-    """Open the DataGrid columns panel and toggle on the matching hidden column."""
-    page.locator("[data-testid='datagrid-columns-button']").first.click()
-    panel = page.locator(".MuiDataGrid-panel")
-    panel.locator("input[type='search']").first.fill(search_text)
-    # After filtering, the matching column's toggle is the only checkbox shown.
-    panel.locator("input[type='checkbox']").last.check()
-    page.keyboard.press("Escape")
+    """Add an annotation/altdata column via the toolbar picker. These are
+    materialized on demand (the registry is unbounded), not listed in the
+    DataGrid columns panel."""
+    picker = page.locator("[data-testid='add-column-picker'] input").first
+    picker.click()
+    picker.fill(search_text)
+    # Options are labelled "<key> (<origin>)"; search_text is distinctive. Match
+    # a specific <li> (MUI re-renders the option list as you type, so a generic
+    # role=option click is unstable).
+    page.locator(f'//li[contains(., "{search_text}")]').first.click()
 
 
 @pytest.mark.flaky(reruns=2)
@@ -76,7 +79,8 @@ def test_source_table_annotation_and_altdata_columns(
         page.locator(f"//a[contains(@href, '/source/{obj_id2}')]").first
     ).to_be_visible()
 
-    # Annotation column: hidden by default, then revealed and showing its value.
+    # Annotation column: absent by default, then added via the picker and
+    # showing its value.
     expect(
         page.locator(f"//*[text()[contains(., '{ann_values[obj_id1]}')]]")
     ).to_have_count(0)
@@ -85,7 +89,7 @@ def test_source_table_annotation_and_altdata_columns(
         page.locator(f"//*[text()[contains(., '{ann_values[obj_id1]}')]]").first
     ).to_be_visible()
 
-    # Altdata column: same flow.
+    # Altdata column: same add-via-picker flow.
     _reveal_column(page, alt_key)
     expect(
         page.locator(f"//*[text()[contains(., '{alt_values[obj_id1]}')]]").first

--- a/static/js/components/candidate/FilterCandidateList.tsx
+++ b/static/js/components/candidate/FilterCandidateList.tsx
@@ -37,6 +37,7 @@ import { useGetGcnEventsQuery } from "../../ducks/gcnEvents";
 import { useGetProfileQuery } from "../../ducks/profile";
 import { useGetTaxonomiesQuery } from "../../ducks/taxonomies";
 import CandidatesPreferences from "./CandidatesPreferences";
+import { filterAnnotationOrigins } from "./annotationSortOptions";
 import FormValidationError from "../FormValidationError";
 import { allowedClasses } from "../classification/ClassificationForm";
 import ClassificationSelect from "../classification/ClassificationSelect";
@@ -1241,6 +1242,9 @@ const FilterCandidateList = ({
                         id="annotationSortingOriginSelect"
                         data-testid="annotationSortingOriginSelect"
                         options={Object.keys(availableAnnotationsInfo || [])}
+                        filterOptions={(options, state) =>
+                          filterAnnotationOrigins(options, state.inputValue)
+                        }
                         style={{ minWidth: "100%" }}
                         value={value}
                         onChange={(_event, newValue) => {

--- a/static/js/components/candidate/annotationSortOptions.test.ts
+++ b/static/js/components/candidate/annotationSortOptions.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "bun:test";
+
+import { filterAnnotationOrigins } from "./annotationSortOptions";
+
+// Annotation origins can be unbounded (one per object), so the selector must cap
+// what it renders or the dropdown hangs.
+const origins = [
+  ...Array.from({ length: 200 }, (_, i) => `ls_dr9-${i}`),
+  "gaiadr3.gaia_source",
+  "acai:high_h__high_n",
+];
+
+describe("filterAnnotationOrigins", () => {
+  it("caps how many render when nothing is typed", () => {
+    expect(filterAnnotationOrigins(origins, "", 50)).toHaveLength(50);
+    // (default limit)
+    expect(filterAnnotationOrigins(origins, "")).toHaveLength(50);
+  });
+
+  it("substring-matches case-insensitively", () => {
+    expect(filterAnnotationOrigins(origins, "GAIA")).toEqual([
+      "gaiadr3.gaia_source",
+    ]);
+    expect(filterAnnotationOrigins(origins, "acai")).toEqual([
+      "acai:high_h__high_n",
+    ]);
+  });
+
+  it("still caps a large match set", () => {
+    expect(filterAnnotationOrigins(origins, "ls_dr9", 10)).toHaveLength(10);
+  });
+
+  it("returns every match when under the limit", () => {
+    expect(filterAnnotationOrigins(["a_x", "b_y"], "x")).toEqual(["a_x"]);
+  });
+});

--- a/static/js/components/candidate/annotationSortOptions.ts
+++ b/static/js/components/candidate/annotationSortOptions.ts
@@ -1,0 +1,15 @@
+// Cap how many annotation-origin options a selector renders: origins can be
+// unbounded, so an uncapped dropdown mounts thousands of items and hangs.
+// Empty query -> the first `limit` (dropdown isn't blank on open); typing
+// narrows via case-insensitive substring match, still capped.
+export function filterAnnotationOrigins(
+  origins: string[],
+  query: string,
+  limit = 50,
+): string[] {
+  const q = query.trim().toLowerCase();
+  const matches = q
+    ? origins.filter((o) => o.toLowerCase().includes(q))
+    : origins;
+  return matches.slice(0, limit);
+}

--- a/static/js/components/source/SourceTable.tsx
+++ b/static/js/components/source/SourceTable.tsx
@@ -30,6 +30,7 @@ import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import KeyboardArrowRightIcon from "@mui/icons-material/KeyboardArrowRight";
 import Select from "@mui/material/Select";
 import MenuItem from "@mui/material/MenuItem";
+import Autocomplete from "@mui/material/Autocomplete";
 import TextField from "@mui/material/TextField";
 import Box from "@mui/material/Box";
 import { makeStyles } from "tss-react/mui";
@@ -89,6 +90,14 @@ import { useGetAnnotationsInfoQuery } from "../../ducks/candidate/candidates";
 import { getContrastColor } from "../ObjectTags";
 import { filterOutEmptyValues } from "../../API";
 import { getAnnotationValueString } from "../candidate/ScanningPageCandidateAnnotations";
+import {
+  altdataKeyForField,
+  buildAltdataColumnMeta,
+  buildAnnotationColumnMeta,
+  buildColumnPickerOptions,
+  filterColumnPickerOptions,
+  originKeyForAnnotationField,
+} from "./sourceTableColumns";
 import ConfirmSourceInGCN from "./ConfirmSourceInGCN";
 import ConfirmDeletionDialog from "../ConfirmDeletionDialog";
 import NewSource from "./NewSource";
@@ -727,81 +736,66 @@ const SourceTable = ({
     }
   }, [sources]);
 
-  const allAnnotationColumnFields = useMemo(
-    () =>
-      Object.entries(annotationsInfo || {}).flatMap(([origin, keys]) =>
-        (keys as any[]).map(
-          (keyObj) => `annotation.${origin}.${Object.keys(keyObj)[0]}`,
-        ),
-      ),
+  // field -> origin/key for every discoverable annotation. A cheap map, NOT a
+  // column each: the registry is unbounded (per-object `ls_dr9-<objid>` origins),
+  // so only saved fields become columns (below). Powers the picker + round-trip.
+  const annotationColumnMeta = useMemo(
+    () => buildAnnotationColumnMeta(annotationsInfo),
     [annotationsInfo],
   );
-
-  const allAltdataColumnFields = useMemo(
-    () =>
-      (altdataInfo?.keys || []).map(
-        (keyObj) => `altdata.${Object.keys(keyObj)[0]}`,
-      ),
+  const altdataColumnMeta = useMemo(
+    () => buildAltdataColumnMeta(altdataInfo),
     [altdataInfo],
   );
 
-  // Annotation and altdata columns are opt-in: default each newly discovered one
-  // to hidden unless the user saved it as visible, preserving in-session choices.
-  useEffect(() => {
-    if (!allAnnotationColumnFields.length && !allAltdataColumnFields.length) {
-      return;
-    }
-    setColumnVisibilityModel((prev) => {
-      const next = { ...prev };
-      allAnnotationColumnFields.forEach((field) => {
-        if (!(field in next)) {
-          next[field] = savedAnnotationColumns.includes(field);
-        }
-      });
-      allAltdataColumnFields.forEach((field) => {
-        if (!(field in next)) {
-          next[field] = savedAltdataColumns.includes(field);
-        }
-      });
-      return next;
-    });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [allAnnotationColumnFields, allAltdataColumnFields, currentUser]);
+  // Picker options: every discoverable field (Autocomplete caps what renders).
+  const columnPickerOptions = useMemo(
+    () => buildColumnPickerOptions(annotationColumnMeta, altdataColumnMeta),
+    [annotationColumnMeta, altdataColumnMeta],
+  );
 
-  // Persist the sets of visible annotation / altdata columns to the user's profile.
+  // Add a discoverable field to the saved selection (= what's materialized).
+  const handleAddColumn = useCallback(
+    (field: string) => {
+      if (!field) return;
+      if (field.startsWith("annotation.")) {
+        if (savedAnnotationColumns.includes(field)) return;
+        updateUserPreferences({
+          sourceTableAnnotationColumns: [...savedAnnotationColumns, field],
+        });
+      } else if (field.startsWith("altdata.")) {
+        if (savedAltdataColumns.includes(field)) return;
+        updateUserPreferences({
+          sourceTableAltdataColumns: [...savedAltdataColumns, field],
+        });
+      }
+    },
+    [savedAnnotationColumns, savedAltdataColumns, updateUserPreferences],
+  );
+
+  // Unchecking a saved annotation/altdata column in the panel drops it from the
+  // saved selection (and so unmaterializes it); re-add via the toolbar picker.
   const handleColumnVisibilityModelChange = useCallback(
     (model: Record<string, boolean>) => {
       setColumnVisibilityModel(model);
       const prefs: Record<string, string[]> = {};
-      const visibleAnnotation = allAnnotationColumnFields.filter(
+      const visibleAnnotation = savedAnnotationColumns.filter(
         (f) => model[f] !== false,
       );
-      if (
-        visibleAnnotation.length !== savedAnnotationColumns.length ||
-        visibleAnnotation.some((f) => !savedAnnotationColumns.includes(f))
-      ) {
+      if (visibleAnnotation.length !== savedAnnotationColumns.length) {
         prefs["sourceTableAnnotationColumns"] = visibleAnnotation;
       }
-      const visibleAltdata = allAltdataColumnFields.filter(
+      const visibleAltdata = savedAltdataColumns.filter(
         (f) => model[f] !== false,
       );
-      if (
-        visibleAltdata.length !== savedAltdataColumns.length ||
-        visibleAltdata.some((f) => !savedAltdataColumns.includes(f))
-      ) {
+      if (visibleAltdata.length !== savedAltdataColumns.length) {
         prefs["sourceTableAltdataColumns"] = visibleAltdata;
       }
       if (Object.keys(prefs).length > 0) {
         updateUserPreferences(prefs);
       }
     },
-    [
-      allAnnotationColumnFields,
-      allAltdataColumnFields,
-      savedAnnotationColumns,
-      savedAltdataColumns,
-      updateUserPreferences,
-    ],
+    [savedAnnotationColumns, savedAltdataColumns, updateUserPreferences],
   );
 
   useEffect(() => {
@@ -1566,39 +1560,34 @@ const SourceTable = ({
       });
     }
 
-    // One opt-in column per annotation origin/key pair. The field encodes the
-    // server sort string ("annotation.<origin>.<key>"), so server-side sorting
-    // works through the existing SERVER_SORT_FIELD fallback.
-    Object.entries(annotationsInfo || {}).forEach(([origin, keys]) => {
-      (keys as any[]).forEach((keyObj) => {
-        const key = Object.keys(keyObj)[0];
-        if (!key) {
-          return;
-        }
-        cols.push({
-          field: `annotation.${origin}.${key}`,
-          headerName: `${key} (${origin})`,
-          flex: 1,
-          minWidth: 120,
-          valueGetter: (_value: any, row: any) => {
-            const ann = (row.annotations || []).find(
-              (a: any) => a.origin === origin,
-            );
-            const value = ann?.data?.[key];
-            return value === undefined ? null : getAnnotationValueString(value);
-          },
-        });
+    // Materialize a column only for each annotation the user has saved (the
+    // global registry is unbounded — see annotationColumnMeta). Field encodes
+    // the server sort string, so server-side sort works via SERVER_SORT_FIELD.
+    savedAnnotationColumns.forEach((field) => {
+      const { origin, key } = originKeyForAnnotationField(
+        field,
+        annotationColumnMeta,
+      );
+      cols.push({
+        field,
+        headerName: `${key} (${origin})`,
+        flex: 1,
+        minWidth: 120,
+        valueGetter: (_value: any, row: any) => {
+          const ann = (row.annotations || []).find(
+            (a: any) => a.origin === origin,
+          );
+          const value = ann?.data?.[key];
+          return value === undefined ? null : getAnnotationValueString(value);
+        },
       });
     });
 
-    // One opt-in column per top-level altdata key (field = server sort string).
-    (altdataInfo?.keys || []).forEach((keyObj) => {
-      const key = Object.keys(keyObj)[0];
-      if (!key) {
-        return;
-      }
+    // Likewise, only saved altdata keys become columns.
+    savedAltdataColumns.forEach((field) => {
+      const key = altdataKeyForField(field, altdataColumnMeta);
       cols.push({
-        field: `altdata.${key}`,
+        field,
         headerName: `${key} (altdata)`,
         flex: 1,
         minWidth: 120,
@@ -1613,8 +1602,10 @@ const SourceTable = ({
 
     return cols;
   }, [
-    annotationsInfo,
-    altdataInfo,
+    annotationColumnMeta,
+    altdataColumnMeta,
+    savedAnnotationColumns,
+    savedAltdataColumns,
     classes,
     navigate,
     taxonomyList,
@@ -1952,6 +1943,31 @@ const SourceTable = ({
                   />
                 ))}
               </div>
+            )}
+            {columnPickerOptions.length > 0 && (
+              <Autocomplete
+                options={columnPickerOptions}
+                getOptionLabel={(o) => o.label}
+                // Nothing until the user types, then capped matches, so a large
+                // registry never floods the dropdown.
+                filterOptions={(opts, state) =>
+                  filterColumnPickerOptions(opts, state.inputValue)
+                }
+                onChange={(_e, value) => value && handleAddColumn(value.field)}
+                value={null}
+                blurOnSelect
+                clearOnBlur
+                size="small"
+                sx={{ width: 340, marginBottom: "0.5rem" }}
+                renderInput={(params) => (
+                  <TextField
+                    {...params}
+                    variant="standard"
+                    placeholder="Add annotation / altdata column…"
+                    data-testid="add-column-picker"
+                  />
+                )}
+              />
             )}
             <Box
               sx={{

--- a/static/js/components/source/sourceTableColumns.test.ts
+++ b/static/js/components/source/sourceTableColumns.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from "bun:test";
+
+import {
+  altdataKeyForField,
+  buildAltdataColumnMeta,
+  buildAnnotationColumnMeta,
+  buildColumnPickerOptions,
+  filterColumnPickerOptions,
+  originKeyForAnnotationField,
+} from "./sourceTableColumns";
+
+// The annotations registry is unbounded (per-object origins like
+// `ls_dr9-<objid>`), so these helpers must build a lookup — not a column each —
+// and round-trip a saved field back to its origin/key.
+const annotationsInfo = {
+  "acai:high_h__high_n": [{ acai_v: "number" }, { age: "number" }],
+  "ls_dr9-9907736172104018": [{ z_phot_median: "number" }, { type: "string" }],
+};
+const altdataInfo = { keys: [{ period: "number" }, { source_name: "string" }] };
+
+describe("buildAnnotationColumnMeta", () => {
+  it("maps every origin/key to a field with its origin+key", () => {
+    const meta = buildAnnotationColumnMeta(annotationsInfo);
+    expect(meta["annotation.acai:high_h__high_n.acai_v"]).toEqual({
+      origin: "acai:high_h__high_n",
+      key: "acai_v",
+    });
+    expect(meta["annotation.ls_dr9-9907736172104018.z_phot_median"]).toEqual({
+      origin: "ls_dr9-9907736172104018",
+      key: "z_phot_median",
+    });
+    expect(Object.keys(meta)).toHaveLength(4);
+  });
+
+  it("tolerates null/empty input", () => {
+    expect(buildAnnotationColumnMeta(null)).toEqual({});
+    expect(buildAnnotationColumnMeta({})).toEqual({});
+  });
+});
+
+describe("buildAltdataColumnMeta", () => {
+  it("maps altdata keys to fields", () => {
+    const meta = buildAltdataColumnMeta(altdataInfo);
+    expect(meta["altdata.period"]).toEqual({ key: "period" });
+    expect(Object.keys(meta)).toHaveLength(2);
+  });
+  it("tolerates missing keys", () => {
+    expect(buildAltdataColumnMeta(null)).toEqual({});
+    expect(buildAltdataColumnMeta({})).toEqual({});
+  });
+});
+
+describe("originKeyForAnnotationField", () => {
+  const meta = buildAnnotationColumnMeta(annotationsInfo);
+
+  it("resolves via the registry when present", () => {
+    expect(
+      originKeyForAnnotationField(
+        "annotation.acai:high_h__high_n.acai_v",
+        meta,
+      ),
+    ).toEqual({ origin: "acai:high_h__high_n", key: "acai_v" });
+  });
+
+  it("falls back to parsing when the origin aged out of the registry", () => {
+    // A saved field whose origin is no longer in annotationsInfo.
+    expect(
+      originKeyForAnnotationField("annotation.ls_dr9-42.z_phot_std", {}),
+    ).toEqual({ origin: "ls_dr9-42", key: "z_phot_std" });
+  });
+});
+
+describe("altdataKeyForField", () => {
+  const meta = buildAltdataColumnMeta(altdataInfo);
+  it("resolves via the registry, else strips the prefix", () => {
+    expect(altdataKeyForField("altdata.period", meta)).toBe("period");
+    expect(altdataKeyForField("altdata.unknown_key", {})).toBe("unknown_key");
+  });
+});
+
+describe("buildColumnPickerOptions", () => {
+  it("labels annotation options `key (origin)` and altdata `key (altdata)`", () => {
+    const opts = buildColumnPickerOptions(
+      buildAnnotationColumnMeta(annotationsInfo),
+      buildAltdataColumnMeta(altdataInfo),
+    );
+    const byField = Object.fromEntries(opts.map((o) => [o.field, o.label]));
+    expect(byField["annotation.acai:high_h__high_n.acai_v"]).toBe(
+      "acai_v (acai:high_h__high_n)",
+    );
+    expect(byField["altdata.period"]).toBe("period (altdata)");
+    expect(opts).toHaveLength(6);
+  });
+});
+
+describe("filterColumnPickerOptions", () => {
+  const options = buildColumnPickerOptions(
+    buildAnnotationColumnMeta(annotationsInfo),
+    buildAltdataColumnMeta(altdataInfo),
+  );
+
+  it("returns nothing for an empty query (don't flood the dropdown)", () => {
+    expect(filterColumnPickerOptions(options, "")).toEqual([]);
+    expect(filterColumnPickerOptions(options, "   ")).toEqual([]);
+  });
+
+  it("case-insensitively substring-matches the label", () => {
+    const hits = filterColumnPickerOptions(options, "z_phot");
+    expect(hits).toHaveLength(1);
+    expect(hits[0]!.field).toBe(
+      "annotation.ls_dr9-9907736172104018.z_phot_median",
+    );
+  });
+
+  it("caps results at the limit", () => {
+    const many = buildColumnPickerOptions(
+      Object.fromEntries(
+        Array.from({ length: 200 }, (_, i) => [
+          `annotation.ls_dr9-${i}.z_phot_median`,
+          { origin: `ls_dr9-${i}`, key: "z_phot_median" },
+        ]),
+      ),
+      {},
+    );
+    expect(filterColumnPickerOptions(many, "z_phot", 50)).toHaveLength(50);
+  });
+});

--- a/static/js/components/source/sourceTableColumns.ts
+++ b/static/js/components/source/sourceTableColumns.ts
@@ -1,0 +1,107 @@
+// Pure helpers for SourceTable annotation/altdata columns. Extracted so the
+// correctness-critical parts (registry -> metadata, saved-field parsing, picker
+// options) are unit-testable without rendering the grid.
+//
+// Only the user's *saved* fields become columns: the annotations registry is
+// unbounded (per-object origins like `ls_dr9-<objid>`), so materializing a
+// column per (origin, key) froze the grid. Discovery goes through the picker.
+
+export interface AnnotationColumnInfo {
+  origin: string;
+  key: string;
+}
+
+export interface ColumnPickerOption {
+  field: string;
+  label: string;
+}
+
+// annotationsInfo: { origin: [{ key: type }, ...] }
+//   -> { "annotation.<origin>.<key>": { origin, key } }
+export function buildAnnotationColumnMeta(
+  annotationsInfo: Record<string, any[]> | null | undefined,
+): Record<string, AnnotationColumnInfo> {
+  const meta: Record<string, AnnotationColumnInfo> = {};
+  Object.entries(annotationsInfo || {}).forEach(([origin, keys]) => {
+    (keys || []).forEach((keyObj) => {
+      const key = Object.keys(keyObj || {})[0];
+      if (key) {
+        meta[`annotation.${origin}.${key}`] = { origin, key };
+      }
+    });
+  });
+  return meta;
+}
+
+// altdataInfo: { keys: [{ key: type }, ...] } -> { "altdata.<key>": { key } }
+export function buildAltdataColumnMeta(
+  altdataInfo: { keys?: any[] } | null | undefined,
+): Record<string, { key: string }> {
+  const meta: Record<string, { key: string }> = {};
+  (altdataInfo?.keys || []).forEach((keyObj) => {
+    const key = Object.keys(keyObj || {})[0];
+    if (key) {
+      meta[`altdata.${key}`] = { key };
+    }
+  });
+  return meta;
+}
+
+// Resolve a saved "annotation.<origin>.<key>" field back to origin/key. Uses the
+// registry when present, and a split fallback when the origin has aged out of it
+// (origins carry no dots; keys are the last segment).
+export function originKeyForAnnotationField(
+  field: string,
+  meta: Record<string, AnnotationColumnInfo>,
+): AnnotationColumnInfo {
+  const m = meta[field];
+  if (m) {
+    return m;
+  }
+  const parts = field.split(".");
+  return {
+    origin: parts.slice(1, -1).join("."),
+    key: parts[parts.length - 1] ?? field,
+  };
+}
+
+// Resolve a saved "altdata.<key>" field back to its key.
+export function altdataKeyForField(
+  field: string,
+  meta: Record<string, { key: string }>,
+): string {
+  return meta[field]?.key ?? field.slice("altdata.".length);
+}
+
+// Every discoverable field as a picker option { field, label }.
+export function buildColumnPickerOptions(
+  annotationMeta: Record<string, AnnotationColumnInfo>,
+  altdataMeta: Record<string, { key: string }>,
+): ColumnPickerOption[] {
+  return [
+    ...Object.keys(annotationMeta).map((field) => {
+      const m = annotationMeta[field];
+      return { field, label: m ? `${m.key} (${m.origin})` : field };
+    }),
+    ...Object.keys(altdataMeta).map((field) => {
+      const m = altdataMeta[field];
+      return { field, label: m ? `${m.key} (altdata)` : field };
+    }),
+  ];
+}
+
+// Picker filter: nothing until the user types, then case-insensitive substring
+// matches capped at `limit` so a large registry never floods the dropdown.
+export function filterColumnPickerOptions(
+  options: ColumnPickerOption[],
+  query: string,
+  limit = 50,
+): ColumnPickerOption[] {
+  const q = query.trim().toLowerCase();
+  if (!q) {
+    return [];
+  }
+  return options
+    .filter((o) => o.label.toLowerCase().includes(q))
+    .slice(0, limit);
+}


### PR DESCRIPTION
This PR fixes the column picking in the source table, where every annotation key in the database was previously shown in one list.