### PR TITLE
broker alert card improvements

### DIFF
--- a/static/js/components/broker/Broker.tsx
+++ b/static/js/components/broker/Broker.tsx
@@ -43,6 +43,7 @@ const useStyles = makeStyles()((theme) => ({
     gridTemplateColumns: "repeat(auto-fill, minmax(520px, 1fr))",
     gap: theme.spacing(2),
   },
+  gridSingle: { gridTemplateColumns: "1fr" },
   json: { padding: theme.spacing(2), maxHeight: "50vh", overflow: "auto" },
   pre: {
     margin: 0,
@@ -98,7 +99,7 @@ const TooltipTab = ({ tooltip, ...tabProps }: any) => (
 );
 
 const Broker = () => {
-  const { classes } = useStyles();
+  const { classes, cx } = useStyles();
   const { brokerId: brokerIdParam } = useParams();
   const brokerId = Number(brokerIdParam);
   const { data: brokers, isLoading: brokersLoading } = useGetBrokersQuery();
@@ -381,7 +382,11 @@ const Broker = () => {
                               objectGroups.length === 1 ? "" : "s"
                             } — showing ${start + 1}–${start + pageGroups.length}`}
                           </Typography>
-                          <div className={classes.grid}>
+                          <div
+                            className={cx(classes.grid, {
+                              [classes.gridSingle]: pageGroups.length === 1,
+                            })}
+                          >
                             {pageGroups.map((g) => (
                               <BrokerAlertCard
                                 key={g.objectId}
@@ -390,6 +395,7 @@ const Broker = () => {
                                 objectId={g.objectId}
                                 survey={survey}
                                 alerts={g.alerts}
+                                expanded={pageGroups.length === 1}
                               />
                             ))}
                           </div>

--- a/static/js/components/broker/BrokerAlertCard.tsx
+++ b/static/js/components/broker/BrokerAlertCard.tsx
@@ -65,6 +65,7 @@ const useStyles = makeStyles()((theme) => ({
     alignItems: "flex-start",
   },
   cutouts: { flex: "1 1 240px", minWidth: 220 },
+  cutoutsExpanded: { flex: "0 0 auto", minWidth: 460 },
   lc: { flex: "1 1 260px", minWidth: 240 },
   footer: {
     marginTop: theme.spacing(1),
@@ -96,6 +97,8 @@ interface BrokerAlertCardProps {
   objectId: string;
   survey: string;
   alerts: AlertOption[];
+  // Card rendered alone on a full-width row: give the cutouts more room.
+  expanded?: boolean;
 }
 
 const num = (v: number | undefined, d = 4) =>
@@ -107,8 +110,9 @@ const BrokerAlertCard = ({
   objectId,
   survey,
   alerts,
+  expanded = false,
 }: BrokerAlertCardProps) => {
-  const { classes } = useStyles();
+  const { classes, cx } = useStyles();
   // Newest alert first (highest jd), so the default selection is the latest.
   const sorted = [...alerts].sort((a, b) => (b.jd ?? 0) - (a.jd ?? 0));
   const [candid, setCandid] = useState<string | number | undefined>(
@@ -228,18 +232,27 @@ const BrokerAlertCard = ({
 
         <div className={classes.body}>
           {ra != null && dec != null && (
-            <div className={classes.cutouts}>
+            <div
+              className={cx(classes.cutouts, {
+                [classes.cutoutsExpanded]: expanded,
+              })}
+            >
               <CutoutTriplet
                 brokerId={brokerId}
                 candid={cutoutKey}
                 survey={survey}
                 ra={ra}
                 dec={dec}
+                size={expanded ? "9rem" : "5rem"}
               />
             </div>
           )}
           <div className={classes.lc}>
-            <BrokerAlertLightCurve brokerId={brokerId} objectId={objectId} />
+            <BrokerAlertLightCurve
+              brokerId={brokerId}
+              objectId={objectId}
+              jd={selected?.jd}
+            />
           </div>
         </div>
 

--- a/static/js/components/broker/BrokerAlertFilters.tsx
+++ b/static/js/components/broker/BrokerAlertFilters.tsx
@@ -19,12 +19,14 @@ interface BrokerAlertFiltersProps {
   fields: string[];
   filters: AlertFilter[];
   onChange: (filters: AlertFilter[]) => void;
+  label?: string;
 }
 
 const BrokerAlertFilters = ({
   fields,
   filters,
   onChange,
+  label = "Filter results",
 }: BrokerAlertFiltersProps) => {
   const [open, setOpen] = useState(false);
 
@@ -39,7 +41,7 @@ const BrokerAlertFilters = ({
         endIcon={open ? <ExpandLessIcon /> : <ExpandMoreIcon />}
         onClick={() => setOpen(!open)}
       >
-        {`Filter results${filters.length ? ` (${filters.length})` : ""}`}
+        {`${label}${filters.length ? ` (${filters.length})` : ""}`}
       </Button>
       <Collapse in={open} unmountOnExit>
         <Box sx={{ display: "flex", flexDirection: "column", gap: 1, mt: 1 }}>

--- a/static/js/components/broker/BrokerAlertLightCurve.tsx
+++ b/static/js/components/broker/BrokerAlertLightCurve.tsx
@@ -8,6 +8,8 @@ import VegaPlotAlert from "./VegaPlotAlert";
 interface BrokerAlertLightCurveProps {
   brokerId: number;
   objectId: string;
+  // Epoch to mark with the vertical rule; defaults to the object's latest alert.
+  jd?: number | undefined;
 }
 
 /**
@@ -17,13 +19,14 @@ interface BrokerAlertLightCurveProps {
 const BrokerAlertLightCurve = ({
   brokerId,
   objectId,
+  jd,
 }: BrokerAlertLightCurveProps) => {
   const { data, isFetching } = useGetBrokerAlertQuery({
     brokerId,
     alertId: objectId,
   });
 
-  const { values, jd } = useMemo(() => {
+  const { values, jd: latestJd } = useMemo(() => {
     if (!data) return { values: [] as any[], jd: null as number | null };
     // Mirror fritz's AlertPhotometryPlot: detections (prv_candidates) +
     // upper-limit non-detections + forced photometry (SNR-gated to limits).
@@ -55,12 +58,14 @@ const BrokerAlertLightCurve = ({
     return { values: points, jd: refJd };
   }, [data]);
 
+  const markedJd = jd ?? latestJd;
+
   if (isFetching) return <CircularProgress size={24} />;
-  if (!values.length || jd == null) return null;
+  if (!values.length || markedJd == null) return null;
 
   return (
     <div style={{ width: "100%", height: "16rem" }}>
-      <VegaPlotAlert values={values} jd={jd} />
+      <VegaPlotAlert values={values} jd={markedJd} />
     </div>
   );
 };

--- a/static/js/components/broker/CutoutTriplet.tsx
+++ b/static/js/components/broker/CutoutTriplet.tsx
@@ -12,6 +12,7 @@ interface CutoutTripletProps {
   survey: string;
   ra: number;
   dec: number;
+  size?: string;
 }
 
 /**
@@ -25,6 +26,7 @@ const CutoutTriplet = ({
   survey,
   ra,
   dec,
+  size = "5rem",
 }: CutoutTripletProps) => {
   const [dataUris, setDataUris] = useState<{
     new?: string | null;
@@ -87,7 +89,7 @@ const CutoutTriplet = ({
       displayTypes={["new", "ref", "sub"]}
       // Compact triplet for the alert card: the default (13rem, for the source
       // page) is too large here and the three cutouts overlap.
-      size="5rem"
+      size={size}
       titleSize="0.7rem"
       noMargin
     />

--- a/static/js/components/broker/VegaPlotAlert.tsx
+++ b/static/js/components/broker/VegaPlotAlert.tsx
@@ -166,7 +166,7 @@ const spec = (url: any, values: any, jd: any): any => {
       // Vertical rule marking the selected alert's JD
       {
         data: { values: [{}] },
-        mark: { type: "rule", strokeDash: [4, 4], size: 1, opacity: 0.3 },
+        mark: { type: "rule", strokeDash: [4, 4], size: 1.5, opacity: 0.6 },
         encoding: {
           x: {
             datum: jd,

--- a/static/js/components/broker/boom/BoomAlertMetadata.tsx
+++ b/static/js/components/broker/boom/BoomAlertMetadata.tsx
@@ -8,7 +8,8 @@ import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 import TableSortLabel from "@mui/material/TableSortLabel";
 import Typography from "@mui/material/Typography";
-import { Theme, useTheme } from "@mui/material/styles";
+import { useTheme } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
 
 import { AlertOption } from "../BrokerAlertCard";
 import BrokerAlertFilters from "../BrokerAlertFilters";

--- a/static/js/components/broker/boom/BoomAlertMetadata.tsx
+++ b/static/js/components/broker/boom/BoomAlertMetadata.tsx
@@ -1,53 +1,98 @@
+import { useMemo, useState } from "react";
+
 import Box from "@mui/material/Box";
 import Table from "@mui/material/Table";
 import TableBody from "@mui/material/TableBody";
 import TableCell from "@mui/material/TableCell";
 import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
+import TableSortLabel from "@mui/material/TableSortLabel";
+import Typography from "@mui/material/Typography";
+import { Theme, useTheme } from "@mui/material/styles";
 
 import { AlertOption } from "../BrokerAlertCard";
+import BrokerAlertFilters from "../BrokerAlertFilters";
+import { AlertFilter, matchesFilters } from "../alertFields";
+import { REAL_BOGUS, collectScores, scoreColor } from "./BoomMlScores";
 
-const num = (v: unknown, d: number) =>
+const num = (d: number) => (v: unknown) =>
   typeof v === "number" ? v.toFixed(d) : "—";
 
 const str = (v: unknown) => (v == null ? "—" : String(v));
 
-const COLUMNS = (isLSST: boolean) => [
+interface Row {
+  alert: AlertOption;
+  raw: any;
+  scores: Record<string, number>;
+}
+
+interface Column {
+  label: string;
+  // Raw value, so the column can be sorted and filtered on, not just displayed.
+  value: (row: Row) => unknown;
+  format: (v: unknown) => string;
+  color?: (v: unknown) => string | undefined;
+}
+
+const COLUMNS = (isLSST: boolean): Column[] => [
   {
     label: isLSST ? "diaSourceId" : "candid",
-    value: (a: any, raw: any) =>
-      str(raw?.diaSourceId ?? a.candid ?? raw?.candid ?? raw?._id),
+    value: ({ alert, raw }) =>
+      raw?.diaSourceId ?? alert.candid ?? raw?.candid ?? raw?._id,
+    format: str,
   },
-  { label: "JD", value: (a: any) => num(a.jd, 5) },
-  { label: "band", value: (_a: any, raw: any) => str(raw?.candidate?.band) },
-  { label: "magpsf", value: (a: any) => num(a.magpsf, 3) },
+  { label: "JD", value: ({ alert }) => alert.jd, format: num(5) },
+  { label: "band", value: ({ raw }) => raw?.candidate?.band, format: str },
+  { label: "magpsf", value: ({ alert }) => alert.magpsf, format: num(3) },
   {
     label: "sigmapsf",
-    value: (_a: any, raw: any) => num(raw?.candidate?.sigmapsf, 3),
+    value: ({ raw }) => raw?.candidate?.sigmapsf,
+    format: num(3),
   },
   {
     label: "isdiffpos",
-    value: (_a: any, raw: any) => str(raw?.candidate?.isdiffpos),
+    value: ({ raw }) => raw?.candidate?.isdiffpos,
+    format: str,
   },
   {
     label: isLSST ? "reliability" : "drb",
-    value: (_a: any, raw: any) =>
-      num(isLSST ? raw?.candidate?.reliability : raw?.candidate?.drb, 5),
+    value: ({ raw }) =>
+      isLSST ? raw?.candidate?.reliability : raw?.candidate?.drb,
+    format: num(5),
   },
   {
     label: "snr",
-    value: (_a: any, raw: any) =>
-      num(raw?.candidate?.snr_psf ?? raw?.candidate?.snr, 2),
+    value: ({ raw }) => raw?.candidate?.snr_psf ?? raw?.candidate?.snr,
+    format: num(2),
   },
   ...(isLSST
     ? []
     : [
         {
           label: "programid",
-          value: (_a: any, raw: any) => str(raw?.candidate?.programid),
+          value: ({ raw }: Row) => raw?.candidate?.programid,
+          format: str,
         },
       ]),
 ];
+
+// The ML scores shown as bubbles, repeated as columns so many alerts can be
+// compared at once.
+const scoreColumns = (rows: Row[], theme: Theme): Column[] => {
+  const names: string[] = [];
+  rows.forEach((r) =>
+    Object.keys(r.scores).forEach((name) => {
+      // Real/Bogus is already the drb/reliability column.
+      if (name !== REAL_BOGUS && !names.includes(name)) names.push(name);
+    }),
+  );
+  return names.map((name) => ({
+    label: name,
+    value: ({ scores }) => scores[name],
+    format: (v) => (typeof v === "number" ? `${(v * 100).toFixed(0)}%` : "—"),
+    color: (v) => (typeof v === "number" ? scoreColor(theme, v) : undefined),
+  }));
+};
 
 interface BoomAlertMetadataProps {
   alerts: AlertOption[];
@@ -62,36 +107,123 @@ const BoomAlertMetadata = ({
   selectedCandid,
   onSelect,
 }: BoomAlertMetadataProps) => {
-  const columns = COLUMNS(survey === "LSST");
+  const theme = useTheme();
+  const [filters, setFilters] = useState<AlertFilter[]>([]);
+  const [orderBy, setOrderBy] = useState("JD");
+  const [order, setOrder] = useState<"asc" | "desc">("desc");
+
+  const rows: Row[] = useMemo(
+    () =>
+      alerts.map((alert) => ({
+        alert,
+        raw: alert.raw,
+        scores: Object.fromEntries(
+          collectScores(alert.raw).map((s) => [s.name, s.score]),
+        ),
+      })),
+    [alerts],
+  );
+
+  const columns = useMemo(
+    () => [...COLUMNS(survey === "LSST"), ...scoreColumns(rows, theme)],
+    [rows, survey, theme],
+  );
+
+  const visible = useMemo(() => {
+    const kept = filters.length
+      ? rows.filter((r) =>
+          matchesFilters(
+            Object.fromEntries(columns.map((c) => [c.label, c.value(r)])),
+            filters,
+          ),
+        )
+      : rows;
+    const col = columns.find((c) => c.label === orderBy);
+    if (!col) return kept;
+    const dir = order === "asc" ? 1 : -1;
+    return [...kept].sort((a, b) => {
+      const va = col.value(a);
+      const vb = col.value(b);
+      // Missing values last, whichever way the column is sorted.
+      if (va == null || vb == null)
+        return va == null ? (vb == null ? 0 : 1) : -1;
+      if (typeof va === "number" && typeof vb === "number")
+        return (va - vb) * dir;
+      return String(va).localeCompare(String(vb)) * dir;
+    });
+  }, [rows, columns, filters, orderBy, order]);
+
+  const onSort = (label: string) => {
+    setOrder(orderBy === label && order === "asc" ? "desc" : "asc");
+    setOrderBy(label);
+  };
+
   return (
-    <Box sx={{ mt: 1, maxHeight: 200, overflow: "auto" }}>
-      <Table
-        size="small"
-        sx={{ "& td, & th": { px: 0.75, fontSize: "0.7rem" } }}
-      >
-        <TableHead>
-          <TableRow>
-            {columns.map((c) => (
-              <TableCell key={c.label}>{c.label}</TableCell>
-            ))}
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {alerts.map((a) => (
-            <TableRow
-              key={String(a.candid)}
-              hover
-              selected={a.candid === selectedCandid}
-              onClick={() => onSelect(a.candid)}
-              sx={{ cursor: "pointer" }}
-            >
+    <Box sx={{ mt: 1 }}>
+      <BrokerAlertFilters
+        label="Filter alerts"
+        fields={columns.map((c) => c.label)}
+        filters={filters}
+        onChange={setFilters}
+      />
+      <Box sx={{ maxHeight: 200, overflow: "auto" }}>
+        <Table
+          size="small"
+          stickyHeader
+          sx={{ "& td, & th": { px: 0.75, fontSize: "0.7rem" } }}
+        >
+          <TableHead>
+            <TableRow>
               {columns.map((c) => (
-                <TableCell key={c.label}>{c.value(a, a.raw)}</TableCell>
+                <TableCell
+                  key={c.label}
+                  sortDirection={orderBy === c.label ? order : false}
+                >
+                  <TableSortLabel
+                    active={orderBy === c.label}
+                    direction={orderBy === c.label ? order : "asc"}
+                    onClick={() => onSort(c.label)}
+                  >
+                    {c.label}
+                  </TableSortLabel>
+                </TableCell>
               ))}
             </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+          </TableHead>
+          <TableBody>
+            {visible.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={columns.length}>
+                  <Typography variant="caption" color="text.secondary">
+                    No alert matches the filters.
+                  </Typography>
+                </TableCell>
+              </TableRow>
+            )}
+            {visible.map((row) => (
+              <TableRow
+                key={String(row.alert.candid)}
+                hover
+                selected={row.alert.candid === selectedCandid}
+                onClick={() => onSelect(row.alert.candid)}
+                sx={{ cursor: "pointer" }}
+              >
+                {columns.map((c) => {
+                  const v = c.value(row);
+                  return (
+                    <TableCell
+                      key={c.label}
+                      sx={{ backgroundColor: c.color?.(v) }}
+                    >
+                      {c.format(v)}
+                    </TableCell>
+                  );
+                })}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </Box>
     </Box>
   );
 };

--- a/static/js/components/broker/boom/BoomMlScores.tsx
+++ b/static/js/components/broker/boom/BoomMlScores.tsx
@@ -1,7 +1,8 @@
 import Box from "@mui/material/Box";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
-import { Theme, alpha } from "@mui/material/styles";
+import { alpha } from "@mui/material/styles";
+import type { Theme } from "@mui/material/styles";
 import { makeStyles } from "tss-react/mui";
 
 const useStyles = makeStyles()((theme) => ({

--- a/static/js/components/broker/boom/BoomMlScores.tsx
+++ b/static/js/components/broker/boom/BoomMlScores.tsx
@@ -1,7 +1,7 @@
 import Box from "@mui/material/Box";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
-import { alpha } from "@mui/material/styles";
+import { Theme, alpha } from "@mui/material/styles";
 import { makeStyles } from "tss-react/mui";
 
 const useStyles = makeStyles()((theme) => ({
@@ -28,12 +28,15 @@ const useStyles = makeStyles()((theme) => ({
   separation: { fontSize: "0.65rem", opacity: 0.7 },
 }));
 
-interface Score {
+export interface Score {
   name: string;
   score: number;
   separation?: number;
   hint?: string;
 }
+
+// Same score name as the drb/reliability metadata column.
+export const REAL_BOGUS = "Real/Bogus";
 
 const ACAI: [string, string][] = [
   ["ACAI Hosted", "acai_h"],
@@ -42,14 +45,14 @@ const ACAI: [string, string][] = [
   ["ACAI Orphan", "acai_o"],
 ];
 
-const collect = (alert: any): Score[] => {
+export const collectScores = (alert: any): Score[] => {
   const cand = alert?.candidate ?? {};
   const cls = alert?.classifications ?? {};
   const scores: Score[] = [];
 
   const realBogus = cand.drb ?? cand.reliability;
   if (typeof realBogus === "number")
-    scores.push({ name: "Real/Bogus", score: realBogus });
+    scores.push({ name: REAL_BOGUS, score: realBogus });
   if (typeof cand.sgscore1 === "number")
     scores.push({
       name: "Star/Galaxy",
@@ -77,20 +80,22 @@ const collect = (alert: any): Score[] => {
 const arcsec = (v: number) =>
   v < 60 ? `${v.toFixed(1)}″` : `${(v / 60).toFixed(2)}′`;
 
+export const scoreColor = (theme: Theme, score: number) =>
+  alpha(
+    score > 0.7
+      ? theme.palette.success.main
+      : score > 0.4
+        ? theme.palette.warning.main
+        : theme.palette.error.main,
+    0.45,
+  );
+
 const BoomMlScores = ({ alert }: { alert: any }) => {
   const { classes, theme } = useStyles();
-  const scores = collect(alert);
+  const scores = collectScores(alert);
   if (!scores.length) return null;
 
-  const color = (score: number) =>
-    alpha(
-      score > 0.7
-        ? theme.palette.success.main
-        : score > 0.4
-          ? theme.palette.warning.main
-          : theme.palette.error.main,
-      0.45,
-    );
+  const color = (score: number) => scoreColor(theme, score);
 
   return (
     <div className={classes.root}>

--- a/static/js/components/user/preferences/CustomizeOpenAIParameters.tsx
+++ b/static/js/components/user/preferences/CustomizeOpenAIParameters.tsx
@@ -174,7 +174,8 @@ const CustomizeOpenAIParameters = () => {
       );
     }
     if (
-      !(formData.model.includes("gpt") || formData.model.includes("davinci"))
+      !formData.model.includes("gpt") &&
+      !formData.model.includes("davinci")
     ) {
       errors.model.addError(
         "must be an Open AI gpt model. See https://platform.openai.com/docs/models/overview for more information.",


### PR DESCRIPTION
- full-width card and larger cutouts when a single object is returned
- mark the selected alert's epoch on the light curve
- sort and filter the BOOM alert metadata table
- show the ML scores as table columns in addition to the bubbles.
<img width="1471" height="737" alt="image" src="https://github.com/user-attachments/assets/e9199114-0986-479d-be15-b5220b2ec12b" />
<img width="424" height="242" alt="image" src="https://github.com/user-attachments/assets/173b8c59-b167-4c01-beb5-44cd40001cc7" />
