### PR TITLE
skip missing enum types on startup and fail clearly on an unmigrated database

### DIFF
--- a/skyportal/app_server.py
+++ b/skyportal/app_server.py
@@ -1,4 +1,5 @@
 import sentry_sdk
+import sqlalchemy as sa
 import tornado.web
 from sentry_sdk.integrations.tornado import TornadoIntegration
 
@@ -251,7 +252,7 @@ from skyportal.handlers.public import (
 )
 
 from . import model_util, openapi
-from .models import init_db
+from .models import DBSession, init_db
 from .utils.observability import setup_observability
 
 log = make_log("app_server")
@@ -797,6 +798,17 @@ def make_app(cfg, baselayer_handlers, baselayer_settings, process=None, env=None
     # in debug mode.  In production, we leave the tables alone, since
     # migrations might be used.
     create_tables(add=env.debug)
+
+    # create_tables() is a no-op outside debug mode, so an unmigrated database
+    # reaches this point empty and every later step fails on a missing table or
+    # type -- once per worker, on every supervisor restart. Say so instead.
+    if not sa.inspect(DBSession.session_factory.kw["bind"]).has_table("users"):
+        raise RuntimeError(
+            "No tables found in the database. Create the schema first: "
+            "`make db_create_tables` (or `alembic upgrade head` where "
+            "migrations are used), then start the app."
+        )
+
     model_util.refresh_enums()
 
     model_util.setup_permissions()

--- a/skyportal/model_util.py
+++ b/skyportal/model_util.py
@@ -2,8 +2,11 @@ import sqlalchemy as sa
 
 from baselayer.app.env import load_env
 from baselayer.app.psa import TornadoStorage
+from baselayer.log import make_log
 from skyportal.enum_types import LISTENER_CLASSES, sqla_enum_types
 from skyportal.models import ACL, DBSession, Group, Role, Token, User
+
+log = make_log("model_util")
 
 all_acl_ids = [
     "Become user",
@@ -104,9 +107,33 @@ def add_user(username, roles=[], auth=False, first_name=None, last_name=None):
     return DBSession().scalars(sa.select(User).where(User.username == username)).first()
 
 
+def visible_enum_types(session):
+    """Names of the enum types this connection can reach unqualified.
+
+    `pg_type_is_visible` applies the same search_path resolution `ALTER TYPE`
+    does, so a name missing here is one that would raise UndefinedObject.
+    """
+    return set(
+        session.scalars(
+            sa.text(
+                "SELECT typname FROM pg_type "
+                "WHERE typtype = 'e' AND pg_type_is_visible(oid)"
+            )
+        )
+    )
+
+
 def refresh_enums():
     with DBSession() as session:
+        # A type only exists once the schema has been created; skip the rest
+        # rather than failing the app's startup on a half-built database.
+        existing = visible_enum_types(session)
+        missing = [t.name for t in sqla_enum_types if t.name not in existing]
+        if missing:
+            log(f"skipping enum refresh for missing types: {', '.join(missing)}")
         for type in sqla_enum_types:
+            if type.name not in existing:
+                continue
             for key in type.enums:
                 session.execute(
                     sa.text(f"ALTER TYPE {type.name} ADD VALUE IF NOT EXISTS '{key}'")

--- a/skyportal/tests/utils/test_refresh_enums.py
+++ b/skyportal/tests/utils/test_refresh_enums.py
@@ -1,0 +1,54 @@
+import sqlalchemy as sa
+
+from skyportal.enum_types import sqla_enum_types
+from skyportal.model_util import refresh_enums
+from skyportal.models import DBSession
+
+
+def test_visible_enum_types_sees_the_schema():
+    from skyportal.model_util import visible_enum_types
+
+    with DBSession() as session:
+        visible = visible_enum_types(session)
+    assert {t.name for t in sqla_enum_types} <= visible
+
+
+def test_visible_enum_types_follows_search_path():
+    """`ALTER TYPE` resolves through search_path, so the check has to as well:
+    a type that is not reachable unqualified must read as missing."""
+    from skyportal.model_util import visible_enum_types
+
+    session = DBSession()
+    try:
+        session.execute(sa.text("SET LOCAL search_path TO pg_temp"))
+        assert visible_enum_types(session) == set()
+    finally:
+        session.rollback()
+
+
+def test_refresh_enums_is_a_noop_when_types_are_missing():
+    """An unmigrated database has no enum types; refreshing them must not be
+    what takes the app's startup down."""
+    session = DBSession()
+    try:
+        session.execute(sa.text("SET LOCAL search_path TO pg_temp"))
+        refresh_enums()
+    finally:
+        session.rollback()
+
+
+def test_refresh_enums_keeps_the_configured_labels():
+    refresh_enums()
+    with DBSession() as session:
+        for type in sqla_enum_types:
+            labels = set(
+                session.scalars(
+                    sa.text(
+                        "SELECT enumlabel FROM pg_enum e "
+                        "JOIN pg_type t ON t.oid = e.enumtypid "
+                        "WHERE t.typname = :name"
+                    ),
+                    {"name": type.name},
+                )
+            )
+            assert set(type.enums) <= labels, type.name


### PR DESCRIPTION
This PR skips missing enum types on startup and fail clearly on an unmigrated database.

Closes https://github.com/skyportal/skyportal/issues/5347