### PR TITLE
display annotation integers as integers

### DIFF
--- a/static/js/components/candidate/ScanningPageCandidateAnnotations.tsx
+++ b/static/js/components/candidate/ScanningPageCandidateAnnotations.tsx
@@ -14,6 +14,7 @@ import TextField from "@mui/material/TextField";
 import { useAppDispatch, useAppSelector } from "../../types/hooks";
 import * as candidatesActions from "../../ducks/candidate/candidates";
 import type { Annotation, Group } from "../../types";
+import { getAnnotationValueString } from "./annotationValue";
 
 const useStyles = makeStyles()((theme) => ({
   root: {
@@ -45,21 +46,8 @@ const useStyles = makeStyles()((theme) => ({
   },
 }));
 
-export const getAnnotationValueString = (value: any): string => {
-  let valueString;
-  const valueType = typeof value;
-  switch (valueType) {
-    case "number":
-      valueString = value.toFixed(4);
-      break;
-    case "object":
-      valueString = JSON.stringify(value, null, 2);
-      break;
-    default:
-      valueString = value.toString();
-  }
-  return valueString;
-};
+// Re-exported for the many consumers that import it from this module.
+export { getAnnotationValueString };
 
 interface ScanningPageCandidateAnnotationsProps {
   annotations: Annotation[];

--- a/static/js/components/candidate/annotationValue.ts
+++ b/static/js/components/candidate/annotationValue.ts
@@ -1,0 +1,20 @@
+// Format an annotation value for display. Kept in a pure (React-free) module so
+// it can be imported into unit tests without pulling in the component tree.
+export const getAnnotationValueString = (value: any): string => {
+  let valueString;
+  const valueType = typeof value;
+  switch (valueType) {
+    case "number":
+      // Keep integers (e.g. survey source ids) as integers; only round floats.
+      valueString = Number.isInteger(value)
+        ? value.toString()
+        : value.toFixed(4);
+      break;
+    case "object":
+      valueString = JSON.stringify(value, null, 2);
+      break;
+    default:
+      valueString = value.toString();
+  }
+  return valueString;
+};

--- a/static/js/components/candidate/getAnnotationValueString.test.ts
+++ b/static/js/components/candidate/getAnnotationValueString.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "bun:test";
+
+import { getAnnotationValueString } from "./annotationValue";
+
+describe("getAnnotationValueString", () => {
+  it("keeps integers as integers (e.g. survey source ids)", () => {
+    expect(getAnnotationValueString(12345)).toBe("12345");
+    expect(getAnnotationValueString(-7)).toBe("-7");
+    expect(getAnnotationValueString(0)).toBe("0");
+  });
+
+  it("rounds non-integer numbers to 4 decimals", () => {
+    expect(getAnnotationValueString(1.23456789)).toBe("1.2346");
+    expect(getAnnotationValueString(0.5)).toBe("0.5000");
+  });
+
+  it("passes strings through unchanged", () => {
+    expect(getAnnotationValueString("ZTF21abc")).toBe("ZTF21abc");
+  });
+
+  it("JSON-stringifies objects", () => {
+    expect(getAnnotationValueString({ a: 1 })).toBe(
+      JSON.stringify({ a: 1 }, null, 2),
+    );
+  });
+});


### PR DESCRIPTION
This PR display annotation integers as integers (previously rendered as floats).

Closes https://github.com/skyportal/skyportal/issues/3487