### PR TITLE
fix: cannot find group X after group deletion

### DIFF
--- a/static/js/components/group/Group.tsx
+++ b/static/js/components/group/Group.tsx
@@ -32,6 +32,7 @@ const Group = () => {
   const navigate = useNavigate();
 
   const [groupLoadError, setGroupLoadError] = useState("");
+  const [isDeleting, setIsDeleting] = useState(false);
 
   const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
   const [tab, setTab] = useState(0);
@@ -43,7 +44,7 @@ const Group = () => {
   const { id } = useParams();
 
   const { data: group, error: groupError } = useGetGroupQuery(id as string, {
-    skip: !id,
+    skip: !id || isDeleting,
   });
   const { data: currentUser } = useGetProfileQuery();
   const { error: streamsError } = useGetStreamsQuery();
@@ -64,10 +65,12 @@ const Group = () => {
 
   const handleDeleteGroup = async () => {
     try {
+      setIsDeleting(true);
       await deleteGroup(group?.["id"] as number).unwrap();
       setConfirmDeleteOpen(false);
       navigate("/groups");
     } catch {
+      setIsDeleting(false);
       // error notification handled by the API layer
     }
   };


### PR DESCRIPTION
The goal of the PR is to fix the error "Cannot fing Group with id XXX" after a group deletion by adding a flag in the frontend.