### PR TITLE
Show associated objs and previous mag in scanning reports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -205,5 +205,10 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 "skyportal/facility_apis/__init__.py" = ['I']
 
+[tool.ruff.lint.isort]
+# Without this, isort's first-party detection depends on whether the
+# baselayer submodule is checked out, making import order CI-dependent.
+known-first-party = ["baselayer"]
+
 [tool.pytest.ini_options]
 addopts = "--import-mode=importlib"

--- a/skyportal/handlers/api/candidate/scan_report_item.py
+++ b/skyportal/handlers/api/candidate/scan_report_item.py
@@ -1,11 +1,11 @@
 from collections import defaultdict
 
 import astropy.units as u
+import sqlalchemy as sa
 from astropy.time import Time
-from sqlalchemy.orm import joinedload, selectinload
-
 from baselayer.app.access import auth_or_token
 from baselayer.log import make_log
+from sqlalchemy.orm import aliased, joinedload, selectinload
 
 from ....models import (
     Allocation,
@@ -14,10 +14,13 @@ from ....models import (
     Comment,
     FollowupRequest,
     Obj,
+    ObjToSuperObj,
     ObservingRun,
+    Photometry,
     Source,
     SourcesConfirmedInGCN,
 )
+from ....models.phot_stat import PHOT_DETECTION_THRESHOLD
 from ....models.scan_report.scan_report_item import ScanReportItem
 from ....utils.gcn_crossmatch import ANNOTATION_ORIGIN as GCN_CROSSMATCH_ORIGIN
 from ....utils.parse import safe_round
@@ -31,16 +34,16 @@ log = make_log("api/scan_report_item")
 DESI_ORIGIN_PREFIX = "desi_"
 
 
-def _survey_of(bandpass):
-    """Map a bandpass name to its survey label for the detections summary."""
-    if not bandpass:
+def _survey_of(band):
+    """Map a band name to its survey label for the detections summary."""
+    if not band:
         return None
-    b = bandpass.lower()
+    b = band.lower()
     if b.startswith("ztf"):
         return "ZTF"
     if b.startswith("lsst"):
         return "LSST"
-    return bandpass
+    return band
 
 
 def _followup_request_type(allocation, instrument, payload=None):
@@ -91,17 +94,21 @@ def _build_scan_report_item(
     now_mjd,
     gcn_match=None,
     desi_annotation=None,
+    associated_objs=None,
+    previous=None,
 ):
     """Build a report item from data already fetched for this obj (no queries)."""
     if obj.photstats:
         current_filter = obj.photstats[0].last_detected_filter
         current_mag = obj.photstats[0].last_detected_mag
+        current_mjd = obj.photstats[0].last_detected_mjd
         current_age = now_mjd - obj.photstats[0].first_detected_mjd
         dm = obj.dm
         abs_mag = current_mag - dm if dm else None
     else:
         current_filter = None
         current_mag = None
+        current_mjd = None
         current_age = None
         abs_mag = None
 
@@ -174,12 +181,13 @@ def _build_scan_report_item(
     if obj.photstats:
         ps = obj.photstats[0]
 
-        def _entry(mjd, mag, fp=None):
+        def _entry(mjd, mag, filt, fp=None):
             if mjd is None:
                 return None
             entry = {
                 "mag": safe_round(mag, 3),
                 "mjd": safe_round(mjd, 5),
+                "filter": filt,
                 "days_ago": safe_round(now_mjd - mjd, 2),
             }
             if fp is not None:
@@ -195,7 +203,10 @@ def _build_scan_report_item(
             or ps.first_detected_no_forced_phot_mjd > ps.first_detected_mjd
         )
         first_entry = _entry(
-            ps.first_detected_mjd, ps.first_detected_mag, fp=is_first_fp
+            ps.first_detected_mjd,
+            ps.first_detected_mag,
+            ps.first_detected_filter,
+            fp=is_first_fp,
         )
         first_survey = _survey_of(ps.first_detected_filter)
 
@@ -207,19 +218,25 @@ def _build_scan_report_item(
             first_real_entry = _entry(
                 ps.first_detected_no_forced_phot_mjd,
                 ps.first_detected_no_forced_phot_mag,
+                ps.first_detected_no_forced_phot_filter,
                 fp=False,
             )
             first_real_survey = _survey_of(ps.first_detected_no_forced_phot_filter)
 
-        peak_by_survey = {}  # survey -> (mag, mjd), brightest (min mag) across filters
+        # survey -> (mag, mjd, filter), brightest (min mag) across the survey's filters
+        peak_by_survey = {}
         peak_mjd_per_filter = ps.peak_mjd_per_filter or {}
-        for bandpass, mag in (ps.peak_mag_per_filter or {}).items():
+        for band, mag in (ps.peak_mag_per_filter or {}).items():
             if mag is None:
                 continue
-            survey = _survey_of(bandpass)
+            survey = _survey_of(band)
             current = peak_by_survey.get(survey)
             if current is None or mag < current[0]:
-                peak_by_survey[survey] = (mag, peak_mjd_per_filter.get(bandpass))
+                peak_by_survey[survey] = (
+                    mag,
+                    peak_mjd_per_filter.get(band),
+                    band,
+                )
 
         surveys = (
             set(peak_by_survey)
@@ -233,7 +250,7 @@ def _build_scan_report_item(
                 "first_real": (
                     first_real_entry if survey == first_real_survey else None
                 ),
-                "peak": _entry(peak[1], peak[0]) if peak else None,
+                "peak": _entry(peak[1], peak[0], peak[2]) if peak else None,
             }
     detections_by_survey = detections_by_survey or None
 
@@ -244,7 +261,9 @@ def _build_scan_report_item(
         scan_report=report,
         data={
             "tns_name": obj.tns_name,
-            "aliases": obj.alias,
+            # Other Objs (e.g. an LSST detection) linked to this one via a shared
+            # SuperObj, each with its own aliases, if any.
+            "associated_objs": associated_objs,
             "comment": comment.text if comment else None,
             "host_redshift": obj.redshift,
             # Spectroscopic redshift from a DESI crossmatch, when one exists.
@@ -259,7 +278,12 @@ def _build_scan_report_item(
             "current_filter": current_filter,
             "abs_mag": safe_round(abs_mag, 3),
             "current_mag": safe_round(current_mag, 3),
+            "current_mjd": safe_round(current_mjd, 5),
             "current_age": safe_round(current_age, 2),
+            # The detection immediately before the current one, in the same filter.
+            "previous_mag": safe_round((previous or {}).get("mag"), 3),
+            "previous_mjd": safe_round((previous or {}).get("mjd"), 5),
+            "previous_filter": (previous or {}).get("filter"),
             "classifications": classifications,
             "saved_info": saved_info,
             "followups": followups,
@@ -347,6 +371,8 @@ async def create_scan_report_items(
     assignments_by_obj = defaultdict(list)
     comment_by_obj = {}  # obj_id -> most recent non-bot scanner comment
     desi_by_obj = {}  # obj_id -> most recent DESI crossmatch Annotation
+    associated_by_obj = defaultdict(dict)  # obj_id -> {assoc_obj_id: aliases}
+    previous_by_obj = {}  # obj_id -> {mag, mjd, filter} of the detection before the last
 
     # Fetch in chunks of objects: a single ``obj_id IN (...)`` over a long report
     # window (thousands of objects) pushes the planner off the obj_id index onto a
@@ -368,6 +394,43 @@ async def create_scan_report_items(
             )
         ).all():
             objs[obj.id] = obj
+
+        # The detection immediately before each obj's current (last-detected) one,
+        # in that same filter. PhotStat only tracks first/last/peak, not the
+        # runner-up, so this needs raw Photometry -- ranked via a window function
+        # and filtered to rn == 2 in SQL so only that one row per (obj, filter)
+        # pair is ever pulled back, not the object's full photometry history.
+        pairs = [
+            (obj_id, objs[obj_id].photstats[0].last_detected_filter)
+            for obj_id in chunk_obj_ids
+            if objs.get(obj_id)
+            and objs[obj_id].photstats
+            and objs[obj_id].photstats[0].last_detected_filter
+        ]
+        if pairs:
+            ranked = (
+                Photometry.select(user_or_token, mode="read")
+                .where(
+                    sa.tuple_(Photometry.obj_id, Photometry.filter).in_(pairs),
+                    Photometry.snr > PHOT_DETECTION_THRESHOLD,
+                )
+                .add_columns(
+                    Photometry.mag.label("mag"),
+                    sa.func.row_number()
+                    .over(
+                        partition_by=Photometry.obj_id,
+                        order_by=Photometry.mjd.desc(),
+                    )
+                    .label("rn"),
+                )
+                .subquery()
+            )
+            for obj_id, filt, mjd, mag in await session.execute(
+                sa.select(
+                    ranked.c.obj_id, ranked.c.filter, ranked.c.mjd, ranked.c.mag
+                ).where(ranked.c.rn == 2)
+            ):
+                previous_by_obj[obj_id] = {"mag": mag, "mjd": mjd, "filter": filt}
 
         for source in (
             await session.scalars(
@@ -436,6 +499,25 @@ async def create_scan_report_items(
         ).all():
             desi_by_obj.setdefault(annotation.obj_id, annotation)
 
+        # Objs sharing a SuperObj with one of this chunk's objs (e.g. the LSST
+        # detection linked to a ZTF one), via a self-join on the link table.
+        # Joined against the access-controlled Obj select so an associated obj
+        # the user can't read is silently dropped, not leaked.
+        accessible_objs = Obj.select(user_or_token, mode="read").subquery()
+        o2s_this = aliased(ObjToSuperObj)
+        o2s_other = aliased(ObjToSuperObj)
+        for obj_id, assoc_obj_id, assoc_alias in await session.execute(
+            sa.select(o2s_this.obj_id, accessible_objs.c.id, accessible_objs.c.alias)
+            .select_from(o2s_this)
+            .join(o2s_other, o2s_other.super_obj_id == o2s_this.super_obj_id)
+            .join(accessible_objs, accessible_objs.c.id == o2s_other.obj_id)
+            .where(
+                o2s_this.obj_id.in_(chunk_obj_ids),
+                o2s_other.obj_id != o2s_this.obj_id,
+            )
+        ):
+            associated_by_obj[obj_id][assoc_obj_id] = assoc_alias
+
     now_mjd = Time.now().mjd
     items = []
     for obj_id, _source_ids in valid:
@@ -453,6 +535,14 @@ async def create_scan_report_items(
                 now_mjd,
                 gcn_match=gcn_match_by_obj.get(obj_id),
                 desi_annotation=desi_by_obj.get(obj_id),
+                previous=previous_by_obj.get(obj_id),
+                associated_objs=[
+                    {"obj_id": assoc_obj_id, "aliases": aliases}
+                    for assoc_obj_id, aliases in associated_by_obj.get(
+                        obj_id, {}
+                    ).items()
+                ]
+                or None,
             )
         )
     return items

--- a/skyportal/handlers/api/candidate/scan_report_item.py
+++ b/skyportal/handlers/api/candidate/scan_report_item.py
@@ -3,9 +3,10 @@ from collections import defaultdict
 import astropy.units as u
 import sqlalchemy as sa
 from astropy.time import Time
+from sqlalchemy.orm import aliased, joinedload, selectinload
+
 from baselayer.app.access import auth_or_token
 from baselayer.log import make_log
-from sqlalchemy.orm import aliased, joinedload, selectinload
 
 from ....models import (
     Allocation,

--- a/skyportal/tests/api_tests/sources_candidates/test_scan_reports.py
+++ b/skyportal/tests/api_tests/sources_candidates/test_scan_reports.py
@@ -282,7 +282,7 @@ def test_scan_report_item_includes_previous_mag(
         fluxerr=1.0,
         groups=[public_group],
     )
-    PhotometryFactory(
+    current_point = PhotometryFactory(
         obj_id=obj.id,
         filter="ztfg",
         mjd=60600.0,
@@ -290,6 +290,16 @@ def test_scan_report_item_includes_previous_mag(
         fluxerr=1.0,
         groups=[public_group],
     )
+    DBSession.commit()
+
+    # PhotStat's incremental after_insert hook isn't guaranteed to process two
+    # same-flush inserts in mjd order, so set "last detected" explicitly rather
+    # than depend on it -- this test is about the report's previous-mag query
+    # against real Photometry rows, not about PhotStat's own update ordering.
+    photstat = DBSession().scalar(sa.select(PhotStat).where(PhotStat.obj_id == obj.id))
+    photstat.last_detected_mjd = current_point.mjd
+    photstat.last_detected_mag = current_point.mag
+    photstat.last_detected_filter = current_point.filter
     DBSession.commit()
 
     window = {

--- a/skyportal/tests/api_tests/sources_candidates/test_scan_reports.py
+++ b/skyportal/tests/api_tests/sources_candidates/test_scan_reports.py
@@ -3,9 +3,16 @@ from datetime import timedelta
 import pytest
 import sqlalchemy as sa
 
-from skyportal.models import Candidate, DBSession, PhotStat, ScanReport, Source
+from skyportal.models import (
+    Candidate,
+    DBSession,
+    PhotStat,
+    ScanReport,
+    Source,
+    SuperObj,
+)
 from skyportal.tests import api
-from skyportal.tests.fixtures import CommentFactory, ObjFactory
+from skyportal.tests.fixtures import CommentFactory, ObjFactory, PhotometryFactory
 from skyportal.utils.naive_datetime import utcnow_naive
 
 
@@ -166,14 +173,161 @@ def test_scan_report_item_includes_followup_and_assignment(
     assert assignment["status"] is not None
     assert assignment["requester"] == user.username
 
-    # First/peak detection per survey (mag, time, days-ago), from PhotStat.
+    # First/peak detection per survey (mag, mjd, filter, days-ago), from PhotStat.
     detections = item["data"]["detections_by_survey"]
     assert detections is not None
     survey_detections = detections["ZTF"]
     assert survey_detections["first"]["mag"] == 18.9
+    assert survey_detections["first"]["filter"] == "ztfg"
     assert survey_detections["peak"]["mag"] == 16.4
+    assert survey_detections["peak"]["filter"] == "ztfr"
     assert survey_detections["first"]["days_ago"] > 0
     assert survey_detections["peak"]["days_ago"] > 0
+
+
+def test_scan_report_item_includes_associated_objs(
+    public_filter,
+    public_group,
+    user,
+    upload_data_token,
+    cleanup_reports,
+):
+    now = utcnow_naive()
+
+    obj = ObjFactory(groups=[public_group])
+    # Another survey's detection of the same physical object (e.g. LSST), with
+    # its own alias, linked via a SuperObj -- distinct from `obj`'s own alias.
+    assoc_obj = ObjFactory(groups=[public_group], alias=["LSST_123"])
+    DBSession.add(SuperObj(objs=[obj, assoc_obj]))
+    DBSession.add(
+        Candidate(obj=obj, filter=public_filter, passed_at=now, uploader_id=user.id)
+    )
+    DBSession.add(
+        Source(
+            obj_id=obj.id,
+            group_id=public_group.id,
+            saved_by_id=user.id,
+            saved_at=now,
+        )
+    )
+    DBSession.commit()
+
+    window = {
+        "start_date": (now - timedelta(days=1)).isoformat(),
+        "end_date": (now + timedelta(days=1)).isoformat(),
+    }
+    status, data = api(
+        "POST",
+        "candidates/scan_reports",
+        data={
+            "group_ids": [public_group.id],
+            "passed_filters_range": window,
+            "saved_candidates_range": {
+                "start_saved_date": (now - timedelta(days=1)).isoformat(),
+                "end_saved_date": (now + timedelta(days=1)).isoformat(),
+            },
+        },
+        token=upload_data_token,
+    )
+    assert status == 200, data
+
+    status, data = api("GET", "candidates/scan_reports", token=upload_data_token)
+    assert status == 200, data
+    report_id = data["data"]["reports"][0]["id"]
+    cleanup_reports.append(report_id)
+
+    status, data = api(
+        "GET", f"candidates/scan_reports/{report_id}/items", token=upload_data_token
+    )
+    assert status == 200, data
+    item = next(item for item in data["data"] if item["obj_id"] == obj.id)
+
+    associated_objs = item["data"]["associated_objs"]
+    assert associated_objs is not None
+    assoc = next(a for a in associated_objs if a["obj_id"] == assoc_obj.id)
+    assert assoc["aliases"] == ["LSST_123"]
+
+
+def test_scan_report_item_includes_previous_mag(
+    public_filter,
+    public_group,
+    user,
+    upload_data_token,
+    cleanup_reports,
+):
+    now = utcnow_naive()
+
+    obj = ObjFactory(groups=[public_group])
+    DBSession.add(
+        Candidate(obj=obj, filter=public_filter, passed_at=now, uploader_id=user.id)
+    )
+    DBSession.add(
+        Source(
+            obj_id=obj.id,
+            group_id=public_group.id,
+            saved_by_id=user.id,
+            saved_at=now,
+        )
+    )
+    DBSession.commit()
+
+    # Two clear detections in the same filter, well past ObjFactory's own random
+    # points (mjd ~58000), so these are unambiguously the last two in that filter:
+    # the older one is what "previous mag" should report.
+    PhotometryFactory(
+        obj_id=obj.id,
+        filter="ztfg",
+        mjd=60500.0,
+        flux=1000.0,
+        fluxerr=1.0,
+        groups=[public_group],
+    )
+    PhotometryFactory(
+        obj_id=obj.id,
+        filter="ztfg",
+        mjd=60600.0,
+        flux=2000.0,
+        fluxerr=1.0,
+        groups=[public_group],
+    )
+    DBSession.commit()
+
+    window = {
+        "start_date": (now - timedelta(days=1)).isoformat(),
+        "end_date": (now + timedelta(days=1)).isoformat(),
+    }
+    status, data = api(
+        "POST",
+        "candidates/scan_reports",
+        data={
+            "group_ids": [public_group.id],
+            "passed_filters_range": window,
+            "saved_candidates_range": {
+                "start_saved_date": (now - timedelta(days=1)).isoformat(),
+                "end_saved_date": (now + timedelta(days=1)).isoformat(),
+            },
+        },
+        token=upload_data_token,
+    )
+    assert status == 200, data
+
+    status, data = api("GET", "candidates/scan_reports", token=upload_data_token)
+    assert status == 200, data
+    report_id = data["data"]["reports"][0]["id"]
+    cleanup_reports.append(report_id)
+
+    status, data = api(
+        "GET", f"candidates/scan_reports/{report_id}/items", token=upload_data_token
+    )
+    assert status == 200, data
+    item = next(item for item in data["data"] if item["obj_id"] == obj.id)
+
+    assert item["data"]["current_mjd"] == 60600.0
+    assert item["data"]["current_filter"] == "ztfg"
+    assert item["data"]["previous_mjd"] == 60500.0
+    assert item["data"]["previous_filter"] == "ztfg"
+    assert item["data"]["previous_mag"] is not None
+    assert item["data"]["previous_mag"] != item["data"]["current_mag"]
 
 
 def test_scan_report_rolling_window(

--- a/static/js/components/candidate/scan_reports/ReportItems.tsx
+++ b/static/js/components/candidate/scan_reports/ReportItems.tsx
@@ -105,6 +105,7 @@ const ReportItem = ({ reportId, isMultiGroup }: ReportItemProps) => {
               <FieldTitle sx={{ flex: 1 }}>sep (\u2032)</FieldTitle>
             )}
             {hasGcnMatch && <FieldTitle>in GCN?</FieldTitle>}
+            <FieldTitle sx={{ flex: 1 }}>previous mag</FieldTitle>
             <FieldTitle sx={{ flex: 1 }}>current mag</FieldTitle>
             <FieldTitle sx={{ flex: 1 }}>absolute mag</FieldTitle>
             <FieldTitle sx={{ flex: 0, minWidth: "auto", borderRight: "none" }}>
@@ -176,8 +177,18 @@ const ReportItem = ({ reportId, isMultiGroup }: ReportItemProps) => {
                   )}
                 </Field>
                 <Field>
-                  {reportItem.data.aliases?.map((alias: string) => (
-                    <div key={alias}>{alias}</div>
+                  {reportItem.data.associated_objs?.map((assoc: any) => (
+                    <div key={assoc.obj_id}>
+                      <Link
+                        to={`/source/${assoc.obj_id}`}
+                        role="link"
+                        target="_blank"
+                      >
+                        {assoc.obj_id}
+                      </Link>
+                      {assoc.aliases?.length > 0 &&
+                        ` (${assoc.aliases.join(", ")})`}
+                    </div>
                   ))}
                 </Field>
                 <Field>{reportItem.data.comment}</Field>
@@ -258,19 +269,19 @@ const ReportItem = ({ reportId, isMultiGroup }: ReportItemProps) => {
                         const parts = [];
                         if (det.first)
                           parts.push(
-                            `first ${det.first.mag} (${det.first.days_ago}d)${det.first.fp ? " [FP]" : ""}`,
+                            `first ${det.first.mag} ${det.first.filter} (${det.first.days_ago}d)${det.first.fp ? " [FP]" : ""}`,
                           );
                         if (det.first_real)
                           parts.push(
-                            `first real ${det.first_real.mag} (${det.first_real.days_ago}d)`,
+                            `first real ${det.first_real.mag} ${det.first_real.filter} (${det.first_real.days_ago}d)`,
                           );
                         if (det.peak)
                           parts.push(
-                            `peak ${det.peak.mag} (${det.peak.days_ago}d)`,
+                            `peak ${det.peak.mag} ${det.peak.filter} (${det.peak.days_ago}d)`,
                           );
                         if (det.last)
                           parts.push(
-                            `last ${det.last.mag} (${det.last.days_ago}d)`,
+                            `last ${det.last.mag} ${det.last.filter} (${det.last.days_ago}d)`,
                           );
                         return (
                           <Tooltip
@@ -322,7 +333,28 @@ const ReportItem = ({ reportId, isMultiGroup }: ReportItemProps) => {
                     )}
                   </Field>
                 )}
-                <Field sx={{ flex: 1 }}>{reportItem.data.current_mag}</Field>
+                <Field sx={{ flex: 1 }}>
+                  {reportItem.data.previous_mag != null && (
+                    <Tooltip
+                      title={`${reportItem.data.previous_filter ?? "?"} @ MJD ${
+                        reportItem.data.previous_mjd ?? "?"
+                      }`}
+                    >
+                      <span>{reportItem.data.previous_mag}</span>
+                    </Tooltip>
+                  )}
+                </Field>
+                <Field sx={{ flex: 1 }}>
+                  {reportItem.data.current_mag != null && (
+                    <Tooltip
+                      title={`${reportItem.data.current_filter ?? "?"} @ MJD ${
+                        reportItem.data.current_mjd ?? "?"
+                      }`}
+                    >
+                      <span>{reportItem.data.current_mag}</span>
+                    </Tooltip>
+                  )}
+                </Field>
                 <Field sx={{ flex: 1 }}>{reportItem.data.abs_mag}</Field>
                 <Field sx={{ flex: 0, minWidth: "auto", borderRight: "none" }}>
                   <IconButton


### PR DESCRIPTION
Additional column previous mag in scanning reports.
Adding band and mjd to detections.
Use associated objects instead of aliases to show matches with other surveys and not names given by users. If those associated objects have aliases, these will be shown.