### PR TITLE
Add walkthrough for filter builder

### DIFF
--- a/static/js/components/PageTourProvider.tsx
+++ b/static/js/components/PageTourProvider.tsx
@@ -38,19 +38,20 @@ const PageTourProvider = () => {
           (step) => !step.acl || permissions.includes(step.acl),
         ),
       );
-      navigate(location.pathname + location.search + location.hash, {
-        replace: true,
-        state: {},
-      });
     }
     // permissions is derived from the cached profile (stable ref); intentionally
     // not a dep — we filter with whatever ACLs are loaded when the tour launches.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [requested, location.pathname, location.search, location.hash, navigate]);
+  }, [requested]);
 
   // Start once per newly-selected step-set, but only after the destination
-  // page (lazy-loaded behind Suspense) has actually mounted the first target —
-  // otherwise the tour starts against an empty DOM and silently gives up.
+  // page (lazy-loaded behind Suspense, and possibly gated behind its own data
+  // fetches) has actually mounted the first target — otherwise the tour
+  // starts against an empty DOM and silently gives up. The trigger is only
+  // cleared once we know the outcome (started or gave up); clearing it
+  // eagerly on mount would wipe location.state before a slow-mounting
+  // destination component gets a chance to read it itself (e.g. to open a
+  // panel the tour's target lives behind).
   const startedFor = useRef<Step[] | null>(null);
   useEffect(() => {
     if (!steps.length || startedFor.current === steps) {
@@ -63,6 +64,11 @@ const PageTourProvider = () => {
         : null;
     let cancelled = false;
     let tries = 0;
+    const clearTrigger = () =>
+      navigate(location.pathname + location.search + location.hash, {
+        replace: true,
+        state: {},
+      });
     const startWhenReady = () => {
       if (cancelled) {
         return;
@@ -70,15 +76,24 @@ const PageTourProvider = () => {
       if (!firstTarget || document.querySelector(firstTarget)) {
         startedFor.current = steps;
         controls.start(0);
+        clearTrigger();
       } else if (tries++ < 100) {
         // Poll ~every 100ms for up to ~10s while the page chunk loads.
         window.setTimeout(startWhenReady, 100);
+      } else {
+        // Target never appeared; drop the trigger so a refresh or
+        // back-navigation doesn't keep retrying.
+        clearTrigger();
       }
     };
     startWhenReady();
     return () => {
       cancelled = true;
     };
+    // location/navigate are read from the outer closure deliberately: we
+    // want the URL captured when this step-set started polling, not to
+    // restart polling if the user navigates again mid-poll.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [steps, controls]);
 
   return <>{Tour}</>;

--- a/static/js/components/PageTours.ts
+++ b/static/js/components/PageTours.ts
@@ -233,6 +233,62 @@ export const PAGE_TOURS: Record<string, TourStep[]> = {
         "feeds candidates into your scanning page.",
     },
   ],
+  // Runs on a filter page (the checklist links to the user's first filter).
+  // Ordered to match a new, never-saved filter's actual on-screen state:
+  // block-builder steps first (always present — a fresh filter starts with
+  // one block and one empty condition), version/validation last since that
+  // panel only appears once a version has been saved.
+  filter: [
+    {
+      target: '[data-testid="tour-filter-blocks"]',
+      title: "Blocks & conditions",
+      content:
+        "A filter is built from blocks of conditions. Every new filter " +
+        "starts with one block holding one empty condition to fill in.",
+    },
+    {
+      target: '[data-testid="tour-filter-operator"]',
+      title: "AND / OR logic",
+      content:
+        "Choose whether everything inside a block must match (And) or only " +
+        "one needs to (Or). Nest blocks to build more complex logic.",
+    },
+    {
+      target: '[data-testid="tour-filter-condition"]',
+      title: "Set a condition",
+      content:
+        "Pick a field, an operator, and a value (e.g. magnitude less than " +
+        "18) to define what an alert has to satisfy.",
+    },
+    {
+      target: '[data-testid="tour-filter-add"]',
+      title: "Add more",
+      content:
+        "Add another condition, a nested block, a computed variable, or a " +
+        "reusable custom block from here.",
+    },
+    {
+      target: '[data-testid="tour-filter-save"]',
+      title: "Save your version",
+      content:
+        "Save creates a new version of this filter. Nothing runs against " +
+        "live alerts until a version is activated.",
+    },
+    {
+      // Unanchored: the version/validate panel this describes only appears
+      // once a version is saved, so a brand-new filter has nothing there yet
+      // to highlight. A centered, target-less step avoids pointing at an
+      // empty area while still explaining what happens next.
+      target: "body",
+      placement: "center",
+      title: "Next: validate & activate",
+      content:
+        "Once you've saved a version, use the Boom filter details panel at " +
+        "the top of the page to switch between versions, validate one " +
+        "against a night of alerts, and activate it to start filtering " +
+        "candidates.",
+    },
+  ],
   // Runs on a GCN event page (the checklist links to the most recent event).
   gcnevents: [
     {

--- a/static/js/components/filter/boom/BoomFilterPlugins.tsx
+++ b/static/js/components/filter/boom/BoomFilterPlugins.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { useLocation } from "react-router-dom";
 import { makeStyles } from "tss-react/mui";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import Switch from "@mui/material/Switch";
@@ -255,7 +256,13 @@ const BoomFilterPlugins = (_props: BoomFilterPluginsProps) => {
   );
 
   // forms
-  const [inlineNewVersion, setInlineNewVersion] = React.useState(false);
+  const location = useLocation();
+  // Read once at mount, during render (before PageTourProvider's effect can
+  // clear location.state) so the "filter" page tour's targets are already
+  // mounted when it starts polling for them.
+  const [inlineNewVersion, setInlineNewVersion] = React.useState(
+    () => (location.state as any)?.tour === "filter",
+  );
   const [showAnnotationBuilder, setShowAnnotationBuilder] = useState(false);
 
   useEffect(() => {

--- a/static/js/components/filter/boom/FilterBuilderContent.tsx
+++ b/static/js/components/filter/boom/FilterBuilderContent.tsx
@@ -427,6 +427,7 @@ const FilterBuilderContent = ({
         </Typography>
         <Box sx={{ display: "flex", gap: 2 }}>
           <Button
+            data-testid="tour-filter-save"
             variant="contained"
             startIcon={<SaveIcon />}
             onClick={handleSaveFilter}
@@ -474,51 +475,53 @@ const FilterBuilderContent = ({
       </Box>
 
       {/* Filter Blocks */}
-      {schemaUnavailable ? (
-        <Alert severity="warning">
-          No filter schema is available for <strong>{resolvedSurvey}</strong>{" "}
-          from this broker, so there are no fields to build conditions with.
-          Filtering isn&apos;t supported for this survey yet.
-        </Alert>
-      ) : rawPipeline ? (
-        <>
-          <Alert severity="info" sx={{ mb: 2 }}>
-            This filter was imported as a raw MongoDB pipeline, so it can&apos;t
-            be edited in the block builder. It&apos;s shown read-only below;
-            edit it through the broker API.
+      <Box data-testid="tour-filter-blocks">
+        {schemaUnavailable ? (
+          <Alert severity="warning">
+            No filter schema is available for <strong>{resolvedSurvey}</strong>{" "}
+            from this broker, so there are no fields to build conditions with.
+            Filtering isn&apos;t supported for this survey yet.
           </Alert>
-          <PipelineViewer
-            pipeline={rawPipeline}
-            showPipeline={showPipeline}
-            setShowPipeline={setShowPipeline}
-            pipelineView={pipelineView}
-            setPipelineView={setPipelineView}
-            expandedStages={expandedStages}
-            handleStageToggle={handleStageToggle}
-            handleCopy={handleCopy}
-            handleCopyStage={handleCopyStage}
-          />
-        </>
-      ) : filtersToRender && filtersToRender.length > 0 ? (
-        filtersToRender.map((block: any, index: number) => {
-          return (
-            <BlockComponent
-              key={block.id || index}
-              block={block}
-              parentBlockId={null}
-              isRoot={index === 0}
-              fieldOptionsList={fieldOptions}
-              stickyBlockId={getMostNestedNonCollapsedBlock.blockId}
-              localFilters={filtersToRender}
-              setLocalFilters={handleFilterUpdate}
+        ) : rawPipeline ? (
+          <>
+            <Alert severity="info" sx={{ mb: 2 }}>
+              This filter was imported as a raw MongoDB pipeline, so it
+              can&apos;t be edited in the block builder. It&apos;s shown
+              read-only below; edit it through the broker API.
+            </Alert>
+            <PipelineViewer
+              pipeline={rawPipeline}
+              showPipeline={showPipeline}
+              setShowPipeline={setShowPipeline}
+              pipelineView={pipelineView}
+              setPipelineView={setPipelineView}
+              expandedStages={expandedStages}
+              handleStageToggle={handleStageToggle}
+              handleCopy={handleCopy}
+              handleCopyStage={handleCopyStage}
             />
-          );
-        })
-      ) : (
-        <Typography variant="body2" color="text.secondary">
-          No filter blocks to display. Add conditions to get started.
-        </Typography>
-      )}
+          </>
+        ) : filtersToRender && filtersToRender.length > 0 ? (
+          filtersToRender.map((block: any, index: number) => {
+            return (
+              <BlockComponent
+                key={block.id || index}
+                block={block}
+                parentBlockId={null}
+                isRoot={index === 0}
+                fieldOptionsList={fieldOptions}
+                stickyBlockId={getMostNestedNonCollapsedBlock.blockId}
+                localFilters={filtersToRender}
+                setLocalFilters={handleFilterUpdate}
+              />
+            );
+          })
+        ) : (
+          <Typography variant="body2" color="text.secondary">
+            No filter blocks to display. Add conditions to get started.
+          </Typography>
+        )}
+      </Box>
 
       {/* Dialogs */}
       <AddVariableDialog />

--- a/static/js/components/filter/boom/block/BlockHeader.tsx
+++ b/static/js/components/filter/boom/block/BlockHeader.tsx
@@ -503,7 +503,11 @@ const BlockHeader = ({
         {/* Controls (except Save) */}
         {isRootCustomBlock && isCollapsed ? null : (
           <>
-            <FormControl size="small" sx={{ minWidth: 80 }}>
+            <FormControl
+              size="small"
+              sx={{ minWidth: 80 }}
+              data-testid="tour-filter-operator"
+            >
               <Select
                 value={(block?.operator || block?.logic || "$and")
                   .replace("$", "")

--- a/static/js/components/filter/boom/block/CustomAddElement.tsx
+++ b/static/js/components/filter/boom/block/CustomAddElement.tsx
@@ -253,6 +253,7 @@ const CustomAddElement = ({
   return (
     <Box>
       <Button
+        data-testid="tour-filter-add"
         ref={setAddButtonRef}
         variant="contained"
         size="medium"

--- a/static/js/components/filter/boom/condition/ConditionComponent.tsx
+++ b/static/js/components/filter/boom/condition/ConditionComponent.tsx
@@ -405,6 +405,7 @@ const ConditionComponentInner = ({
   return (
     <Box
       key={conditionOrBlock.id}
+      data-testid="tour-filter-condition"
       sx={{
         ml: 2,
         pr: "140px",

--- a/static/js/components/widget/GettingStarted.tsx
+++ b/static/js/components/widget/GettingStarted.tsx
@@ -101,6 +101,8 @@ const GettingStarted = (_props: { classes?: Record<string, string> }) => {
   )?.id;
   // The GCN tour runs on an event page; use the most recent event.
   const firstGcnDateobs = (recentGcnEvents as any)?.[0]?.dateobs;
+  // The filter tour runs on a filter page; use the user's first filter.
+  const firstFilterId = ((filters as any[] | undefined) ?? [])[0]?.id;
 
   // `tour` names a PAGE_TOURS entry launched as a how-to on the destination.
   const checklist = [
@@ -124,6 +126,13 @@ const GettingStarted = (_props: { classes?: Record<string, string> }) => {
       to: "/groups",
       tour: "groups",
       help: "Open a group and add an alert filter to start collecting candidates.",
+    },
+    {
+      label: "Build filter logic",
+      explore: true,
+      to: firstFilterId ? `/filter/${firstFilterId}` : "/groups",
+      tour: firstFilterId ? "filter" : undefined,
+      help: "Combine conditions with AND/OR blocks to define which alerts pass your filter.",
     },
     {
       label: "Save your first source",


### PR DESCRIPTION
This pull request introduces a new interactive tour for the filter builder page, improves the reliability of tour triggers, and adds data attributes to key UI elements to support the new tour. The main changes are grouped as follows:

**New filter builder page tour:**

* Added a comprehensive "filter" tour to `PAGE_TOURS` in `PageTours.ts`, with steps covering blocks, AND/OR logic, conditions, adding elements, saving, and post-save actions.
* Updated the "Getting Started" checklist to include the new filter builder tour, linking users to their first filter for an interactive walkthrough. 

**Tour trigger logic and reliability improvements:**

* Refactored `PageTourProvider.tsx` to move the navigation state-clearing logic so that the tour trigger is only cleared after the tour actually starts or gives up, ensuring the tour runs reliably even if the destination page loads slowly. 
* Updated `BoomFilterPlugins.tsx` to detect the filter tour trigger from `location.state` at mount time, so the filter builder is ready before the tour starts polling for targets. 

**Data attributes for tour targeting:**

* Added `data-testid` attributes to key filter builder UI elements (`tour-filter-blocks`, `tour-filter-operator`, `tour-filter-condition`, `tour-filter-add`, `tour-filter-save`) to anchor tour steps accurately. 

**Minor UI and code improvements:**

* Improved formatting of the read-only pipeline alert in `FilterBuilderContent.tsx` for better readability.

These changes collectively make the filter builder more approachable for new users and ensure the tour system works reliably across navigation and slow-loading pages.