### PR TITLE
Drop unrecognized filter rows in ATLAS forced photometry ingestion

### DIFF
--- a/skyportal/facility_apis/atlas.py
+++ b/skyportal/facility_apis/atlas.py
@@ -175,6 +175,19 @@ def commit_photometry(
         cyan = df["filter"] == "c"
         orange = df["filter"] == "o"
 
+        # ATLAS forced photometry should only report "c" or "o"; drop any
+        # other rows instead of failing the whole batch on ingestion
+        known = cyan | orange
+        if not known.all():
+            log(
+                f"Discarding {(~known).sum()} ATLAS forced-photometry row(s) "
+                f"for request {request_id} with unrecognized filter(s) "
+                f"{sorted(df.loc[~known, 'filter'].unique().tolist())}"
+            )
+            df = df[known]
+            cyan = cyan[known]
+            orange = orange[known]
+
         # not detection if SNR < 3 or chi/N > 10, or mag > limiting_mag
         reject = df["uJy"] / df["duJy"] < 3
         reject |= df["chi/N"] > 10


### PR DESCRIPTION
ATLAS FP results should only contain filter codes "c"/"o", but a stray value (e.g. "t") in the response was passed through unmapped and made the whole photometry commit fail validation. Drop such rows and log them instead of aborting the entire batch.

This was made assuming we don't want to keep filter code 't', maybe we do?