### PR TITLE
Add one-time feature announcement popups.

### DIFF
--- a/skyportal/tests/test_getting_started_tour.py
+++ b/skyportal/tests/test_getting_started_tour.py
@@ -1,12 +1,7 @@
-"""Staleness guard for the Getting Started tours.
+"""Staleness guard for the tours and feature announcements.
 
-The Home Page tour (``static/js/components/widget/GettingStartedTour.ts``) and
-the per-page how-to tours (``static/js/components/PageTours.ts``) each point a
-step at an element by ``data-testid``. If a targeted element is renamed or
-removed the tour silently breaks, so this test parses every tour's
-``data-testid`` targets and asserts each one still exists as a ``data-testid``
-attribute somewhere else in ``static/js``. Pure static check — no server or
-browser needed.
+A tour silently breaks when a targeted element is renamed or removed, so assert
+every ``data-testid`` target still exists somewhere in ``static/js``.
 """
 
 import re
@@ -17,10 +12,13 @@ STATIC_JS = REPO_ROOT / "static" / "js"
 TOUR_FILES = [
     STATIC_JS / "components" / "widget" / "GettingStartedTour.ts",
     STATIC_JS / "components" / "PageTours.ts",
+    STATIC_JS / "components" / "FeatureAnnouncements.ts",
 ]
 
 _TARGET_RE = re.compile(r'\[data-testid="([^"]+)"\]')
 _ATTR_RE = re.compile(r'data-testid="([^"]+)"')
+# Some components take the id as a prop and render it as data-testid.
+_PROP_RE = re.compile(r'testId:\s*"([^"]+)"')
 _SRC_SUFFIXES = {".tsx", ".ts", ".jsx", ".js", ".template"}
 
 
@@ -32,14 +30,15 @@ def _tour_target_testids():
 
 
 def _testids_used_in_static_js():
-    """Every data-testid attribute used in static/js, excluding the tour configs
-    themselves (whose target selectors would otherwise satisfy the check
-    trivially)."""
+    """Every data-testid used in static/js, minus the tour configs themselves
+    (whose selectors would satisfy the check trivially)."""
     used = set()
     for path in STATIC_JS.rglob("*"):
         if path.suffix not in _SRC_SUFFIXES or path in TOUR_FILES:
             continue
-        used.update(_ATTR_RE.findall(path.read_text(errors="ignore")))
+        text = path.read_text(errors="ignore")
+        used.update(_ATTR_RE.findall(text))
+        used.update(_PROP_RE.findall(text))
     return used
 
 

--- a/static/js/components/FeatureAnnouncementProvider.tsx
+++ b/static/js/components/FeatureAnnouncementProvider.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useRef, useState } from "react";
+import { useLocation } from "react-router-dom";
+import { EVENTS, useJoyride } from "react-joyride";
+import type { Step } from "react-joyride";
+
+import { FEATURE_ANNOUNCEMENTS } from "./FeatureAnnouncements";
+import { useTourStyles } from "./tourStyles";
+import {
+  useGetProfileQuery,
+  useUpdateUserPreferencesMutation,
+} from "../ducks/profile";
+
+const SEEN_PREF = "featureAnnouncementsSeen";
+
+// App-level provider, mounted once inside the router: it runs the first
+// announcement this user hasn't seen yet on the page they just opened.
+const FeatureAnnouncementProvider = () => {
+  const location = useLocation();
+  const { data: profile } = useGetProfileQuery();
+  const [updatePreferences] = useUpdateUserPreferencesMutation();
+  const [steps, setSteps] = useState<Step[]>([]);
+  const announcementID = useRef<string | null>(null);
+  const { options, styles } = useTourStyles();
+  const { controls, on, Tour } = useJoyride({
+    steps,
+    continuous: true,
+    scrollToFirstStep: true,
+    // A single "what's new" step: no progress counter, just an acknowledgement.
+    options: { ...options, showProgress: false },
+    styles,
+    locale: { last: "Got it", close: "Got it" },
+  });
+
+  useEffect(() => {
+    if (!profile || profile.is_anonymous || announcementID.current) {
+      return;
+    }
+    const permissions: string[] = profile.permissions ?? [];
+    const seen = profile.preferences?.[SEEN_PREF] ?? {};
+    const createdAt = profile.created_at ? new Date(profile.created_at) : null;
+    const pending = FEATURE_ANNOUNCEMENTS.find(
+      (announcement) =>
+        !seen[announcement.id] &&
+        announcement.path.test(location.pathname) &&
+        (!createdAt || createdAt < new Date(announcement.announcedAt)),
+    );
+    if (!pending) {
+      return;
+    }
+    const applicable = pending.steps.filter(
+      (step) => !step.acl || permissions.includes(step.acl),
+    );
+    if (!applicable.length) {
+      return;
+    }
+    announcementID.current = pending.id;
+    setSteps(applicable);
+  }, [profile, location.pathname]);
+
+  // Start only once the target has actually mounted, otherwise the tour runs
+  // against an empty DOM and silently gives up.
+  const startedFor = useRef<Step[] | null>(null);
+  useEffect(() => {
+    if (!steps.length || startedFor.current === steps) {
+      return;
+    }
+    const firstTarget = steps[0]?.target;
+    const target = typeof firstTarget === "string" ? firstTarget : null;
+    let cancelled = false;
+    let tries = 0;
+    const startWhenReady = () => {
+      if (cancelled) {
+        return;
+      }
+      if (!target || document.querySelector(target)) {
+        startedFor.current = steps;
+        controls.start(0);
+      } else if (tries++ < 100) {
+        window.setTimeout(startWhenReady, 100);
+      }
+    };
+    startWhenReady();
+    return () => {
+      cancelled = true;
+    };
+  }, [steps, controls]);
+
+  useEffect(
+    () =>
+      on(EVENTS.TOUR_END, () => {
+        if (announcementID.current) {
+          updatePreferences({
+            [SEEN_PREF]: { [announcementID.current]: true },
+          });
+        }
+      }),
+    [on, updatePreferences],
+  );
+
+  return <>{Tour}</>;
+};
+
+export default FeatureAnnouncementProvider;

--- a/static/js/components/FeatureAnnouncements.ts
+++ b/static/js/components/FeatureAnnouncements.ts
@@ -1,0 +1,14 @@
+import type { TourStep } from "./PageTours";
+
+// One-time "what's new" popups. Each entry runs once per user, on the first
+// matching page they open, then is marked seen in their preferences.
+// Only display if the user is older than the announcedAt date.
+export interface FeatureAnnouncement {
+  // Stable key stored in preferences.featureAnnouncementsSeen; never reuse one.
+  id: string;
+  path: RegExp;
+  announcedAt: string;
+  steps: TourStep[];
+}
+
+export const FEATURE_ANNOUNCEMENTS: FeatureAnnouncement[] = [];

--- a/static/js/components/PageTourProvider.tsx
+++ b/static/js/components/PageTourProvider.tsx
@@ -4,32 +4,29 @@ import { useJoyride } from "react-joyride";
 import type { Step } from "react-joyride";
 
 import { PAGE_TOURS } from "./PageTours";
+import { useTourStyles } from "./tourStyles";
 import { useGetProfileQuery } from "../ducks/profile";
 
-// App-level provider, mounted once inside the router so it survives navigation
-// and can target the destination page. A Getting Started checklist item
-// navigates with { state: { tour: <key> } }; we look up PAGE_TOURS[key], run it,
-// then clear the trigger so a refresh or back-navigation won't replay it.
+// Runs the tour requested by a navigation's { state: { tour: <key> } }, then
+// clears the trigger so a refresh or back-navigation won't replay it.
 const PageTourProvider = () => {
   const location = useLocation();
   const navigate = useNavigate();
   const { data: profile } = useGetProfileQuery();
   const [steps, setSteps] = useState<Step[]>([]);
+  const { options, styles } = useTourStyles();
   const { controls, Tour } = useJoyride({
     steps,
     continuous: true,
     // Scroll each target into view, including the first step.
     scrollToFirstStep: true,
-    // Lift above the app's low sidebar/modal z-indexes, give lazy-loaded pages
-    // a little longer to mount a step's target, and show each tooltip directly
-    // instead of a click-to-open beacon.
-    options: { zIndex: 2000, targetWaitTimeout: 3000, skipBeacon: true },
+    options,
+    styles,
+    locale: { last: "Got it" },
   });
 
   const requested = (location.state as { tour?: string } | null)?.tour;
-  // Effective ACLs; steps tagged with an `acl` the user lacks are dropped so
-  // permission-gated features don't appear (and the tour doesn't stall on a
-  // target that isn't rendered for this user).
+  // Steps tagged with an `acl` the user lacks target elements that aren't rendered.
   const permissions: string[] = (profile as any)?.permissions ?? [];
   useEffect(() => {
     if (requested && PAGE_TOURS[requested]) {
@@ -39,19 +36,13 @@ const PageTourProvider = () => {
         ),
       );
     }
-    // permissions is derived from the cached profile (stable ref); intentionally
-    // not a dep — we filter with whatever ACLs are loaded when the tour launches.
+    // permissions intentionally not a dep: filter with the ACLs loaded at launch.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [requested]);
 
-  // Start once per newly-selected step-set, but only after the destination
-  // page (lazy-loaded behind Suspense, and possibly gated behind its own data
-  // fetches) has actually mounted the first target — otherwise the tour
-  // starts against an empty DOM and silently gives up. The trigger is only
-  // cleared once we know the outcome (started or gave up); clearing it
-  // eagerly on mount would wipe location.state before a slow-mounting
-  // destination component gets a chance to read it itself (e.g. to open a
-  // panel the tour's target lives behind).
+  // Wait for the lazy-loaded page to mount the first target, otherwise the tour
+  // runs against an empty DOM. The trigger is only cleared once we know the
+  // outcome, so a slow-mounting page can still read location.state itself.
   const startedFor = useRef<Step[] | null>(null);
   useEffect(() => {
     if (!steps.length || startedFor.current === steps) {
@@ -90,9 +81,7 @@ const PageTourProvider = () => {
     return () => {
       cancelled = true;
     };
-    // location/navigate are read from the outer closure deliberately: we
-    // want the URL captured when this step-set started polling, not to
-    // restart polling if the user navigates again mid-poll.
+    // location/navigate read from the closure: keep the URL captured at poll start.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [steps, controls]);
 

--- a/static/js/components/templates/Main.tsx.template
+++ b/static/js/components/templates/Main.tsx.template
@@ -32,6 +32,7 @@ import NoMatchingRoute from "../NoMatchingRoute";
 import SidebarAndHeader from "./SidebarAndHeader";
 import ErrorBoundary from "../ErrorBoundary";
 import PageTourProvider from "../PageTourProvider";
+import FeatureAnnouncementProvider from "../FeatureAnnouncementProvider";
 
 {% for route in app.routes -%}
 const {{ (route.component).split('/').pop() }} = React.lazy(() => import("../{{ route.component }}"));
@@ -105,6 +106,7 @@ const MainContentInternal = ({ root }: MainContentInternalProps) => {
       />
       <LocalizationProvider dateAdapter={AdapterDateFns}>
         <PageTourProvider />
+        <FeatureAnnouncementProvider />
         <SidebarAndHeader/>
         <div
           role="main"

--- a/static/js/components/tourStyles.ts
+++ b/static/js/components/tourStyles.ts
@@ -1,0 +1,74 @@
+import { alpha, useTheme } from "@mui/material/styles";
+import type { Options, PartialDeep, Styles } from "react-joyride";
+
+// Shared look for every Joyride tour (guided tours + feature announcements)
+export const useTourStyles = () => {
+  const theme = useTheme();
+  const dark = theme.palette.mode === "dark";
+
+  const options: Partial<Options> = {
+    // Lift above the app's low sidebar z-index (~140) and MUI modals.
+    zIndex: 2000,
+    skipBeacon: true,
+    targetWaitTimeout: 3000,
+    showProgress: true,
+    width: 380,
+    backgroundColor: theme.palette.background.paper,
+    arrowColor: theme.palette.background.paper,
+    textColor: theme.palette.text.primary,
+    primaryColor: theme.palette.primary.main,
+    overlayColor: alpha("#0b1220", dark ? 0.72 : 0.48),
+    spotlightPadding: 8,
+    spotlightRadius: 8,
+  };
+
+  const styles: PartialDeep<Styles> = {
+    tooltip: {
+      borderRadius: "0.75rem",
+      padding: "1.25rem",
+      border: `1px solid ${theme.palette.divider}`,
+      boxShadow: theme.shadows[8],
+      fontFamily: theme.typography.fontFamily,
+    },
+    tooltipContainer: { textAlign: "left" },
+    tooltipTitle: {
+      // Room for the close button.
+      paddingRight: "1.5rem",
+      fontSize: "1.05rem",
+      fontWeight: 600,
+      color: dark ? theme.palette.secondary.main : theme.palette.primary.main,
+    },
+    tooltipContent: {
+      padding: "0.5rem 0 0",
+      fontSize: "0.875rem",
+      lineHeight: 1.6,
+      color: theme.palette.text.secondary,
+    },
+    tooltipFooter: { marginTop: "1rem", gap: "0.5rem" },
+    buttonPrimary: {
+      borderRadius: "2rem",
+      padding: "0.4rem 1.1rem",
+      fontSize: "0.85rem",
+      fontWeight: 600,
+      color: theme.palette.primary.contrastText,
+      boxShadow: `0 0.125rem 0.5rem ${alpha(theme.palette.primary.main, 0.4)}`,
+    },
+    buttonBack: {
+      marginRight: 0,
+      fontSize: "0.85rem",
+      fontWeight: 500,
+      color: theme.palette.text.secondary,
+    },
+    buttonSkip: {
+      fontSize: "0.85rem",
+      color: theme.palette.text.secondary,
+    },
+    buttonClose: {
+      top: "0.75rem",
+      right: "0.75rem",
+      color: theme.palette.text.secondary,
+    },
+  };
+
+  return { options, styles };
+};

--- a/static/js/components/widget/GettingStarted.tsx
+++ b/static/js/components/widget/GettingStarted.tsx
@@ -29,12 +29,11 @@ import { useAppDispatch } from "../../types/hooks";
 import store from "../../store";
 import { setSidebar } from "../../ducks/sidebar";
 import { TOUR_STEPS } from "./GettingStartedTour";
+import { useTourStyles } from "../tourStyles";
 
-// Onboarding checklist + guided tour, rendered as a Home Page widget. Shows for
-// every user until dismissed (persisted in `preferences.onboardingDismissed`)
-// and can be reopened at any time. Each checklist step auto-detects completion
-// from the user's profile, groups, filters, saved sources, and preferences.
-// The `classes` prop is injected by the Home Page grid but unused here.
+// Onboarding checklist + guided tour, rendered as a Home Page widget until
+// dismissed (persisted in `preferences.onboardingDismissed`). Each step
+// auto-detects completion from the user's profile, groups, filters and sources.
 const GettingStarted = (_props: { classes?: Record<string, string> }) => {
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
@@ -48,15 +47,15 @@ const GettingStarted = (_props: { classes?: Record<string, string> }) => {
   });
   const { data: recentGcnEvents } = useGetRecentGcnEventsQuery();
   const [updatePreferences] = useUpdateUserPreferencesMutation();
+  const { options, styles } = useTourStyles();
   const { controls, on, Tour } = useJoyride({
     steps: TOUR_STEPS,
     continuous: true,
     // Scroll each target into view, including the first step.
     scrollToFirstStep: true,
-    // App sets a low sidebar z-index (~140); lift the tour above it and MUI
-    // modals so tooltips aren't hidden behind the drawer. Show tooltips
-    // directly instead of a click-to-open beacon.
-    options: { zIndex: 2000, skipBeacon: true },
+    options,
+    styles,
+    locale: { last: "Got it" },
   });
 
   // Sidebar-targeted steps need the drawer mounted; on mobile it's a closed
@@ -184,9 +183,8 @@ const GettingStarted = (_props: { classes?: Record<string, string> }) => {
       tour: firstGcnDateobs ? "gcnevents" : undefined,
       help: "Localizations, counterpart searches, and observation plans for multi-messenger alerts.",
     },
-    // Facility-management tours: shown only to users with the relevant ACL.
-    // These launch a how-to tour rather than track a completion, so they show
-    // no checkbox (there's no per-user signal for who created a telescope/etc.).
+    // Facility-management tours: ACL-gated, and no checkbox since there's no
+    // per-user completion signal.
     {
       label: "Register a telescope",
       explore: true,


### PR DESCRIPTION
- Add feature announcement provider and styles for guided tours.
- FeatureAnnouncementProvider plays the first announcement a user hasn't seen, then records it in preferences.featureAnnouncementsSeen
- Extract the shared Joyride look into useTourStyles
- Clean up some comments.