### PR TITLE
Make tests reliable and faster

### DIFF
--- a/skyportal/app_server.py
+++ b/skyportal/app_server.py
@@ -4,6 +4,7 @@ import concurrent.futures
 import sentry_sdk
 import sqlalchemy as sa
 import tornado.web
+from astropy.utils.iers import conf as iers_conf
 from sentry_sdk.integrations.tornado import TornadoIntegration
 
 from baselayer.app.app_server import MainPageHandler
@@ -727,6 +728,10 @@ def make_app(cfg, baselayer_handlers, baselayer_settings, process=None, env=None
         print("  Your server is insecure. Please update the secret string ")
         print("  in the configuration file!")
         print("!" * 80)
+
+    if cfg.get("testing", False):
+        iers_conf.auto_download = False
+        iers_conf.iers_degraded_accuracy = "ignore"
 
     handlers = baselayer_handlers + skyportal_handlers
 

--- a/skyportal/tests/__init__.py
+++ b/skyportal/tests/__init__.py
@@ -122,6 +122,22 @@ def assert_api_fail(status, data, expected_status=None, expected_error_partial=N
             raise Exception(f"Expected status {expected_status}, got {status}")
 
 
+def retry_until(check, timeout=60, interval=1):
+    """Call `check` until it stops raising AssertionError, then return its result.
+
+    Polls on a short interval instead of sleeping a fixed amount, so a test only
+    waits as long as the background work actually takes.
+    """
+    deadline = time.time() + timeout
+    while True:
+        try:
+            return check()
+        except AssertionError:
+            if time.time() >= deadline:
+                raise
+            time.sleep(interval)
+
+
 def wait_for_gcn_event(dateobs, token, timeout=120):
     """Poll until the GCN event for `dateobs` has finished processing.
 

--- a/skyportal/tests/api_tests/groups_users_analysis/test_analysis.py
+++ b/skyportal/tests/api_tests/groups_users_analysis/test_analysis.py
@@ -887,8 +887,9 @@ def test_delete_analysis_service_cascades_to_delete_associated_analysis(
         status, data = api("GET", f"obj/analysis/{analysis_id}", token=analysis_token)
         assert status == 200
         assert data["data"]["status"] != "queued"
+        return data["data"]["status"]
 
-    retry_until(analysis_done, timeout=100)
+    analysis_status = retry_until(analysis_done, timeout=100)
 
     # get the analysis associated with the
     # analysis service

--- a/skyportal/tests/api_tests/groups_users_analysis/test_analysis.py
+++ b/skyportal/tests/api_tests/groups_users_analysis/test_analysis.py
@@ -7,7 +7,7 @@ import uuid
 
 from tdtax import __version__, taxonomy
 
-from skyportal.tests import api
+from skyportal.tests import api, retry_until
 
 analysis_port = 6802
 
@@ -606,26 +606,21 @@ def test_run_analysis_with_correct_and_incorrect_token(
     analysis_id = data["data"].get("id")
     assert analysis_id is not None
 
-    max_attempts = 20
-    analysis_status = "queued"
     params = {"includeAnalysisData": True}
 
-    while max_attempts > 0:
-        if analysis_status != "queued":
-            break
+    def analysis_started():
         status, data = api(
             "GET", f"obj/analysis/{analysis_id}", token=analysis_token, params=params
         )
         assert status == 200
         assert data["data"]["analysis_service_id"] == analysis_service_id
-        analysis_status = data["data"]["status"]
-
-        max_attempts -= 1
-        time.sleep(5)
-    else:
-        assert False, (
+        assert data["data"]["status"] != "queued", (
             f"analysis was not started properly ({data['data']['status_message']})"
         )
+        return data
+
+    data = retry_until(analysis_started, timeout=100)
+    analysis_status = data["data"]["status"]
 
     # Since this is random data, this fit might succeed (usually) or fail (seldom)
     # that's ok because it means we're getting the
@@ -753,20 +748,13 @@ def test_run_analysis_with_down_and_wrong_analysis_service(
     analysis_id = data["data"].get("id")
     assert analysis_id is not None
 
-    max_attempts = 20
-    analysis_status = "queued"
-
-    while max_attempts > 0:
-        if analysis_status != "queued":
-            break
+    def analysis_done():
         status, data = api("GET", f"obj/analysis/{analysis_id}", token=analysis_token)
         assert status == 200
-        analysis_status = data["data"]["status"]
+        assert data["data"]["status"] != "queued"
+        return data["data"]["status"]
 
-        max_attempts -= 1
-        time.sleep(5)
-
-    assert analysis_status == "failure"
+    assert retry_until(analysis_done, timeout=100) == "failure"
 
     # now try a bad endpoint
     name_bad_endpoint = str(uuid.uuid4())
@@ -805,20 +793,7 @@ def test_run_analysis_with_down_and_wrong_analysis_service(
     assert status == 200
     assert data["status"] == "success"
 
-    max_attempts = 5
-    analysis_status = "queued"
-
-    while max_attempts > 0:
-        if analysis_status != "queued":
-            break
-        status, data = api("GET", f"obj/analysis/{analysis_id}", token=analysis_token)
-        assert status == 200
-        analysis_status = data["data"]["status"]
-
-        max_attempts -= 1
-        time.sleep(1)
-
-    assert analysis_status == "failure"
+    assert retry_until(analysis_done, timeout=10) == "failure"
 
 
 def test_delete_analysis(
@@ -908,18 +883,12 @@ def test_delete_analysis_service_cascades_to_delete_associated_analysis(
     analysis_id = data["data"].get("id")
     assert analysis_id is not None
 
-    # wait until the analysis is done
-    max_attempts = 20
-    analysis_status = "queued"
-    while max_attempts > 0:
-        if analysis_status != "queued":
-            break
+    def analysis_done():
         status, data = api("GET", f"obj/analysis/{analysis_id}", token=analysis_token)
         assert status == 200
-        analysis_status = data["data"]["status"]
+        assert data["data"]["status"] != "queued"
 
-        max_attempts -= 1
-        time.sleep(5)
+    retry_until(analysis_done, timeout=100)
 
     # get the analysis associated with the
     # analysis service
@@ -1001,12 +970,7 @@ def test_retrieve_data_products(
     analysis_id = data["data"].get("id")
     assert analysis_id is not None
 
-    max_attempts = 20
-    analysis_status = "queued"
-
-    while max_attempts > 0:
-        if analysis_status not in ["queued", "pending"]:
-            break
+    def analysis_started():
         status, data = api(
             "GET",
             f"obj/analysis/{analysis_id}",
@@ -1014,14 +978,12 @@ def test_retrieve_data_products(
         )
         assert status == 200
         assert data["data"]["analysis_service_id"] == analysis_service_id
-        analysis_status = data["data"]["status"]
-
-        max_attempts -= 1
-        time.sleep(3)
-    else:
-        assert False, (
+        assert data["data"]["status"] not in ["queued", "pending"], (
             f"analysis was not started properly ({data['data']['status_message']})"
         )
+        return data["data"]["status"]
+
+    analysis_status = retry_until(analysis_started, timeout=60)
 
     if analysis_status == "completed":
         # try to get a plot
@@ -1222,26 +1184,19 @@ def test_run_analysis_with_file_input(
     analysis_id = data["data"].get("id")
     assert analysis_id is not None
 
-    max_attempts = 20
-    analysis_status = "queued"
     params = {"includeAnalysisData": True}
 
-    while max_attempts > 0:
-        if analysis_status != "queued":
-            break
+    def analysis_started():
         status, data = api(
             "GET", f"obj/analysis/{analysis_id}", token=analysis_token, params=params
         )
         assert status == 200
         assert data["data"]["analysis_service_id"] == analysis_service_id
-        analysis_status = data["data"]["status"]
-
-        max_attempts -= 1
-        time.sleep(5)
-    else:
-        assert False, (
+        assert data["data"]["status"] != "queued", (
             f"analysis was not started properly ({data['data']['status_message']})"
         )
+
+    retry_until(analysis_started, timeout=100)
 
 
 def test_default_analysis(

--- a/skyportal/tests/api_tests/groups_users_analysis/test_observation_plan.py
+++ b/skyportal/tests/api_tests/groups_users_analysis/test_observation_plan.py
@@ -1,11 +1,10 @@
 import os
-import time
 import uuid
 
 import numpy as np
 from astropy.table import Table
 
-from skyportal.tests import api
+from skyportal.tests import api, retry_until
 from skyportal.tests.external.test_moving_objects import (
     add_telescope_and_instrument,
     remove_telescope_and_instrument,
@@ -73,85 +72,65 @@ def test_observation_plan_tiling(super_admin_token, public_group, gcn_GW190814):
         assert status == 200
         assert data["status"] == "success"
 
-    # wait for the observation plans to finish, we added some patience later, but we know that it takes at least 30 seconds
-    time.sleep(10)
+    def plans_ready():
+        status, data = api(
+            "GET",
+            "observation_plan",
+            params={
+                "includePlannedObservations": "true",
+                "dateobs": dateobs,
+                "instrumentID": instrument_id,
+            },
+            token=super_admin_token,
+        )
+        assert status == 200
+        assert data["status"] == "success"
 
-    n_retries = 0
-    request_ids = []
-    while n_retries < 10:
-        try:
-            status, data = api(
-                "GET",
-                "observation_plan",
-                params={
-                    "includePlannedObservations": "true",
-                    "dateobs": dateobs,
-                    "instrumentID": instrument_id,
-                },
-                token=super_admin_token,
+        # get those which have been created on the right event
+        requests = [
+            d
+            for d in data["data"]["requests"]
+            if d["gcnevent_id"] == gcnevent_id and d["allocation_id"] == allocation_id
+        ]
+        assert len(requests) == len(requests_data)
+        for d in requests:
+            assert any(
+                d["payload"] == request_data["payload"]
+                for request_data in requests_data
             )
-            assert status == 200
-            assert data["status"] == "success"
+            observation_plans = d["observation_plans"]
+            assert len(observation_plans) == 1
+            observation_plan = observation_plans[0]
 
-            # get those which have been created on the right event
-            data = [
-                d
-                for d in data["data"]["requests"]
-                if d["gcnevent_id"] == gcnevent_id
-                and d["allocation_id"] == allocation_id
-            ]
-            assert len(data) == len(requests_data)
-            request_ids = [d["id"] for d in data]
-            for i, d in enumerate(data):
-                assert any(
-                    d["payload"] == request_data["payload"]
-                    for request_data in requests_data
-                )
-                observation_plans = d["observation_plans"]
-                assert len(observation_plans) == 1
-                observation_plan = observation_plans[0]
+            assert any(
+                observation_plan["plan_name"] == request_data["payload"]["queue_name"]
+                for request_data in requests_data
+            )
+            assert any(
+                observation_plan["validity_window_start"]
+                == request_data["payload"]["start_date"].replace(" ", "T")
+                for request_data in requests_data
+            )
+            assert any(
+                observation_plan["validity_window_end"]
+                == request_data["payload"]["end_date"].replace(" ", "T")
+                for request_data in requests_data
+            )
 
-                assert any(
-                    observation_plan["plan_name"]
-                    == request_data["payload"]["queue_name"]
-                    for request_data in requests_data
-                )
-                assert any(
-                    observation_plan["validity_window_start"]
-                    == request_data["payload"]["start_date"].replace(" ", "T")
-                    for request_data in requests_data
-                )
-                # same with the validity window start
-                assert any(
-                    observation_plan["validity_window_start"]
-                    == request_data["payload"]["start_date"].replace(" ", "T")
-                    for request_data in requests_data
-                )
-                # same with the validity window end
-                assert any(
-                    observation_plan["validity_window_end"]
-                    == request_data["payload"]["end_date"].replace(" ", "T")
-                    for request_data in requests_data
-                )
+            planned_observations = observation_plan["planned_observations"]
 
-                planned_observations = observation_plan["planned_observations"]
+            assert all(
+                obs["filt"] == requests_data[0]["payload"]["filters"]
+                for obs in planned_observations
+            )
+            assert all(
+                obs["exposure_time"]
+                == int(requests_data[0]["payload"]["exposure_time"])
+                for obs in planned_observations
+            )
+        return [d["id"] for d in requests]
 
-                assert all(
-                    obs["filt"] == requests_data[0]["payload"]["filters"]
-                    for obs in planned_observations
-                )
-                assert all(
-                    obs["exposure_time"]
-                    == int(requests_data[0]["payload"]["exposure_time"])
-                    for obs in planned_observations
-                )
-            break
-        except AssertionError:
-            n_retries += 1
-            time.sleep(5)
-
-    assert n_retries < 10
-    assert len(request_ids) == len(requests_data)
+    request_ids = retry_until(plans_ready, timeout=60)
 
     # exercise the (async) delete path: DELETE each request and verify it is gone
     for request_id in request_ids:
@@ -245,45 +224,34 @@ def test_observation_plan_combined(super_admin_token, public_group, gcn_GW190814
     assert status == 200, data
     assert data["status"] == "success"
 
-    time.sleep(10)
+    def combined_plans_ready():
+        status, data = api(
+            "GET",
+            "observation_plan",
+            params={
+                "includePlannedObservations": "true",
+                "dateobs": dateobs,
+                "instrumentID": instrument_id,
+            },
+            token=super_admin_token,
+        )
+        assert status == 200
+        assert data["status"] == "success"
 
-    n_retries = 0
-    request_ids = []
-    while n_retries < 10:
-        try:
-            status, data = api(
-                "GET",
-                "observation_plan",
-                params={
-                    "includePlannedObservations": "true",
-                    "dateobs": dateobs,
-                    "instrumentID": instrument_id,
-                },
-                token=super_admin_token,
-            )
-            assert status == 200
-            assert data["status"] == "success"
+        requests = [
+            d
+            for d in data["data"]["requests"]
+            if d["gcnevent_id"] == gcnevent_id and d["allocation_id"] == allocation_id
+        ]
+        assert len(requests) == len(observation_plans)
+        # every request should be combined (share a combined_id) and complete
+        assert all(d["combined_id"] is not None for d in requests)
+        assert all(d["status"] == "complete" for d in requests)
+        for d in requests:
+            assert len(d["observation_plans"]) == 1
+        return [d["id"] for d in requests]
 
-            data = [
-                d
-                for d in data["data"]["requests"]
-                if d["gcnevent_id"] == gcnevent_id
-                and d["allocation_id"] == allocation_id
-            ]
-            assert len(data) == len(observation_plans)
-            # every request should be combined (share a combined_id) and complete
-            assert all(d["combined_id"] is not None for d in data)
-            assert all(d["status"] == "complete" for d in data)
-            for d in data:
-                assert len(d["observation_plans"]) == 1
-            request_ids = [d["id"] for d in data]
-            break
-        except AssertionError:
-            n_retries += 1
-            time.sleep(5)
-
-    assert n_retries < 10
-    assert len(request_ids) == len(observation_plans)
+    request_ids = retry_until(combined_plans_ready, timeout=60)
 
     # exercise the (async) delete path on the combined requests
     for request_id in request_ids:
@@ -325,9 +293,7 @@ def test_observation_plan_galaxy(
         "ZTF", super_admin_token, list(range(200, 250))
     )
 
-    nretries = 0
-    galaxies_loaded = False
-    while nretries < 10:
+    def galaxies_loaded():
         status, data = api(
             "GET",
             "galaxy_catalog",
@@ -335,18 +301,14 @@ def test_observation_plan_galaxy(
             params={"catalog_name": catalog_name},
         )
         assert status == 200
-        data = data["data"]["galaxies"]
-        if len(data) == 92 and any(
+        galaxies = data["data"]["galaxies"]
+        assert len(galaxies) == 92
+        assert any(
             d["name"] == "6dFgs gJ0001313-055904" and d["mstar"] == 336.60756522868667
-            for d in data
-        ):
-            galaxies_loaded = True
-            break
-        nretries = nretries + 1
-        time.sleep(5)
+            for d in galaxies
+        )
 
-    assert nretries < 10
-    assert galaxies_loaded
+    retry_until(galaxies_loaded, timeout=50)
 
     request_data = {
         "group_id": public_group.id,
@@ -401,68 +363,57 @@ def test_observation_plan_galaxy(
         assert status == 200
         assert data["status"] == "success"
 
-    # wait for the observation plans to finish, we added some patience later, but we know that it takes at least 30 seconds
-    time.sleep(10)
+    def galaxy_plans_ready():
+        status, data = api(
+            "GET",
+            "observation_plan",
+            params={"includePlannedObservations": "true"},
+            token=super_admin_token,
+        )
+        assert status == 200
+        assert data["status"] == "success"
 
-    n_retries = 0
-    while n_retries < 10:
-        try:
-            status, data = api(
-                "GET",
-                "observation_plan",
-                params={"includePlannedObservations": "true"},
-                token=super_admin_token,
+        # get those which have been created on the right event
+        requests = [
+            d
+            for d in data["data"]["requests"]
+            if d["gcnevent_id"] == gcnevent_id and d["allocation_id"] == allocation_id
+        ]
+        assert len(requests) == len(requests_data)
+
+        for i, d in enumerate(requests):
+            assert any(
+                d["payload"]["queue_name"] == request_data["payload"]["queue_name"]
+                for request_data in requests_data
             )
-            assert status == 200
-            assert data["status"] == "success"
+            observation_plans = d["observation_plans"]
+            assert len(observation_plans) == 1
+            observation_plan = observation_plans[0]
 
-            # get those which have been created on the right event
-            data = [
-                d
-                for d in data["data"]["requests"]
-                if d["gcnevent_id"] == gcnevent_id
-                and d["allocation_id"] == allocation_id
-            ]
-            assert len(data) == len(requests_data)
+            assert any(
+                observation_plan["plan_name"] == request_data["payload"]["queue_name"]
+                for request_data in requests_data
+            )
+            assert observation_plan["validity_window_start"] == requests_data[0][
+                "payload"
+            ]["start_date"].replace(" ", "T")
+            assert observation_plan["validity_window_end"] == requests_data[0][
+                "payload"
+            ]["end_date"].replace(" ", "T")
 
-            for i, d in enumerate(data):
-                assert any(
-                    d["payload"]["queue_name"] == request_data["payload"]["queue_name"]
-                    for request_data in requests_data
-                )
-                observation_plans = d["observation_plans"]
-                assert len(observation_plans) == 1
-                observation_plan = observation_plans[0]
+            planned_observations = observation_plan["planned_observations"]
+            assert len(planned_observations) >= 2
 
-                assert any(
-                    observation_plan["plan_name"]
-                    == request_data["payload"]["queue_name"]
-                    for request_data in requests_data
-                )
-                assert observation_plan["validity_window_start"] == requests_data[0][
-                    "payload"
-                ]["start_date"].replace(" ", "T")
-                assert observation_plan["validity_window_end"] == requests_data[0][
-                    "payload"
-                ]["end_date"].replace(" ", "T")
+            assert all(
+                obs["filt"] == requests_data[i]["payload"]["filters"]
+                for obs in planned_observations
+            )
+            assert all(
+                obs["exposure_time"]
+                == int(requests_data[i]["payload"]["exposure_time"])
+                for obs in planned_observations
+            )
 
-                planned_observations = observation_plan["planned_observations"]
-                assert len(planned_observations) >= 2
-
-                assert all(
-                    obs["filt"] == requests_data[i]["payload"]["filters"]
-                    for obs in planned_observations
-                )
-                assert all(
-                    obs["exposure_time"]
-                    == int(requests_data[i]["payload"]["exposure_time"])
-                    for obs in planned_observations
-                )
-            break
-        except AssertionError:
-            n_retries = n_retries + 1
-            time.sleep(5)
-
-    assert n_retries < 10
+    retry_until(galaxy_plans_ready, timeout=60)
 
     remove_telescope_and_instrument(telescope_id, instrument_id, super_admin_token)

--- a/skyportal/tests/api_tests/sources_candidates/test_gcn.py
+++ b/skyportal/tests/api_tests/sources_candidates/test_gcn.py
@@ -12,7 +12,7 @@ from astropy.time import Time
 
 from skyportal.handlers.api.gcn import add_default_gcn_tags
 from skyportal.models import DBSession, DefaultGcnTag, User
-from skyportal.tests import api
+from skyportal.tests import api, retry_until
 from skyportal.tests.external.test_moving_objects import (
     add_telescope_and_instrument,
     remove_telescope_and_instrument,
@@ -514,29 +514,17 @@ def test_gcn_summary_sources(
     assert status == 200
     summary_id = data["data"]["id"]
 
-    nretries = 0
-    summaries_loaded = False
-    while nretries < 40:
+    def summary_ready():
         status, data = api(
             "GET",
             f"gcn_event/{dateobs}/summary/{summary_id}",
             token=view_only_token,
         )
-        if status == 404:
-            nretries = nretries + 1
-            time.sleep(5)
-        if status == 200:
-            data = data["data"]
-            if data["text"] == "pending":
-                nretries = nretries + 1
-                time.sleep(5)
-            else:
-                summaries_loaded = True
-                break
+        assert status == 200
+        assert data["data"]["text"] != "pending"
+        return data["data"]["text"]
 
-    assert nretries < 40
-    assert summaries_loaded
-    text = data["text"]
+    text = retry_until(summary_ready, timeout=200)
     lines = list(filter(None, text.split("\n")))
 
     def _find(*substrings):
@@ -608,25 +596,19 @@ def test_gcn_summary_galaxies(
 
     params = {"catalog_name": catalog_name}
 
-    nretries = 0
-    galaxies_loaded = False
-    while nretries < 40:
+    def galaxies_loaded():
         status, data = api(
             "GET", "galaxy_catalog", token=view_only_token, params=params
         )
         assert status == 200
-        data = data["data"]["galaxies"]
-        if len(data) == 92 and any(
+        galaxies = data["data"]["galaxies"]
+        assert len(galaxies) == 92
+        assert any(
             d["name"] == "6dFgs gJ0001313-055904" and d["mstar"] == 336.60756522868667
-            for d in data
-        ):
-            galaxies_loaded = True
-            break
-        nretries = nretries + 1
-        time.sleep(2)
+            for d in galaxies
+        )
 
-    assert nretries < 40
-    assert galaxies_loaded
+    retry_until(galaxies_loaded, timeout=80)
 
     # get the gcn event summary
     data = {
@@ -652,30 +634,18 @@ def test_gcn_summary_galaxies(
     assert status == 200
     summary_id = data["data"]["id"]
 
-    nretries = 0
-    summaries_loaded = False
-    while nretries < 40:
+    def summary_ready():
         status, data = api(
             "GET",
             f"gcn_event/{dateobs}/summary/{summary_id}",
             token=view_only_token,
             params=params,
         )
-        if status == 404:
-            nretries = nretries + 1
-            time.sleep(5)
-        if status == 200:
-            data = data["data"]
-            if data["text"] == "pending":
-                nretries = nretries + 1
-                time.sleep(5)
-            else:
-                summaries_loaded = True
-                break
+        assert status == 200
+        assert data["data"]["text"] != "pending"
+        return data["data"]["text"]
 
-    assert nretries < 40
-    assert summaries_loaded
-    lines = list(filter(None, data["text"].split("\n")))
+    lines = list(filter(None, retry_until(summary_ready, timeout=200).split("\n")))
 
     def _find(*substrings):
         # index of the first line containing all of `substrings`; asserts presence

--- a/skyportal/tests/api_tests/sources_candidates/test_gcn_crossmatch_service.py
+++ b/skyportal/tests/api_tests/sources_candidates/test_gcn_crossmatch_service.py
@@ -76,6 +76,15 @@ def _post_event(token, group_ids, ra, dec):
 
 
 @pytest.fixture()
+def crossmatch_event(super_admin_token, public_group2):
+    """Deleted afterwards: run_cycle walks every recent event and loads its skymap."""
+    ra, dec = _unique_position()
+    dateobs, trigger_id = _post_event(super_admin_token, [public_group2.id], ra, dec)
+    yield dateobs, trigger_id, ra, dec
+    api("DELETE", f"gcn_event/{dateobs.isoformat()}", token=super_admin_token)
+
+
+@pytest.fixture()
 def crossmatch_filter(public_group, broker):
     """A filter opted into the crossmatch.
 
@@ -141,11 +150,13 @@ def _alert(object_id, ra, dec, jd):
 
 
 def test_crossmatch_saves_only_contained_in_window_alerts(
-    super_admin_token, public_group2, broker, crossmatch_filter, monkeypatch
+    broker,
+    crossmatch_filter,
+    crossmatch_event,
+    monkeypatch,
 ):
     """Only alerts inside the localization *and* inside the epoch window are saved."""
-    ra, dec = _unique_position()
-    dateobs, _ = _post_event(super_admin_token, [public_group2.id], ra, dec)
+    dateobs, _, ra, dec = crossmatch_event
     from astropy.time import Time
 
     event_jd = float(Time(dateobs).jd)
@@ -178,15 +189,17 @@ def test_crossmatch_saves_only_contained_in_window_alerts(
 
 
 def test_crossmatch_passes_event_groups_and_epoch_window(
-    super_admin_token, public_group2, broker, crossmatch_filter, monkeypatch
+    broker,
+    crossmatch_filter,
+    crossmatch_event,
+    monkeypatch,
 ):
     """Saves inherit the event's groups, and the broker is given the epoch window.
 
     The group assertion is the security-relevant one: a restricted event's
     matches must not be saved into wider groups than the event itself.
     """
-    ra, dec = _unique_position()
-    dateobs, _ = _post_event(super_admin_token, [public_group2.id], ra, dec)
+    dateobs, _, ra, dec = crossmatch_event
     from astropy.time import Time
 
     event_jd = float(Time(dateobs).jd)
@@ -216,11 +229,13 @@ def test_crossmatch_passes_event_groups_and_epoch_window(
 
 
 def test_crossmatch_records_state_and_annotation(
-    super_admin_token, public_group2, broker, crossmatch_filter, monkeypatch
+    broker,
+    crossmatch_filter,
+    crossmatch_event,
+    monkeypatch,
 ):
     """A match leaves per-broker state and an event-relative annotation behind."""
-    ra, dec = _unique_position()
-    dateobs, trigger_id = _post_event(super_admin_token, [public_group2.id], ra, dec)
+    dateobs, trigger_id, ra, dec = crossmatch_event
     from astropy.time import Time
 
     event_jd = float(Time(dateobs).jd)
@@ -319,7 +334,10 @@ def _stub_filter_provider(monkeypatch, alerts, recorded, ra=0.0, dec=0.0):
 
 
 def test_crossmatch_runs_quality_cuts_as_a_broker_filter(
-    super_admin_token, public_group2, broker, crossmatch_filter, monkeypatch
+    broker,
+    crossmatch_filter,
+    crossmatch_event,
+    monkeypatch,
 ):
     """When the broker supports filters, cuts run server-side as a pipeline.
 
@@ -327,8 +345,7 @@ def test_crossmatch_runs_quality_cuts_as_a_broker_filter(
     artifacts and asteroids are rejected by the broker rather than transferred
     and discarded here. query_alerts must not be used in this case.
     """
-    ra, dec = _unique_position()
-    dateobs, _ = _post_event(super_admin_token, [public_group2.id], ra, dec)
+    dateobs, _, ra, dec = crossmatch_event
     from astropy.time import Time
 
     event_jd = float(Time(dateobs).jd)
@@ -375,11 +392,13 @@ def test_crossmatch_runs_quality_cuts_as_a_broker_filter(
 
 
 def test_annotation_carries_alert_quality_fields(
-    super_admin_token, public_group2, broker, crossmatch_filter, monkeypatch
+    broker,
+    crossmatch_filter,
+    crossmatch_event,
+    monkeypatch,
 ):
     """The annotation exposes the columns reviewers triage on."""
-    ra, dec = _unique_position()
-    dateobs, trigger_id = _post_event(super_admin_token, [public_group2.id], ra, dec)
+    dateobs, trigger_id, ra, dec = crossmatch_event
     from astropy.time import Time
 
     event_jd = float(Time(dateobs).jd)
@@ -436,7 +455,10 @@ def test_annotation_carries_alert_quality_fields(
 
 
 def test_archival_match_flags_prior_activity_and_survives_forward_pass(
-    super_admin_token, public_group2, broker, crossmatch_filter, monkeypatch
+    broker,
+    crossmatch_filter,
+    crossmatch_event,
+    monkeypatch,
 ):
     """A pre-event detection marks the candidate, and a later match keeps the mark.
 
@@ -444,8 +466,7 @@ def test_archival_match_flags_prior_activity_and_survives_forward_pass(
     would overwrite the archival entry and erase the very fact that rules the
     candidate out.
     """
-    ra, dec = _unique_position()
-    dateobs, trigger_id = _post_event(super_admin_token, [public_group2.id], ra, dec)
+    dateobs, trigger_id, ra, dec = crossmatch_event
     from astropy.time import Time
 
     event_jd = float(Time(dateobs).jd)
@@ -493,15 +514,17 @@ def test_archival_match_flags_prior_activity_and_survives_forward_pass(
 
 
 def test_match_creates_candidate_not_source(
-    super_admin_token, public_group2, crossmatch_filter, broker, monkeypatch
+    crossmatch_filter,
+    crossmatch_event,
+    broker,
+    monkeypatch,
 ):
     """With a filter configured, a match becomes a scannable Candidate only.
 
     The Obj and Candidate put it on the scanning page; no Source is created,
     so it stays a suggestion until a human saves it.
     """
-    ra, dec = _unique_position()
-    dateobs, _ = _post_event(super_admin_token, [public_group2.id], ra, dec)
+    dateobs, _, ra, dec = crossmatch_event
     from astropy.time import Time
 
     event_jd = float(Time(dateobs).jd)
@@ -535,11 +558,13 @@ def test_match_creates_candidate_not_source(
 
 
 def test_candidate_creation_is_idempotent(
-    super_admin_token, public_group2, crossmatch_filter, broker, monkeypatch
+    crossmatch_filter,
+    crossmatch_event,
+    broker,
+    monkeypatch,
 ):
     """Re-running must not pile up duplicate candidates for the same epoch."""
-    ra, dec = _unique_position()
-    dateobs, _ = _post_event(super_admin_token, [public_group2.id], ra, dec)
+    dateobs, _, ra, dec = crossmatch_event
     from astropy.time import Time
 
     event_jd = float(Time(dateobs).jd)
@@ -570,7 +595,10 @@ def test_candidate_creation_is_idempotent(
 
 
 def test_filter_only_runs_against_matching_events(
-    super_admin_token, public_group2, broker, crossmatch_filter, monkeypatch
+    broker,
+    crossmatch_filter,
+    crossmatch_event,
+    monkeypatch,
 ):
     """A filter scoped by gcn_tags skips events that do not carry one.
 
@@ -580,8 +608,7 @@ def test_filter_only_runs_against_matching_events(
     """
     # capture before opening other sessions: the fixture instance detaches
     filter_id = crossmatch_filter.id
-    ra, dec = _unique_position()
-    dateobs, _ = _post_event(super_admin_token, [public_group2.id], ra, dec)
+    dateobs, _, ra, dec = crossmatch_event
     alert_jd = Time(dateobs).jd + 0.5
 
     # the event above carries ["TEST"]; scope the filter to something else
@@ -659,17 +686,15 @@ def _stub_provider_with_photometry(monkeypatch, alerts, saved, ra, dec, history)
 
 
 def test_crossmatch_ingests_photometry_for_a_match(
-    super_admin_token,
-    public_group2,
     broker,
     crossmatch_filter,
+    crossmatch_event,
     ztf_instrument,
     monkeypatch,
 ):
     """A scanner judges a candidate on its light curve, so the match must bring
     one: the crossmatch query itself returns no detection history."""
-    ra, dec = _unique_position()
-    dateobs, _ = _post_event(super_admin_token, [public_group2.id], ra, dec)
+    dateobs, _, ra, dec = crossmatch_event
     event_jd = float(Time(dateobs).jd)
 
     obj_id = _unique_id("XM_phot")
@@ -711,16 +736,14 @@ def test_crossmatch_ingests_photometry_for_a_match(
 
 
 def test_crossmatch_keeps_the_match_when_photometry_fails(
-    super_admin_token,
-    public_group2,
     broker,
     crossmatch_filter,
+    crossmatch_event,
     ztf_instrument,
     monkeypatch,
 ):
     """A broker that cannot serve the history must not cost us the match."""
-    ra, dec = _unique_position()
-    dateobs, _ = _post_event(super_admin_token, [public_group2.id], ra, dec)
+    dateobs, _, ra, dec = crossmatch_event
     event_jd = float(Time(dateobs).jd)
 
     obj_id = _unique_id("XM_nophot")

--- a/skyportal/tests/frontend/observations_and_instruments/test_download.py
+++ b/skyportal/tests/frontend/observations_and_instruments/test_download.py
@@ -11,7 +11,12 @@ from numpy import random
 from playwright.sync_api import expect
 
 from baselayer.app.config import load_config
-from skyportal.tests import api, wait_for_gcn_event, wait_for_localization
+from skyportal.tests import (
+    api,
+    retry_until,
+    wait_for_gcn_event,
+    wait_for_localization,
+)
 from skyportal.tests.external.test_moving_objects import (
     add_telescope_and_instrument,
     remove_telescope_and_instrument,
@@ -267,23 +272,23 @@ def test_gcn_summary_observations(
 
     id = data["data"]["ids"][0]
 
-    # wait for the observation plan to finish loading
-    time.sleep(15)
+    def plan_ready():
+        status, data = api(
+            "GET",
+            f"observation_plan/{id}",
+            params={"includePlannedObservations": "true"},
+            token=super_admin_token,
+        )
+        assert status == 200
+        assert data["status"] == "success"
 
-    status, data = api(
-        "GET",
-        f"observation_plan/{id}",
-        params={"includePlannedObservations": "true"},
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+        assert data["data"]["gcnevent_id"] == gcnevent_id
+        assert data["data"]["allocation_id"] == allocation_id
+        assert data["data"]["payload"] == request_data["payload"]
 
-    assert data["data"]["gcnevent_id"] == gcnevent_id
-    assert data["data"]["allocation_id"] == allocation_id
-    assert data["data"]["payload"] == request_data["payload"]
+        assert len(data["data"]["observation_plans"]) == 1
 
-    assert len(data["data"]["observation_plans"]) == 1
+    retry_until(plan_ready, timeout=60)
 
     datafile = f"{os.path.dirname(__file__)}/../../../../data/sample_observation_gw.csv"
     data = {
@@ -305,24 +310,13 @@ def test_gcn_summary_observations(
         "startDate": "2019-08-13 08:18:05",
         "endDate": "2019-08-19 08:18:05",
     }
-    nretries = 0
-    observations_loaded = False
-    while not observations_loaded and nretries < 25:
-        try:
-            status, data = api(
-                "GET", "observation", params=params, token=super_admin_token
-            )
-            assert status == 200
-            data = data["data"]
-            assert len(data["observations"]) >= 9
-            observations_loaded = True
-        except AssertionError:
-            nretries = nretries + 1
-            time.sleep(2)
 
-    assert nretries < 25
-    assert status == 200
-    assert observations_loaded is True
+    def observations_loaded():
+        status, data = api("GET", "observation", params=params, token=super_admin_token)
+        assert status == 200
+        assert len(data["data"]["observations"]) >= 9
+
+    retry_until(observations_loaded, timeout=50)
     # generate the GCN summary (with observations) and read it back
     text = get_summary(
         page, super_admin_user, public_group, False, False, True, super_admin_token
@@ -413,25 +407,19 @@ def test_gcn_summary_galaxies(
 
     params = {"catalog_name": catalog_name}
 
-    nretries = 0
-    galaxies_loaded = False
-    while nretries < 40:
+    def galaxies_loaded():
         status, data = api(
             "GET", "galaxy_catalog", token=view_only_token, params=params
         )
         assert status == 200
-        data = data["data"]["galaxies"]
-        if len(data) == 92 and any(
+        galaxies = data["data"]["galaxies"]
+        assert len(galaxies) == 92
+        assert any(
             d["name"] == "6dFgs gJ0001313-055904" and d["mstar"] == 336.60756522868667
-            for d in data
-        ):
-            galaxies_loaded = True
-            break
-        nretries = nretries + 1
-        time.sleep(2)
+            for d in galaxies
+        )
 
-    assert nretries < 40
-    assert galaxies_loaded
+    retry_until(galaxies_loaded, timeout=80)
 
     # The catalog row count being ready doesn't mean the galaxies are yet matchable
     # within the localization (the probability cross-match lags), and the summary's
@@ -445,18 +433,15 @@ def test_gcn_summary_galaxies(
         "localizationCumprob": 0.95,
         "returnProbability": True,
     }
-    nretries = 0
-    galaxies_in_localization = False
-    while nretries < 40:
+
+    def galaxies_in_localization():
         status, data = api(
             "GET", "galaxy_catalog", token=super_admin_token, params=loc_params
         )
-        if status == 200 and len(data["data"]["galaxies"]) > 0:
-            galaxies_in_localization = True
-            break
-        nretries += 1
-        time.sleep(2)
-    assert galaxies_in_localization
+        assert status == 200
+        assert len(data["data"]["galaxies"]) > 0
+
+    retry_until(galaxies_in_localization, timeout=80)
 
     text = get_summary(
         page, super_admin_user, public_group, False, True, False, super_admin_token
@@ -696,17 +681,17 @@ def get_summary(
         time.sleep(2)
     assert summary_id is not None, "GCN summary was not created by the Generate action"
 
-    summary_text = "pending"
-    for _ in range(40):
+    def summary_ready():
         status, data = api(
             "GET", f"gcn_event/{dateobs}/summary/{summary_id}", token=token
         )
-        if status == 200 and data["data"]["text"] != "pending":
-            summary_text = data["data"]["text"]
-            break
-        time.sleep(5)
-    assert summary_text != "pending", "GCN summary text did not finish generating"
-    return summary_text
+        assert status == 200
+        assert data["data"]["text"] != "pending", (
+            "GCN summary text did not finish generating"
+        )
+        return data["data"]["text"]
+
+    return retry_until(summary_ready, timeout=200)
 
 
 def test_download_localization(super_admin_token):


### PR DESCRIPTION
The crossmatch tests were slow and intermittently failing.

- Disable astropy IERS auto-download in tests.
- Poll (with a timeout) instead of sleeping a fixed time while waiting for
  background tasks.
- Delete the crossmatch test event after each test so `run_cycle` keeps
  walking a single event.