### PR TITLE
Parallelize broker ingestion via Kafka consumer groups and multi-process broker_ingest

### DIFF
--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -742,6 +742,11 @@ brokers:
   # (the /brokers/{id} page) works regardless of this setting.
   ingest_enabled: False
 
+  # Number of broker_ingest OS processes. Process 0 runs every broker; extra
+  # processes run only providers whose ingestion is safe to replicate (Kafka
+  # consumer groups, which Kafka rebalances) so REST pollers aren't duplicated.
+  ingest_processes: 1
+
 # BOOM-specific settings. The filter builder's user-created modules (variables,
 # list variables, switch cases, blocks) live in BOOM's own MongoDB store, not in
 # skyportal's database. Point this at that store, or set the equivalent

--- a/services/broker_ingest/broker_ingest.py
+++ b/services/broker_ingest/broker_ingest.py
@@ -5,10 +5,16 @@ long-running consumer: Kafka/REST -> shared save transform). One asyncio task
 per broker in a single event loop; the providers offload blocking I/O (e.g.
 Kafka poll) via `asyncio.to_thread` so brokers don't starve each other.
 
+Scales out to `brokers.ingest_processes` OS processes (supervisor numprocs).
+Process 0 runs every broker; higher-index processes run only providers whose
+ingestion is safe to replicate (a shared Kafka consumer group Kafka rebalances),
+so REST-polling providers are not duplicated.
+
 Enable with `brokers.ingest_enabled: true` in the config.
 """
 
 import asyncio
+import sys
 
 import sqlalchemy as sa
 
@@ -22,6 +28,15 @@ env, cfg = load_env()
 log = make_log("broker_ingest")
 
 init_db(**cfg["database"])
+
+# This process's index within the broker_ingest program (supervisor --process).
+_PROCESS_INDEX = 0
+for _arg in sys.argv[1:]:
+    if _arg.startswith("--process="):
+        try:
+            _PROCESS_INDEX = int(_arg.split("=", 1)[1])
+        except ValueError:
+            pass
 
 # How often to re-scan the DB for newly-added / activated brokers.
 RESCAN_INTERVAL = 60  # seconds
@@ -43,9 +58,16 @@ async def _active_ingestion_brokers(session):
     wanted = {}
     for b in brokers:
         try:
-            if b.broker_class.implements().get("run_ingestion"):
-                session.expunge(b)  # detached: used from a long-lived task
-                wanted[b.id] = b
+            if not b.broker_class.implements().get("run_ingestion"):
+                continue
+            # Replica processes run only providers safe to replicate across a
+            # shared Kafka consumer group; REST pollers stay on process 0.
+            if _PROCESS_INDEX > 0 and not getattr(
+                b.broker_class, "parallel_ingestion", False
+            ):
+                continue
+            session.expunge(b)  # detached: used from a long-lived task
+            wanted[b.id] = b
         except Exception as e:
             log(f"skipping broker {b.id}: {e}")
     return wanted
@@ -82,4 +104,5 @@ if __name__ == "__main__":
         while True:
             time.sleep(3600)
     else:
+        log(f"broker_ingest process {_PROCESS_INDEX} starting")
         asyncio.run(_run_loop())

--- a/services/broker_ingest/supervisor.conf
+++ b/services/broker_ingest/supervisor.conf
@@ -1,7 +1,0 @@
-[program:broker_ingest]
-command=/usr/bin/env python services/broker_ingest/broker_ingest.py %(ENV_FLAGS)s
-environment=PYTHONPATH=".",PYTHONUNBUFFERED="1"
-stdout_logfile=log/broker_ingest.log
-redirect_stderr=true
-autorestart=true
-startretries=10

--- a/services/broker_ingest/supervisor.conf.template
+++ b/services/broker_ingest/supervisor.conf.template
@@ -1,0 +1,9 @@
+[program:broker_ingest]
+numprocs={{ brokers.ingest_processes }}
+command=/usr/bin/env python services/broker_ingest/broker_ingest.py --process=%(process_num)s %(ENV_FLAGS)s
+process_name=%(program_name)s_%(process_num)02d
+environment=PYTHONPATH=".",PYTHONUNBUFFERED="1"
+stdout_logfile=log/broker_ingest_%(process_num)02d.log
+redirect_stderr=true
+autorestart=true
+startretries=10

--- a/skyportal/broker_apis/ampel.py
+++ b/skyportal/broker_apis/ampel.py
@@ -60,6 +60,8 @@ class AMPELBROKER(BrokerAPI):
     (username/password, optional servers/group_id/topics) + ``filter_ids``.
     """
 
+    parallel_ingestion = True  # shared Kafka consumer group
+
     surveys = ["LSST"]
     filter_kind = "tags"  # the Hopskotch topics are the science-tag menu
 

--- a/skyportal/broker_apis/boom.py
+++ b/skyportal/broker_apis/boom.py
@@ -473,6 +473,8 @@ class BOOMBROKER(BrokerAPI):
     "username", "password", "survey"}``.
     """
 
+    parallel_ingestion = True  # shared Kafka consumer group
+
     surveys = ["ZTF", "LSST"]
     filter_kind = "pipeline"
     # cone_search returns BOOM's reference catalogs (Gaia/PS1/AllWISE, ...).
@@ -662,33 +664,22 @@ class BOOMBROKER(BrokerAPI):
         import asyncio
 
         import sqlalchemy as sa
-        from confluent_kafka import Consumer, KafkaError
 
         from baselayer.app.models import async_plain_session_factory
 
-        from ..models import Filter, User
-        from ..utils.sso_ingest import (
-            extract_designation,
-            ingest_sso_alert,
-            sidereal_filter_ids,
-            sso_filter_targets,
-            sso_routing_for,
-        )
-        from ._kafka import kafka_consumer_config, read_avro
-        from ._save import save_object_as_candidate
+        from ..models import Filter
+        from ..utils.sso_ingest import sso_filter_targets
 
         altdata = broker.altdata or {}
         kafka = altdata.get("kafka") or {}
         default_filter_ids = altdata.get("filter_ids") or []
-
-        consumer = Consumer(
-            kafka_consumer_config(kafka, f"skyportal-broker-{broker.id}")
-        )
         topics = kafka.get("topics") or ["ZTF_alerts_results", "LSST_alerts_results"]
-        consumer.subscribe(topics)
-        log(f"BOOM ingestion (broker {broker.id}): subscribed to {topics}")
+        # kafka_consumer_config prefers altdata's group_id; match it so the log
+        # and the actual Kafka group agree.
+        group_id = kafka.get("group_id") or f"skyportal-broker-{broker.id}"
 
-        # Map BOOM filter ids -> skyportal Filter ids once at startup.
+        # Map BOOM filter ids -> skyportal Filter ids once at startup (shared,
+        # read-only across the consumers below).
         async with async_plain_session_factory() as session:
             boom_map = {}
             filters = (await session.scalars(sa.select(Filter))).all()
@@ -700,10 +691,72 @@ class BOOMBROKER(BrokerAPI):
             # solar-system ingest instead of the sidereal one.
             sso_targets = sso_filter_targets(filters)
 
+        # N consumers sharing one group id; Kafka rebalances partitions across
+        # them. Defaults to 1.
+        num_consumers = max(1, int(kafka.get("num_consumers", 1)))
+        log(
+            f"BOOM ingestion (broker {broker.id}): {num_consumers} consumer(s) "
+            f"in group {group_id}, topics {topics}"
+        )
+        # TaskGroup so one consumer crashing cancels its siblings, not orphans them.
+        async with asyncio.TaskGroup() as tg:
+            tasks = [
+                tg.create_task(
+                    BOOMBROKER._consume_stream(
+                        broker,
+                        kafka,
+                        topics,
+                        group_id,
+                        boom_map,
+                        sso_targets,
+                        default_filter_ids,
+                        stop,
+                        max_messages,
+                    )
+                )
+                for _ in range(num_consumers)
+            ]
+        total = sum(t.result() for t in tasks)
+        log(f"BOOM ingestion (broker {broker.id}): consumed {total} alerts")
+        return total
+
+    @staticmethod
+    async def _consume_stream(
+        broker,
+        kafka,
+        topics,
+        group_id,
+        boom_map,
+        sso_targets,
+        default_filter_ids,
+        stop,
+        max_messages,
+    ):
+        """One Kafka consumer's poll/ingest loop. Consumers sharing ``group_id``
+        have Kafka rebalance the topic partitions across them."""
+        import asyncio
+
+        import sqlalchemy as sa
+        from confluent_kafka import Consumer, KafkaError
+
+        from baselayer.app.models import async_plain_session_factory
+
+        from ..models import User
+        from ..utils.sso_ingest import (
+            extract_designation,
+            ingest_sso_alert,
+            sidereal_filter_ids,
+            sso_routing_for,
+        )
+        from ._kafka import kafka_consumer_config, read_avro
+        from ._save import save_object_as_candidate
+
+        consumer = Consumer(kafka_consumer_config(kafka, group_id))
+        consumer.subscribe(topics)
         count = 0
         try:
             while not (stop is not None and stop.is_set()):
-                # poll is blocking; offload so one loop can host several brokers.
+                # poll is blocking; offload so one loop can host several consumers.
                 msg = await asyncio.to_thread(consumer.poll, 2.0)
                 if msg is None:
                     continue

--- a/skyportal/broker_apis/fink.py
+++ b/skyportal/broker_apis/fink.py
@@ -136,6 +136,8 @@ class FINKBROKER(BrokerAPI):
     science tags (e.g. ``fink_kn_candidates_ztf``).
     """
 
+    parallel_ingestion = True  # shared Kafka consumer group
+
     surveys = ["ZTF", "LSST"]
 
     form_json_schema_config = {

--- a/skyportal/broker_apis/interface.py
+++ b/skyportal/broker_apis/interface.py
@@ -66,6 +66,11 @@ class BrokerAPI(_Base):
     instance) plus a DB ``session`` and operation-specific keyword arguments.
     """
 
+    # Safe to run in multiple broker_ingest processes at once? True only for
+    # providers that consume via a shared Kafka consumer group (Kafka rebalances
+    # partitions across them); False for REST pollers, which would duplicate.
+    parallel_ingestion = False
+
     # ------------------------------------------------------------------ #
     # Interactive operations (skyportal -> broker)                       #
     # ------------------------------------------------------------------ #


### PR DESCRIPTION
This PR parallelizes broker ingestion via Kafka consumer groups and multi-process broker_ingest.

Closes #6122 