### PR TITLE
Fix object query on broker alerts page

### DIFF
--- a/skyportal/broker_apis/boom.py
+++ b/skyportal/broker_apis/boom.py
@@ -8,6 +8,7 @@ from pymongo import MongoClient
 from baselayer.app.env import load_env
 from baselayer.log import make_log
 
+from ..utils.survey import survey_from_object_id
 from .interface import BrokerAPI, normalize_module_streams
 
 log = make_log("broker/boom")
@@ -83,8 +84,20 @@ def _request(broker, method, path, *, params=None, json=None):
     return payload.get("data", payload) if isinstance(payload, dict) else payload
 
 
-def _survey(broker, kwargs):
-    return kwargs.get("survey") or (broker.altdata or {}).get("survey", DEFAULT_SURVEY)
+def _survey(broker, kwargs, object_id=None):
+    return (
+        kwargs.get("survey")
+        or survey_from_object_id(
+            object_id or kwargs.get("objectId"), BOOMBROKER.surveys
+        )
+        or (broker.altdata or {}).get("survey", DEFAULT_SURVEY)
+    )
+
+
+def _object_id_clause(object_id):
+    """Mongo clause matching an objectId stored as text or, for LSST, as an int64."""
+    text = str(object_id)
+    return {"$in": [text, int(text)]} if text.isdigit() else text
 
 
 # BOOM rejects a filter test whose window is wider than this ("JD window for
@@ -150,11 +163,17 @@ def _programids(kwargs, survey):
     return list(permissions.get(survey) or [])
 
 
+NO_PROGRAMID_SURVEYS = {"LSST"}
+DENY_ALL = {"_id": {"$in": []}}
+
+
 def _scope_filter(kwargs, survey):
     """Mongo clause restricting a query to the requester's accessible programids."""
     programids = _programids(kwargs, survey)
     if programids is None:
         return {}
+    if survey in NO_PROGRAMID_SURVEYS:
+        return {} if programids else DENY_ALL
     return {"candidate.programid": {"$in": programids}}
 
 
@@ -527,9 +546,9 @@ class BOOMBROKER(BrokerAPI):
 
     @staticmethod
     def query_alerts(broker, session, **kwargs):
-        survey = _survey(broker, kwargs)
-        catalog = f"{survey}_alerts"
         object_id = kwargs.get("objectId")
+        survey = _survey(broker, kwargs, object_id)
+        catalog = f"{survey}_alerts"
         ra, dec, radius = kwargs.get("ra"), kwargs.get("dec"), kwargs.get("radius")
         scope = {**_scope_filter(kwargs, survey), **_epoch_filter(kwargs)}
 
@@ -540,7 +559,7 @@ class BOOMBROKER(BrokerAPI):
                 "queries/find",
                 json={
                     "catalog_name": catalog,
-                    "filter": {"objectId": object_id, **scope},
+                    "filter": {"objectId": _object_id_clause(object_id), **scope},
                     "projection": NO_CUTOUT_PROJECTION,
                     "max_time_ms": 10000,
                 },
@@ -568,11 +587,16 @@ class BOOMBROKER(BrokerAPI):
     @staticmethod
     def get_alert(broker, alert_id, session, **kwargs):
         # Full object: brightest alert joined with its aux history.
-        survey = _survey(broker, kwargs)
+        survey = _survey(broker, kwargs, alert_id)
         catalog = f"{survey}_alerts"
         programids = _programids(kwargs, survey)
         pipeline = [
-            {"$match": {"objectId": alert_id, **_scope_filter(kwargs, survey)}},
+            {
+                "$match": {
+                    "objectId": _object_id_clause(alert_id),
+                    **_scope_filter(kwargs, survey),
+                }
+            },
             {"$sort": {"candidate.magpsf": 1}},
             {"$group": {"_id": "$objectId", "data": {"$first": "$$ROOT"}}},
             {"$replaceRoot": {"newRoot": "$data"}},

--- a/skyportal/tests/api_tests/test_broker_providers.py
+++ b/skyportal/tests/api_tests/test_broker_providers.py
@@ -257,6 +257,37 @@ def test_boom_query_alerts_unrestricted_for_admins(monkeypatch):
     assert calls[0]["json"]["filter"] == {"objectId": "ZTF20aapnxry"}
 
 
+def test_boom_query_alerts_infers_survey_from_object_id(monkeypatch):
+    calls = _capture_boom_request(monkeypatch)
+    broker = _MockBroker({"survey": "ZTF"})
+    BOOMBROKER.query_alerts(
+        broker, None, objectId="170591514995458386", permissions=None
+    )
+    assert calls[0]["json"]["catalog_name"] == "LSST_alerts"
+    assert calls[0]["json"]["filter"]["objectId"] == {
+        "$in": ["170591514995458386", 170591514995458386]
+    }
+
+
+@pytest.mark.parametrize(
+    ("permissions", "expected"),
+    [
+        ({"LSST": [1]}, {}),
+        ({"ZTF": [1]}, {"_id": {"$in": []}}),
+        ({}, {"_id": {"$in": []}}),
+    ],
+)
+def test_boom_query_alerts_lsst_scoped_by_stream(monkeypatch, permissions, expected):
+    calls = _capture_boom_request(monkeypatch)
+    broker = _MockBroker({"survey": "ZTF"})
+    BOOMBROKER.query_alerts(
+        broker, None, objectId="170591514995458386", permissions=permissions
+    )
+    filter_ = dict(calls[0]["json"]["filter"])
+    filter_.pop("objectId")
+    assert filter_ == expected
+
+
 def test_boom_get_alert_drops_out_of_scope_history(monkeypatch):
     record = {
         "objectId": "ZTF20aapnxry",

--- a/skyportal/utils/survey.py
+++ b/skyportal/utils/survey.py
@@ -1,0 +1,24 @@
+import re
+
+OBJECT_ID_PATTERNS = {
+    "ZTF": r"ZTF\d{2}[a-z]{7}$",  # ZTF + 2 digits + 7 lowercase characters
+    "DECAM": r"[ACT]20\d{6}\d{7}[pm]\d{6}$",  # A or C or T + 20 + 6 digits + 7 digits + p or m + 6 digits
+    "LSST": r"LSST-P-DO-\d+$",  # LSST-P-DO- + diaObjectId (int64)
+}
+
+
+def survey_from_object_id(object_id, surveys=None):
+    """Survey an object id belongs to, from its shape ("ZTF18abcdefg" -> ZTF, a
+    raw numeric diaObjectId -> LSST), or ``None`` when it says nothing (or names
+    a survey outside ``surveys``).
+    """
+    object_id = str(object_id or "").strip()
+    if not object_id:
+        return None
+    survey = next(
+        (s for s, regex in OBJECT_ID_PATTERNS.items() if re.match(regex, object_id)),
+        "LSST" if object_id.isdigit() else None,
+    )
+    if surveys is not None and survey not in surveys:
+        return None
+    return survey

--- a/skyportal/utils/tns.py
+++ b/skyportal/utils/tns.py
@@ -19,6 +19,7 @@ from baselayer.log import make_log
 from ..models import Instrument
 from .calculations import great_circle_distance
 from .parse import is_null
+from .survey import OBJECT_ID_PATTERNS
 
 env, cfg = load_env()
 
@@ -95,18 +96,9 @@ SNCOSMO_TO_TNSFILTER = {
 TNSFILTER_TO_SNCOSMO = {v: k for k, v in SNCOSMO_TO_TNSFILTER.items()}
 
 SURVEYS = {
-    "ZTF": {
-        "discovery_data_source_id": 48,
-        "regex": r"ZTF\d{2}[a-z]{7}$",  # ZTF + 2 digits + 7 lowercase characters
-    },
-    "DECAM": {
-        "discovery_data_source_id": 88,
-        "regex": r"[ACT]20\d{6}\d{7}[pm]\d{6}$",  # A or C or T + 20 + 6 digits + 7 digits + p or m + 6 digits
-    },
-    "LSST": {
-        "discovery_data_source_id": 165,
-        "regex": r"LSST-P-DO-\d+$",  # LSST-P-DO- + diaObjectId (int64)
-    },
+    "ZTF": {"discovery_data_source_id": 48, "regex": OBJECT_ID_PATTERNS["ZTF"]},
+    "DECAM": {"discovery_data_source_id": 88, "regex": OBJECT_ID_PATTERNS["DECAM"]},
+    "LSST": {"discovery_data_source_id": 165, "regex": OBJECT_ID_PATTERNS["LSST"]},
 }
 
 

--- a/static/js/components/broker/Broker.tsx
+++ b/static/js/components/broker/Broker.tsx
@@ -5,6 +5,7 @@ import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import IconButton from "@mui/material/IconButton";
+import MenuItem from "@mui/material/MenuItem";
 import Pagination from "@mui/material/Pagination";
 import Paper from "@mui/material/Paper";
 import Tab from "@mui/material/Tab";
@@ -81,13 +82,25 @@ const normalizeAlert = (a: any): NormalizedAlert => {
       a?.object_id ??
       a?.object ??
       cand?.objectId,
-    candid: cand?.candid ?? a?.candid,
+    candid: cand?.candid ?? a?.candid ?? a?._id ?? cand?.diaSourceId,
     ra: cand?.ra ?? a?.ra,
     dec: cand?.dec ?? a?.dec,
     magpsf: cand?.magpsf ?? a?.magpsf ?? cand?.mag,
     jd: cand?.jd ?? a?.jd,
     raw: a,
   };
+};
+
+// Mirrors the backend's survey_from_object_id.
+const surveyFromObjectId = (
+  objectId: string,
+  surveys: string[],
+): string | undefined => {
+  const id = objectId.trim();
+  let survey;
+  if (/^ZTF\d{2}[a-z]{7}$/.test(id)) survey = "ZTF";
+  else if (/^\d+$/.test(id)) survey = "LSST";
+  return survey && surveys.includes(survey) ? survey : undefined;
 };
 
 const TooltipTab = ({ tooltip, ...tabProps }: any) => (
@@ -108,6 +121,8 @@ const Broker = () => {
   const [ra, setRa] = useState("");
   const [dec, setDec] = useState("");
   const [radius, setRadius] = useState("");
+  const [survey, setSurvey] = useState("");
+  const [queriedSurvey, setQueriedSurvey] = useState("");
   const [mode, setMode] = useState<"search" | "preview">("search");
   const [page, setPage] = useState(1);
   const [tab, setTab] = useState(0);
@@ -127,7 +142,9 @@ const Broker = () => {
   const isFetching = alertFetching || filterFetching;
 
   const broker = (brokers || []).find((b) => b.id === brokerId);
-  const survey = broker?.surveys?.[0] ?? "ZTF";
+  const surveys = broker?.surveys ?? [];
+  const searchSurvey =
+    survey || surveyFromObjectId(objectId, surveys) || surveys[0] || "ZTF";
   const canQuery = Boolean(broker?.capabilities?.["query_alerts"]);
   const canPreview = Boolean(broker?.capabilities?.["test_filter"]);
   const hasFilters = Boolean(broker && broker.filter_kind !== "none");
@@ -163,10 +180,17 @@ const Broker = () => {
     const uRadius = searchParams.get("radius") || "";
     if (!oid && !uRa) return;
 
+    const uSurvey =
+      searchParams.get("survey") ||
+      surveyFromObjectId(oid, broker.surveys ?? []) ||
+      broker.surveys?.[0] ||
+      "ZTF";
     setObjectId(oid);
     setRa(uRa);
     setDec(uDec);
     setRadius(uRadius);
+    setSurvey(uSurvey);
+    setQueriedSurvey(uSurvey);
     setMode("search");
     setPage(1);
     triggerAlerts({
@@ -177,6 +201,7 @@ const Broker = () => {
         dec: uDec || undefined,
         radius: uRadius || undefined,
         radius_units: uRadius ? "arcsec" : undefined,
+        survey: uSurvey,
       },
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -192,6 +217,7 @@ const Broker = () => {
     setMode("search");
     setPage(1);
     setFilters([]);
+    setQueriedSurvey(searchSurvey);
     triggerAlerts({
       brokerId,
       params: {
@@ -200,6 +226,7 @@ const Broker = () => {
         dec: coneDisabled ? undefined : dec || undefined,
         radius: coneDisabled ? undefined : radius || undefined,
         radius_units: !coneDisabled && radius ? "arcsec" : undefined,
+        survey: searchSurvey,
       },
     });
   };
@@ -284,6 +311,22 @@ const Broker = () => {
                 value={objectId}
                 onChange={(e) => setObjectId(e.target.value)}
               />
+              {surveys.length > 1 && (
+                <TextField
+                  select
+                  size="small"
+                  label="Survey"
+                  value={searchSurvey}
+                  onChange={(e) => setSurvey(e.target.value)}
+                  sx={{ minWidth: 120 }}
+                >
+                  {surveys.map((s) => (
+                    <MenuItem key={s} value={s}>
+                      {s}
+                    </MenuItem>
+                  ))}
+                </TextField>
+              )}
               <Tooltip title={coneDisabled ? coneReason : ""}>
                 <span>
                   <TextField
@@ -333,7 +376,7 @@ const Broker = () => {
             ) : broker.filter_kind === "query" && canPreview ? (
               <LasairFilterBuilder
                 brokerId={brokerId}
-                survey={survey}
+                survey={searchSurvey}
                 onPreview={onPreview}
               />
             ) : (
@@ -393,7 +436,7 @@ const Broker = () => {
                                 brokerId={brokerId}
                                 brokerClassname={broker.broker_classname}
                                 objectId={g.objectId}
-                                survey={survey}
+                                survey={queriedSurvey || searchSurvey}
                                 alerts={g.alerts}
                                 expanded={pageGroups.length === 1}
                               />

--- a/static/js/components/broker/Broker.tsx
+++ b/static/js/components/broker/Broker.tsx
@@ -312,20 +312,22 @@ const Broker = () => {
                 onChange={(e) => setObjectId(e.target.value)}
               />
               {surveys.length > 1 && (
-                <TextField
-                  select
-                  size="small"
-                  label="Survey"
-                  value={searchSurvey}
-                  onChange={(e) => setSurvey(e.target.value)}
-                  sx={{ minWidth: 120 }}
-                >
-                  {surveys.map((s) => (
-                    <MenuItem key={s} value={s}>
-                      {s}
-                    </MenuItem>
-                  ))}
-                </TextField>
+                <Tooltip title="Selected automatically from the object ID format, override it if needed">
+                  <TextField
+                    select
+                    size="small"
+                    label="Survey"
+                    value={searchSurvey}
+                    onChange={(e) => setSurvey(e.target.value)}
+                    sx={{ minWidth: 120 }}
+                  >
+                    {surveys.map((s) => (
+                      <MenuItem key={s} value={s}>
+                        {s}
+                      </MenuItem>
+                    ))}
+                  </TextField>
+                </Tooltip>
               )}
               <Tooltip title={coneDisabled ? coneReason : ""}>
                 <span>

--- a/static/js/components/broker/CutoutTriplet.tsx
+++ b/static/js/components/broker/CutoutTriplet.tsx
@@ -44,7 +44,8 @@ const CutoutTriplet = ({
       setDataUris({});
       return;
     }
-    fetch(`/api/brokers/${brokerId}/alerts/${candid}/cutouts`, {
+    const qs = survey ? `?survey=${encodeURIComponent(survey)}` : "";
+    fetch(`/api/brokers/${brokerId}/alerts/${candid}/cutouts${qs}`, {
       credentials: "include",
     })
       .then((r) => r.json())

--- a/static/js/ducks/brokers.ts
+++ b/static/js/ducks/brokers.ts
@@ -49,7 +49,7 @@ const buildQuery = (params: Record<string, string | number | undefined>) => {
 };
 
 // 64-bit alert ids: JSON.parse would round them, so keep them as strings.
-const ID_KEYS = /"(candid|diaSourceId|diaObjectId)":\s*(\d{16,})/g;
+const ID_KEYS = /"(candid|_id|diaSourceId|diaObjectId)":\s*(\d{16,})/g;
 const parseKeepingIds = async (response: Response) => {
   const text = await response.text();
   return JSON.parse(text.replace(ID_KEYS, '"$1":"$2"'));


### PR DESCRIPTION
- Fix LSST object search on the broker alerts page.
- Infer the survey from the objectId (with a manual selector when a broker has several), match LSST ids stored as int64, and scope LSST alerts by stream instead of programid.
- Fix the fetch of LSST cutouts
- Add tooltip to survey selection for improved user guidance in Broker component.