### PR TITLE
Fix lost update on profile preferences

### DIFF
--- a/skyportal/handlers/api/internal/profile.py
+++ b/skyportal/handlers/api/internal/profile.py
@@ -314,7 +314,13 @@ class ProfileHandler(BaseHandler):
             for k, v in preferences.items():
                 if isinstance(v, dict):
                     preferences[k] = {key: val for key, val in v.items() if val != ""}
-            user_prefs = deepcopy(user.preferences)
+            user_prefs = deepcopy(
+                await session.scalar(
+                    sa.select(User.preferences)
+                    .where(User.id == user_id)
+                    .with_for_update()
+                )
+            )
             if not user_prefs:
                 user_prefs = preferences
             else:

--- a/skyportal/tests/frontend/observations_and_instruments/test_notifications.py
+++ b/skyportal/tests/frontend/observations_and_instruments/test_notifications.py
@@ -19,6 +19,12 @@ def filter_for_value(page, value, last=False):
     page.locator(input_xpath).first.fill(value)
 
 
+def _profile_patch(page):
+    return page.expect_response(
+        lambda r: "api/internal/profile" in r.url and r.request.method == "PATCH"
+    )
+
+
 def _enable_switch(page, name, attempts=3):
     """Click a notification preference switch and wait until it's checked.
 
@@ -420,9 +426,11 @@ def test_notification_setting_select(page, user):
     page.locator('//*[@name="notification_settings_button_mention"]').first.click()
 
     def _enable_setting(name):
-        page.locator(
-            f'//*[@name="{name}" and contains(@class, "MuiSwitch-input")]'
-        ).first.click()
+        # wait for each save: the switch flips optimistically, before the PATCH lands
+        with _profile_patch(page):
+            page.locator(
+                f'//*[@name="{name}" and contains(@class, "MuiSwitch-input")]'
+            ).first.click()
         expect(
             page.locator(
                 f'//*[@name="{name}" and contains(@class, "MuiSwitch-input")]/../../span[contains(@class,"Mui-checked")]'
@@ -432,7 +440,8 @@ def test_notification_setting_select(page, user):
     _enable_setting("email")
     _enable_setting("slack")
     # sms toggle reveals further sms options
-    page.locator('//*[@name="sms"]').first.click()
+    with _profile_patch(page):
+        page.locator('//*[@name="sms"]').first.click()
     expect(
         page.locator(
             '//*[@name="sms" and contains(@class, "MuiSwitch-input")]/../../span[contains(@class,"Mui-checked")]'
@@ -455,15 +464,14 @@ def test_notification_setting_select(page, user):
     ).first
     slider.focus()
     for _ in range(5):
-        slider.press("ArrowLeft")
+        with _profile_patch(page):
+            slider.press("ArrowLeft")
 
     expect(
         page.locator('//*[@aria-label="time_slot_slider" and @value="3"]').first
     ).to_be_visible()
 
-    with page.expect_response(
-        lambda r: "api/internal/profile" in r.url and r.request.method == "PATCH"
-    ):
+    with _profile_patch(page):
         page.locator(
             '//*[@label="Invert" and contains(@class, "MuiCheckbox-root")]'
         ).first.click()


### PR DESCRIPTION
Fix lost updates when saving profile preferences concurrently. Lock the user row and re-read preferences in the transaction: the JSONB. blob is merged in Python, so racing PATCHes clobbered each other.