### PR TITLE
Dogfood skyportal-py in the API tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,6 +131,7 @@ dev = [
     "pytest-rerunfailures>=14.0",
     "playwright==1.58.0",
     "pytest-playwright==0.8.0",
+    "skyportal-py==0.2.0",
 ]
 docs = [
     "sphinx>=9.1.0; python_version >= '3.12'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,7 +131,7 @@ dev = [
     "pytest-rerunfailures>=14.0",
     "playwright==1.58.0",
     "pytest-playwright==0.8.0",
-    "skyportal-py==0.2.0",
+    "skyportal-py==0.3.0",
 ]
 docs = [
     "sphinx>=9.1.0; python_version >= '3.12'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,7 +131,7 @@ dev = [
     "pytest-rerunfailures>=14.0",
     "playwright==1.58.0",
     "pytest-playwright==0.8.0",
-    "skyportal-py==0.3.0",
+    "skyportal-py==0.3.1",
 ]
 docs = [
     "sphinx>=9.1.0; python_version >= '3.12'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,7 +131,7 @@ dev = [
     "pytest-rerunfailures>=14.0",
     "playwright==1.58.0",
     "pytest-playwright==0.8.0",
-    "skyportal-py==0.3.1",
+    "skyportal-py==0.3.3",
 ]
 docs = [
     "sphinx>=9.1.0; python_version >= '3.12'",

--- a/skyportal/tests/__init__.py
+++ b/skyportal/tests/__init__.py
@@ -3,7 +3,7 @@ import time
 import urllib.parse
 
 import requests
-from skyportal_py import SkyPortal
+from skyportal_py import create_client
 
 from baselayer.app.config import load_config
 
@@ -28,14 +28,15 @@ def client(token=None, host=None):
     first-party client in the API tests).
 
     Clients are cached per (host, token) so connections are pooled.
-    trust_env=False for the same netrc reason as the requests session above.
+    trust_env=False for the same netrc reason as the requests session above;
+    timeout=None because, like the requests session, tests wait out slow
+    endpoints rather than failing on a client-side deadline.
     """
     if host is None:
         host = f"http://localhost:{cfg['ports.app']}"
     key = (host, token)
     if key not in _clients:
-        headers = {"Authorization": f"token {token}"} if token else {}
-        _clients[key] = SkyPortal(base_url=host, headers=headers, trust_env=False)
+        _clients[key] = create_client(host, token=token, timeout=None, trust_env=False)
     return _clients[key]
 
 

--- a/skyportal/tests/__init__.py
+++ b/skyportal/tests/__init__.py
@@ -3,6 +3,7 @@ import time
 import urllib.parse
 
 import requests
+from skyportal_py import SkyPortal
 
 from baselayer.app.config import load_config
 
@@ -18,6 +19,24 @@ session.trust_env = (
 )
 
 cfg = load_config(config_files=["test_config.yaml"])
+
+_clients = {}
+
+
+def client(token=None, host=None):
+    """Return a skyportal-py client for the test server (we dogfood the
+    first-party client in the API tests).
+
+    Clients are cached per (host, token) so connections are pooled.
+    trust_env=False for the same netrc reason as the requests session above.
+    """
+    if host is None:
+        host = f"http://localhost:{cfg['ports.app']}"
+    key = (host, token)
+    if key not in _clients:
+        headers = {"Authorization": f"token {token}"} if token else {}
+        _clients[key] = SkyPortal(base_url=host, headers=headers, trust_env=False)
+    return _clients[key]
 
 
 def api(

--- a/skyportal/tests/api_tests/groups_users_analysis/test_allocations.py
+++ b/skyportal/tests/api_tests/groups_users_analysis/test_allocations.py
@@ -1,265 +1,203 @@
-from skyportal.tests import api
+import pytest
+from skyportal_py import SkyPortalError
+from skyportal_py.allocations import AllocationPost, AllocationUpdate
+from skyportal_py.followup_requests import FollowupRequestPost
+
+from skyportal.tests import client
 
 
 def test_super_user_post_allocation(
     sedm, public_group, public_group2, super_admin_token
 ):
-    request_data = {
-        "group_id": public_group.id,
-        "instrument_id": sedm.id,
-        "pi": "Shri Kulkarni",
-        "hours_allocated": 200,
-        "validity_ranges": [
+    sp = client(super_admin_token)
+    request_data = AllocationPost(
+        group_id=public_group.id,
+        instrument_id=sedm.id,
+        pi="Shri Kulkarni",
+        hours_allocated=200,
+        validity_ranges=[
             {
                 "start_date": "2021-02-27T00:00:00.000Z",
                 "end_date": "3021-07-20T00:00:00.000Z",
             }
         ],
-        "proposal_id": "COO-2020A-P01",
-        "default_share_group_ids": [public_group.id, public_group2.id],
-    }
+        proposal_id="COO-2020A-P01",
+        default_share_group_ids=[public_group.id, public_group2.id],
+    )
 
-    status, data = api("POST", "allocation", data=request_data, token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-    id = data["data"]["id"]
+    id = sp.post_allocation(request_data).id
 
-    status, data = api("GET", f"allocation/{id}", token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
+    allocation = sp.fetch_allocation(id)
 
-    for key in request_data:
-        assert data["data"]["allocation"][key] == request_data[key]
+    for key, value in request_data.model_dump(exclude_none=True).items():
+        assert getattr(allocation, key) == value
 
 
 def test_super_user_modify_allocation(sedm, public_group, super_admin_token):
-    request_data = {
-        "group_id": public_group.id,
-        "instrument_id": sedm.id,
-        "pi": "Shri Kulkarni",
-        "hours_allocated": 200,
-        "validity_ranges": [
+    sp = client(super_admin_token)
+    request_data = AllocationPost(
+        group_id=public_group.id,
+        instrument_id=sedm.id,
+        pi="Shri Kulkarni",
+        hours_allocated=200,
+        validity_ranges=[
             {
                 "start_date": "2021-02-27T00:00:00.000Z",
                 "end_date": "3021-07-20T00:00:00.000Z",
             }
         ],
-        "proposal_id": "COO-2020A-P01",
-    }
-
-    status, data = api("POST", "allocation", data=request_data, token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-    id = data["data"]["id"]
-
-    status, data = api("GET", f"allocation/{id}", token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-
-    for key in request_data:
-        assert data["data"]["allocation"][key] == request_data[key]
-
-    request2_data = {"proposal_id": "COO-2020A-P02"}
-
-    status, data = api(
-        "PUT", f"allocation/{id}", data=request2_data, token=super_admin_token
+        proposal_id="COO-2020A-P01",
     )
-    assert status == 200
 
-    status, data = api("GET", f"allocation/{id}", token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
+    id = sp.post_allocation(request_data).id
 
-    request_data.update(request2_data)
-    for key in request_data:
-        assert data["data"]["allocation"][key] == request_data[key]
+    allocation = sp.fetch_allocation(id)
+
+    for key, value in request_data.model_dump(exclude_none=True).items():
+        assert getattr(allocation, key) == value
+
+    request2_data = AllocationUpdate(proposal_id="COO-2020A-P02")
+
+    sp.update_allocation(id, request2_data)
+
+    allocation = sp.fetch_allocation(id)
+
+    expected = request_data.model_dump(exclude_none=True)
+    expected.update(request2_data.model_dump(exclude_none=True))
+    for key, value in expected.items():
+        assert getattr(allocation, key) == value
 
 
 def test_read_only_user_cannot_get_unowned_allocation(
     view_only_token, super_admin_token, sedm, public_group2
 ):
-    request_data = {
-        "group_id": public_group2.id,
-        "instrument_id": sedm.id,
-        "pi": "Shri Kulkarni",
-        "hours_allocated": 200,
-        "validity_ranges": [
+    sp = client(super_admin_token)
+    request_data = AllocationPost(
+        group_id=public_group2.id,
+        instrument_id=sedm.id,
+        pi="Shri Kulkarni",
+        hours_allocated=200,
+        validity_ranges=[
             {
                 "start_date": "2021-02-27T00:00:00.000Z",
                 "end_date": "3021-07-20T00:00:00.000Z",
             }
         ],
-        "proposal_id": "COO-2020A-P01",
-    }
+        proposal_id="COO-2020A-P01",
+    )
 
-    status, data = api("POST", "allocation", data=request_data, token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-    id = data["data"]["id"]
+    id = sp.post_allocation(request_data).id
 
-    status, data = api("GET", f"allocation/{id}", token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
+    allocation = sp.fetch_allocation(id)
 
-    for key in request_data:
-        assert data["data"]["allocation"][key] == request_data[key]
+    for key, value in request_data.model_dump(exclude_none=True).items():
+        assert getattr(allocation, key) == value
 
-    status, data = api("GET", f"allocation/{id}", token=view_only_token)
-    assert status == 400
-    assert data["status"] == "error"
+    with pytest.raises(SkyPortalError) as err:
+        client(view_only_token).fetch_allocation(id)
+    assert err.value.status_code == 400
 
 
 def test_read_only_user_get_invalid_allocation_id(view_only_token):
-    status, data = api("GET", f"allocation/{-1}", token=view_only_token)
-    assert status == 400
-    assert data["status"] == "error"
+    with pytest.raises(SkyPortalError) as err:
+        client(view_only_token).fetch_allocation(-1)
+    assert err.value.status_code == 400
 
 
 def test_delete_allocation_cascades_to_requests(
     public_group, public_source, super_admin_token, sedm
 ):
-    request_data = {
-        "group_id": public_group.id,
-        "instrument_id": sedm.id,
-        "pi": "Shri Kulkarni",
-        "hours_allocated": 200,
-        "validity_ranges": [
-            {
-                "start_date": "2021-02-27T00:00:00.000Z",
-                "end_date": "3021-07-20T00:00:00.000Z",
-            }
-        ],
-        "proposal_id": "COO-2020A-P01",
-    }
+    sp = client(super_admin_token)
+    allocation_id = sp.post_allocation(
+        AllocationPost(
+            group_id=public_group.id,
+            instrument_id=sedm.id,
+            pi="Shri Kulkarni",
+            hours_allocated=200,
+            validity_ranges=[
+                {
+                    "start_date": "2021-02-27T00:00:00.000Z",
+                    "end_date": "3021-07-20T00:00:00.000Z",
+                }
+            ],
+            proposal_id="COO-2020A-P01",
+        )
+    ).id
 
-    status, data = api("POST", "allocation", data=request_data, token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-    allocation_id = data["data"]["id"]
+    request_id = sp.post_followup_request(
+        FollowupRequestPost(
+            allocation_id=allocation_id,
+            obj_id=public_source.id,
+            payload={
+                "priority": 5,
+                "start_date": "3010-09-01",
+                "end_date": "3012-09-01",
+                "observation_type": "IFU",
+                "exposure_time": 300,
+                "maximum_airmass": 2,
+                "maximum_fwhm": 1.2,
+            },
+        )
+    ).id
 
-    request_data = {
-        "allocation_id": allocation_id,
-        "obj_id": public_source.id,
-        "payload": {
-            "priority": 5,
-            "start_date": "3010-09-01",
-            "end_date": "3012-09-01",
-            "observation_type": "IFU",
-            "exposure_time": 300,
-            "maximum_airmass": 2,
-            "maximum_fwhm": 1.2,
-        },
-    }
+    sp.fetch_followup_request(request_id)
 
-    status, data = api(
-        "POST", "followup_request", data=request_data, token=super_admin_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    request_id = data["data"]["id"]
+    sp.delete_allocation(allocation_id)
 
-    status, data = api("GET", f"followup_request/{request_id}", token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-
-    status, data = api("DELETE", f"allocation/{allocation_id}", token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-
-    status, data = api("GET", f"followup_request/{request_id}", token=super_admin_token)
-    assert status == 400
-    assert "Could not retrieve followup request" in data["message"]
+    with pytest.raises(
+        SkyPortalError, match="Could not retrieve followup request"
+    ) as err:
+        sp.fetch_followup_request(request_id)
+    assert err.value.status_code == 400
 
 
 def test_allocation_comment(public_group, public_source, super_admin_token, sedm):
-    # Create an allocation
-    request_data = {
-        "group_id": public_group.id,
-        "instrument_id": sedm.id,
-        "pi": "Shri Kulkarni",
-        "hours_allocated": 200,
-        "validity_ranges": [
-            {
-                "start_date": "2021-02-27T00:00:00.000Z",
-                "end_date": "3021-07-20T00:00:00.000Z",
-            }
-        ],
-        "proposal_id": "COO-2020A-P01",
-    }
+    sp = client(super_admin_token)
+    # Create and post an allocation
+    allocation_id = sp.post_allocation(
+        AllocationPost(
+            group_id=public_group.id,
+            instrument_id=sedm.id,
+            pi="Shri Kulkarni",
+            hours_allocated=200,
+            validity_ranges=[
+                {
+                    "start_date": "2021-02-27T00:00:00.000Z",
+                    "end_date": "3021-07-20T00:00:00.000Z",
+                }
+            ],
+            proposal_id="COO-2020A-P01",
+        )
+    ).id
 
-    # Post the allocation
-    status, data = api("POST", "allocation", data=request_data, token=super_admin_token)
-
-    # Check that the allocation was created
-    assert status == 200
-    assert data["status"] == "success"
-    allocation_id = data["data"]["id"]
-
-    # Create a followup request with the allocation id
-    request_data = {
-        "allocation_id": allocation_id,
-        "obj_id": public_source.id,
-        "payload": {
-            "priority": 5,
-            "start_date": "3010-09-01",
-            "end_date": "3012-09-01",
-            "observation_type": "IFU",
-            "exposure_time": 300,
-            "maximum_airmass": 2,
-            "maximum_fwhm": 1.2,
-        },
-    }
-
-    # Post the followup request with no comment
-    status, data = api(
-        "POST", "followup_request", data=request_data, token=super_admin_token
-    )
-    # Check that the followup request was created and get the request id
-    assert status == 200
-    assert data["status"] == "success"
-    request_id = data["data"]["id"]
+    # Post a followup request with the allocation id and no comment
+    request_id = sp.post_followup_request(
+        FollowupRequestPost(
+            allocation_id=allocation_id,
+            obj_id=public_source.id,
+            payload={
+                "priority": 5,
+                "start_date": "3010-09-01",
+                "end_date": "3012-09-01",
+                "observation_type": "IFU",
+                "exposure_time": 300,
+                "maximum_airmass": 2,
+                "maximum_fwhm": 1.2,
+            },
+        )
+    ).id
 
     # Check that the comment on the followup request is empty
-    status, data = api("GET", f"followup_request/{request_id}", token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-    assert data["data"]["comment"] is None
-
-    # Create a comment to put on the followup request
-    request_data = {"comment": "This is a test comment"}
+    assert sp.fetch_followup_request(request_id).comment is None
 
     # Put a comment on the followup request
-    status, data = api(
-        "PUT",
-        f"followup_request/{request_id}/comment",
-        data=request_data,
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp.post_followup_request_comment(request_id, "This is a test comment")
 
     # Check that the comment is now set
-    status, data = api("GET", f"followup_request/{request_id}", token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-    assert data["data"]["comment"] == "This is a test comment"
-
-    # Check if comment can be set to empty
-    request_data = {"comment": ""}
+    assert sp.fetch_followup_request(request_id).comment == "This is a test comment"
 
     # Put an empty comment on the followup request
-    status, data = api(
-        "PUT",
-        f"followup_request/{request_id}/comment",
-        data=request_data,
-        token=super_admin_token,
-    )
-
-    assert status == 200
-    assert data["status"] == "success"
+    sp.post_followup_request_comment(request_id, "")
 
     # Check that the comment is now set to empty
-    status, data = api("GET", f"followup_request/{request_id}", token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-    assert data["data"]["comment"] is None
+    assert sp.fetch_followup_request(request_id).comment is None

--- a/skyportal/tests/api_tests/groups_users_analysis/test_analysis.py
+++ b/skyportal/tests/api_tests/groups_users_analysis/test_analysis.py
@@ -5,311 +5,243 @@ import socketserver
 import time
 import uuid
 
+import pytest
+from skyportal_py import SkyPortalError
+from skyportal_py.analysis import (
+    AnalysisPost,
+    AnalysisServicePost,
+    AnalysisServiceUpdate,
+    AnalysisUploadPost,
+    DefaultAnalysisPost,
+)
+from skyportal_py.classifications import ClassificationPost
+from skyportal_py.sources import SourcePost
+from skyportal_py.taxonomies import TaxonomyPost
 from tdtax import __version__, taxonomy
 
-from skyportal.tests import api, retry_until
+from skyportal.tests import api, client, retry_until
 
 analysis_port = 6802
 
 
 def test_post_new_analysis_service(analysis_service_token, public_group):
+    sp = client(analysis_service_token)
     name = str(uuid.uuid4())
 
     optional_analysis_parameters = {"test_parameters": ["test_value_1", "test_value_2"]}
 
-    post_data = {
-        "name": name,
-        "display_name": "test analysis service name",
-        "description": "A test analysis service description",
-        "version": "1.0",
-        "contact_name": "Vera Rubin",
-        "contact_email": "vr@ls.st",
-        "url": f"http://localhost:5000/analysis/{name}",
-        "optional_analysis_parameters": json.dumps(optional_analysis_parameters),
-        "authentication_type": "none",
-        "analysis_type": "lightcurve_fitting",
-        "input_data_types": ["photometry", "redshift"],
-        "timeout": 60,
-        "group_ids": [public_group.id],
-    }
+    analysis_service_id = sp.post_analysis_service(
+        AnalysisServicePost(
+            name=name,
+            display_name="test analysis service name",
+            description="A test analysis service description",
+            version="1.0",
+            contact_name="Vera Rubin",
+            contact_email="vr@ls.st",
+            url=f"http://localhost:5000/analysis/{name}",
+            optional_analysis_parameters=json.dumps(optional_analysis_parameters),
+            authentication_type="none",
+            analysis_type="lightcurve_fitting",
+            input_data_types=["photometry", "redshift"],
+            timeout=60,
+            group_ids=[public_group.id],
+        )
+    ).id
 
-    status, data = api(
-        "POST", "analysis_service", data=post_data, token=analysis_service_token
+    service = sp.fetch_analysis_service(analysis_service_id)
+    assert service.name == name
+    assert service.display_name == "test analysis service name"
+    assert service.description == "A test analysis service description"
+    assert service.version == "1.0"
+    assert service.contact_name == "Vera Rubin"
+    assert service.contact_email == "vr@ls.st"
+    assert service.url == f"http://localhost:5000/analysis/{name}"
+    assert service.optional_analysis_parameters == json.dumps(
+        optional_analysis_parameters
     )
-    assert status == 200
-    assert data["status"] == "success"
+    assert service.authentication_type == "none"
+    assert service.analysis_type == "lightcurve_fitting"
+    assert service.input_data_types == ["photometry", "redshift"]
+    assert service.timeout == 60
+    assert sorted(g.id for g in service.groups) == sorted([public_group.id])
 
-    analysis_service_id = data["data"]["id"]
-    status, data = api(
-        "GET", f"analysis_service/{analysis_service_id}", token=analysis_service_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    for key in post_data:
-        if key != "group_ids":
-            assert data["data"][key] == post_data[key]
-        else:
-            assert sorted(g["id"] for g in data["data"]["groups"]) == sorted(
-                post_data["group_ids"]
-            )
-
-    status, data = api(
-        "DELETE",
-        f"analysis_service/{analysis_service_id}",
-        token=analysis_service_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp.delete_analysis_service(analysis_service_id)
 
 
 def test_update_analysis_service(analysis_service_token, public_group):
+    sp = client(analysis_service_token)
     name = str(uuid.uuid4())
-    post_data = {
-        "name": name,
-        "display_name": "test analysis service name",
-        "description": "A test analysis service description",
-        "version": "1.0",
-        "contact_name": "Vera Rubin",
-        "contact_email": "vr@ls.st",
-        "url": f"http://localhost:5000/analysis/{name}",
-        "authentication_type": "none",
-        "analysis_type": "lightcurve_fitting",
-        "input_data_types": ["photometry", "redshift"],
-        "timeout": 60,
-        "group_ids": [public_group.id],
-    }
+    analysis_service_id = sp.post_analysis_service(
+        AnalysisServicePost(
+            name=name,
+            display_name="test analysis service name",
+            description="A test analysis service description",
+            version="1.0",
+            contact_name="Vera Rubin",
+            contact_email="vr@ls.st",
+            url=f"http://localhost:5000/analysis/{name}",
+            authentication_type="none",
+            analysis_type="lightcurve_fitting",
+            input_data_types=["photometry", "redshift"],
+            timeout=60,
+            group_ids=[public_group.id],
+        )
+    ).id
 
-    status, data = api(
-        "POST", "analysis_service", data=post_data, token=analysis_service_token
+    sp.update_analysis_service(
+        analysis_service_id, AnalysisServiceUpdate(version="2.0", timeout=120.0)
     )
-    assert status == 200
-    assert data["status"] == "success"
 
-    analysis_service_id = data["data"]["id"]
+    service = sp.fetch_analysis_service(analysis_service_id)
+    assert service.version == "2.0"
+    assert service.timeout == 120.0
 
-    new_post_data = {"version": "2.0", "timeout": 120.0}
-
-    status, data = api(
-        "PATCH",
-        f"analysis_service/{analysis_service_id}",
-        data=new_post_data,
-        token=analysis_service_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-
-    status, data = api(
-        "GET", f"analysis_service/{analysis_service_id}", token=analysis_service_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
-
-    for key in new_post_data:
-        assert data["data"][key] == new_post_data[key]
-
-    status, data = api(
-        "DELETE",
-        f"analysis_service/{analysis_service_id}",
-        token=analysis_service_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp.delete_analysis_service(analysis_service_id)
 
 
 def test_update_analysis_service_groups(super_admin_token, public_group, public_group2):
     # Super admin, so the group-membership check passes and we reach the
     # groups reassignment (the fixed code path).
+    sp = client(super_admin_token)
     name = str(uuid.uuid4())
-    post_data = {
-        "name": name,
-        "display_name": "test analysis service name",
-        "description": "A test analysis service description",
-        "version": "1.0",
-        "contact_name": "Vera Rubin",
-        "contact_email": "vr@ls.st",
-        "url": f"http://localhost:5000/analysis/{name}",
-        "authentication_type": "none",
-        "analysis_type": "lightcurve_fitting",
-        "input_data_types": ["photometry", "redshift"],
-        "timeout": 60,
-        "group_ids": [public_group.id],
-    }
-
-    status, data = api(
-        "POST", "analysis_service", data=post_data, token=super_admin_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    analysis_service_id = data["data"]["id"]
+    analysis_service_id = sp.post_analysis_service(
+        AnalysisServicePost(
+            name=name,
+            display_name="test analysis service name",
+            description="A test analysis service description",
+            version="1.0",
+            contact_name="Vera Rubin",
+            contact_email="vr@ls.st",
+            url=f"http://localhost:5000/analysis/{name}",
+            authentication_type="none",
+            analysis_type="lightcurve_fitting",
+            input_data_types=["photometry", "redshift"],
+            timeout=60,
+            group_ids=[public_group.id],
+        )
+    ).id
 
     # Reassigning groups on an existing service must not raise the async
     # greenlet_spawn error from lazy-loading the old groups collection to diff it.
-    status, data = api(
-        "PATCH",
-        f"analysis_service/{analysis_service_id}",
-        data={"group_ids": [public_group.id, public_group2.id]},
-        token=super_admin_token,
+    sp.update_analysis_service(
+        analysis_service_id,
+        AnalysisServiceUpdate(group_ids=[public_group.id, public_group2.id]),
     )
-    assert status == 200
-    assert data["status"] == "success"
 
-    status, data = api(
-        "GET", f"analysis_service/{analysis_service_id}", token=super_admin_token
-    )
-    assert status == 200
-    assert sorted(g["id"] for g in data["data"]["groups"]) == sorted(
+    service = sp.fetch_analysis_service(analysis_service_id)
+    assert sorted(g.id for g in service.groups) == sorted(
         [public_group.id, public_group2.id]
     )
 
-    status, data = api(
-        "DELETE",
-        f"analysis_service/{analysis_service_id}",
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp.delete_analysis_service(analysis_service_id)
 
 
 def test_update_default_analysis(super_admin_token, public_group, public_group2):
     # Super admin so the group-membership check passes for both groups.
+    sp = client(super_admin_token)
     name = str(uuid.uuid4())
     optional_analysis_parameters = {"first": ["a", "b"], "second": ["x"]}
-    post_data = {
-        "name": name,
-        "display_name": "test default analysis update",
-        "description": "A test default analysis service description",
-        "version": "1.0",
-        "contact_name": "Vera Rubin",
-        "contact_email": "vr@ls.st",
-        "url": f"http://localhost:5000/analysis/{name}",
-        "optional_analysis_parameters": json.dumps(optional_analysis_parameters),
-        "authentication_type": "none",
-        "analysis_type": "lightcurve_fitting",
-        "input_data_types": ["photometry", "redshift"],
-        "timeout": 60,
-        "group_ids": [public_group.id],
-    }
-    status, data = api(
-        "POST", "analysis_service", data=post_data, token=super_admin_token
-    )
-    assert status == 200
-    analysis_service_id = data["data"]["id"]
+    analysis_service_id = sp.post_analysis_service(
+        AnalysisServicePost(
+            name=name,
+            display_name="test default analysis update",
+            description="A test default analysis service description",
+            version="1.0",
+            contact_name="Vera Rubin",
+            contact_email="vr@ls.st",
+            url=f"http://localhost:5000/analysis/{name}",
+            optional_analysis_parameters=json.dumps(optional_analysis_parameters),
+            authentication_type="none",
+            analysis_type="lightcurve_fitting",
+            input_data_types=["photometry", "redshift"],
+            timeout=60,
+            group_ids=[public_group.id],
+        )
+    ).id
 
-    url = f"analysis_service/{analysis_service_id}/default_analysis"
-    status, data = api(
-        "POST",
-        url,
-        data={
-            "default_analysis_parameters": {"first": "a"},
-            "source_filter": {"group_id": public_group.id},
-            "daily_limit": 1,
-            "group_ids": [public_group.id],
-        },
-        token=super_admin_token,
-    )
-    assert status == 200
-    default_analysis_id = data["data"]["id"]
+    default_analysis_id = sp.post_default_analysis(
+        analysis_service_id,
+        DefaultAnalysisPost(
+            default_analysis_parameters={"first": "a"},
+            source_filter={"group_id": public_group.id},
+            daily_limit=1,
+            group_ids=[public_group.id],
+        ),
+    ).id
 
     # Partial update: change params + source_filter + reassign groups (the group
     # reassignment is the lazy-load path that must not raise greenlet_spawn).
-    status, data = api(
-        "PATCH",
-        f"{url}/{default_analysis_id}",
-        data={
-            "default_analysis_parameters": {"first": "b", "second": "x"},
-            "source_filter": {"group_id": public_group2.id},
-            "daily_limit": 5,
-            "group_ids": [public_group.id, public_group2.id],
-        },
-        token=super_admin_token,
+    sp.update_default_analysis(
+        analysis_service_id,
+        default_analysis_id,
+        DefaultAnalysisPost(
+            default_analysis_parameters={"first": "b", "second": "x"},
+            source_filter={"group_id": public_group2.id},
+            daily_limit=5,
+            group_ids=[public_group.id, public_group2.id],
+        ),
     )
-    assert status == 200
-    assert data["status"] == "success"
 
-    status, data = api("GET", f"{url}/{default_analysis_id}", token=super_admin_token)
-    assert status == 200
-    d = data["data"]
-    assert d["default_analysis_parameters"] == {"first": "b", "second": "x"}
-    assert d["source_filter"] == {"group_id": public_group2.id}
-    assert sorted(g["id"] for g in d["groups"]) == sorted(
-        [public_group.id, public_group2.id]
-    )
+    d = sp.fetch_default_analysis(analysis_service_id, default_analysis_id)
+    assert d.default_analysis_parameters == {"first": "b", "second": "x"}
+    assert d.source_filter == {"group_id": public_group2.id}
+    assert sorted(g.id for g in d.groups) == sorted([public_group.id, public_group2.id])
 
     # A param key not declared in optional_analysis_parameters is rejected.
-    status, data = api(
-        "PATCH",
-        f"{url}/{default_analysis_id}",
-        data={"default_analysis_parameters": {"undeclared_key": "z"}},
-        token=super_admin_token,
-    )
-    assert status == 400
+    with pytest.raises(SkyPortalError) as err:
+        sp.update_default_analysis(
+            analysis_service_id,
+            default_analysis_id,
+            DefaultAnalysisPost(default_analysis_parameters={"undeclared_key": "z"}),
+        )
+    assert err.value.status_code == 400
 
-    status, data = api(
-        "DELETE", f"{url}/{default_analysis_id}", token=super_admin_token
-    )
-    assert status == 200
+    sp.delete_default_analysis(analysis_service_id, default_analysis_id)
 
 
 def test_get_two_analysis_services(analysis_service_token, public_group):
+    sp = client(analysis_service_token)
     name = str(uuid.uuid4())
-    post_data = {
-        "name": name,
-        "display_name": "test analysis service name",
-        "description": "A test analysis service description",
-        "version": "1.0",
-        "contact_name": "Vera Rubin",
-        "contact_email": "vr@ls.st",
-        "url": f"http://localhost:5000/analysis/{name}",
-        "authentication_type": "none",
-        "analysis_type": "lightcurve_fitting",
-        "input_data_types": ["photometry", "redshift"],
-        "timeout": 60,
-        "group_ids": [public_group.id],
-    }
-
-    status, data = api(
-        "POST", "analysis_service", data=post_data, token=analysis_service_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    analysis_service_id = data["data"]["id"]
+    analysis_service_id = sp.post_analysis_service(
+        AnalysisServicePost(
+            name=name,
+            display_name="test analysis service name",
+            description="A test analysis service description",
+            version="1.0",
+            contact_name="Vera Rubin",
+            contact_email="vr@ls.st",
+            url=f"http://localhost:5000/analysis/{name}",
+            authentication_type="none",
+            analysis_type="lightcurve_fitting",
+            input_data_types=["photometry", "redshift"],
+            timeout=60,
+            group_ids=[public_group.id],
+        )
+    ).id
 
     name_1 = str(uuid.uuid4())
-    post_data_1 = {
-        "name": name_1,
-        "display_name": "another test analysis service name",
-        "description": "Another test analysis service description",
-        "version": "1.1",
-        "contact_name": "Henrietta Swan Leavitt",
-        "contact_email": "hsl@harvard.edu",
-        "url": f"http://localhost:5000/analysis/{name_1}",
-        "authentication_type": "none",
-        "analysis_type": "lightcurve_fitting",
-        "input_data_types": ["spectra"],
-        "timeout": 1200.0,
-        "group_ids": [public_group.id],
-    }
+    analysis_service_id_1 = sp.post_analysis_service(
+        AnalysisServicePost(
+            name=name_1,
+            display_name="another test analysis service name",
+            description="Another test analysis service description",
+            version="1.1",
+            contact_name="Henrietta Swan Leavitt",
+            contact_email="hsl@harvard.edu",
+            url=f"http://localhost:5000/analysis/{name_1}",
+            authentication_type="none",
+            analysis_type="lightcurve_fitting",
+            input_data_types=["spectra"],
+            timeout=1200.0,
+            group_ids=[public_group.id],
+        )
+    ).id
 
-    status, data = api(
-        "POST", "analysis_service", data=post_data_1, token=analysis_service_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    analysis_service_id_1 = data["data"]["id"]
-
-    status, data = api("GET", "analysis_service", token=analysis_service_token)
-    assert status == 200
-    assert data["status"] == "success"
-
-    as_ids = [a["id"] for a in data["data"]]
+    as_ids = [a.id for a in sp.fetch_analysis_services()]
     assert {analysis_service_id, analysis_service_id_1} == set(as_ids)
 
     for as_id in [analysis_service_id, analysis_service_id_1]:
-        status, data = api(
-            "DELETE", f"analysis_service/{as_id}", token=analysis_service_token
-        )
-        assert status == 200
-        assert data["status"] == "success"
+        sp.delete_analysis_service(as_id)
 
 
 def test_missing_required_analysis_service_parameter(
@@ -330,6 +262,7 @@ def test_missing_required_analysis_service_parameter(
         "group_ids": [public_group.id],
     }
 
+    # raw api: intentionally malformed payload the typed client can't produce
     status, data = api(
         "POST", "analysis_service", data=post_data, token=analysis_service_token
     )
@@ -338,64 +271,50 @@ def test_missing_required_analysis_service_parameter(
 
 
 def test_duplicate_analysis_service(analysis_service_token, public_group):
+    sp = client(analysis_service_token)
     name = str(uuid.uuid4())
-    post_data = {
-        "name": name,
-        "display_name": "test analysis service name",
-        "description": "A test analysis service description",
-        "version": "1.0",
-        "contact_name": "Vera Rubin",
-        "url": f"http://localhost:5000/analysis/{name}",
-        "authentication_type": "none",
-        "analysis_type": "lightcurve_fitting",
-        "input_data_types": ["photometry", "redshift"],
-        "group_ids": [public_group.id],
-    }
-
-    status, data = api(
-        "POST", "analysis_service", data=post_data, token=analysis_service_token
+    payload = AnalysisServicePost(
+        name=name,
+        display_name="test analysis service name",
+        description="A test analysis service description",
+        version="1.0",
+        contact_name="Vera Rubin",
+        url=f"http://localhost:5000/analysis/{name}",
+        authentication_type="none",
+        analysis_type="lightcurve_fitting",
+        input_data_types=["photometry", "redshift"],
+        group_ids=[public_group.id],
     )
 
-    assert status == 200
-    assert data["status"] == "success"
-    analysis_service_id = data["data"]["id"]
+    analysis_service_id = sp.post_analysis_service(payload).id
 
-    status, data = api(
-        "POST", "analysis_service", data=post_data, token=analysis_service_token
-    )
-    assert status == 400
-    assert "duplicate key value violates unique constraint" in data["message"]
+    with pytest.raises(
+        SkyPortalError, match="duplicate key value violates unique constraint"
+    ) as err:
+        sp.post_analysis_service(payload)
+    assert err.value.status_code == 400
 
-    status, data = api(
-        "DELETE",
-        f"analysis_service/{analysis_service_id}",
-        token=analysis_service_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp.delete_analysis_service(analysis_service_id)
 
 
 def test_bad_url(analysis_service_token, public_group):
     name = str(uuid.uuid4())
-    post_data = {
-        "name": name,
-        "display_name": "test analysis service name",
-        "description": "A test analysis service description",
-        "version": "1.0",
-        "contact_name": "Vera Rubin",
-        "url": f"my_code_{name}.py",
-        "authentication_type": "none",
-        "analysis_type": "lightcurve_fitting",
-        "input_data_types": ["photometry", "redshift"],
-        "group_ids": [public_group.id],
-    }
-
-    status, data = api(
-        "POST", "analysis_service", data=post_data, token=analysis_service_token
-    )
-
-    assert status == 400
-    assert "a valid `url` is required" in data["message"]
+    with pytest.raises(SkyPortalError, match="a valid `url` is required") as err:
+        client(analysis_service_token).post_analysis_service(
+            AnalysisServicePost(
+                name=name,
+                display_name="test analysis service name",
+                description="A test analysis service description",
+                version="1.0",
+                contact_name="Vera Rubin",
+                url=f"my_code_{name}.py",
+                authentication_type="none",
+                analysis_type="lightcurve_fitting",
+                input_data_types=["photometry", "redshift"],
+                group_ids=[public_group.id],
+            )
+        )
+    assert err.value.status_code == 400
 
 
 def test_bad_authentication_type(analysis_service_token, public_group):
@@ -413,6 +332,7 @@ def test_bad_authentication_type(analysis_service_token, public_group):
         "group_ids": [public_group.id],
     }
 
+    # raw api: intentionally malformed payload the typed client can't produce
     status, data = api(
         "POST", "analysis_service", data=post_data, token=analysis_service_token
     )
@@ -424,67 +344,54 @@ def test_bad_authentication_type(analysis_service_token, public_group):
 
 
 def test_authentication_credentials(analysis_service_token, public_group):
+    sp = client(analysis_service_token)
     name = str(uuid.uuid4())
 
     authinfo = {"header_token": {"Authorization": "Bearer MY_TOKEN"}}
-    post_data = {
-        "name": name,
-        "display_name": "test analysis service name",
-        "description": "A test analysis service description",
-        "version": "1.0",
-        "contact_name": "Vera Rubin",
-        "url": f"http://localhost:5000/analysis/{name}",
-        "authentication_type": "header_token",
-        "_authinfo": json.dumps(authinfo),
-        "analysis_type": "lightcurve_fitting",
-        "input_data_types": ["photometry", "redshift"],
-        "group_ids": [public_group.id],
-    }
-
-    status, data = api(
-        "POST", "analysis_service", data=post_data, token=analysis_service_token
-    )
-    assert status == 200
-    analysis_service_id = data["data"]["id"]
-    status, data = api(
-        "GET", f"analysis_service/{analysis_service_id}", token=analysis_service_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    analysis_service_id = sp.post_analysis_service(
+        AnalysisServicePost(
+            name=name,
+            display_name="test analysis service name",
+            description="A test analysis service description",
+            version="1.0",
+            contact_name="Vera Rubin",
+            url=f"http://localhost:5000/analysis/{name}",
+            authentication_type="header_token",
+            authinfo=json.dumps(authinfo),
+            analysis_type="lightcurve_fitting",
+            input_data_types=["photometry", "redshift"],
+            group_ids=[public_group.id],
+        )
+    ).id
+    sp.fetch_analysis_service(analysis_service_id)
 
     # do the credentials match?
-    data["data"]["authinfo"] = authinfo
+    # (the original test only reassigned the response dict here; no assertion)
 
-    status, data = api(
-        "DELETE",
-        f"analysis_service/{analysis_service_id}",
-        token=analysis_service_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp.delete_analysis_service(analysis_service_id)
 
     # Send auth info but for the wrong authentication type
     name = str(uuid.uuid4())
     authinfo = {"header_token": {"Authorization": "Bearer MY_TOKEN"}}
-    post_data = {
-        "name": name,
-        "display_name": "test analysis service name",
-        "description": "A test analysis service description",
-        "version": "1.0",
-        "contact_name": "Vera Rubin",
-        "url": f"http://localhost:5000/analysis/{name}",
-        "authentication_type": "api_key",
-        "_authinfo": json.dumps(authinfo),
-        "analysis_type": "lightcurve_fitting",
-        "input_data_types": ["photometry", "redshift"],
-        "group_ids": [public_group.id],
-    }
-
-    status, data = api(
-        "POST", "analysis_service", data=post_data, token=analysis_service_token
-    )
-    assert status == 400
-    assert """`_authinfo` must contain a key for "api_key".""" in data["message"]
+    with pytest.raises(
+        SkyPortalError, match='`_authinfo` must contain a key for "api_key"'
+    ) as err:
+        sp.post_analysis_service(
+            AnalysisServicePost(
+                name=name,
+                display_name="test analysis service name",
+                description="A test analysis service description",
+                version="1.0",
+                contact_name="Vera Rubin",
+                url=f"http://localhost:5000/analysis/{name}",
+                authentication_type="api_key",
+                authinfo=json.dumps(authinfo),
+                analysis_type="lightcurve_fitting",
+                input_data_types=["photometry", "redshift"],
+                group_ids=[public_group.id],
+            )
+        )
+    assert err.value.status_code == 400
 
 
 def test_add_and_retrieve_analysis_service_group_access(
@@ -493,204 +400,153 @@ def test_add_and_retrieve_analysis_service_group_access(
     public_group,
     analysis_service_token,
 ):
+    sp_two_groups = client(analysis_service_token_two_groups)
+    sp = client(analysis_service_token)
     name = str(uuid.uuid4())
-    post_data = {
-        "name": name,
-        "display_name": "test analysis service name",
-        "description": "A test analysis service description",
-        "version": "1.0",
-        "contact_name": "Vera Rubin",
-        "contact_email": "vr@ls.st",
-        "url": f"http://localhost:5000/analysis/{name}",
-        "authentication_type": "none",
-        "analysis_type": "lightcurve_fitting",
-        "input_data_types": ["photometry", "redshift"],
-        "timeout": 60,
-        "group_ids": [public_group2.id],
-    }
-
-    status, data = api(
-        "POST",
-        "analysis_service",
-        data=post_data,
-        token=analysis_service_token_two_groups,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    analysis_service_id = data["data"]["id"]
+    analysis_service_id = sp_two_groups.post_analysis_service(
+        AnalysisServicePost(
+            name=name,
+            display_name="test analysis service name",
+            description="A test analysis service description",
+            version="1.0",
+            contact_name="Vera Rubin",
+            contact_email="vr@ls.st",
+            url=f"http://localhost:5000/analysis/{name}",
+            authentication_type="none",
+            analysis_type="lightcurve_fitting",
+            input_data_types=["photometry", "redshift"],
+            timeout=60,
+            group_ids=[public_group2.id],
+        )
+    ).id
 
     # This token does not belong to public_group2
-    status, data = api(
-        "GET", f"analysis_service/{analysis_service_id}", token=analysis_service_token
-    )
-    assert status == 403
+    with pytest.raises(SkyPortalError) as err:
+        sp.fetch_analysis_service(analysis_service_id)
+    assert err.value.status_code == 403
 
     # Both tokens should be able to view this analysis service
     name = str(uuid.uuid4())
-    post_data = {
-        "name": name,
-        "display_name": "test analysis service name",
-        "description": "A test analysis service description",
-        "version": "1.0",
-        "contact_name": "Vera Rubin",
-        "contact_email": "vr@ls.st",
-        "url": f"http://localhost:5000/analysis/{name}",
-        "authentication_type": "none",
-        "analysis_type": "lightcurve_fitting",
-        "input_data_types": ["photometry", "redshift"],
-        "timeout": 60,
-        "group_ids": [public_group.id, public_group2.id],
-    }
-    status, data = api(
-        "POST",
-        "analysis_service",
-        data=post_data,
-        token=analysis_service_token_two_groups,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    analysis_service_id = data["data"]["id"]
+    analysis_service_id = sp_two_groups.post_analysis_service(
+        AnalysisServicePost(
+            name=name,
+            display_name="test analysis service name",
+            description="A test analysis service description",
+            version="1.0",
+            contact_name="Vera Rubin",
+            contact_email="vr@ls.st",
+            url=f"http://localhost:5000/analysis/{name}",
+            authentication_type="none",
+            analysis_type="lightcurve_fitting",
+            input_data_types=["photometry", "redshift"],
+            timeout=60,
+            group_ids=[public_group.id, public_group2.id],
+        )
+    ).id
 
-    status, data = api(
-        "GET", f"analysis_service/{analysis_service_id}", token=analysis_service_token
-    )
-    assert status == 200
-    status, data = api(
-        "GET",
-        f"analysis_service/{analysis_service_id}",
-        token=analysis_service_token_two_groups,
-    )
-    assert status == 200
+    sp.fetch_analysis_service(analysis_service_id)
+    sp_two_groups.fetch_analysis_service(analysis_service_id)
 
 
 def test_run_analysis_with_correct_and_incorrect_token(
     analysis_service_token, analysis_token, public_group, public_source
 ):
+    sp_service = client(analysis_service_token)
+    sp_analysis = client(analysis_token)
     name = str(uuid.uuid4())
 
     optional_analysis_parameters = {"test_parameters": ["test_value_1", "test_value_2"]}
 
-    post_data = {
-        "name": name,
-        "display_name": "test analysis service name",
-        "description": "A test analysis service description",
-        "version": "1.0",
-        "contact_name": "Vera Rubin",
-        "contact_email": "vr@ls.st",
-        # this is the URL/port of the SN analysis service that will be running during testing
-        "url": f"http://localhost:{analysis_port}/analysis/demo_analysis",
-        "optional_analysis_parameters": json.dumps(optional_analysis_parameters),
-        "authentication_type": "none",
-        "analysis_type": "lightcurve_fitting",
-        "input_data_types": ["photometry", "redshift"],
-        "timeout": 60,
-        "group_ids": [public_group.id],
-    }
+    analysis_service_id = sp_service.post_analysis_service(
+        AnalysisServicePost(
+            name=name,
+            display_name="test analysis service name",
+            description="A test analysis service description",
+            version="1.0",
+            contact_name="Vera Rubin",
+            contact_email="vr@ls.st",
+            # this is the URL/port of the SN analysis service that will be running during testing
+            url=f"http://localhost:{analysis_port}/analysis/demo_analysis",
+            optional_analysis_parameters=json.dumps(optional_analysis_parameters),
+            authentication_type="none",
+            analysis_type="lightcurve_fitting",
+            input_data_types=["photometry", "redshift"],
+            timeout=60,
+            group_ids=[public_group.id],
+        )
+    ).id
 
-    status, data = api(
-        "POST", "analysis_service", data=post_data, token=analysis_service_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
-
-    analysis_service_id = data["data"]["id"]
-
-    status, data = api(
-        "POST",
-        f"obj/{public_source.id}/analysis/{analysis_service_id}",
-        token=analysis_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-
-    analysis_id = data["data"].get("id")
+    analysis_id = sp_analysis.post_analysis(public_source.id, analysis_service_id).id
     assert analysis_id is not None
 
-    params = {"includeAnalysisData": True}
-
     def analysis_started():
-        status, data = api(
-            "GET", f"obj/analysis/{analysis_id}", token=analysis_token, params=params
+        analysis = sp_analysis.fetch_analysis(analysis_id, include_analysis_data=True)
+        assert analysis.analysis_service_id == analysis_service_id
+        assert analysis.status != "queued", (
+            f"analysis was not started properly ({analysis.status_message})"
         )
-        assert status == 200
-        assert data["data"]["analysis_service_id"] == analysis_service_id
-        assert data["data"]["status"] != "queued", (
-            f"analysis was not started properly ({data['data']['status_message']})"
-        )
-        return data
+        return analysis
 
-    data = retry_until(analysis_started, timeout=100)
-    analysis_status = data["data"]["status"]
+    analysis = retry_until(analysis_started, timeout=100)
+    analysis_status = analysis.status
 
     # Since this is random data, this fit might succeed (usually) or fail (seldom)
     # that's ok because it means we're getting the
     # roundtrip return of the webhhook
     if analysis_status == "success":
-        assert set(data["data"]["data"].keys()) == {
+        assert set(analysis.data.keys()) == {
             "inference_data",
             "plots",
             "results",
         }
 
     # try to start an analysis with the wrong token access
-    status, data = api(
-        "POST",
-        f"obj/{public_source.id}/analysis/{analysis_service_id}",
-        token=analysis_service_token,
-    )
-    assert status == 401
+    with pytest.raises(SkyPortalError) as err:
+        sp_service.post_analysis(public_source.id, analysis_service_id)
+    assert err.value.status_code == 401
 
 
 def test_run_analysis_with_bad_inputs(
     analysis_service_token, analysis_token, public_group, public_source
 ):
+    sp_service = client(analysis_service_token)
+    sp_analysis = client(analysis_token)
     name = str(uuid.uuid4())
 
     optional_analysis_parameters = {"test_parameters": ["test_value_1", "test_value_2"]}
 
-    post_data = {
-        "name": name,
-        "display_name": "test analysis service name",
-        "description": "A test analysis service description",
-        "version": "1.0",
-        "contact_name": "Vera Rubin",
-        "contact_email": "vr@ls.st",
-        "url": f"http://localhost:{analysis_port}/analysis/demo_analysis",
-        "optional_analysis_parameters": json.dumps(optional_analysis_parameters),
-        "authentication_type": "none",
-        "analysis_type": "lightcurve_fitting",
-        "input_data_types": ["photometry", "redshift"],
-        "timeout": 60,
-        "group_ids": [public_group.id],
-    }
-
-    status, data = api(
-        "POST", "analysis_service", data=post_data, token=analysis_service_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
-
-    analysis_service_id = data["data"]["id"]
+    analysis_service_id = sp_service.post_analysis_service(
+        AnalysisServicePost(
+            name=name,
+            display_name="test analysis service name",
+            description="A test analysis service description",
+            version="1.0",
+            contact_name="Vera Rubin",
+            contact_email="vr@ls.st",
+            url=f"http://localhost:{analysis_port}/analysis/demo_analysis",
+            optional_analysis_parameters=json.dumps(optional_analysis_parameters),
+            authentication_type="none",
+            analysis_type="lightcurve_fitting",
+            input_data_types=["photometry", "redshift"],
+            timeout=60,
+            group_ids=[public_group.id],
+        )
+    ).id
 
     # bad analysis service id
-    status, data = api(
-        "POST",
-        f"obj/{public_source.id}/analysis/999999999",
-        token=analysis_token,
-    )
-    assert status == 403
-    assert data["message"].find("Could not access Analysis Service") != -1
+    with pytest.raises(
+        SkyPortalError, match="Could not access Analysis Service"
+    ) as err:
+        sp_analysis.post_analysis(public_source.id, 999999999)
+    assert err.value.status_code == 403
 
     # bad obj id
-    status, data = api(
-        "POST",
-        f"obj/badObjectName1/analysis/{analysis_service_id}",
-        token=analysis_token,
-    )
-    assert status == 404
-    assert data["message"].find("not found") != -1
+    with pytest.raises(SkyPortalError, match="not found") as err:
+        sp_analysis.post_analysis("badObjectName1", analysis_service_id)
+    assert err.value.status_code == 404
 
     # bad resource type. This route does not exist.
+    # raw api: nonexistent route the typed client can't produce
     status, data = api(
         "POST",
         f"candidate/{public_source.id}/analysis/{analysis_service_id}",
@@ -702,6 +558,8 @@ def test_run_analysis_with_bad_inputs(
 def test_run_analysis_with_down_and_wrong_analysis_service(
     analysis_service_token, analysis_token, public_group, public_source
 ):
+    sp_service = client(analysis_service_token)
+    sp_analysis = client(analysis_token)
     name = str(uuid.uuid4())
 
     optional_analysis_parameters = {"test_parameters": ["test_value_1", "test_value_2"]}
@@ -710,88 +568,61 @@ def test_run_analysis_with_down_and_wrong_analysis_service(
     with socketserver.TCPServer(("localhost", 0), None) as s:
         unused_port = s.server_address[1]
 
-    post_data = {
-        "name": name,
-        "display_name": "test analysis service name",
-        "description": "A test analysis service description",
-        "version": "1.0",
-        "contact_name": "Vera Rubin",
-        "contact_email": "vr@ls.st",
-        "url": f"http://localhost:{unused_port}/analysis/demo_analysis",
-        "optional_analysis_parameters": json.dumps(optional_analysis_parameters),
-        "authentication_type": "none",
-        "analysis_type": "lightcurve_fitting",
-        "input_data_types": ["photometry", "redshift"],
-        "timeout": 60,
-        "group_ids": [public_group.id],
-    }
+    analysis_service_id = sp_service.post_analysis_service(
+        AnalysisServicePost(
+            name=name,
+            display_name="test analysis service name",
+            description="A test analysis service description",
+            version="1.0",
+            contact_name="Vera Rubin",
+            contact_email="vr@ls.st",
+            url=f"http://localhost:{unused_port}/analysis/demo_analysis",
+            optional_analysis_parameters=json.dumps(optional_analysis_parameters),
+            authentication_type="none",
+            analysis_type="lightcurve_fitting",
+            input_data_types=["photometry", "redshift"],
+            timeout=60,
+            group_ids=[public_group.id],
+        )
+    ).id
 
-    status, data = api(
-        "POST", "analysis_service", data=post_data, token=analysis_service_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
-
-    analysis_service_id = data["data"]["id"]
-
-    status, data = api(
-        "POST",
-        f"obj/{public_source.id}/analysis/{analysis_service_id}",
-        token=analysis_token,
-    )
     # this should still go through but the analysis
     # itself should not work because we're sending this off
     # to a service that does not exist
-    assert status == 200
-    assert data["status"] == "success"
-
-    analysis_id = data["data"].get("id")
+    analysis_id = sp_analysis.post_analysis(public_source.id, analysis_service_id).id
     assert analysis_id is not None
 
     def analysis_done():
-        status, data = api("GET", f"obj/analysis/{analysis_id}", token=analysis_token)
-        assert status == 200
-        assert data["data"]["status"] != "queued"
-        return data["data"]["status"]
+        analysis = sp_analysis.fetch_analysis(analysis_id)
+        assert analysis.status != "queued"
+        return analysis.status
 
     assert retry_until(analysis_done, timeout=100) == "failure"
 
     # now try a bad endpoint
     name_bad_endpoint = str(uuid.uuid4())
 
-    post_data = {
-        "name": name_bad_endpoint,
-        "display_name": "a bad endpoint test analysis service name",
-        "description": "A test analysis service description",
-        "version": "1.0",
-        "contact_name": "Vera Rubin",
-        "contact_email": "vr@ls.st",
-        "url": f"http://localhost:{analysis_port}/analysis/bad_endpoint_analysis",
-        "optional_analysis_parameters": json.dumps(optional_analysis_parameters),
-        "authentication_type": "none",
-        "analysis_type": "lightcurve_fitting",
-        "input_data_types": ["photometry", "redshift"],
-        "timeout": 60,
-        "group_ids": [public_group.id],
-    }
+    analysis_service_id = sp_service.post_analysis_service(
+        AnalysisServicePost(
+            name=name_bad_endpoint,
+            display_name="a bad endpoint test analysis service name",
+            description="A test analysis service description",
+            version="1.0",
+            contact_name="Vera Rubin",
+            contact_email="vr@ls.st",
+            url=f"http://localhost:{analysis_port}/analysis/bad_endpoint_analysis",
+            optional_analysis_parameters=json.dumps(optional_analysis_parameters),
+            authentication_type="none",
+            analysis_type="lightcurve_fitting",
+            input_data_types=["photometry", "redshift"],
+            timeout=60,
+            group_ids=[public_group.id],
+        )
+    ).id
 
-    status, data = api(
-        "POST", "analysis_service", data=post_data, token=analysis_service_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
-
-    analysis_service_id = data["data"]["id"]
-
-    status, data = api(
-        "POST",
-        f"obj/{public_source.id}/analysis/{analysis_service_id}",
-        token=analysis_token,
-    )
     # this should still go through but the analysis
     # itself should not work
-    assert status == 200
-    assert data["status"] == "success"
+    sp_analysis.post_analysis(public_source.id, analysis_service_id)
 
     assert retry_until(analysis_done, timeout=10) == "failure"
 
@@ -799,131 +630,83 @@ def test_run_analysis_with_down_and_wrong_analysis_service(
 def test_delete_analysis(
     analysis_service_token, analysis_token, public_group, public_source
 ):
+    sp_service = client(analysis_service_token)
+    sp_analysis = client(analysis_token)
     name = str(uuid.uuid4())
 
-    post_data = {
-        "name": name,
-        "display_name": "test analysis service name",
-        "description": "A test analysis service description",
-        "version": "1.0",
-        "contact_name": "Vera Rubin",
-        "contact_email": "vr@ls.st",
-        "url": f"http://localhost:{analysis_port}/analysis/demo_analysis",
-        "authentication_type": "none",
-        "analysis_type": "lightcurve_fitting",
-        "input_data_types": ["photometry", "redshift"],
-        "timeout": 60,
-        "group_ids": [public_group.id],
-    }
+    analysis_service_id = sp_service.post_analysis_service(
+        AnalysisServicePost(
+            name=name,
+            display_name="test analysis service name",
+            description="A test analysis service description",
+            version="1.0",
+            contact_name="Vera Rubin",
+            contact_email="vr@ls.st",
+            url=f"http://localhost:{analysis_port}/analysis/demo_analysis",
+            authentication_type="none",
+            analysis_type="lightcurve_fitting",
+            input_data_types=["photometry", "redshift"],
+            timeout=60,
+            group_ids=[public_group.id],
+        )
+    ).id
 
-    status, data = api(
-        "POST", "analysis_service", data=post_data, token=analysis_service_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
-
-    analysis_service_id = data["data"]["id"]
-
-    status, data = api(
-        "POST",
-        f"obj/{public_source.id}/analysis/{analysis_service_id}",
-        token=analysis_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-
-    analysis_id = data["data"].get("id")
+    analysis_id = sp_analysis.post_analysis(public_source.id, analysis_service_id).id
     assert analysis_id is not None
 
-    status, data = api(
-        "DELETE",
-        f"obj/analysis/{analysis_id}",
-        token=analysis_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp_analysis.delete_analysis(analysis_id)
 
 
 def test_delete_analysis_service_cascades_to_delete_associated_analysis(
     analysis_service_token, analysis_token, public_group, public_source
 ):
+    sp_service = client(analysis_service_token)
+    sp_analysis = client(analysis_token)
     name = str(uuid.uuid4())
 
-    post_data = {
-        "name": name,
-        "display_name": "test analysis service name",
-        "description": "A test analysis service description",
-        "version": "1.0",
-        "contact_name": "Vera Rubin",
-        "contact_email": "vr@ls.st",
-        "url": f"http://localhost:{analysis_port}/analysis/demo_analysis",
-        "authentication_type": "none",
-        "analysis_type": "lightcurve_fitting",
-        "input_data_types": ["photometry", "redshift"],
-        "timeout": 60,
-        "group_ids": [public_group.id],
-    }
+    analysis_service_id = sp_service.post_analysis_service(
+        AnalysisServicePost(
+            name=name,
+            display_name="test analysis service name",
+            description="A test analysis service description",
+            version="1.0",
+            contact_name="Vera Rubin",
+            contact_email="vr@ls.st",
+            url=f"http://localhost:{analysis_port}/analysis/demo_analysis",
+            authentication_type="none",
+            analysis_type="lightcurve_fitting",
+            input_data_types=["photometry", "redshift"],
+            timeout=60,
+            group_ids=[public_group.id],
+        )
+    ).id
 
-    status, data = api(
-        "POST", "analysis_service", data=post_data, token=analysis_service_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
-
-    analysis_service_id = data["data"]["id"]
-
-    status, data = api(
-        "POST",
-        f"obj/{public_source.id}/analysis/{analysis_service_id}",
-        token=analysis_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-
-    analysis_id = data["data"].get("id")
+    analysis_id = sp_analysis.post_analysis(public_source.id, analysis_service_id).id
     assert analysis_id is not None
 
     def analysis_done():
-        status, data = api("GET", f"obj/analysis/{analysis_id}", token=analysis_token)
-        assert status == 200
-        assert data["data"]["status"] != "queued"
-        return data["data"]["status"]
+        analysis = sp_analysis.fetch_analysis(analysis_id)
+        assert analysis.status != "queued"
+        return analysis.status
 
     analysis_status = retry_until(analysis_done, timeout=100)
 
     # get the analysis associated with the
     # analysis service
-    params = {"includeFilename": True}
-    status, data = api(
-        "GET",
-        f"obj/analysis/{analysis_id}",
-        token=analysis_token,
-        params=params,
-    )
-    assert status == 200
+    analysis = sp_analysis.fetch_analysis(analysis_id, include_filename=True)
     if analysis_status == "completed":
         # there should be a filename if the analysis succeeded
-        filename = data["data"]["filename"]
+        filename = analysis.filename
         assert os.path.exists(filename)
 
     # delete the analysis service...
-    status, data = api(
-        "DELETE",
-        f"analysis_service/{analysis_service_id}",
-        token=analysis_service_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp_service.delete_analysis_service(analysis_service_id)
 
     # now to try get the analysis associated with the
     # deleted analysis service
-    status, data = api(
-        "GET",
-        f"obj/analysis/{analysis_id}",
-        token=analysis_token,
-    )
-    assert status == 403
-    assert data["status"] == "error"
+    with pytest.raises(SkyPortalError) as err:
+        sp_analysis.fetch_analysis(analysis_id)
+    assert err.value.status_code == 403
     if analysis_status == "completed":
         # this file should be removed if it was
         # created when the analysis service completed
@@ -933,61 +716,45 @@ def test_delete_analysis_service_cascades_to_delete_associated_analysis(
 def test_retrieve_data_products(
     analysis_service_token, analysis_token, public_group, public_source
 ):
+    sp_service = client(analysis_service_token)
+    sp_analysis = client(analysis_token)
     name = str(uuid.uuid4())
     optional_analysis_parameters = {"test_parameters": ["test_value_1", "test_value_2"]}
-    post_data = {
-        "name": name,
-        "display_name": "test analysis service name",
-        "description": "A test analysis service description",
-        "version": "1.0",
-        "contact_name": "Vera Rubin",
-        "contact_email": "vr@ls.st",
-        # this is the URL/port of the SN analysis service that will be running during testing
-        "url": f"http://localhost:{analysis_port}/analysis/demo_analysis",
-        "optional_analysis_parameters": json.dumps(optional_analysis_parameters),
-        "authentication_type": "none",
-        "analysis_type": "lightcurve_fitting",
-        "input_data_types": ["photometry", "redshift"],
-        "timeout": 60,
-        "group_ids": [public_group.id],
-    }
+    analysis_service_id = sp_service.post_analysis_service(
+        AnalysisServicePost(
+            name=name,
+            display_name="test analysis service name",
+            description="A test analysis service description",
+            version="1.0",
+            contact_name="Vera Rubin",
+            contact_email="vr@ls.st",
+            # this is the URL/port of the SN analysis service that will be running during testing
+            url=f"http://localhost:{analysis_port}/analysis/demo_analysis",
+            optional_analysis_parameters=json.dumps(optional_analysis_parameters),
+            authentication_type="none",
+            analysis_type="lightcurve_fitting",
+            input_data_types=["photometry", "redshift"],
+            timeout=60,
+            group_ids=[public_group.id],
+        )
+    ).id
 
-    status, data = api(
-        "POST", "analysis_service", data=post_data, token=analysis_service_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
-
-    analysis_service_id = data["data"]["id"]
-
-    status, data = api(
-        "POST",
-        f"obj/{public_source.id}/analysis/{analysis_service_id}",
-        token=analysis_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-
-    analysis_id = data["data"].get("id")
+    analysis_id = sp_analysis.post_analysis(public_source.id, analysis_service_id).id
     assert analysis_id is not None
 
     def analysis_started():
-        status, data = api(
-            "GET",
-            f"obj/analysis/{analysis_id}",
-            token=analysis_token,
+        analysis = sp_analysis.fetch_analysis(analysis_id)
+        assert analysis.analysis_service_id == analysis_service_id
+        assert analysis.status not in ["queued", "pending"], (
+            f"analysis was not started properly ({analysis.status_message})"
         )
-        assert status == 200
-        assert data["data"]["analysis_service_id"] == analysis_service_id
-        assert data["data"]["status"] not in ["queued", "pending"], (
-            f"analysis was not started properly ({data['data']['status_message']})"
-        )
-        return data["data"]["status"]
+        return analysis.status
 
     analysis_status = retry_until(analysis_started, timeout=60)
 
     if analysis_status == "completed":
         # try to get a plot
+        # raw api: response-header assertion the typed client would mask
         response = api(
             "GET",
             f"obj/analysis/{analysis_id}/plots/0",
@@ -1002,132 +769,98 @@ def test_retrieve_data_products(
         assert response.headers.get("Content-Type", "Empty").find("image/png") != -1
 
         # try to get a plot which should not be there
-        response = api(
-            "GET",
-            f"obj/analysis/{analysis_id}/plots/99999",
-            token=analysis_token,
-            raw_response=True,
-        )
-        status = response.status_code
-        data = response.text
-        assert status == 404
+        with pytest.raises(SkyPortalError) as err:
+            sp_analysis.fetch_analysis_plot(analysis_id, plot_number=99999)
+        assert err.value.status_code == 404
 
         # try to get the results
-        status, data = api(
-            "GET",
-            f"obj/analysis/{analysis_id}/results",
-            token=analysis_token,
-        )
-        assert status == 200
-        assert data["status"] == "success"
-        assert isinstance(data["data"], dict)
+        results = sp_analysis.fetch_analysis_results(analysis_id)
+        assert isinstance(results, dict)
     else:
         # try to get a plot which does not exist
-        response = api(
-            "GET",
-            f"obj/analysis/{analysis_id}/plots/0",
-            token=analysis_token,
-            raw_response=True,
-        )
-        status = response.status_code
-        data = response.text
-        assert status == 404
+        with pytest.raises(SkyPortalError) as err:
+            sp_analysis.fetch_analysis_plot(analysis_id, plot_number=0)
+        assert err.value.status_code == 404
 
         # try to get a non-existing results
-        status, data = api(
-            "GET",
-            f"obj/analysis/{analysis_id}/results",
-            token=analysis_token,
-        )
-        assert status == 404
-        assert data["message"].find("No data found") != -1
+        with pytest.raises(SkyPortalError, match="No data found") as err:
+            sp_analysis.fetch_analysis_results(analysis_id)
+        assert err.value.status_code == 404
 
 
 def test_upload_analysis(
     analysis_service_token, analysis_token, public_group, public_source, view_only_token
 ):
+    sp_service = client(analysis_service_token)
+    sp_analysis = client(analysis_token)
     name = str(uuid.uuid4())
 
-    post_data = {
-        "name": name,
-        "display_name": "test analysis service name",
-        "description": "A test analysis service description",
-        "version": "1.0",
-        "contact_name": "Vesto Slipher",
-        "contact_email": "vs@ls.st",
-        "url": "http://example.com",
-        "authentication_type": "none",
-        "analysis_type": "meta_analysis",
-        "upload_only": True,
-        "group_ids": [public_group.id],
-    }
-
-    status, data = api(
-        "POST", "analysis_service", data=post_data, token=analysis_service_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
-
-    analysis_service_id = data["data"]["id"]
+    analysis_service_id = sp_service.post_analysis_service(
+        AnalysisServicePost(
+            name=name,
+            display_name="test analysis service name",
+            description="A test analysis service description",
+            version="1.0",
+            contact_name="Vesto Slipher",
+            contact_email="vs@ls.st",
+            url="http://example.com",
+            authentication_type="none",
+            analysis_type="meta_analysis",
+            # the original payload omitted input_data_types; [] is the server default
+            input_data_types=[],
+            upload_only=True,
+            group_ids=[public_group.id],
+        )
+    ).id
 
     # this should fail because the analysis service is an upload_only service
     # and the normal analysis endpoint (which kicks off a webhook) is
     # not allowed.
-    status, data = api(
-        "POST",
-        f"obj/{public_source.id}/analysis/{analysis_service_id}",
-        token=analysis_token,
-    )
-    assert status == 403
-    assert data["message"].find("analysis_upload endpoint") != -1
+    with pytest.raises(SkyPortalError, match="analysis_upload endpoint") as err:
+        sp_analysis.post_analysis(public_source.id, analysis_service_id)
+    assert err.value.status_code == 403
 
     # this should succeed as the correct endpoint is being used for an
     # upload_only service
-    params = {
-        "show_parameters": True,
-        "analysis": {
-            "results": {
-                "format": "json",
-                "data": {"external_provenance_id": str(uuid.uuid4())},
-            }
-        },
-    }
-    status, data = api(
-        "POST",
-        f"obj/{public_source.id}/analysis_upload/{analysis_service_id}",
-        token=analysis_token,
-        data=params,
+    sp_analysis.post_analysis_upload(
+        public_source.id,
+        analysis_service_id,
+        AnalysisUploadPost(
+            show_parameters=True,
+            analysis={
+                "results": {
+                    "format": "json",
+                    "data": {"external_provenance_id": str(uuid.uuid4())},
+                }
+            },
+        ),
     )
-    assert status == 200
-    assert data["status"] == "success"
 
     # this should succeed but we should be warned that we didn't
     # provide any analysis results
-    params = {"show_parameters": True}
-    status, data = api(
-        "POST",
-        f"obj/{public_source.id}/analysis_upload/{analysis_service_id}",
-        token=analysis_token,
-        data=params,
+    upload = sp_analysis.post_analysis_upload(
+        public_source.id,
+        analysis_service_id,
+        AnalysisUploadPost(show_parameters=True),
     )
-    assert status == 200
-    assert data["status"] == "success"
-    assert data["data"]["message"].find("empty analysis upload_only results") != -1
+    assert upload.message.find("empty analysis upload_only results") != -1
 
     # this should fail because the user's token does not have "Run Analyses"
     # persmissions
-    status, data = api(
-        "POST",
-        f"obj/{public_source.id}/analysis_upload/{analysis_service_id}",
-        token=view_only_token,
-        data=params,
-    )
-    assert status == 401
+    with pytest.raises(SkyPortalError) as err:
+        client(view_only_token).post_analysis_upload(
+            public_source.id,
+            analysis_service_id,
+            AnalysisUploadPost(show_parameters=True),
+        )
+    assert err.value.status_code == 401
 
 
 def test_run_analysis_with_file_input(
     analysis_service_token, analysis_token, public_group, public_source
 ):
+    sp_service = client(analysis_service_token)
+    sp_analysis = client(analysis_token)
     name = str(uuid.uuid4())
 
     optional_analysis_parameters = {
@@ -1138,29 +871,23 @@ def test_run_analysis_with_file_input(
         "spaxel_buffer": {"type": "number"},
     }
 
-    post_data = {
-        "name": name,
-        "display_name": "Spectral_Cube_Analysis",
-        "description": "Spectral_Cube_Analysis description",
-        "version": "1.0",
-        "contact_name": "Michael Coughlin",
-        # this is the URL/port of the Spectral_Cube_Analysis service that will be running during testing
-        "url": "http://localhost:7003/analysis/spectral_cube_analysis",
-        "optional_analysis_parameters": json.dumps(optional_analysis_parameters),
-        "authentication_type": "none",
-        "analysis_type": "spectrum_fitting",
-        "input_data_types": [],
-        "timeout": 60,
-        "group_ids": [public_group.id],
-    }
-
-    status, data = api(
-        "POST", "analysis_service", data=post_data, token=analysis_service_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
-
-    analysis_service_id = data["data"]["id"]
+    analysis_service_id = sp_service.post_analysis_service(
+        AnalysisServicePost(
+            name=name,
+            display_name="Spectral_Cube_Analysis",
+            description="Spectral_Cube_Analysis description",
+            version="1.0",
+            contact_name="Michael Coughlin",
+            # this is the URL/port of the Spectral_Cube_Analysis service that will be running during testing
+            url="http://localhost:7003/analysis/spectral_cube_analysis",
+            optional_analysis_parameters=json.dumps(optional_analysis_parameters),
+            authentication_type="none",
+            analysis_type="spectrum_fitting",
+            input_data_types=[],
+            timeout=60,
+            group_ids=[public_group.id],
+        )
+    ).id
 
     datafile = f"{os.path.dirname(__file__)}/../../data/spectral_cube_analysis.fits"
     with open(datafile, "rb") as fid:
@@ -1168,33 +895,23 @@ def test_run_analysis_with_file_input(
 
     payload = f"data:image/fits;name=spectral_cube_analysis.fits;base64,{base64.b64encode(payload).decode('utf-8')}"
 
-    status, data = api(
-        "POST",
-        f"obj/{public_source.id}/analysis/{analysis_service_id}",
-        token=analysis_token,
-        data={
-            "show_parameters": True,
-            "show_plots": True,
-            "show_corner": True,
-            "analysis_parameters": {"image_data": payload},
-        },
-    )
-    assert status == 200
-    assert data["status"] == "success"
-
-    analysis_id = data["data"].get("id")
+    analysis_id = sp_analysis.post_analysis(
+        public_source.id,
+        analysis_service_id,
+        AnalysisPost(
+            show_parameters=True,
+            show_plots=True,
+            show_corner=True,
+            analysis_parameters={"image_data": payload},
+        ),
+    ).id
     assert analysis_id is not None
 
-    params = {"includeAnalysisData": True}
-
     def analysis_started():
-        status, data = api(
-            "GET", f"obj/analysis/{analysis_id}", token=analysis_token, params=params
-        )
-        assert status == 200
-        assert data["data"]["analysis_service_id"] == analysis_service_id
-        assert data["data"]["status"] != "queued", (
-            f"analysis was not started properly ({data['data']['status_message']})"
+        analysis = sp_analysis.fetch_analysis(analysis_id, include_analysis_data=True)
+        assert analysis.analysis_service_id == analysis_service_id
+        assert analysis.status != "queued", (
+            f"analysis was not started properly ({analysis.status_message})"
         )
 
     retry_until(analysis_started, timeout=100)
@@ -1209,132 +926,99 @@ def test_default_analysis(
     classification_token,
 ):
     taxonomy_name = "test taxonomy" + str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "taxonomy",
-        data={
-            "name": taxonomy_name,
-            "hierarchy": taxonomy,
-            "group_ids": [public_group.id],
-            "provenance": f"tdtax_{__version__}",
-            "version": __version__,
-            "isLatest": True,
-        },
-        token=taxonomy_token,
+    taxonomy_id = (
+        client(taxonomy_token)
+        .post_taxonomy(
+            TaxonomyPost(
+                name=taxonomy_name,
+                hierarchy=taxonomy,
+                group_ids=[public_group.id],
+                provenance=f"tdtax_{__version__}",
+                version=__version__,
+                is_latest=True,
+            )
+        )
+        .taxonomy_id
     )
-    assert status == 200
-    taxonomy_id = data["data"]["taxonomy_id"]
+
+    sp_service = client(analysis_service_token)
+    sp_analysis = client(analysis_token)
+    sp_classification = client(classification_token)
 
     name = str(uuid.uuid4())
 
     optional_analysis_parameters = {"test_parameters": ["test_value_1", "test_value_2"]}
 
-    post_data = {
-        "name": name,
-        "display_name": "test default analysis service name",
-        "description": "A test default analysis service description",
-        "version": "1.0",
-        "contact_name": "Vera Rubin",
-        "contact_email": "vr@ls.st",
-        # this is the URL/port of the SN analysis service that will be running during testing
-        "url": f"http://localhost:{analysis_port}/analysis/demo_analysis",
-        "optional_analysis_parameters": json.dumps(optional_analysis_parameters),
-        "authentication_type": "none",
-        "analysis_type": "lightcurve_fitting",
-        "input_data_types": ["photometry", "redshift"],
-        "timeout": 60,
-        "group_ids": [public_group.id],
-    }
+    analysis_service_id = sp_service.post_analysis_service(
+        AnalysisServicePost(
+            name=name,
+            display_name="test default analysis service name",
+            description="A test default analysis service description",
+            version="1.0",
+            contact_name="Vera Rubin",
+            contact_email="vr@ls.st",
+            # this is the URL/port of the SN analysis service that will be running during testing
+            url=f"http://localhost:{analysis_port}/analysis/demo_analysis",
+            optional_analysis_parameters=json.dumps(optional_analysis_parameters),
+            authentication_type="none",
+            analysis_type="lightcurve_fitting",
+            input_data_types=["photometry", "redshift"],
+            timeout=60,
+            group_ids=[public_group.id],
+        )
+    ).id
 
-    status, data = api(
-        "POST", "analysis_service", data=post_data, token=analysis_service_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
-
-    analysis_service_id = data["data"]["id"]
-
-    data = {
-        "default_analysis_parameters": {
-            "test_parameters": "test_value_1",
-        },
-        "group_ids": [public_group.id],
-        "source_filter": {"classifications": [{"name": "Algol", "probability": 0.5}]},
-        "daily_limit": 1,
-    }
-
-    url = f"analysis_service/{analysis_service_id}/default_analysis"
-
-    status, data = api(
-        "POST",
-        url,
-        data=data,
-        token=analysis_token,
-    )
-
-    assert status == 200
-    assert data["status"] == "success"
-    default_analysis_id = data["data"]["id"]
+    default_analysis_id = sp_analysis.post_default_analysis(
+        analysis_service_id,
+        DefaultAnalysisPost(
+            default_analysis_parameters={
+                "test_parameters": "test_value_1",
+            },
+            group_ids=[public_group.id],
+            source_filter={"classifications": [{"name": "Algol", "probability": 0.5}]},
+            daily_limit=1,
+        ),
+    ).id
 
     # insert a classification which probability is too low to trigger the default analysis
-    status, data = api(
-        "POST",
-        "classification",
-        data={
-            "obj_id": public_source.id,
-            "classification": "Algol",
-            "taxonomy_id": taxonomy_id,
-            "probability": 0.4,
-            "group_ids": [public_group.id],
-        },
-        token=classification_token,
+    sp_classification.post_classification(
+        ClassificationPost(
+            obj_id=public_source.id,
+            classification="Algol",
+            taxonomy_id=taxonomy_id,
+            probability=0.4,
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
 
     n_retries = 0
     while n_retries < 10:
-        status, data = api(
-            "GET",
-            "obj/analysis",
-            params={
-                "objID": public_source.id,
-                "analysisServiceID": analysis_service_id,
-            },
-            token=analysis_token,
+        analyses = sp_analysis.fetch_analyses(
+            obj_id=public_source.id, analysis_service_id=analysis_service_id
         )
-        if len(data["data"]) == 1:
+        if len(analyses) == 1:
             assert False
         else:
             time.sleep(1)
             n_retries += 1
 
     # insert a classification which probability is high enough to trigger the default analysis
-    status, data = api(
-        "POST",
-        "classification",
-        data={
-            "obj_id": public_source.id,
-            "classification": "Algol",
-            "taxonomy_id": taxonomy_id,
-            "probability": 0.9,
-            "group_ids": [public_group.id],
-        },
-        token=classification_token,
+    sp_classification.post_classification(
+        ClassificationPost(
+            obj_id=public_source.id,
+            classification="Algol",
+            taxonomy_id=taxonomy_id,
+            probability=0.9,
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
 
     n_retries = 0
     while n_retries < 20:
-        status, data = api(
-            "GET",
-            "obj/analysis",
-            params={
-                "objID": public_source.id,
-                "analysisServiceID": analysis_service_id,
-            },
-            token=analysis_token,
+        analyses = sp_analysis.fetch_analyses(
+            obj_id=public_source.id, analysis_service_id=analysis_service_id
         )
-        if status == 200 and data["status"] == "success" and len(data["data"]) == 1:
+        if len(analyses) == 1:
             break
         else:
             time.sleep(1)
@@ -1343,92 +1027,62 @@ def test_default_analysis(
     assert n_retries < 20
 
     # verify that the daily limit is respected, i.e. that the default analysis is not run again
-    status, data = api(
-        "POST",
-        "classification",
-        data={
-            "obj_id": public_source.id,
-            "classification": "Algol",
-            "taxonomy_id": taxonomy_id,
-            "probability": 0.9,
-            "group_ids": [public_group.id],
-        },
-        token=classification_token,
+    sp_classification.post_classification(
+        ClassificationPost(
+            obj_id=public_source.id,
+            classification="Algol",
+            taxonomy_id=taxonomy_id,
+            probability=0.9,
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
 
     n_retries = 0
     while n_retries < 10:
-        status, data = api(
-            "GET",
-            "obj/analysis",
-            params={
-                "objID": public_source.id,
-                "analysisServiceID": analysis_service_id,
-            },
-            token=analysis_token,
+        analyses = sp_analysis.fetch_analyses(
+            obj_id=public_source.id, analysis_service_id=analysis_service_id
         )
-        if len(data["data"]) == 2:
+        if len(analyses) == 2:
             assert False
         else:
             time.sleep(1)
             n_retries += 1
 
-    status, data = api(
-        "DELETE",
-        f"{url}/{default_analysis_id}",
-        token=analysis_token,
-    )
-    assert status == 200
+    sp_analysis.delete_default_analysis(analysis_service_id, default_analysis_id)
 
 
 def test_source_analysis(
     analysis_service_token, view_only_token, analysis_token, public_group, public_source
 ):
+    sp_service = client(analysis_service_token)
     name = str(uuid.uuid4())
 
-    post_data = {
-        "name": name,
-        "display_name": "test analysis service name",
-        "description": "A test analysis service description",
-        "version": "1.0",
-        "contact_name": "Vera Rubin",
-        "contact_email": "vr@ls.st",
-        "url": f"http://localhost:{analysis_port}/analysis/demo_analysis",
-        "authentication_type": "none",
-        "analysis_type": "lightcurve_fitting",
-        "input_data_types": ["photometry", "redshift"],
-        "timeout": 60,
-        "group_ids": [public_group.id],
-    }
+    analysis_service_id = sp_service.post_analysis_service(
+        AnalysisServicePost(
+            name=name,
+            display_name="test analysis service name",
+            description="A test analysis service description",
+            version="1.0",
+            contact_name="Vera Rubin",
+            contact_email="vr@ls.st",
+            url=f"http://localhost:{analysis_port}/analysis/demo_analysis",
+            authentication_type="none",
+            analysis_type="lightcurve_fitting",
+            input_data_types=["photometry", "redshift"],
+            timeout=60,
+            group_ids=[public_group.id],
+        )
+    ).id
 
-    status, data = api(
-        "POST", "analysis_service", data=post_data, token=analysis_service_token
+    analysis_id = (
+        client(analysis_token).post_analysis(public_source.id, analysis_service_id).id
     )
-    assert status == 200
-    assert data["status"] == "success"
-
-    analysis_service_id = data["data"]["id"]
-
-    status, data = api(
-        "POST",
-        f"obj/{public_source.id}/analysis/{analysis_service_id}",
-        token=analysis_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-
-    analysis_id = data["data"].get("id")
     assert analysis_id is not None
 
-    params = {"includeAnalyses": True}
-    status, data = api(
-        "GET", f"sources/{public_source.id}", token=view_only_token, params=params
+    source = client(view_only_token).fetch_source(
+        public_source.id, include_analyses=True
     )
-    assert status == 200
-    assert data["status"] == "success"
-    assert "analyses" in data["data"]
-    assert any(analysis["id"] == analysis_id for analysis in data["data"]["analyses"])
+    assert any(analysis.id == analysis_id for analysis in source.analyses)
 
 
 def test_default_analysis_on_save(
@@ -1437,69 +1091,57 @@ def test_default_analysis_on_save(
     upload_data_token,
     public_group,
 ):
+    sp_service = client(analysis_service_token)
+    sp_analysis = client(analysis_token)
     # A (non-upload_only) analysis service backed by the demo analysis server.
     name = str(uuid.uuid4())
-    post_data = {
-        "name": name,
-        "display_name": "test default analysis on save",
-        "description": "A test default analysis (save-to-group trigger)",
-        "version": "1.0",
-        "contact_name": "Vera Rubin",
-        "contact_email": "vr@ls.st",
-        "url": f"http://localhost:{analysis_port}/analysis/demo_analysis",
-        "authentication_type": "none",
-        "analysis_type": "lightcurve_fitting",
-        "input_data_types": [],
-        "timeout": 60,
-        "group_ids": [public_group.id],
-    }
-    status, data = api(
-        "POST", "analysis_service", data=post_data, token=analysis_service_token
-    )
-    assert status == 200, data
-    analysis_service_id = data["data"]["id"]
+    analysis_service_id = sp_service.post_analysis_service(
+        AnalysisServicePost(
+            name=name,
+            display_name="test default analysis on save",
+            description="A test default analysis (save-to-group trigger)",
+            version="1.0",
+            contact_name="Vera Rubin",
+            contact_email="vr@ls.st",
+            url=f"http://localhost:{analysis_port}/analysis/demo_analysis",
+            authentication_type="none",
+            analysis_type="lightcurve_fitting",
+            input_data_types=[],
+            timeout=60,
+            group_ids=[public_group.id],
+        )
+    ).id
 
     # A default analysis that triggers when a source is saved to public_group
     # (source_filter pins a group_id rather than a classification).
-    status, data = api(
-        "POST",
-        f"analysis_service/{analysis_service_id}/default_analysis",
-        data={
-            "default_analysis_parameters": {},
-            "group_ids": [public_group.id],
-            "source_filter": {"group_id": public_group.id},
-            "daily_limit": 5,
-        },
-        token=analysis_token,
+    sp_analysis.post_default_analysis(
+        analysis_service_id,
+        DefaultAnalysisPost(
+            default_analysis_parameters={},
+            group_ids=[public_group.id],
+            source_filter={"group_id": public_group.id},
+            daily_limit=5,
+        ),
     )
-    assert status == 200, data
-    assert data["status"] == "success"
 
     # Saving a NEW source to that group should auto-trigger the default analysis.
     obj_id = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id,
-            "ra": 24.6258,
-            "dec": -32.9024,
-            "redshift": 0.1,
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    client(upload_data_token).post_source(
+        SourcePost(
+            id=obj_id,
+            ra=24.6258,
+            dec=-32.9024,
+            redshift=0.1,
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200, data
 
     n_retries = 0
     while n_retries < 20:
-        status, data = api(
-            "GET",
-            "obj/analysis",
-            params={"objID": obj_id, "analysisServiceID": analysis_service_id},
-            token=analysis_token,
+        analyses = sp_analysis.fetch_analyses(
+            obj_id=obj_id, analysis_service_id=analysis_service_id
         )
-        if status == 200 and data["status"] == "success" and len(data["data"]) == 1:
+        if len(analyses) == 1:
             break
         time.sleep(1)
         n_retries += 1
@@ -1514,27 +1156,25 @@ def test_default_analysis_multiple_per_service(
     analysis_token,
     public_group,
 ):
+    sp_service = client(analysis_service_token)
+    sp_analysis = client(analysis_token)
     name = str(uuid.uuid4())
-    post_data = {
-        "name": name,
-        "display_name": "test multiple default analyses",
-        "description": "A test service allowing multiple default analyses",
-        "version": "1.0",
-        "contact_name": "Vera Rubin",
-        "contact_email": "vr@ls.st",
-        "url": f"http://localhost:{analysis_port}/analysis/demo_analysis",
-        "authentication_type": "none",
-        "analysis_type": "lightcurve_fitting",
-        "input_data_types": [],
-        "timeout": 60,
-        "group_ids": [public_group.id],
-    }
-    status, data = api(
-        "POST", "analysis_service", data=post_data, token=analysis_service_token
-    )
-    assert status == 200, data
-    analysis_service_id = data["data"]["id"]
-    url = f"analysis_service/{analysis_service_id}/default_analysis"
+    analysis_service_id = sp_service.post_analysis_service(
+        AnalysisServicePost(
+            name=name,
+            display_name="test multiple default analyses",
+            description="A test service allowing multiple default analyses",
+            version="1.0",
+            contact_name="Vera Rubin",
+            contact_email="vr@ls.st",
+            url=f"http://localhost:{analysis_port}/analysis/demo_analysis",
+            authentication_type="none",
+            analysis_type="lightcurve_fitting",
+            input_data_types=[],
+            timeout=60,
+            group_ids=[public_group.id],
+        )
+    ).id
 
     # Multiple default analyses on the SAME service are allowed (repeats):
     # different triggers, or the same trigger with different parameters.
@@ -1542,20 +1182,14 @@ def test_default_analysis_multiple_per_service(
         {"classifications": [{"name": "Algol", "probability": 0.5}]},
         {"group_id": public_group.id},
     ):
-        status, data = api(
-            "POST",
-            url,
-            data={
-                "default_analysis_parameters": {},
-                "group_ids": [public_group.id],
-                "source_filter": source_filter,
-                "daily_limit": 5,
-            },
-            token=analysis_token,
+        sp_analysis.post_default_analysis(
+            analysis_service_id,
+            DefaultAnalysisPost(
+                default_analysis_parameters={},
+                group_ids=[public_group.id],
+                source_filter=source_filter,
+                daily_limit=5,
+            ),
         )
-        assert status == 200, data
-        assert data["status"] == "success"
 
-    status, data = api("GET", url, token=analysis_token)
-    assert status == 200
-    assert len(data["data"]) == 2
+    assert len(sp_analysis.fetch_default_analyses(analysis_service_id)) == 2

--- a/skyportal/tests/api_tests/groups_users_analysis/test_assignments.py
+++ b/skyportal/tests/api_tests/groups_users_analysis/test_assignments.py
@@ -1,4 +1,6 @@
-from skyportal.tests import api
+from skyportal_py.assignments import AssignmentPost
+
+from skyportal.tests import client
 
 
 def test_token_user_post_classical_followup_request(
@@ -11,17 +13,12 @@ def test_token_user_post_classical_followup_request(
         "comment": "Please take spectrum only below airmass 1.5",
     }
 
-    status, data = api("POST", "assignment", data=request_data, token=upload_data_token)
-    assert status == 200
-    assert data["status"] == "success"
-    id = data["data"]["id"]
+    sp = client(upload_data_token)
+    id = sp.post_assignment(AssignmentPost(**request_data)).id
 
-    status, data = api("GET", f"assignment/{id}", token=upload_data_token)
-    assert status == 200
-    assert data["status"] == "success"
-
+    assignment = sp.fetch_assignment(id)
     for key in request_data:
-        assert data["data"][key] == request_data[key]
+        assert getattr(assignment, key) == request_data[key]
 
 
 def test_token_user_delete_owned_assignment(
@@ -34,14 +31,10 @@ def test_token_user_delete_owned_assignment(
         "comment": "Please take spectrum only below airmass 1.5",
     }
 
-    status, data = api("POST", "assignment", data=request_data, token=upload_data_token)
-    assert status == 200
-    assert data["status"] == "success"
-    id = data["data"]["id"]
+    sp = client(upload_data_token)
+    id = sp.post_assignment(AssignmentPost(**request_data)).id
 
-    status, data = api("DELETE", f"assignment/{id}", token=upload_data_token)
-    assert status == 200
-    assert data["status"] == "success"
+    sp.delete_assignment(id)
 
 
 def test_regular_user_can_delete_super_admin_assignment(
@@ -54,14 +47,9 @@ def test_regular_user_can_delete_super_admin_assignment(
         "comment": "Please take spectrum only below airmass 1.5",
     }
 
-    status, data = api("POST", "assignment", data=request_data, token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-    id = data["data"]["id"]
+    id = client(super_admin_token).post_assignment(AssignmentPost(**request_data)).id
 
-    status, data = api("DELETE", f"assignment/{id}", token=upload_data_token)
-    assert status == 200
-    assert data["status"] == "success"
+    client(upload_data_token).delete_assignment(id)
 
 
 def test_regular_user_can_modify_super_admin_assignment(
@@ -79,29 +67,18 @@ def test_regular_user_can_modify_super_admin_assignment(
         "comment": "Please take spectrum only below airmass 1.5",
     }
 
-    status, data = api("POST", "assignment", data=request_data, token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-    id = data["data"]["id"]
+    id = client(super_admin_token).post_assignment(AssignmentPost(**request_data)).id
 
-    request_data = {
-        "run_id": red_transients_run.id,
-        "obj_id": public_source.id,
-        "priority": "4",
-        "comment": "Please take spectrum only below airmass 1.5",
-    }
-
-    status, data = api(
-        "PUT", f"assignment/{id}", data=request_data, token=upload_data_token
+    sp = client(upload_data_token)
+    sp.update_assignment(
+        id,
+        priority="4",
+        comment="Please take spectrum only below airmass 1.5",
     )
-    assert status == 200
-    assert data["status"] == "success"
 
-    status, data = api("GET", f"assignment/{id}", token=upload_data_token)
-    assert status == 200
-    assert data["status"] == "success"
-    assert data["data"]["last_modified_by_id"] == user.id
-    assert data["data"]["requester_id"] == super_admin_user.id
+    assignment = sp.fetch_assignment(id)
+    assert assignment.last_modified_by_id == user.id
+    assert assignment.requester_id == super_admin_user.id
 
 
 def test_group1_user_can_see_group2_assignment(
@@ -118,10 +95,8 @@ def test_group1_user_can_see_group2_assignment(
         "comment": "Please take spectrum only below airmass 1.5",
     }
 
-    status, data = api("POST", "assignment", data=request_data, token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-    id = data["data"]["id"]
+    sp_admin = client(super_admin_token)
+    id = sp_admin.post_assignment(AssignmentPost(**request_data)).id
 
     request_data = {
         "run_id": red_transients_run.id,
@@ -130,10 +105,6 @@ def test_group1_user_can_see_group2_assignment(
         "comment": "Please take spectrum only below airmass 1.5",
     }
 
-    status, data = api("POST", "assignment", data=request_data, token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
+    sp_admin.post_assignment(AssignmentPost(**request_data))
 
-    status, data = api("GET", f"assignment/{id}", token=view_only_token)
-    assert status == 200
-    assert data["status"] == "success"
+    client(view_only_token).fetch_assignment(id)

--- a/skyportal/tests/api_tests/groups_users_analysis/test_comments.py
+++ b/skyportal/tests/api_tests/groups_users_analysis/test_comments.py
@@ -2,10 +2,14 @@ import base64
 import json
 import uuid
 
-from skyportal.tests import api
+import pytest
+from skyportal_py import SkyPortalError
+
+from skyportal.tests import api, client
 
 
 def test_add_and_retrieve_comment_group_id(comment_token, public_source, public_group):
+    # raw api: intentionally malformed payload the typed client can't produce (extra ra/dec/redshift fields)
     status, data = api(
         "POST",
         f"sources/{public_source.id}/comments",
@@ -21,30 +25,17 @@ def test_add_and_retrieve_comment_group_id(comment_token, public_source, public_
     assert status == 200
     comment_id = data["data"]["comment_id"]
 
-    status, data = api(
-        "GET", f"sources/{public_source.id}/comments/{comment_id}", token=comment_token
-    )
-    assert status == 200
-    assert data["data"]["text"] == "Comment text"
-    assert data["data"]["bot"]
+    comment = client(comment_token).fetch_comment(public_source.id, comment_id)
+    assert comment.text == "Comment text"
+    assert comment.bot
 
 
 def test_add_and_retrieve_comment_no_group_id(comment_token, public_source):
-    status, data = api(
-        "POST",
-        f"sources/{public_source.id}/comments",
-        data={"text": "Comment text"},
-        token=comment_token,
-    )
-    assert status == 200
-    comment_id = data["data"]["comment_id"]
+    sp = client(comment_token)
+    comment_id = sp.post_comment(public_source.id, "Comment text").comment_id
 
-    status, data = api(
-        "GET", f"sources/{public_source.id}/comments/{comment_id}", token=comment_token
-    )
-
-    assert status == 200
-    assert data["data"]["text"] == "Comment text"
+    comment = sp.fetch_comment(public_source.id, comment_id)
+    assert comment.text == "Comment text"
 
 
 def test_add_and_retrieve_comment_group_access(
@@ -54,63 +45,33 @@ def test_add_and_retrieve_comment_group_access(
     public_group,
     comment_token,
 ):
-    status, data = api(
-        "POST",
-        f"sources/{public_source_two_groups.id}/comments",
-        data={
-            "text": "Comment text",
-            "group_ids": [public_group2.id],
-        },
-        token=comment_token_two_groups,
-    )
-    assert status == 200
-    comment_id = data["data"]["comment_id"]
+    sp_two_groups = client(comment_token_two_groups)
+    sp = client(comment_token)
+    comment_id = sp_two_groups.post_comment(
+        public_source_two_groups.id, "Comment text", group_ids=[public_group2.id]
+    ).comment_id
 
     # This token belongs to public_group2
-    status, data = api(
-        "GET",
-        f"sources/{public_source_two_groups.id}/comments/{comment_id}",
-        token=comment_token_two_groups,
-    )
-    assert status == 200
-    assert data["data"]["text"] == "Comment text"
+    comment = sp_two_groups.fetch_comment(public_source_two_groups.id, comment_id)
+    assert comment.text == "Comment text"
 
     # This token does not belong to public_group2
-    status, data = api(
-        "GET",
-        f"sources/{public_source_two_groups.id}/comments/{comment_id}",
-        token=comment_token,
-    )
-    assert status == 403
+    with pytest.raises(SkyPortalError) as err:
+        sp.fetch_comment(public_source_two_groups.id, comment_id)
+    assert err.value.status_code == 403
 
     # Both tokens should be able to view this comment
-    status, data = api(
-        "POST",
-        f"sources/{public_source_two_groups.id}/comments",
-        data={
-            "text": "Comment text",
-            "group_ids": [public_group.id, public_group2.id],
-        },
-        token=comment_token_two_groups,
-    )
-    assert status == 200
-    comment_id = data["data"]["comment_id"]
+    comment_id = sp_two_groups.post_comment(
+        public_source_two_groups.id,
+        "Comment text",
+        group_ids=[public_group.id, public_group2.id],
+    ).comment_id
 
-    status, data = api(
-        "GET",
-        f"sources/{public_source_two_groups.id}/comments/{comment_id}",
-        token=comment_token_two_groups,
-    )
-    assert status == 200
-    assert data["data"]["text"] == "Comment text"
+    comment = sp_two_groups.fetch_comment(public_source_two_groups.id, comment_id)
+    assert comment.text == "Comment text"
 
-    status, data = api(
-        "GET",
-        f"sources/{public_source_two_groups.id}/comments/{comment_id}",
-        token=comment_token,
-    )
-    assert status == 200
-    assert data["data"]["text"] == "Comment text"
+    comment = sp.fetch_comment(public_source_two_groups.id, comment_id)
+    assert comment.text == "Comment text"
 
 
 def test_update_comment_group_list(
@@ -120,138 +81,80 @@ def test_update_comment_group_list(
     public_group,
     comment_token,
 ):
-    status, data = api(
-        "POST",
-        f"sources/{public_source_two_groups.id}/comments",
-        data={
-            "text": "Comment text",
-            "group_ids": [public_group2.id],
-        },
-        token=comment_token_two_groups,
-    )
-    assert status == 200
-    comment_id = data["data"]["comment_id"]
+    sp_two_groups = client(comment_token_two_groups)
+    sp = client(comment_token)
+    comment_id = sp_two_groups.post_comment(
+        public_source_two_groups.id, "Comment text", group_ids=[public_group2.id]
+    ).comment_id
 
     # This token belongs to public_group2
 
-    status, data = api(
-        "GET",
-        f"sources/{public_source_two_groups.id}/comments/{comment_id}",
-        token=comment_token_two_groups,
-    )
-    assert status == 200
-    assert data["data"]["text"] == "Comment text"
+    comment = sp_two_groups.fetch_comment(public_source_two_groups.id, comment_id)
+    assert comment.text == "Comment text"
 
     # This token does not belnog to public_group2
-    status, data = api(
-        "GET",
-        f"sources/{public_source_two_groups.id}/comments/{comment_id}",
-        token=comment_token,
-    )
-    assert status == 403
+    with pytest.raises(SkyPortalError) as err:
+        sp.fetch_comment(public_source_two_groups.id, comment_id)
+    assert err.value.status_code == 403
 
     # Both tokens should be able to view comment after updating group list
-    status, data = api(
-        "PUT",
-        f"sources/{public_source_two_groups.id}/comments/{comment_id}",
-        data={
-            "text": "Comment text new",
-            "group_ids": [public_group.id, public_group2.id],
-        },
-        token=comment_token_two_groups,
+    sp_two_groups.update_comment(
+        public_source_two_groups.id,
+        comment_id,
+        "Comment text new",
+        group_ids=[public_group.id, public_group2.id],
     )
-    assert status == 200
 
-    status, data = api(
-        "GET",
-        f"sources/{public_source_two_groups.id}/comments/{comment_id}",
-        token=comment_token_two_groups,
-    )
-    assert status == 200
-    assert data["data"]["text"] == "Comment text new"
+    comment = sp_two_groups.fetch_comment(public_source_two_groups.id, comment_id)
+    assert comment.text == "Comment text new"
 
-    status, data = api(
-        "GET",
-        f"sources/{public_source_two_groups.id}/comments/{comment_id}",
-        token=comment_token,
-    )
-    assert status == 200
-    assert data["data"]["text"] == "Comment text new"
+    comment = sp.fetch_comment(public_source_two_groups.id, comment_id)
+    assert comment.text == "Comment text new"
 
 
 def test_cannot_add_comment_without_permission(view_only_token, public_source):
-    status, data = api(
-        "POST",
-        f"sources/{public_source.id}/comments",
-        data={"text": "Comment text"},
-        token=view_only_token,
-    )
-    assert status == 401
-    assert data["status"] == "error"
+    with pytest.raises(SkyPortalError) as err:
+        client(view_only_token).post_comment(public_source.id, "Comment text")
+    assert err.value.status_code == 401
 
 
 def test_delete_comment(comment_token, public_source):
-    status, data = api(
-        "POST",
-        f"sources/{public_source.id}/comments",
-        data={"text": "Comment text"},
-        token=comment_token,
-    )
-    assert status == 200
-    comment_id = data["data"]["comment_id"]
+    sp = client(comment_token)
+    comment_id = sp.post_comment(public_source.id, "Comment text").comment_id
 
-    status, data = api(
-        "GET", f"sources/{public_source.id}/comments/{comment_id}", token=comment_token
-    )
-    assert status == 200
-    assert data["data"]["text"] == "Comment text"
+    comment = sp.fetch_comment(public_source.id, comment_id)
+    assert comment.text == "Comment text"
 
     # try to delete using the wrong object ID
-    status, data = api(
-        "DELETE",
-        f"sources/{public_source.id}zzz/comments/{comment_id}",
-        token=comment_token,
-    )
-    assert status == 400
-    assert (
-        "Comment resource ID does not match resource ID given in path"
-        in data["message"]
-    )
+    with pytest.raises(
+        SkyPortalError,
+        match="Comment resource ID does not match resource ID given in path",
+    ) as err:
+        sp.delete_comment(f"{public_source.id}zzz", comment_id)
+    assert err.value.status_code == 400
 
-    status, data = api(
-        "DELETE",
-        f"sources/{public_source.id}/comments/{comment_id}",
-        token=comment_token,
-    )
-    assert status == 200
+    sp.delete_comment(public_source.id, comment_id)
 
-    status, data = api(
-        "GET", f"sources/{public_source.id}/comments/{comment_id}", token=comment_token
-    )
-    assert status == 403
+    with pytest.raises(SkyPortalError) as err:
+        sp.fetch_comment(public_source.id, comment_id)
+    assert err.value.status_code == 403
 
 
 def test_problematic_put_comment_attachment_1275(
     super_admin_token, public_source, public_group
 ):
-    status, data = api(
-        "POST",
-        f"sources/{public_source.id}/comments",
-        data={
-            "text": "asdf",
-            "group_ids": [public_group.id],
-        },
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp = client(super_admin_token)
+    comment_id = sp.post_comment(
+        public_source.id, "asdf", group_ids=[public_group.id]
+    ).comment_id
 
     # note: the attachment_bytes is base64 encoded. The values are a json with a fit to a lightcurve: {"timestamp": "2020-11-04T12:00:03", "run": 1839, "duration": 0.146, "result": {"model": "salt2", "fit_lc_parameters": {"bounds": {"c": [-2, 5], "x1": [-5, 5], "z": [0, 0.2]}}, "fit_acceptable": false, "plot_info": "salt2 chisq 20.29 ndof 1 ok fit False", "model_analysis": {"has_premax_data": true, "has_postmax_data": false, "x1_in_range": true, "_x1_range": [-4, 4], "c_ok": true, "_c_range": [-1, 2]}, "fit_results": {"z": 0.11743956051701065, "t0": 2459158.8197625163, "x0": 0.0006085587726229467, "x1": -0.8735839568199673, "c": -0.05985581166006315, "mwebv": 0.09956195603903112, "mwr_v": 3.1, "z.err": 0.021552540312395424, "t0.err": 0.9573493564967066, "x0.err": 6.746016946789949e-05, "x1.err": 0.6478509759869966, "c.err": 0.13441303639641355}, "sncosmo_info": {"success": true, "chisq": 20.294017910112313, "ndof": 1, "chisqdof": 20.294017910112313}, "flux_dict": {"ztfg": [0.0, -0.04260585575047336, -0.15976361246431942, -0.5059839853552485, -0.10597904547829083, 3.822308947484571, 12.196754867100147, 23.88354491353415, 38.22323282037752, 55.01546727827308, 74.34254141634922, 96.32745393316009, 121.23085521718683, 149.67197334583886, 178.58713367255027, 205.07205565878846, 228.055316068424, 247.35232398087857, 262.6092519634573, 273.960191191851, 282.016391751773, 286.37262876586163, 286.68870101813445, 283.5545671173481, 277.6926455246088, 269.4835459846133, 259.1014121912208, 246.96912944976515, 233.89916873691928, 220.13227246260834, 205.71668739341314, 190.59715200394385, 175.55384144022622, 161.16599396445432, 147.51051782262417, 134.44622046218694, 121.89425017001439, 109.90492674308672, 98.85858205599014, 88.82224924498806, 79.85546579979393, 72.0957233314672, 65.30282339443757, 59.253128203636344, 53.92626603229452, 49.41979031775328, 45.67854825903064, 42.31292073534097, 39.13504249266131, 36.1755465721297, 33.42898795818345, 30.928719726233187, 28.75228186158564, 26.902478590030096, 25.33397834831236, 24.011056239382935, 22.903882222640554, 21.985521103960558, 21.183615798259172, 20.452263069130467, 19.784648140823755, 19.175559755403427, 18.62037487657529, 18.115085014172315, 17.65627039976832, 17.24032085612599, 16.859113035014577, 16.486188766741698, 16.118940802977047, 15.758473743647862, 15.405745704001246, 15.061723334246043, 14.727381022979804, 14.40369531565953, 14.091639911177353, 13.792181144905058, 13.506273869935807, 13.234868483767539, 12.981573318789627], "ztfr": [0.0, 0.2090292759377349, 0.7887464988107039, 1.7225720490024614, 3.6929293270041432, 8.790715650854805, 17.632454021162335, 29.250018351092617, 43.06962940203071, 58.82721079098557, 76.48663042438139, 96.19948398810972, 118.2043531796085, 143.00763850651066, 168.31296079567204, 191.94315051545507, 213.1124920184503, 231.70586709452542, 247.4778402032156, 260.56639507687237, 271.4781846619027, 279.88995582585454, 285.53637206609505, 288.56043234810784, 289.2091803834655, 287.6502117554417, 284.0123913503557, 278.4012742990645, 270.74784523583617, 261.2093367641972, 249.96542520909364, 236.99608084174656, 223.8221883025723, 211.60223019395332, 200.5768848516765, 190.59497704310533, 181.58622220425553, 173.41804171877473, 165.73070457689184, 158.48229532486502, 151.69958908533786, 145.45181494290867, 139.5840753333532, 133.95918683286877, 128.5735130683405, 123.5116847305524, 118.72179052112413, 113.80440771664829, 108.60835586471713, 103.24138668302145, 97.76524682254008, 92.33371416772081, 87.19749220219904, 82.42831046478832, 77.97792527637088, 73.81007156568363, 69.891944326849, 66.1993381916304, 62.814068298745696, 59.77509113972063, 57.05107267689715, 54.614319764565344, 52.44133768365566, 50.51152762252092, 48.80688504102122, 47.309219888691615, 45.98551564214617, 44.74140069344704, 43.562709928609166, 42.44799099342699, 41.3954501168835, 40.40343076096168, 39.47040612822724, 38.5949607206674, 37.77577772586994, 37.011630964854525, 36.301380383465656, 35.64395943646715, 35.043860807349894], "obsjd": [2459136.470971306, 2459137.470971306, 2459138.470971306, 2459139.470971306, 2459140.470971306, 2459141.470971306, 2459142.470971306, 2459143.470971306, 2459144.470971306, 2459145.470971306, 2459146.470971306, 2459147.470971306, 2459148.470971306, 2459149.470971306, 2459150.470971306, 2459151.470971306, 2459152.470971306, 2459153.470971306, 2459154.470971306, 2459155.470971306, 2459156.470971306, 2459157.470971306, 2459158.470971306, 2459159.470971306, 2459160.470971306, 2459161.470971306, 2459162.470971306, 2459163.470971306, 2459164.470971306, 2459165.470971306, 2459166.470971306, 2459167.470971306, 2459168.470971306, 2459169.470971306, 2459170.470971306, 2459171.470971306, 2459172.470971306, 2459173.470971306, 2459174.470971306, 2459175.470971306, 2459176.470971306, 2459177.470971306, 2459178.470971306, 2459179.470971306, 2459180.470971306, 2459181.470971306, 2459182.470971306, 2459183.470971306, 2459184.470971306, 2459185.470971306, 2459186.470971306, 2459187.470971306, 2459188.470971306, 2459189.470971306, 2459190.470971306, 2459191.470971306, 2459192.470971306, 2459193.470971306, 2459194.470971306, 2459195.470971306, 2459196.470971306, 2459197.470971306, 2459198.470971306, 2459199.470971306, 2459200.470971306, 2459201.470971306, 2459202.470971306, 2459203.470971306, 2459204.470971306, 2459205.470971306, 2459206.470971306, 2459207.470971306, 2459208.470971306, 2459209.470971306, 2459210.470971306, 2459211.470971306, 2459212.470971306, 2459213.470971306, 2459214.470971306]}}}
 
     # need to specify both comment name and bytes
+    # raw api: intentionally malformed payload the typed client can't produce
     status2, data2 = api(
         "PUT",
-        f"sources/{public_source.id}/comments/{data['data']['comment_id']}",
+        f"sources/{public_source.id}/comments/{comment_id}",
         data={
             "attachment": "eyJ0aW1lc3RhbXAiOiAiMjAyMC0xMS0wNFQxMjowMDowMyIsICJydW4iOiAxODM5LCAiZHVyYXRpb24iOiAwLjE0NiwgInJlc3VsdCI6IHsibW9kZWwiOiAic2FsdDIiLCAiZml0X2xjX3BhcmFtZXRlcnMiOiB7ImJvdW5kcyI6IHsiYyI6IFstMiwgNV0sICJ4MSI6IFstNSwgNV0sICJ6IjogWzAsIDAuMl19fSwgImZpdF9hY2NlcHRhYmxlIjogZmFsc2UsICJwbG90X2luZm8iOiAic2FsdDIgY2hpc3EgMjAuMjkgbmRvZiAxIG9rIGZpdCBGYWxzZSIsICJtb2RlbF9hbmFseXNpcyI6IHsiaGFzX3ByZW1heF9kYXRhIjogdHJ1ZSwgImhhc19wb3N0bWF4X2RhdGEiOiBmYWxzZSwgIngxX2luX3JhbmdlIjogdHJ1ZSwgIl94MV9yYW5nZSI6IFstNCwgNF0sICJjX29rIjogdHJ1ZSwgIl9jX3JhbmdlIjogWy0xLCAyXX0sICJmaXRfcmVzdWx0cyI6IHsieiI6IDAuMTE3NDM5NTYwNTE3MDEwNjUsICJ0MCI6IDI0NTkxNTguODE5NzYyNTE2MywgIngwIjogMC4wMDA2MDg1NTg3NzI2MjI5NDY3LCAieDEiOiAtMC44NzM1ODM5NTY4MTk5NjczLCAiYyI6IC0wLjA1OTg1NTgxMTY2MDA2MzE1LCAibXdlYnYiOiAwLjA5OTU2MTk1NjAzOTAzMTEyLCAibXdyX3YiOiAzLjEsICJ6LmVyciI6IDAuMDIxNTUyNTQwMzEyMzk1NDI0LCAidDAuZXJyIjogMC45NTczNDkzNTY0OTY3MDY2LCAieDAuZXJyIjogNi43NDYwMTY5NDY3ODk5NDllLTA1LCAieDEuZXJyIjogMC42NDc4NTA5NzU5ODY5OTY2LCAiYy5lcnIiOiAwLjEzNDQxMzAzNjM5NjQxMzU1fSwgInNuY29zbW9faW5mbyI6IHsic3VjY2VzcyI6IHRydWUsICJjaGlzcSI6IDIwLjI5NDAxNzkxMDExMjMxMywgIm5kb2YiOiAxLCAiY2hpc3Fkb2YiOiAyMC4yOTQwMTc5MTAxMTIzMTN9LCAiZmx1eF9kaWN0IjogeyJ6dGZnIjogWzAuMCwgLTAuMDQyNjA1ODU1NzUwNDczMzYsIC0wLjE1OTc2MzYxMjQ2NDMxOTQyLCAtMC41MDU5ODM5ODUzNTUyNDg1LCAtMC4xMDU5NzkwNDU0NzgyOTA4MywgMy44MjIzMDg5NDc0ODQ1NzEsIDEyLjE5Njc1NDg2NzEwMDE0NywgMjMuODgzNTQ0OTEzNTM0MTUsIDM4LjIyMzIzMjgyMDM3NzUyLCA1NS4wMTU0NjcyNzgyNzMwOCwgNzQuMzQyNTQxNDE2MzQ5MjIsIDk2LjMyNzQ1MzkzMzE2MDA5LCAxMjEuMjMwODU1MjE3MTg2ODMsIDE0OS42NzE5NzMzNDU4Mzg4NiwgMTc4LjU4NzEzMzY3MjU1MDI3LCAyMDUuMDcyMDU1NjU4Nzg4NDYsIDIyOC4wNTUzMTYwNjg0MjQsIDI0Ny4zNTIzMjM5ODA4Nzg1NywgMjYyLjYwOTI1MTk2MzQ1NzMsIDI3My45NjAxOTExOTE4NTEsIDI4Mi4wMTYzOTE3NTE3NzMsIDI4Ni4zNzI2Mjg3NjU4NjE2MywgMjg2LjY4ODcwMTAxODEzNDQ1LCAyODMuNTU0NTY3MTE3MzQ4MSwgMjc3LjY5MjY0NTUyNDYwODgsIDI2OS40ODM1NDU5ODQ2MTMzLCAyNTkuMTAxNDEyMTkxMjIwOCwgMjQ2Ljk2OTEyOTQ0OTc2NTE1LCAyMzMuODk5MTY4NzM2OTE5MjgsIDIyMC4xMzIyNzI0NjI2MDgzNCwgMjA1LjcxNjY4NzM5MzQxMzE0LCAxOTAuNTk3MTUyMDAzOTQzODUsIDE3NS41NTM4NDE0NDAyMjYyMiwgMTYxLjE2NTk5Mzk2NDQ1NDMyLCAxNDcuNTEwNTE3ODIyNjI0MTcsIDEzNC40NDYyMjA0NjIxODY5NCwgMTIxLjg5NDI1MDE3MDAxNDM5LCAxMDkuOTA0OTI2NzQzMDg2NzIsIDk4Ljg1ODU4MjA1NTk5MDE0LCA4OC44MjIyNDkyNDQ5ODgwNiwgNzkuODU1NDY1Nzk5NzkzOTMsIDcyLjA5NTcyMzMzMTQ2NzIsIDY1LjMwMjgyMzM5NDQzNzU3LCA1OS4yNTMxMjgyMDM2MzYzNDQsIDUzLjkyNjI2NjAzMjI5NDUyLCA0OS40MTk3OTAzMTc3NTMyOCwgNDUuNjc4NTQ4MjU5MDMwNjQsIDQyLjMxMjkyMDczNTM0MDk3LCAzOS4xMzUwNDI0OTI2NjEzMSwgMzYuMTc1NTQ2NTcyMTI5NywgMzMuNDI4OTg3OTU4MTgzNDUsIDMwLjkyODcxOTcyNjIzMzE4NywgMjguNzUyMjgxODYxNTg1NjQsIDI2LjkwMjQ3ODU5MDAzMDA5NiwgMjUuMzMzOTc4MzQ4MzEyMzYsIDI0LjAxMTA1NjIzOTM4MjkzNSwgMjIuOTAzODgyMjIyNjQwNTU0LCAyMS45ODU1MjExMDM5NjA1NTgsIDIxLjE4MzYxNTc5ODI1OTE3MiwgMjAuNDUyMjYzMDY5MTMwNDY3LCAxOS43ODQ2NDgxNDA4MjM3NTUsIDE5LjE3NTU1OTc1NTQwMzQyNywgMTguNjIwMzc0ODc2NTc1MjksIDE4LjExNTA4NTAxNDE3MjMxNSwgMTcuNjU2MjcwMzk5NzY4MzIsIDE3LjI0MDMyMDg1NjEyNTk5LCAxNi44NTkxMTMwMzUwMTQ1NzcsIDE2LjQ4NjE4ODc2Njc0MTY5OCwgMTYuMTE4OTQwODAyOTc3MDQ3LCAxNS43NTg0NzM3NDM2NDc4NjIsIDE1LjQwNTc0NTcwNDAwMTI0NiwgMTUuMDYxNzIzMzM0MjQ2MDQzLCAxNC43MjczODEwMjI5Nzk4MDQsIDE0LjQwMzY5NTMxNTY1OTUzLCAxNC4wOTE2Mzk5MTExNzczNTMsIDEzLjc5MjE4MTE0NDkwNTA1OCwgMTMuNTA2MjczODY5OTM1ODA3LCAxMy4yMzQ4Njg0ODM3Njc1MzksIDEyLjk4MTU3MzMxODc4OTYyN10sICJ6dGZyIjogWzAuMCwgMC4yMDkwMjkyNzU5Mzc3MzQ5LCAwLjc4ODc0NjQ5ODgxMDcwMzksIDEuNzIyNTcyMDQ5MDAyNDYxNCwgMy42OTI5MjkzMjcwMDQxNDMyLCA4Ljc5MDcxNTY1MDg1NDgwNSwgMTcuNjMyNDU0MDIxMTYyMzM1LCAyOS4yNTAwMTgzNTEwOTI2MTcsIDQzLjA2OTYyOTQwMjAzMDcxLCA1OC44MjcyMTA3OTA5ODU1NywgNzYuNDg2NjMwNDI0MzgxMzksIDk2LjE5OTQ4Mzk4ODEwOTcyLCAxMTguMjA0MzUzMTc5NjA4NSwgMTQzLjAwNzYzODUwNjUxMDY2LCAxNjguMzEyOTYwNzk1NjcyMDQsIDE5MS45NDMxNTA1MTU0NTUwNywgMjEzLjExMjQ5MjAxODQ1MDMsIDIzMS43MDU4NjcwOTQ1MjU0MiwgMjQ3LjQ3Nzg0MDIwMzIxNTYsIDI2MC41NjYzOTUwNzY4NzIzNywgMjcxLjQ3ODE4NDY2MTkwMjcsIDI3OS44ODk5NTU4MjU4NTQ1NCwgMjg1LjUzNjM3MjA2NjA5NTA1LCAyODguNTYwNDMyMzQ4MTA3ODQsIDI4OS4yMDkxODAzODM0NjU1LCAyODcuNjUwMjExNzU1NDQxNywgMjg0LjAxMjM5MTM1MDM1NTcsIDI3OC40MDEyNzQyOTkwNjQ1LCAyNzAuNzQ3ODQ1MjM1ODM2MTcsIDI2MS4yMDkzMzY3NjQxOTcyLCAyNDkuOTY1NDI1MjA5MDkzNjQsIDIzNi45OTYwODA4NDE3NDY1NiwgMjIzLjgyMjE4ODMwMjU3MjMsIDIxMS42MDIyMzAxOTM5NTMzMiwgMjAwLjU3Njg4NDg1MTY3NjUsIDE5MC41OTQ5NzcwNDMxMDUzMywgMTgxLjU4NjIyMjIwNDI1NTUzLCAxNzMuNDE4MDQxNzE4Nzc0NzMsIDE2NS43MzA3MDQ1NzY4OTE4NCwgMTU4LjQ4MjI5NTMyNDg2NTAyLCAxNTEuNjk5NTg5MDg1MzM3ODYsIDE0NS40NTE4MTQ5NDI5MDg2NywgMTM5LjU4NDA3NTMzMzM1MzIsIDEzMy45NTkxODY4MzI4Njg3NywgMTI4LjU3MzUxMzA2ODM0MDUsIDEyMy41MTE2ODQ3MzA1NTI0LCAxMTguNzIxNzkwNTIxMTI0MTMsIDExMy44MDQ0MDc3MTY2NDgyOSwgMTA4LjYwODM1NTg2NDcxNzEzLCAxMDMuMjQxMzg2NjgzMDIxNDUsIDk3Ljc2NTI0NjgyMjU0MDA4LCA5Mi4zMzM3MTQxNjc3MjA4MSwgODcuMTk3NDkyMjAyMTk5MDQsIDgyLjQyODMxMDQ2NDc4ODMyLCA3Ny45Nzc5MjUyNzYzNzA4OCwgNzMuODEwMDcxNTY1NjgzNjMsIDY5Ljg5MTk0NDMyNjg0OSwgNjYuMTk5MzM4MTkxNjMwNCwgNjIuODE0MDY4Mjk4NzQ1Njk2LCA1OS43NzUwOTExMzk3MjA2MywgNTcuMDUxMDcyNjc2ODk3MTUsIDU0LjYxNDMxOTc2NDU2NTM0NCwgNTIuNDQxMzM3NjgzNjU1NjYsIDUwLjUxMTUyNzYyMjUyMDkyLCA0OC44MDY4ODUwNDEwMjEyMiwgNDcuMzA5MjE5ODg4NjkxNjE1LCA0NS45ODU1MTU2NDIxNDYxNywgNDQuNzQxNDAwNjkzNDQ3MDQsIDQzLjU2MjcwOTkyODYwOTE2NiwgNDIuNDQ3OTkwOTkzNDI2OTksIDQxLjM5NTQ1MDExNjg4MzUsIDQwLjQwMzQzMDc2MDk2MTY4LCAzOS40NzA0MDYxMjgyMjcyNCwgMzguNTk0OTYwNzIwNjY3NCwgMzcuNzc1Nzc3NzI1ODY5OTQsIDM3LjAxMTYzMDk2NDg1NDUyNSwgMzYuMzAxMzgwMzgzNDY1NjU2LCAzNS42NDM5NTk0MzY0NjcxNSwgMzUuMDQzODYwODA3MzQ5ODk0XSwgIm9ic2pkIjogWzI0NTkxMzYuNDcwOTcxMzA2LCAyNDU5MTM3LjQ3MDk3MTMwNiwgMjQ1OTEzOC40NzA5NzEzMDYsIDI0NTkxMzkuNDcwOTcxMzA2LCAyNDU5MTQwLjQ3MDk3MTMwNiwgMjQ1OTE0MS40NzA5NzEzMDYsIDI0NTkxNDIuNDcwOTcxMzA2LCAyNDU5MTQzLjQ3MDk3MTMwNiwgMjQ1OTE0NC40NzA5NzEzMDYsIDI0NTkxNDUuNDcwOTcxMzA2LCAyNDU5MTQ2LjQ3MDk3MTMwNiwgMjQ1OTE0Ny40NzA5NzEzMDYsIDI0NTkxNDguNDcwOTcxMzA2LCAyNDU5MTQ5LjQ3MDk3MTMwNiwgMjQ1OTE1MC40NzA5NzEzMDYsIDI0NTkxNTEuNDcwOTcxMzA2LCAyNDU5MTUyLjQ3MDk3MTMwNiwgMjQ1OTE1My40NzA5NzEzMDYsIDI0NTkxNTQuNDcwOTcxMzA2LCAyNDU5MTU1LjQ3MDk3MTMwNiwgMjQ1OTE1Ni40NzA5NzEzMDYsIDI0NTkxNTcuNDcwOTcxMzA2LCAyNDU5MTU4LjQ3MDk3MTMwNiwgMjQ1OTE1OS40NzA5NzEzMDYsIDI0NTkxNjAuNDcwOTcxMzA2LCAyNDU5MTYxLjQ3MDk3MTMwNiwgMjQ1OTE2Mi40NzA5NzEzMDYsIDI0NTkxNjMuNDcwOTcxMzA2LCAyNDU5MTY0LjQ3MDk3MTMwNiwgMjQ1OTE2NS40NzA5NzEzMDYsIDI0NTkxNjYuNDcwOTcxMzA2LCAyNDU5MTY3LjQ3MDk3MTMwNiwgMjQ1OTE2OC40NzA5NzEzMDYsIDI0NTkxNjkuNDcwOTcxMzA2LCAyNDU5MTcwLjQ3MDk3MTMwNiwgMjQ1OTE3MS40NzA5NzEzMDYsIDI0NTkxNzIuNDcwOTcxMzA2LCAyNDU5MTczLjQ3MDk3MTMwNiwgMjQ1OTE3NC40NzA5NzEzMDYsIDI0NTkxNzUuNDcwOTcxMzA2LCAyNDU5MTc2LjQ3MDk3MTMwNiwgMjQ1OTE3Ny40NzA5NzEzMDYsIDI0NTkxNzguNDcwOTcxMzA2LCAyNDU5MTc5LjQ3MDk3MTMwNiwgMjQ1OTE4MC40NzA5NzEzMDYsIDI0NTkxODEuNDcwOTcxMzA2LCAyNDU5MTgyLjQ3MDk3MTMwNiwgMjQ1OTE4My40NzA5NzEzMDYsIDI0NTkxODQuNDcwOTcxMzA2LCAyNDU5MTg1LjQ3MDk3MTMwNiwgMjQ1OTE4Ni40NzA5NzEzMDYsIDI0NTkxODcuNDcwOTcxMzA2LCAyNDU5MTg4LjQ3MDk3MTMwNiwgMjQ1OTE4OS40NzA5NzEzMDYsIDI0NTkxOTAuNDcwOTcxMzA2LCAyNDU5MTkxLjQ3MDk3MTMwNiwgMjQ1OTE5Mi40NzA5NzEzMDYsIDI0NTkxOTMuNDcwOTcxMzA2LCAyNDU5MTk0LjQ3MDk3MTMwNiwgMjQ1OTE5NS40NzA5NzEzMDYsIDI0NTkxOTYuNDcwOTcxMzA2LCAyNDU5MTk3LjQ3MDk3MTMwNiwgMjQ1OTE5OC40NzA5NzEzMDYsIDI0NTkxOTkuNDcwOTcxMzA2LCAyNDU5MjAwLjQ3MDk3MTMwNiwgMjQ1OTIwMS40NzA5NzEzMDYsIDI0NTkyMDIuNDcwOTcxMzA2LCAyNDU5MjAzLjQ3MDk3MTMwNiwgMjQ1OTIwNC40NzA5NzEzMDYsIDI0NTkyMDUuNDcwOTcxMzA2LCAyNDU5MjA2LjQ3MDk3MTMwNiwgMjQ1OTIwNy40NzA5NzEzMDYsIDI0NTkyMDguNDcwOTcxMzA2LCAyNDU5MjA5LjQ3MDk3MTMwNiwgMjQ1OTIxMC40NzA5NzEzMDYsIDI0NTkyMTEuNDcwOTcxMzA2LCAyNDU5MjEyLjQ3MDk3MTMwNiwgMjQ1OTIxMy40NzA5NzEzMDYsIDI0NTkyMTQuNDcwOTcxMzA2XX19fQ=="
         },
@@ -268,66 +171,38 @@ def test_problematic_put_comment_attachment_1275(
         }
     }
 
-    status2, data2 = api(
-        "PUT",
-        f"sources/{public_source.id}/comments/{data['data']['comment_id']}",
-        data=payload,
-        token=super_admin_token,
+    sp.update_comment(
+        public_source.id,
+        comment_id,
+        attachment_name=payload["attachment"]["name"],
+        attachment_body=payload["attachment"]["body"],
     )
-    assert status2 == 200
-    assert data2["status"] == "success"
 
-    status3, data3 = api(
-        "GET",
-        f"sources/{public_source.id}/comments/{data['data']['comment_id']}",
-        token=super_admin_token,
-    )
-    assert status3 == 200
-    assert data3["status"] == "success"
-    assert data3["data"]["attachment_name"] == "ampel_test.json"
+    comment = sp.fetch_comment(public_source.id, comment_id)
+    assert comment.attachment_name == "ampel_test.json"
 
-    status4, data4 = api(
-        "GET",
-        f"sources/{public_source.id}/comments/{data['data']['comment_id']}/attachment",
-        token=super_admin_token,
+    attachment = sp.fetch_comment_attachment(public_source.id, comment_id)
+    assert json.loads(attachment) == json.loads(
+        base64.b64decode(payload["attachment"]["body"]).decode()
     )
-    assert status4 == 200
-    assert data4 == json.loads(base64.b64decode(payload["attachment"]["body"]).decode())
 
 
 def test_problematic_post_comment_attachment_1275(
     super_admin_token, public_source, public_group
 ):
-    status, data = api(
-        "POST",
-        f"sources/{public_source.id}/comments",
-        data={
-            "text": "asdf",
-            "group_ids": [public_group.id],
-            "attachment": {
-                "body": "eyJ0aW1lc3RhbXAiOiAiMjAyMC0xMS0wNFQxMjowMDowMyIsICJydW4iOiAxODM5LCAiZHVyYXRpb24iOiAwLjE0NiwgInJlc3VsdCI6IHsibW9kZWwiOiAic2FsdDIiLCAiZml0X2xjX3BhcmFtZXRlcnMiOiB7ImJvdW5kcyI6IHsiYyI6IFstMiwgNV0sICJ4MSI6IFstNSwgNV0sICJ6IjogWzAsIDAuMl19fSwgImZpdF9hY2NlcHRhYmxlIjogZmFsc2UsICJwbG90X2luZm8iOiAic2FsdDIgY2hpc3EgMjAuMjkgbmRvZiAxIG9rIGZpdCBGYWxzZSIsICJtb2RlbF9hbmFseXNpcyI6IHsiaGFzX3ByZW1heF9kYXRhIjogdHJ1ZSwgImhhc19wb3N0bWF4X2RhdGEiOiBmYWxzZSwgIngxX2luX3JhbmdlIjogdHJ1ZSwgIl94MV9yYW5nZSI6IFstNCwgNF0sICJjX29rIjogdHJ1ZSwgIl9jX3JhbmdlIjogWy0xLCAyXX0sICJmaXRfcmVzdWx0cyI6IHsieiI6IDAuMTE3NDM5NTYwNTE3MDEwNjUsICJ0MCI6IDI0NTkxNTguODE5NzYyNTE2MywgIngwIjogMC4wMDA2MDg1NTg3NzI2MjI5NDY3LCAieDEiOiAtMC44NzM1ODM5NTY4MTk5NjczLCAiYyI6IC0wLjA1OTg1NTgxMTY2MDA2MzE1LCAibXdlYnYiOiAwLjA5OTU2MTk1NjAzOTAzMTEyLCAibXdyX3YiOiAzLjEsICJ6LmVyciI6IDAuMDIxNTUyNTQwMzEyMzk1NDI0LCAidDAuZXJyIjogMC45NTczNDkzNTY0OTY3MDY2LCAieDAuZXJyIjogNi43NDYwMTY5NDY3ODk5NDllLTA1LCAieDEuZXJyIjogMC42NDc4NTA5NzU5ODY5OTY2LCAiYy5lcnIiOiAwLjEzNDQxMzAzNjM5NjQxMzU1fSwgInNuY29zbW9faW5mbyI6IHsic3VjY2VzcyI6IHRydWUsICJjaGlzcSI6IDIwLjI5NDAxNzkxMDExMjMxMywgIm5kb2YiOiAxLCAiY2hpc3Fkb2YiOiAyMC4yOTQwMTc5MTAxMTIzMTN9LCAiZmx1eF9kaWN0IjogeyJ6dGZnIjogWzAuMCwgLTAuMDQyNjA1ODU1NzUwNDczMzYsIC0wLjE1OTc2MzYxMjQ2NDMxOTQyLCAtMC41MDU5ODM5ODUzNTUyNDg1LCAtMC4xMDU5NzkwNDU0NzgyOTA4MywgMy44MjIzMDg5NDc0ODQ1NzEsIDEyLjE5Njc1NDg2NzEwMDE0NywgMjMuODgzNTQ0OTEzNTM0MTUsIDM4LjIyMzIzMjgyMDM3NzUyLCA1NS4wMTU0NjcyNzgyNzMwOCwgNzQuMzQyNTQxNDE2MzQ5MjIsIDk2LjMyNzQ1MzkzMzE2MDA5LCAxMjEuMjMwODU1MjE3MTg2ODMsIDE0OS42NzE5NzMzNDU4Mzg4NiwgMTc4LjU4NzEzMzY3MjU1MDI3LCAyMDUuMDcyMDU1NjU4Nzg4NDYsIDIyOC4wNTUzMTYwNjg0MjQsIDI0Ny4zNTIzMjM5ODA4Nzg1NywgMjYyLjYwOTI1MTk2MzQ1NzMsIDI3My45NjAxOTExOTE4NTEsIDI4Mi4wMTYzOTE3NTE3NzMsIDI4Ni4zNzI2Mjg3NjU4NjE2MywgMjg2LjY4ODcwMTAxODEzNDQ1LCAyODMuNTU0NTY3MTE3MzQ4MSwgMjc3LjY5MjY0NTUyNDYwODgsIDI2OS40ODM1NDU5ODQ2MTMzLCAyNTkuMTAxNDEyMTkxMjIwOCwgMjQ2Ljk2OTEyOTQ0OTc2NTE1LCAyMzMuODk5MTY4NzM2OTE5MjgsIDIyMC4xMzIyNzI0NjI2MDgzNCwgMjA1LjcxNjY4NzM5MzQxMzE0LCAxOTAuNTk3MTUyMDAzOTQzODUsIDE3NS41NTM4NDE0NDAyMjYyMiwgMTYxLjE2NTk5Mzk2NDQ1NDMyLCAxNDcuNTEwNTE3ODIyNjI0MTcsIDEzNC40NDYyMjA0NjIxODY5NCwgMTIxLjg5NDI1MDE3MDAxNDM5LCAxMDkuOTA0OTI2NzQzMDg2NzIsIDk4Ljg1ODU4MjA1NTk5MDE0LCA4OC44MjIyNDkyNDQ5ODgwNiwgNzkuODU1NDY1Nzk5NzkzOTMsIDcyLjA5NTcyMzMzMTQ2NzIsIDY1LjMwMjgyMzM5NDQzNzU3LCA1OS4yNTMxMjgyMDM2MzYzNDQsIDUzLjkyNjI2NjAzMjI5NDUyLCA0OS40MTk3OTAzMTc3NTMyOCwgNDUuNjc4NTQ4MjU5MDMwNjQsIDQyLjMxMjkyMDczNTM0MDk3LCAzOS4xMzUwNDI0OTI2NjEzMSwgMzYuMTc1NTQ2NTcyMTI5NywgMzMuNDI4OTg3OTU4MTgzNDUsIDMwLjkyODcxOTcyNjIzMzE4NywgMjguNzUyMjgxODYxNTg1NjQsIDI2LjkwMjQ3ODU5MDAzMDA5NiwgMjUuMzMzOTc4MzQ4MzEyMzYsIDI0LjAxMTA1NjIzOTM4MjkzNSwgMjIuOTAzODgyMjIyNjQwNTU0LCAyMS45ODU1MjExMDM5NjA1NTgsIDIxLjE4MzYxNTc5ODI1OTE3MiwgMjAuNDUyMjYzMDY5MTMwNDY3LCAxOS43ODQ2NDgxNDA4MjM3NTUsIDE5LjE3NTU1OTc1NTQwMzQyNywgMTguNjIwMzc0ODc2NTc1MjksIDE4LjExNTA4NTAxNDE3MjMxNSwgMTcuNjU2MjcwMzk5NzY4MzIsIDE3LjI0MDMyMDg1NjEyNTk5LCAxNi44NTkxMTMwMzUwMTQ1NzcsIDE2LjQ4NjE4ODc2Njc0MTY5OCwgMTYuMTE4OTQwODAyOTc3MDQ3LCAxNS43NTg0NzM3NDM2NDc4NjIsIDE1LjQwNTc0NTcwNDAwMTI0NiwgMTUuMDYxNzIzMzM0MjQ2MDQzLCAxNC43MjczODEwMjI5Nzk4MDQsIDE0LjQwMzY5NTMxNTY1OTUzLCAxNC4wOTE2Mzk5MTExNzczNTMsIDEzLjc5MjE4MTE0NDkwNTA1OCwgMTMuNTA2MjczODY5OTM1ODA3LCAxMy4yMzQ4Njg0ODM3Njc1MzksIDEyLjk4MTU3MzMxODc4OTYyN10sICJ6dGZyIjogWzAuMCwgMC4yMDkwMjkyNzU5Mzc3MzQ5LCAwLjc4ODc0NjQ5ODgxMDcwMzksIDEuNzIyNTcyMDQ5MDAyNDYxNCwgMy42OTI5MjkzMjcwMDQxNDMyLCA4Ljc5MDcxNTY1MDg1NDgwNSwgMTcuNjMyNDU0MDIxMTYyMzM1LCAyOS4yNTAwMTgzNTEwOTI2MTcsIDQzLjA2OTYyOTQwMjAzMDcxLCA1OC44MjcyMTA3OTA5ODU1NywgNzYuNDg2NjMwNDI0MzgxMzksIDk2LjE5OTQ4Mzk4ODEwOTcyLCAxMTguMjA0MzUzMTc5NjA4NSwgMTQzLjAwNzYzODUwNjUxMDY2LCAxNjguMzEyOTYwNzk1NjcyMDQsIDE5MS45NDMxNTA1MTU0NTUwNywgMjEzLjExMjQ5MjAxODQ1MDMsIDIzMS43MDU4NjcwOTQ1MjU0MiwgMjQ3LjQ3Nzg0MDIwMzIxNTYsIDI2MC41NjYzOTUwNzY4NzIzNywgMjcxLjQ3ODE4NDY2MTkwMjcsIDI3OS44ODk5NTU4MjU4NTQ1NCwgMjg1LjUzNjM3MjA2NjA5NTA1LCAyODguNTYwNDMyMzQ4MTA3ODQsIDI4OS4yMDkxODAzODM0NjU1LCAyODcuNjUwMjExNzU1NDQxNywgMjg0LjAxMjM5MTM1MDM1NTcsIDI3OC40MDEyNzQyOTkwNjQ1LCAyNzAuNzQ3ODQ1MjM1ODM2MTcsIDI2MS4yMDkzMzY3NjQxOTcyLCAyNDkuOTY1NDI1MjA5MDkzNjQsIDIzNi45OTYwODA4NDE3NDY1NiwgMjIzLjgyMjE4ODMwMjU3MjMsIDIxMS42MDIyMzAxOTM5NTMzMiwgMjAwLjU3Njg4NDg1MTY3NjUsIDE5MC41OTQ5NzcwNDMxMDUzMywgMTgxLjU4NjIyMjIwNDI1NTUzLCAxNzMuNDE4MDQxNzE4Nzc0NzMsIDE2NS43MzA3MDQ1NzY4OTE4NCwgMTU4LjQ4MjI5NTMyNDg2NTAyLCAxNTEuNjk5NTg5MDg1MzM3ODYsIDE0NS40NTE4MTQ5NDI5MDg2NywgMTM5LjU4NDA3NTMzMzM1MzIsIDEzMy45NTkxODY4MzI4Njg3NywgMTI4LjU3MzUxMzA2ODM0MDUsIDEyMy41MTE2ODQ3MzA1NTI0LCAxMTguNzIxNzkwNTIxMTI0MTMsIDExMy44MDQ0MDc3MTY2NDgyOSwgMTA4LjYwODM1NTg2NDcxNzEzLCAxMDMuMjQxMzg2NjgzMDIxNDUsIDk3Ljc2NTI0NjgyMjU0MDA4LCA5Mi4zMzM3MTQxNjc3MjA4MSwgODcuMTk3NDkyMjAyMTk5MDQsIDgyLjQyODMxMDQ2NDc4ODMyLCA3Ny45Nzc5MjUyNzYzNzA4OCwgNzMuODEwMDcxNTY1NjgzNjMsIDY5Ljg5MTk0NDMyNjg0OSwgNjYuMTk5MzM4MTkxNjMwNCwgNjIuODE0MDY4Mjk4NzQ1Njk2LCA1OS43NzUwOTExMzk3MjA2MywgNTcuMDUxMDcyNjc2ODk3MTUsIDU0LjYxNDMxOTc2NDU2NTM0NCwgNTIuNDQxMzM3NjgzNjU1NjYsIDUwLjUxMTUyNzYyMjUyMDkyLCA0OC44MDY4ODUwNDEwMjEyMiwgNDcuMzA5MjE5ODg4NjkxNjE1LCA0NS45ODU1MTU2NDIxNDYxNywgNDQuNzQxNDAwNjkzNDQ3MDQsIDQzLjU2MjcwOTkyODYwOTE2NiwgNDIuNDQ3OTkwOTkzNDI2OTksIDQxLjM5NTQ1MDExNjg4MzUsIDQwLjQwMzQzMDc2MDk2MTY4LCAzOS40NzA0MDYxMjgyMjcyNCwgMzguNTk0OTYwNzIwNjY3NCwgMzcuNzc1Nzc3NzI1ODY5OTQsIDM3LjAxMTYzMDk2NDg1NDUyNSwgMzYuMzAxMzgwMzgzNDY1NjU2LCAzNS42NDM5NTk0MzY0NjcxNSwgMzUuMDQzODYwODA3MzQ5ODk0XSwgIm9ic2pkIjogWzI0NTkxMzYuNDcwOTcxMzA2LCAyNDU5MTM3LjQ3MDk3MTMwNiwgMjQ1OTEzOC40NzA5NzEzMDYsIDI0NTkxMzkuNDcwOTcxMzA2LCAyNDU5MTQwLjQ3MDk3MTMwNiwgMjQ1OTE0MS40NzA5NzEzMDYsIDI0NTkxNDIuNDcwOTcxMzA2LCAyNDU5MTQzLjQ3MDk3MTMwNiwgMjQ1OTE0NC40NzA5NzEzMDYsIDI0NTkxNDUuNDcwOTcxMzA2LCAyNDU5MTQ2LjQ3MDk3MTMwNiwgMjQ1OTE0Ny40NzA5NzEzMDYsIDI0NTkxNDguNDcwOTcxMzA2LCAyNDU5MTQ5LjQ3MDk3MTMwNiwgMjQ1OTE1MC40NzA5NzEzMDYsIDI0NTkxNTEuNDcwOTcxMzA2LCAyNDU5MTUyLjQ3MDk3MTMwNiwgMjQ1OTE1My40NzA5NzEzMDYsIDI0NTkxNTQuNDcwOTcxMzA2LCAyNDU5MTU1LjQ3MDk3MTMwNiwgMjQ1OTE1Ni40NzA5NzEzMDYsIDI0NTkxNTcuNDcwOTcxMzA2LCAyNDU5MTU4LjQ3MDk3MTMwNiwgMjQ1OTE1OS40NzA5NzEzMDYsIDI0NTkxNjAuNDcwOTcxMzA2LCAyNDU5MTYxLjQ3MDk3MTMwNiwgMjQ1OTE2Mi40NzA5NzEzMDYsIDI0NTkxNjMuNDcwOTcxMzA2LCAyNDU5MTY0LjQ3MDk3MTMwNiwgMjQ1OTE2NS40NzA5NzEzMDYsIDI0NTkxNjYuNDcwOTcxMzA2LCAyNDU5MTY3LjQ3MDk3MTMwNiwgMjQ1OTE2OC40NzA5NzEzMDYsIDI0NTkxNjkuNDcwOTcxMzA2LCAyNDU5MTcwLjQ3MDk3MTMwNiwgMjQ1OTE3MS40NzA5NzEzMDYsIDI0NTkxNzIuNDcwOTcxMzA2LCAyNDU5MTczLjQ3MDk3MTMwNiwgMjQ1OTE3NC40NzA5NzEzMDYsIDI0NTkxNzUuNDcwOTcxMzA2LCAyNDU5MTc2LjQ3MDk3MTMwNiwgMjQ1OTE3Ny40NzA5NzEzMDYsIDI0NTkxNzguNDcwOTcxMzA2LCAyNDU5MTc5LjQ3MDk3MTMwNiwgMjQ1OTE4MC40NzA5NzEzMDYsIDI0NTkxODEuNDcwOTcxMzA2LCAyNDU5MTgyLjQ3MDk3MTMwNiwgMjQ1OTE4My40NzA5NzEzMDYsIDI0NTkxODQuNDcwOTcxMzA2LCAyNDU5MTg1LjQ3MDk3MTMwNiwgMjQ1OTE4Ni40NzA5NzEzMDYsIDI0NTkxODcuNDcwOTcxMzA2LCAyNDU5MTg4LjQ3MDk3MTMwNiwgMjQ1OTE4OS40NzA5NzEzMDYsIDI0NTkxOTAuNDcwOTcxMzA2LCAyNDU5MTkxLjQ3MDk3MTMwNiwgMjQ1OTE5Mi40NzA5NzEzMDYsIDI0NTkxOTMuNDcwOTcxMzA2LCAyNDU5MTk0LjQ3MDk3MTMwNiwgMjQ1OTE5NS40NzA5NzEzMDYsIDI0NTkxOTYuNDcwOTcxMzA2LCAyNDU5MTk3LjQ3MDk3MTMwNiwgMjQ1OTE5OC40NzA5NzEzMDYsIDI0NTkxOTkuNDcwOTcxMzA2LCAyNDU5MjAwLjQ3MDk3MTMwNiwgMjQ1OTIwMS40NzA5NzEzMDYsIDI0NTkyMDIuNDcwOTcxMzA2LCAyNDU5MjAzLjQ3MDk3MTMwNiwgMjQ1OTIwNC40NzA5NzEzMDYsIDI0NTkyMDUuNDcwOTcxMzA2LCAyNDU5MjA2LjQ3MDk3MTMwNiwgMjQ1OTIwNy40NzA5NzEzMDYsIDI0NTkyMDguNDcwOTcxMzA2LCAyNDU5MjA5LjQ3MDk3MTMwNiwgMjQ1OTIxMC40NzA5NzEzMDYsIDI0NTkyMTEuNDcwOTcxMzA2LCAyNDU5MjEyLjQ3MDk3MTMwNiwgMjQ1OTIxMy40NzA5NzEzMDYsIDI0NTkyMTQuNDcwOTcxMzA2XX19fQ==",
-                "name": "ampel_test.json",
-            },
-        },
-        token=super_admin_token,
+    client(super_admin_token).post_comment_with_attachment(
+        public_source.id,
+        "asdf",
+        attachment_body="eyJ0aW1lc3RhbXAiOiAiMjAyMC0xMS0wNFQxMjowMDowMyIsICJydW4iOiAxODM5LCAiZHVyYXRpb24iOiAwLjE0NiwgInJlc3VsdCI6IHsibW9kZWwiOiAic2FsdDIiLCAiZml0X2xjX3BhcmFtZXRlcnMiOiB7ImJvdW5kcyI6IHsiYyI6IFstMiwgNV0sICJ4MSI6IFstNSwgNV0sICJ6IjogWzAsIDAuMl19fSwgImZpdF9hY2NlcHRhYmxlIjogZmFsc2UsICJwbG90X2luZm8iOiAic2FsdDIgY2hpc3EgMjAuMjkgbmRvZiAxIG9rIGZpdCBGYWxzZSIsICJtb2RlbF9hbmFseXNpcyI6IHsiaGFzX3ByZW1heF9kYXRhIjogdHJ1ZSwgImhhc19wb3N0bWF4X2RhdGEiOiBmYWxzZSwgIngxX2luX3JhbmdlIjogdHJ1ZSwgIl94MV9yYW5nZSI6IFstNCwgNF0sICJjX29rIjogdHJ1ZSwgIl9jX3JhbmdlIjogWy0xLCAyXX0sICJmaXRfcmVzdWx0cyI6IHsieiI6IDAuMTE3NDM5NTYwNTE3MDEwNjUsICJ0MCI6IDI0NTkxNTguODE5NzYyNTE2MywgIngwIjogMC4wMDA2MDg1NTg3NzI2MjI5NDY3LCAieDEiOiAtMC44NzM1ODM5NTY4MTk5NjczLCAiYyI6IC0wLjA1OTg1NTgxMTY2MDA2MzE1LCAibXdlYnYiOiAwLjA5OTU2MTk1NjAzOTAzMTEyLCAibXdyX3YiOiAzLjEsICJ6LmVyciI6IDAuMDIxNTUyNTQwMzEyMzk1NDI0LCAidDAuZXJyIjogMC45NTczNDkzNTY0OTY3MDY2LCAieDAuZXJyIjogNi43NDYwMTY5NDY3ODk5NDllLTA1LCAieDEuZXJyIjogMC42NDc4NTA5NzU5ODY5OTY2LCAiYy5lcnIiOiAwLjEzNDQxMzAzNjM5NjQxMzU1fSwgInNuY29zbW9faW5mbyI6IHsic3VjY2VzcyI6IHRydWUsICJjaGlzcSI6IDIwLjI5NDAxNzkxMDExMjMxMywgIm5kb2YiOiAxLCAiY2hpc3Fkb2YiOiAyMC4yOTQwMTc5MTAxMTIzMTN9LCAiZmx1eF9kaWN0IjogeyJ6dGZnIjogWzAuMCwgLTAuMDQyNjA1ODU1NzUwNDczMzYsIC0wLjE1OTc2MzYxMjQ2NDMxOTQyLCAtMC41MDU5ODM5ODUzNTUyNDg1LCAtMC4xMDU5NzkwNDU0NzgyOTA4MywgMy44MjIzMDg5NDc0ODQ1NzEsIDEyLjE5Njc1NDg2NzEwMDE0NywgMjMuODgzNTQ0OTEzNTM0MTUsIDM4LjIyMzIzMjgyMDM3NzUyLCA1NS4wMTU0NjcyNzgyNzMwOCwgNzQuMzQyNTQxNDE2MzQ5MjIsIDk2LjMyNzQ1MzkzMzE2MDA5LCAxMjEuMjMwODU1MjE3MTg2ODMsIDE0OS42NzE5NzMzNDU4Mzg4NiwgMTc4LjU4NzEzMzY3MjU1MDI3LCAyMDUuMDcyMDU1NjU4Nzg4NDYsIDIyOC4wNTUzMTYwNjg0MjQsIDI0Ny4zNTIzMjM5ODA4Nzg1NywgMjYyLjYwOTI1MTk2MzQ1NzMsIDI3My45NjAxOTExOTE4NTEsIDI4Mi4wMTYzOTE3NTE3NzMsIDI4Ni4zNzI2Mjg3NjU4NjE2MywgMjg2LjY4ODcwMTAxODEzNDQ1LCAyODMuNTU0NTY3MTE3MzQ4MSwgMjc3LjY5MjY0NTUyNDYwODgsIDI2OS40ODM1NDU5ODQ2MTMzLCAyNTkuMTAxNDEyMTkxMjIwOCwgMjQ2Ljk2OTEyOTQ0OTc2NTE1LCAyMzMuODk5MTY4NzM2OTE5MjgsIDIyMC4xMzIyNzI0NjI2MDgzNCwgMjA1LjcxNjY4NzM5MzQxMzE0LCAxOTAuNTk3MTUyMDAzOTQzODUsIDE3NS41NTM4NDE0NDAyMjYyMiwgMTYxLjE2NTk5Mzk2NDQ1NDMyLCAxNDcuNTEwNTE3ODIyNjI0MTcsIDEzNC40NDYyMjA0NjIxODY5NCwgMTIxLjg5NDI1MDE3MDAxNDM5LCAxMDkuOTA0OTI2NzQzMDg2NzIsIDk4Ljg1ODU4MjA1NTk5MDE0LCA4OC44MjIyNDkyNDQ5ODgwNiwgNzkuODU1NDY1Nzk5NzkzOTMsIDcyLjA5NTcyMzMzMTQ2NzIsIDY1LjMwMjgyMzM5NDQzNzU3LCA1OS4yNTMxMjgyMDM2MzYzNDQsIDUzLjkyNjI2NjAzMjI5NDUyLCA0OS40MTk3OTAzMTc3NTMyOCwgNDUuNjc4NTQ4MjU5MDMwNjQsIDQyLjMxMjkyMDczNTM0MDk3LCAzOS4xMzUwNDI0OTI2NjEzMSwgMzYuMTc1NTQ2NTcyMTI5NywgMzMuNDI4OTg3OTU4MTgzNDUsIDMwLjkyODcxOTcyNjIzMzE4NywgMjguNzUyMjgxODYxNTg1NjQsIDI2LjkwMjQ3ODU5MDAzMDA5NiwgMjUuMzMzOTc4MzQ4MzEyMzYsIDI0LjAxMTA1NjIzOTM4MjkzNSwgMjIuOTAzODgyMjIyNjQwNTU0LCAyMS45ODU1MjExMDM5NjA1NTgsIDIxLjE4MzYxNTc5ODI1OTE3MiwgMjAuNDUyMjYzMDY5MTMwNDY3LCAxOS43ODQ2NDgxNDA4MjM3NTUsIDE5LjE3NTU1OTc1NTQwMzQyNywgMTguNjIwMzc0ODc2NTc1MjksIDE4LjExNTA4NTAxNDE3MjMxNSwgMTcuNjU2MjcwMzk5NzY4MzIsIDE3LjI0MDMyMDg1NjEyNTk5LCAxNi44NTkxMTMwMzUwMTQ1NzcsIDE2LjQ4NjE4ODc2Njc0MTY5OCwgMTYuMTE4OTQwODAyOTc3MDQ3LCAxNS43NTg0NzM3NDM2NDc4NjIsIDE1LjQwNTc0NTcwNDAwMTI0NiwgMTUuMDYxNzIzMzM0MjQ2MDQzLCAxNC43MjczODEwMjI5Nzk4MDQsIDE0LjQwMzY5NTMxNTY1OTUzLCAxNC4wOTE2Mzk5MTExNzczNTMsIDEzLjc5MjE4MTE0NDkwNTA1OCwgMTMuNTA2MjczODY5OTM1ODA3LCAxMy4yMzQ4Njg0ODM3Njc1MzksIDEyLjk4MTU3MzMxODc4OTYyN10sICJ6dGZyIjogWzAuMCwgMC4yMDkwMjkyNzU5Mzc3MzQ5LCAwLjc4ODc0NjQ5ODgxMDcwMzksIDEuNzIyNTcyMDQ5MDAyNDYxNCwgMy42OTI5MjkzMjcwMDQxNDMyLCA4Ljc5MDcxNTY1MDg1NDgwNSwgMTcuNjMyNDU0MDIxMTYyMzM1LCAyOS4yNTAwMTgzNTEwOTI2MTcsIDQzLjA2OTYyOTQwMjAzMDcxLCA1OC44MjcyMTA3OTA5ODU1NywgNzYuNDg2NjMwNDI0MzgxMzksIDk2LjE5OTQ4Mzk4ODEwOTcyLCAxMTguMjA0MzUzMTc5NjA4NSwgMTQzLjAwNzYzODUwNjUxMDY2LCAxNjguMzEyOTYwNzk1NjcyMDQsIDE5MS45NDMxNTA1MTU0NTUwNywgMjEzLjExMjQ5MjAxODQ1MDMsIDIzMS43MDU4NjcwOTQ1MjU0MiwgMjQ3LjQ3Nzg0MDIwMzIxNTYsIDI2MC41NjYzOTUwNzY4NzIzNywgMjcxLjQ3ODE4NDY2MTkwMjcsIDI3OS44ODk5NTU4MjU4NTQ1NCwgMjg1LjUzNjM3MjA2NjA5NTA1LCAyODguNTYwNDMyMzQ4MTA3ODQsIDI4OS4yMDkxODAzODM0NjU1LCAyODcuNjUwMjExNzU1NDQxNywgMjg0LjAxMjM5MTM1MDM1NTcsIDI3OC40MDEyNzQyOTkwNjQ1LCAyNzAuNzQ3ODQ1MjM1ODM2MTcsIDI2MS4yMDkzMzY3NjQxOTcyLCAyNDkuOTY1NDI1MjA5MDkzNjQsIDIzNi45OTYwODA4NDE3NDY1NiwgMjIzLjgyMjE4ODMwMjU3MjMsIDIxMS42MDIyMzAxOTM5NTMzMiwgMjAwLjU3Njg4NDg1MTY3NjUsIDE5MC41OTQ5NzcwNDMxMDUzMywgMTgxLjU4NjIyMjIwNDI1NTUzLCAxNzMuNDE4MDQxNzE4Nzc0NzMsIDE2NS43MzA3MDQ1NzY4OTE4NCwgMTU4LjQ4MjI5NTMyNDg2NTAyLCAxNTEuNjk5NTg5MDg1MzM3ODYsIDE0NS40NTE4MTQ5NDI5MDg2NywgMTM5LjU4NDA3NTMzMzM1MzIsIDEzMy45NTkxODY4MzI4Njg3NywgMTI4LjU3MzUxMzA2ODM0MDUsIDEyMy41MTE2ODQ3MzA1NTI0LCAxMTguNzIxNzkwNTIxMTI0MTMsIDExMy44MDQ0MDc3MTY2NDgyOSwgMTA4LjYwODM1NTg2NDcxNzEzLCAxMDMuMjQxMzg2NjgzMDIxNDUsIDk3Ljc2NTI0NjgyMjU0MDA4LCA5Mi4zMzM3MTQxNjc3MjA4MSwgODcuMTk3NDkyMjAyMTk5MDQsIDgyLjQyODMxMDQ2NDc4ODMyLCA3Ny45Nzc5MjUyNzYzNzA4OCwgNzMuODEwMDcxNTY1NjgzNjMsIDY5Ljg5MTk0NDMyNjg0OSwgNjYuMTk5MzM4MTkxNjMwNCwgNjIuODE0MDY4Mjk4NzQ1Njk2LCA1OS43NzUwOTExMzk3MjA2MywgNTcuMDUxMDcyNjc2ODk3MTUsIDU0LjYxNDMxOTc2NDU2NTM0NCwgNTIuNDQxMzM3NjgzNjU1NjYsIDUwLjUxMTUyNzYyMjUyMDkyLCA0OC44MDY4ODUwNDEwMjEyMiwgNDcuMzA5MjE5ODg4NjkxNjE1LCA0NS45ODU1MTU2NDIxNDYxNywgNDQuNzQxNDAwNjkzNDQ3MDQsIDQzLjU2MjcwOTkyODYwOTE2NiwgNDIuNDQ3OTkwOTkzNDI2OTksIDQxLjM5NTQ1MDExNjg4MzUsIDQwLjQwMzQzMDc2MDk2MTY4LCAzOS40NzA0MDYxMjgyMjcyNCwgMzguNTk0OTYwNzIwNjY3NCwgMzcuNzc1Nzc3NzI1ODY5OTQsIDM3LjAxMTYzMDk2NDg1NDUyNSwgMzYuMzAxMzgwMzgzNDY1NjU2LCAzNS42NDM5NTk0MzY0NjcxNSwgMzUuMDQzODYwODA3MzQ5ODk0XSwgIm9ic2pkIjogWzI0NTkxMzYuNDcwOTcxMzA2LCAyNDU5MTM3LjQ3MDk3MTMwNiwgMjQ1OTEzOC40NzA5NzEzMDYsIDI0NTkxMzkuNDcwOTcxMzA2LCAyNDU5MTQwLjQ3MDk3MTMwNiwgMjQ1OTE0MS40NzA5NzEzMDYsIDI0NTkxNDIuNDcwOTcxMzA2LCAyNDU5MTQzLjQ3MDk3MTMwNiwgMjQ1OTE0NC40NzA5NzEzMDYsIDI0NTkxNDUuNDcwOTcxMzA2LCAyNDU5MTQ2LjQ3MDk3MTMwNiwgMjQ1OTE0Ny40NzA5NzEzMDYsIDI0NTkxNDguNDcwOTcxMzA2LCAyNDU5MTQ5LjQ3MDk3MTMwNiwgMjQ1OTE1MC40NzA5NzEzMDYsIDI0NTkxNTEuNDcwOTcxMzA2LCAyNDU5MTUyLjQ3MDk3MTMwNiwgMjQ1OTE1My40NzA5NzEzMDYsIDI0NTkxNTQuNDcwOTcxMzA2LCAyNDU5MTU1LjQ3MDk3MTMwNiwgMjQ1OTE1Ni40NzA5NzEzMDYsIDI0NTkxNTcuNDcwOTcxMzA2LCAyNDU5MTU4LjQ3MDk3MTMwNiwgMjQ1OTE1OS40NzA5NzEzMDYsIDI0NTkxNjAuNDcwOTcxMzA2LCAyNDU5MTYxLjQ3MDk3MTMwNiwgMjQ1OTE2Mi40NzA5NzEzMDYsIDI0NTkxNjMuNDcwOTcxMzA2LCAyNDU5MTY0LjQ3MDk3MTMwNiwgMjQ1OTE2NS40NzA5NzEzMDYsIDI0NTkxNjYuNDcwOTcxMzA2LCAyNDU5MTY3LjQ3MDk3MTMwNiwgMjQ1OTE2OC40NzA5NzEzMDYsIDI0NTkxNjkuNDcwOTcxMzA2LCAyNDU5MTcwLjQ3MDk3MTMwNiwgMjQ1OTE3MS40NzA5NzEzMDYsIDI0NTkxNzIuNDcwOTcxMzA2LCAyNDU5MTczLjQ3MDk3MTMwNiwgMjQ1OTE3NC40NzA5NzEzMDYsIDI0NTkxNzUuNDcwOTcxMzA2LCAyNDU5MTc2LjQ3MDk3MTMwNiwgMjQ1OTE3Ny40NzA5NzEzMDYsIDI0NTkxNzguNDcwOTcxMzA2LCAyNDU5MTc5LjQ3MDk3MTMwNiwgMjQ1OTE4MC40NzA5NzEzMDYsIDI0NTkxODEuNDcwOTcxMzA2LCAyNDU5MTgyLjQ3MDk3MTMwNiwgMjQ1OTE4My40NzA5NzEzMDYsIDI0NTkxODQuNDcwOTcxMzA2LCAyNDU5MTg1LjQ3MDk3MTMwNiwgMjQ1OTE4Ni40NzA5NzEzMDYsIDI0NTkxODcuNDcwOTcxMzA2LCAyNDU5MTg4LjQ3MDk3MTMwNiwgMjQ1OTE4OS40NzA5NzEzMDYsIDI0NTkxOTAuNDcwOTcxMzA2LCAyNDU5MTkxLjQ3MDk3MTMwNiwgMjQ1OTE5Mi40NzA5NzEzMDYsIDI0NTkxOTMuNDcwOTcxMzA2LCAyNDU5MTk0LjQ3MDk3MTMwNiwgMjQ1OTE5NS40NzA5NzEzMDYsIDI0NTkxOTYuNDcwOTcxMzA2LCAyNDU5MTk3LjQ3MDk3MTMwNiwgMjQ1OTE5OC40NzA5NzEzMDYsIDI0NTkxOTkuNDcwOTcxMzA2LCAyNDU5MjAwLjQ3MDk3MTMwNiwgMjQ1OTIwMS40NzA5NzEzMDYsIDI0NTkyMDIuNDcwOTcxMzA2LCAyNDU5MjAzLjQ3MDk3MTMwNiwgMjQ1OTIwNC40NzA5NzEzMDYsIDI0NTkyMDUuNDcwOTcxMzA2LCAyNDU5MjA2LjQ3MDk3MTMwNiwgMjQ1OTIwNy40NzA5NzEzMDYsIDI0NTkyMDguNDcwOTcxMzA2LCAyNDU5MjA5LjQ3MDk3MTMwNiwgMjQ1OTIxMC40NzA5NzEzMDYsIDI0NTkyMTEuNDcwOTcxMzA2LCAyNDU5MjEyLjQ3MDk3MTMwNiwgMjQ1OTIxMy40NzA5NzEzMDYsIDI0NTkyMTQuNDcwOTcxMzA2XX19fQ==",
+        attachment_name="ampel_test.json",
+        group_ids=[public_group.id],
     )
-    assert status == 200
-    assert data["status"] == "success"
 
 
 def test_fetch_all_comments_on_obj(comment_token, public_source):
+    sp = client(comment_token)
     comment_text = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        f"sources/{public_source.id}/comments",
-        data={"text": comment_text},
-        token=comment_token,
-    )
-    assert status == 200
+    sp.post_comment(public_source.id, comment_text)
 
-    status, data = api(
-        "GET", f"sources/{public_source.id}/comments", token=comment_token
-    )
-
-    assert status == 200
-    assert any(comment["text"] == comment_text for comment in data["data"])
+    comments = sp.fetch_comments(public_source.id)
+    assert any(comment.text == comment_text for comment in comments)

--- a/skyportal/tests/api_tests/groups_users_analysis/test_comments_on_gcn.py
+++ b/skyportal/tests/api_tests/groups_users_analysis/test_comments_on_gcn.py
@@ -1,4 +1,7 @@
-from skyportal.tests import api
+import pytest
+from skyportal_py import SkyPortalError
+
+from skyportal.tests import client
 
 
 def test_add_and_retrieve_comment_on_gcn(
@@ -6,24 +9,16 @@ def test_add_and_retrieve_comment_on_gcn(
 ):
     gcnevent_id = gcn_GW190425.id
 
-    status, data = api(
-        "POST",
-        f"gcn_event/{gcnevent_id}/comments",
-        data={
-            "text": "Comment text",
-            "group_ids": [public_group.id],
-        },
-        token=comment_token,
-    )
-    assert status == 200
-    comment_id = data["data"]["comment_id"]
+    sp = client(comment_token)
+    comment_id = sp.post_comment(
+        gcnevent_id,
+        "Comment text",
+        resource_type="gcn_event",
+        group_ids=[public_group.id],
+    ).comment_id
 
-    status, data = api(
-        "GET", f"gcn_event/{gcnevent_id}/comments/{comment_id}", token=comment_token
-    )
-
-    assert status == 200
-    assert data["data"]["text"] == "Comment text"
+    comment = sp.fetch_comment(gcnevent_id, comment_id, resource_type="gcn_event")
+    assert comment.text == "Comment text"
 
 
 def test_delete_comment_on_gcn(
@@ -31,41 +26,24 @@ def test_delete_comment_on_gcn(
 ):
     gcnevent_id = gcn_GW190425.id
 
-    status, data = api(
-        "POST",
-        f"gcn_event/{gcnevent_id}/comments",
-        data={"text": "Comment text"},
-        token=comment_token,
-    )
-    assert status == 200
-    comment_id = data["data"]["comment_id"]
+    sp = client(comment_token)
+    comment_id = sp.post_comment(
+        gcnevent_id, "Comment text", resource_type="gcn_event"
+    ).comment_id
 
-    status, data = api(
-        "GET", f"gcn_event/{gcnevent_id}/comments/{comment_id}", token=comment_token
-    )
-    assert status == 200
-    assert data["data"]["text"] == "Comment text"
+    comment = sp.fetch_comment(gcnevent_id, comment_id, resource_type="gcn_event")
+    assert comment.text == "Comment text"
 
     # try to delete using the wrong object ID
-    status, data = api(
-        "DELETE",
-        f"gcn_event/{gcnevent_id}zzz/comments/{comment_id}",
-        token=comment_token,
-    )
-    assert status == 400
-    assert (
-        "Comment resource ID does not match resource ID given in path"
-        in data["message"]
-    )
+    with pytest.raises(
+        SkyPortalError,
+        match="Comment resource ID does not match resource ID given in path",
+    ) as err:
+        sp.delete_comment(f"{gcnevent_id}zzz", comment_id, resource_type="gcn_event")
+    assert err.value.status_code == 400
 
-    status, data = api(
-        "DELETE",
-        f"gcn_event/{gcnevent_id}/comments/{comment_id}",
-        token=comment_token,
-    )
-    assert status == 200
+    sp.delete_comment(gcnevent_id, comment_id, resource_type="gcn_event")
 
-    status, data = api(
-        "GET", f"gcn_event/{gcnevent_id}/comments/{comment_id}", token=comment_token
-    )
-    assert status == 403
+    with pytest.raises(SkyPortalError) as err:
+        sp.fetch_comment(gcnevent_id, comment_id, resource_type="gcn_event")
+    assert err.value.status_code == 403

--- a/skyportal/tests/api_tests/groups_users_analysis/test_comments_on_shift.py
+++ b/skyportal/tests/api_tests/groups_users_analysis/test_comments_on_shift.py
@@ -1,7 +1,11 @@
 import uuid
 from datetime import date, timedelta
 
-from skyportal.tests import api
+import pytest
+from skyportal_py import SkyPortalError
+from skyportal_py.shifts import ShiftPost
+
+from skyportal.tests import client
 
 
 def test_add_and_retrieve_comment_on_shift(
@@ -10,40 +14,29 @@ def test_add_and_retrieve_comment_on_shift(
     name = str(uuid.uuid4())
     start_date = date.today().strftime("%Y-%m-%dT%H:%M:%S")
     end_date = (date.today() + timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%S")
-    request_data = {
-        "name": name,
-        "group_id": public_group.id,
-        "start_date": start_date,
-        "end_date": end_date,
-        "description": "the Test Shift",
-        "shift_admins": [super_admin_user.id],
-    }
+    sp_admin = client(super_admin_token)
+    shift_id = sp_admin.post_shift(
+        ShiftPost(
+            name=name,
+            group_id=public_group.id,
+            start_date=start_date,
+            end_date=end_date,
+            description="the Test Shift",
+            shift_admins=[super_admin_user.id],
+        )
+    ).id
 
-    status, data = api("POST", "shifts", data=request_data, token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-    shift_id = data["data"]["id"]
+    comment_id = sp_admin.post_comment(
+        shift_id,
+        "Comment on shift text",
+        resource_type="shift",
+        group_ids=[public_group.id],
+    ).comment_id
 
-    status, data = api(
-        "POST",
-        f"shift/{shift_id}/comments",
-        data={
-            "text": "Comment on shift text",
-            "group_ids": [public_group.id],
-        },
-        token=super_admin_token,
+    comment = client(comment_token).fetch_comment(
+        shift_id, comment_id, resource_type="shift"
     )
-
-    assert status == 200
-    assert data["status"] == "success"
-    comment_id = data["data"]["comment_id"]
-
-    status, data = api(
-        "GET", f"shift/{shift_id}/comments/{comment_id}", token=comment_token
-    )
-
-    assert status == 200
-    assert data["data"]["text"] == "Comment on shift text"
+    assert comment.text == "Comment on shift text"
 
 
 def test_delete_comment_on_shift(
@@ -52,51 +45,36 @@ def test_delete_comment_on_shift(
     name = str(uuid.uuid4())
     start_date = date.today().strftime("%Y-%m-%dT%H:%M:%S")
     end_date = (date.today() + timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%S")
-    request_data = {
-        "name": name,
-        "group_id": public_group.id,
-        "start_date": start_date,
-        "end_date": end_date,
-        "description": "the Test Shift",
-        "shift_admins": [super_admin_user.id],
-    }
+    sp_admin = client(super_admin_token)
+    shift_id = sp_admin.post_shift(
+        ShiftPost(
+            name=name,
+            group_id=public_group.id,
+            start_date=start_date,
+            end_date=end_date,
+            description="the Test Shift",
+            shift_admins=[super_admin_user.id],
+        )
+    ).id
 
-    status, data = api("POST", "shifts", data=request_data, token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-    shift_id = data["data"]["id"]
-
-    status, data = api(
-        "POST",
-        f"shift/{shift_id}/comments",
-        data={
-            "text": "Comment on shift text",
-            "group_ids": [public_group.id],
-        },
-        token=super_admin_token,
-    )
-
-    assert status == 200
-    assert data["status"] == "success"
-    comment_id = data["data"]["comment_id"]
+    comment_id = sp_admin.post_comment(
+        shift_id,
+        "Comment on shift text",
+        resource_type="shift",
+        group_ids=[public_group.id],
+    ).comment_id
 
     # try to delete using the wrong object ID
-    status, data = api(
-        "DELETE",
-        f"shift/{shift_id}zzz/comments/{comment_id}",
-        token=comment_token,
-    )
-    assert status == 403
-    assert "Could not find any accessible comments." in data["message"]
+    with pytest.raises(
+        SkyPortalError, match="Could not find any accessible comments"
+    ) as err:
+        client(comment_token).delete_comment(
+            f"{shift_id}zzz", comment_id, resource_type="shift"
+        )
+    assert err.value.status_code == 403
 
-    status, data = api(
-        "DELETE",
-        f"shift/{shift_id}/comments/{comment_id}",
-        token=super_admin_token,
-    )
-    assert status == 200
+    sp_admin.delete_comment(shift_id, comment_id, resource_type="shift")
 
-    status, data = api(
-        "GET", f"shift/{shift_id}/comments/{comment_id}", token=comment_token
-    )
-    assert status == 403
+    with pytest.raises(SkyPortalError) as err:
+        client(comment_token).fetch_comment(shift_id, comment_id, resource_type="shift")
+    assert err.value.status_code == 403

--- a/skyportal/tests/api_tests/groups_users_analysis/test_comments_on_spectrum.py
+++ b/skyportal/tests/api_tests/groups_users_analysis/test_comments_on_spectrum.py
@@ -3,46 +3,45 @@ import datetime
 import json
 import uuid
 
-from skyportal.tests import api, assert_api, assert_api_fail
+import pytest
+from skyportal_py import SkyPortalError
+from skyportal_py.spectra import SpectrumPost
+
+from skyportal.tests import client
 
 
 def test_add_and_retrieve_comment_on_spectrum_group_id(
     comment_token, upload_data_token, public_source, public_group, lris
 ):
-    status, data = api(
-        "POST",
-        "spectrum",
-        data={
-            "obj_id": public_source.id,
-            "observed_at": str(datetime.datetime.now()),
-            "instrument_id": lris.id,
-            "wavelengths": [664, 665, 666],
-            "fluxes": [234.2, 232.1, 235.3],
-        },
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    spectrum_id = data["data"]["id"]
-
-    status, data = api(
-        "POST",
-        f"spectra/{spectrum_id}/comments",
-        data={
-            "text": "Comment text",
-            "group_ids": [public_group.id],
-        },
-        token=comment_token,
-    )
-    assert status == 200
-    comment_id = data["data"]["comment_id"]
-
-    status, data = api(
-        "GET", f"spectra/{spectrum_id}/comments/{comment_id}", token=comment_token
+    spectrum_id = (
+        client(upload_data_token)
+        .post_spectrum(
+            SpectrumPost(
+                obj_id=public_source.id,
+                observed_at=str(datetime.datetime.now()),
+                instrument_id=lris.id,
+                wavelengths=[664, 665, 666],
+                fluxes=[234.2, 232.1, 235.3],
+            )
+        )
+        .id
     )
 
-    assert status == 200
-    assert data["data"]["text"] == "Comment text"
+    comment_id = (
+        client(comment_token)
+        .post_comment(
+            spectrum_id,
+            "Comment text",
+            resource_type="spectra",
+            group_ids=[public_group.id],
+        )
+        .comment_id
+    )
+
+    comment = client(comment_token).fetch_comment(
+        spectrum_id, comment_id, resource_type="spectra"
+    )
+    assert comment.text == "Comment text"
 
 
 def test_add_and_retrieve_comment_on_spectrum_group_access(
@@ -54,316 +53,233 @@ def test_add_and_retrieve_comment_on_spectrum_group_access(
     comment_token,
     lris,
 ):
-    status, data = api(
-        "POST",
-        "spectrum",
-        data={
-            "obj_id": str(public_source_two_groups.id),
-            "observed_at": str(datetime.datetime.now()),
-            "instrument_id": lris.id,
-            "wavelengths": [664, 665, 666],
-            "fluxes": [234.2, 232.1, 235.3],
-            "group_ids": [public_group2.id],
-        },
-        token=upload_data_token_two_groups,
+    sp_two_groups = client(comment_token_two_groups)
+    sp = client(comment_token)
+    spectrum_id = (
+        client(upload_data_token_two_groups)
+        .post_spectrum(
+            SpectrumPost(
+                obj_id=str(public_source_two_groups.id),
+                observed_at=str(datetime.datetime.now()),
+                instrument_id=lris.id,
+                wavelengths=[664, 665, 666],
+                fluxes=[234.2, 232.1, 235.3],
+                group_ids=[public_group2.id],
+            )
+        )
+        .id
     )
-    assert status == 200
-    assert data["status"] == "success"
-    spectrum_id = data["data"]["id"]
 
-    status, data = api(
-        "POST",
-        f"spectra/{spectrum_id}/comments",
-        data={
-            "text": "Comment text",
-            "group_ids": [public_group2.id],
-        },
-        token=comment_token_two_groups,
-    )
-    assert status == 200
-    comment_id = data["data"]["comment_id"]
+    comment_id = sp_two_groups.post_comment(
+        spectrum_id,
+        "Comment text",
+        resource_type="spectra",
+        group_ids=[public_group2.id],
+    ).comment_id
 
     # This token belongs to public_group2
-    status, data = api(
-        "GET",
-        f"spectra/{spectrum_id}/comments/{comment_id}",
-        token=comment_token_two_groups,
+    comment = sp_two_groups.fetch_comment(
+        spectrum_id, comment_id, resource_type="spectra"
     )
-    assert status == 200
-    assert data["data"]["text"] == "Comment text"
+    assert comment.text == "Comment text"
 
     # This token does not belong to public_group2
-    status, data = api(
-        "GET", f"spectra/{spectrum_id}/comments/{comment_id}", token=comment_token
-    )
-    assert status == 403
+    with pytest.raises(SkyPortalError) as err:
+        sp.fetch_comment(spectrum_id, comment_id, resource_type="spectra")
+    assert err.value.status_code == 403
 
     # Both tokens should be able to view this comment, but not the underlying spectrum
-    status, data = api(
-        "POST",
-        f"spectra/{spectrum_id}/comments",
-        data={
-            "text": "Comment text",
-            "group_ids": [public_group.id, public_group2.id],
-        },
-        token=comment_token_two_groups,
-    )
-    assert status == 200
-    comment_id = data["data"]["comment_id"]
+    comment_id = sp_two_groups.post_comment(
+        spectrum_id,
+        "Comment text",
+        resource_type="spectra",
+        group_ids=[public_group.id, public_group2.id],
+    ).comment_id
 
-    status, data = api(
-        "GET",
-        f"spectra/{spectrum_id}/comments/{comment_id}",
-        token=comment_token_two_groups,
+    comment = sp_two_groups.fetch_comment(
+        spectrum_id, comment_id, resource_type="spectra"
     )
-    assert status == 200
-    assert data["data"]["text"] == "Comment text"
+    assert comment.text == "Comment text"
 
-    status, data = api(
-        "GET", f"spectra/{spectrum_id}/comments/{comment_id}", token=comment_token
-    )
-    assert status == 403  # the underlying spectrum is not accessible to group1
+    with pytest.raises(SkyPortalError) as err:
+        sp.fetch_comment(spectrum_id, comment_id, resource_type="spectra")
+    assert (
+        err.value.status_code == 403
+    )  # the underlying spectrum is not accessible to group1
 
     # post a new spectrum with a comment, open to both groups
-    status, data = api(
-        "POST",
-        "spectrum",
-        data={
-            "obj_id": str(public_source_two_groups.id),
-            "observed_at": str(datetime.datetime.now()),
-            "instrument_id": lris.id,
-            "wavelengths": [664, 665, 666],
-            "fluxes": [234.2, 232.1, 235.3],
-            "group_ids": [public_group.id, public_group2.id],
-        },
-        token=upload_data_token_two_groups,
+    spectrum_id = (
+        client(upload_data_token_two_groups)
+        .post_spectrum(
+            SpectrumPost(
+                obj_id=str(public_source_two_groups.id),
+                observed_at=str(datetime.datetime.now()),
+                instrument_id=lris.id,
+                wavelengths=[664, 665, 666],
+                fluxes=[234.2, 232.1, 235.3],
+                group_ids=[public_group.id, public_group2.id],
+            )
+        )
+        .id
     )
-    assert status == 200
-    assert data["status"] == "success"
-    spectrum_id = data["data"]["id"]
 
-    status, data = api(
-        "POST",
-        f"spectra/{spectrum_id}/comments",
-        data={
-            "text": "New comment text",
-            "group_ids": [public_group2.id],
-        },
-        token=comment_token_two_groups,
-    )
-    assert status == 200
-    comment_id = data["data"]["comment_id"]
+    comment_id = sp_two_groups.post_comment(
+        spectrum_id,
+        "New comment text",
+        resource_type="spectra",
+        group_ids=[public_group2.id],
+    ).comment_id
 
     # token for group1 can view the spectrum but cannot see comment
-    status, data = api(
-        "GET", f"spectra/{spectrum_id}/comments/{comment_id}", token=comment_token
-    )
-    assert status == 403
+    with pytest.raises(SkyPortalError) as err:
+        sp.fetch_comment(spectrum_id, comment_id, resource_type="spectra")
+    assert err.value.status_code == 403
 
     # Both tokens should be able to view comment after updating group list
-    status, data = api(
-        "PUT",
-        f"spectra/{spectrum_id}/comments/{comment_id}",
-        data={
-            "text": "New comment text",
-            "group_ids": [public_group.id, public_group2.id],
-        },
-        token=comment_token_two_groups,
+    sp_two_groups.update_comment(
+        spectrum_id,
+        comment_id,
+        "New comment text",
+        resource_type="spectra",
+        group_ids=[public_group.id, public_group2.id],
     )
-    assert status == 200
 
     # the new comment on the new spectrum should now accessible
-    status, data = api(
-        "GET", f"spectra/{spectrum_id}/comments/{comment_id}", token=comment_token
-    )
-    assert status == 200
-    assert data["data"]["text"] == "New comment text"
+    comment = sp.fetch_comment(spectrum_id, comment_id, resource_type="spectra")
+    assert comment.text == "New comment text"
 
 
 def test_cannot_add_comment_on_spectrum_without_permission(
     view_only_token, upload_data_token, public_source, lris
 ):
-    status, data = api(
-        "POST",
-        "spectrum",
-        data={
-            "obj_id": str(public_source.id),
-            "observed_at": str(datetime.datetime.now()),
-            "instrument_id": lris.id,
-            "wavelengths": [664, 665, 666],
-            "fluxes": [234.2, 232.1, 235.3],
-            "group_ids": "all",
-        },
-        token=upload_data_token,
+    spectrum_id = (
+        client(upload_data_token)
+        .post_spectrum(
+            SpectrumPost(
+                obj_id=str(public_source.id),
+                observed_at=str(datetime.datetime.now()),
+                instrument_id=lris.id,
+                wavelengths=[664, 665, 666],
+                fluxes=[234.2, 232.1, 235.3],
+                group_ids="all",
+            )
+        )
+        .id
     )
-    assert status == 200
-    assert data["status"] == "success"
-    spectrum_id = data["data"]["id"]
 
-    status, data = api(
-        "POST",
-        f"spectra/{spectrum_id}/comments",
-        data={
-            "spectrum_id": spectrum_id,
-            "text": "Comment text",
-        },
-        token=view_only_token,
-    )
-    assert status == 401
-    assert data["status"] == "error"
+    with pytest.raises(SkyPortalError) as err:
+        client(view_only_token).post_comment(
+            spectrum_id, "Comment text", resource_type="spectra"
+        )
+    assert err.value.status_code == 401
 
 
 def test_delete_comment_on_spectrum(
     comment_token, upload_data_token, public_source, lris
 ):
-    status, data = api(
-        "POST",
-        "spectrum",
-        data={
-            "obj_id": str(public_source.id),
-            "observed_at": str(datetime.datetime.now()),
-            "instrument_id": lris.id,
-            "wavelengths": [664, 665, 666],
-            "fluxes": [234.2, 232.1, 235.3],
-            "group_ids": "all",
-        },
-        token=upload_data_token,
+    sp = client(comment_token)
+    spectrum_id = (
+        client(upload_data_token)
+        .post_spectrum(
+            SpectrumPost(
+                obj_id=str(public_source.id),
+                observed_at=str(datetime.datetime.now()),
+                instrument_id=lris.id,
+                wavelengths=[664, 665, 666],
+                fluxes=[234.2, 232.1, 235.3],
+                group_ids="all",
+            )
+        )
+        .id
     )
-    assert_api(status, data)
-    spectrum_id = data["data"]["id"]
 
-    status, data = api(
-        "POST",
-        f"spectra/{spectrum_id}/comments",
-        data={
-            "spectrum_id": spectrum_id,
-            "text": "Comment text",
-        },
-        token=comment_token,
-    )
-    assert_api(status, data)
-    comment_id = data["data"]["comment_id"]
+    comment_id = sp.post_comment(
+        spectrum_id, "Comment text", resource_type="spectra"
+    ).comment_id
 
-    status, data = api(
-        "GET", f"spectra/{spectrum_id}/comments/{comment_id}", token=comment_token
-    )
-    assert_api(status, data)
-    assert data["data"]["text"] == "Comment text"
+    comment = sp.fetch_comment(spectrum_id, comment_id, resource_type="spectra")
+    assert comment.text == "Comment text"
 
     # try to delete using the wrong spectrum ID
-    status, data = api(
-        "DELETE",
-        f"spectra/{spectrum_id + 1}/comments/{comment_id}",
-        token=comment_token,
-    )
-    assert_api_fail(
-        status,
-        data,
-        400,
-        "Comment resource ID does not match resource ID given in path",
-    )
+    with pytest.raises(
+        SkyPortalError,
+        match="Comment resource ID does not match resource ID given in path",
+    ) as err:
+        sp.delete_comment(spectrum_id + 1, comment_id, resource_type="spectra")
+    assert err.value.status_code == 400
 
-    status, data = api(
-        "DELETE", f"spectra/{spectrum_id}/comments/{comment_id}", token=comment_token
-    )
-    assert_api(status, data)
+    sp.delete_comment(spectrum_id, comment_id, resource_type="spectra")
 
-    status, data = api(
-        "GET", f"spectra/{spectrum_id}/comments/{comment_id}", token=comment_token
-    )
-    assert_api_fail(status, data, 403)
+    with pytest.raises(SkyPortalError) as err:
+        sp.fetch_comment(spectrum_id, comment_id, resource_type="spectra")
+    assert err.value.status_code == 403
 
 
 def test_post_comment_on_spectrum_attachment(
     super_admin_token, public_source, lris, public_group
 ):
-    status, data = api(
-        "POST",
-        "spectrum",
-        data={
-            "obj_id": str(public_source.id),
-            "observed_at": str(datetime.datetime.now()),
-            "instrument_id": lris.id,
-            "wavelengths": [664, 665, 666],
-            "fluxes": [234.2, 232.1, 235.3],
-            "group_ids": "all",
-        },
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    spectrum_id = data["data"]["id"]
+    sp = client(super_admin_token)
+    spectrum_id = sp.post_spectrum(
+        SpectrumPost(
+            obj_id=str(public_source.id),
+            observed_at=str(datetime.datetime.now()),
+            instrument_id=lris.id,
+            wavelengths=[664, 665, 666],
+            fluxes=[234.2, 232.1, 235.3],
+            group_ids="all",
+        )
+    ).id
 
     payload = {
         "body": "eyJ0aW1lc3RhbXAiOiAiMjAyMC0xMS0wNFQxMjowMDowMyIsICJydW4iOiAxODM5LCAiZHVyYXRpb24iOiAwLjE0NiwgInJlc3VsdCI6IHsibW9kZWwiOiAic2FsdDIiLCAiZml0X2xjX3BhcmFtZXRlcnMiOiB7ImJvdW5kcyI6IHsiYyI6IFstMiwgNV0sICJ4MSI6IFstNSwgNV0sICJ6IjogWzAsIDAuMl19fSwgImZpdF9hY2NlcHRhYmxlIjogZmFsc2UsICJwbG90X2luZm8iOiAic2FsdDIgY2hpc3EgMjAuMjkgbmRvZiAxIG9rIGZpdCBGYWxzZSIsICJtb2RlbF9hbmFseXNpcyI6IHsiaGFzX3ByZW1heF9kYXRhIjogdHJ1ZSwgImhhc19wb3N0bWF4X2RhdGEiOiBmYWxzZSwgIngxX2luX3JhbmdlIjogdHJ1ZSwgIl94MV9yYW5nZSI6IFstNCwgNF0sICJjX29rIjogdHJ1ZSwgIl9jX3JhbmdlIjogWy0xLCAyXX0sICJmaXRfcmVzdWx0cyI6IHsieiI6IDAuMTE3NDM5NTYwNTE3MDEwNjUsICJ0MCI6IDI0NTkxNTguODE5NzYyNTE2MywgIngwIjogMC4wMDA2MDg1NTg3NzI2MjI5NDY3LCAieDEiOiAtMC44NzM1ODM5NTY4MTk5NjczLCAiYyI6IC0wLjA1OTg1NTgxMTY2MDA2MzE1LCAibXdlYnYiOiAwLjA5OTU2MTk1NjAzOTAzMTEyLCAibXdyX3YiOiAzLjEsICJ6LmVyciI6IDAuMDIxNTUyNTQwMzEyMzk1NDI0LCAidDAuZXJyIjogMC45NTczNDkzNTY0OTY3MDY2LCAieDAuZXJyIjogNi43NDYwMTY5NDY3ODk5NDllLTA1LCAieDEuZXJyIjogMC42NDc4NTA5NzU5ODY5OTY2LCAiYy5lcnIiOiAwLjEzNDQxMzAzNjM5NjQxMzU1fSwgInNuY29zbW9faW5mbyI6IHsic3VjY2VzcyI6IHRydWUsICJjaGlzcSI6IDIwLjI5NDAxNzkxMDExMjMxMywgIm5kb2YiOiAxLCAiY2hpc3Fkb2YiOiAyMC4yOTQwMTc5MTAxMTIzMTN9LCAiZmx1eF9kaWN0IjogeyJ6dGZnIjogWzAuMCwgLTAuMDQyNjA1ODU1NzUwNDczMzYsIC0wLjE1OTc2MzYxMjQ2NDMxOTQyLCAtMC41MDU5ODM5ODUzNTUyNDg1LCAtMC4xMDU5NzkwNDU0NzgyOTA4MywgMy44MjIzMDg5NDc0ODQ1NzEsIDEyLjE5Njc1NDg2NzEwMDE0NywgMjMuODgzNTQ0OTEzNTM0MTUsIDM4LjIyMzIzMjgyMDM3NzUyLCA1NS4wMTU0NjcyNzgyNzMwOCwgNzQuMzQyNTQxNDE2MzQ5MjIsIDk2LjMyNzQ1MzkzMzE2MDA5LCAxMjEuMjMwODU1MjE3MTg2ODMsIDE0OS42NzE5NzMzNDU4Mzg4NiwgMTc4LjU4NzEzMzY3MjU1MDI3LCAyMDUuMDcyMDU1NjU4Nzg4NDYsIDIyOC4wNTUzMTYwNjg0MjQsIDI0Ny4zNTIzMjM5ODA4Nzg1NywgMjYyLjYwOTI1MTk2MzQ1NzMsIDI3My45NjAxOTExOTE4NTEsIDI4Mi4wMTYzOTE3NTE3NzMsIDI4Ni4zNzI2Mjg3NjU4NjE2MywgMjg2LjY4ODcwMTAxODEzNDQ1LCAyODMuNTU0NTY3MTE3MzQ4MSwgMjc3LjY5MjY0NTUyNDYwODgsIDI2OS40ODM1NDU5ODQ2MTMzLCAyNTkuMTAxNDEyMTkxMjIwOCwgMjQ2Ljk2OTEyOTQ0OTc2NTE1LCAyMzMuODk5MTY4NzM2OTE5MjgsIDIyMC4xMzIyNzI0NjI2MDgzNCwgMjA1LjcxNjY4NzM5MzQxMzE0LCAxOTAuNTk3MTUyMDAzOTQzODUsIDE3NS41NTM4NDE0NDAyMjYyMiwgMTYxLjE2NTk5Mzk2NDQ1NDMyLCAxNDcuNTEwNTE3ODIyNjI0MTcsIDEzNC40NDYyMjA0NjIxODY5NCwgMTIxLjg5NDI1MDE3MDAxNDM5LCAxMDkuOTA0OTI2NzQzMDg2NzIsIDk4Ljg1ODU4MjA1NTk5MDE0LCA4OC44MjIyNDkyNDQ5ODgwNiwgNzkuODU1NDY1Nzk5NzkzOTMsIDcyLjA5NTcyMzMzMTQ2NzIsIDY1LjMwMjgyMzM5NDQzNzU3LCA1OS4yNTMxMjgyMDM2MzYzNDQsIDUzLjkyNjI2NjAzMjI5NDUyLCA0OS40MTk3OTAzMTc3NTMyOCwgNDUuNjc4NTQ4MjU5MDMwNjQsIDQyLjMxMjkyMDczNTM0MDk3LCAzOS4xMzUwNDI0OTI2NjEzMSwgMzYuMTc1NTQ2NTcyMTI5NywgMzMuNDI4OTg3OTU4MTgzNDUsIDMwLjkyODcxOTcyNjIzMzE4NywgMjguNzUyMjgxODYxNTg1NjQsIDI2LjkwMjQ3ODU5MDAzMDA5NiwgMjUuMzMzOTc4MzQ4MzEyMzYsIDI0LjAxMTA1NjIzOTM4MjkzNSwgMjIuOTAzODgyMjIyNjQwNTU0LCAyMS45ODU1MjExMDM5NjA1NTgsIDIxLjE4MzYxNTc5ODI1OTE3MiwgMjAuNDUyMjYzMDY5MTMwNDY3LCAxOS43ODQ2NDgxNDA4MjM3NTUsIDE5LjE3NTU1OTc1NTQwMzQyNywgMTguNjIwMzc0ODc2NTc1MjksIDE4LjExNTA4NTAxNDE3MjMxNSwgMTcuNjU2MjcwMzk5NzY4MzIsIDE3LjI0MDMyMDg1NjEyNTk5LCAxNi44NTkxMTMwMzUwMTQ1NzcsIDE2LjQ4NjE4ODc2Njc0MTY5OCwgMTYuMTE4OTQwODAyOTc3MDQ3LCAxNS43NTg0NzM3NDM2NDc4NjIsIDE1LjQwNTc0NTcwNDAwMTI0NiwgMTUuMDYxNzIzMzM0MjQ2MDQzLCAxNC43MjczODEwMjI5Nzk4MDQsIDE0LjQwMzY5NTMxNTY1OTUzLCAxNC4wOTE2Mzk5MTExNzczNTMsIDEzLjc5MjE4MTE0NDkwNTA1OCwgMTMuNTA2MjczODY5OTM1ODA3LCAxMy4yMzQ4Njg0ODM3Njc1MzksIDEyLjk4MTU3MzMxODc4OTYyN10sICJ6dGZyIjogWzAuMCwgMC4yMDkwMjkyNzU5Mzc3MzQ5LCAwLjc4ODc0NjQ5ODgxMDcwMzksIDEuNzIyNTcyMDQ5MDAyNDYxNCwgMy42OTI5MjkzMjcwMDQxNDMyLCA4Ljc5MDcxNTY1MDg1NDgwNSwgMTcuNjMyNDU0MDIxMTYyMzM1LCAyOS4yNTAwMTgzNTEwOTI2MTcsIDQzLjA2OTYyOTQwMjAzMDcxLCA1OC44MjcyMTA3OTA5ODU1NywgNzYuNDg2NjMwNDI0MzgxMzksIDk2LjE5OTQ4Mzk4ODEwOTcyLCAxMTguMjA0MzUzMTc5NjA4NSwgMTQzLjAwNzYzODUwNjUxMDY2LCAxNjguMzEyOTYwNzk1NjcyMDQsIDE5MS45NDMxNTA1MTU0NTUwNywgMjEzLjExMjQ5MjAxODQ1MDMsIDIzMS43MDU4NjcwOTQ1MjU0MiwgMjQ3LjQ3Nzg0MDIwMzIxNTYsIDI2MC41NjYzOTUwNzY4NzIzNywgMjcxLjQ3ODE4NDY2MTkwMjcsIDI3OS44ODk5NTU4MjU4NTQ1NCwgMjg1LjUzNjM3MjA2NjA5NTA1LCAyODguNTYwNDMyMzQ4MTA3ODQsIDI4OS4yMDkxODAzODM0NjU1LCAyODcuNjUwMjExNzU1NDQxNywgMjg0LjAxMjM5MTM1MDM1NTcsIDI3OC40MDEyNzQyOTkwNjQ1LCAyNzAuNzQ3ODQ1MjM1ODM2MTcsIDI2MS4yMDkzMzY3NjQxOTcyLCAyNDkuOTY1NDI1MjA5MDkzNjQsIDIzNi45OTYwODA4NDE3NDY1NiwgMjIzLjgyMjE4ODMwMjU3MjMsIDIxMS42MDIyMzAxOTM5NTMzMiwgMjAwLjU3Njg4NDg1MTY3NjUsIDE5MC41OTQ5NzcwNDMxMDUzMywgMTgxLjU4NjIyMjIwNDI1NTUzLCAxNzMuNDE4MDQxNzE4Nzc0NzMsIDE2NS43MzA3MDQ1NzY4OTE4NCwgMTU4LjQ4MjI5NTMyNDg2NTAyLCAxNTEuNjk5NTg5MDg1MzM3ODYsIDE0NS40NTE4MTQ5NDI5MDg2NywgMTM5LjU4NDA3NTMzMzM1MzIsIDEzMy45NTkxODY4MzI4Njg3NywgMTI4LjU3MzUxMzA2ODM0MDUsIDEyMy41MTE2ODQ3MzA1NTI0LCAxMTguNzIxNzkwNTIxMTI0MTMsIDExMy44MDQ0MDc3MTY2NDgyOSwgMTA4LjYwODM1NTg2NDcxNzEzLCAxMDMuMjQxMzg2NjgzMDIxNDUsIDk3Ljc2NTI0NjgyMjU0MDA4LCA5Mi4zMzM3MTQxNjc3MjA4MSwgODcuMTk3NDkyMjAyMTk5MDQsIDgyLjQyODMxMDQ2NDc4ODMyLCA3Ny45Nzc5MjUyNzYzNzA4OCwgNzMuODEwMDcxNTY1NjgzNjMsIDY5Ljg5MTk0NDMyNjg0OSwgNjYuMTk5MzM4MTkxNjMwNCwgNjIuODE0MDY4Mjk4NzQ1Njk2LCA1OS43NzUwOTExMzk3MjA2MywgNTcuMDUxMDcyNjc2ODk3MTUsIDU0LjYxNDMxOTc2NDU2NTM0NCwgNTIuNDQxMzM3NjgzNjU1NjYsIDUwLjUxMTUyNzYyMjUyMDkyLCA0OC44MDY4ODUwNDEwMjEyMiwgNDcuMzA5MjE5ODg4NjkxNjE1LCA0NS45ODU1MTU2NDIxNDYxNywgNDQuNzQxNDAwNjkzNDQ3MDQsIDQzLjU2MjcwOTkyODYwOTE2NiwgNDIuNDQ3OTkwOTkzNDI2OTksIDQxLjM5NTQ1MDExNjg4MzUsIDQwLjQwMzQzMDc2MDk2MTY4LCAzOS40NzA0MDYxMjgyMjcyNCwgMzguNTk0OTYwNzIwNjY3NCwgMzcuNzc1Nzc3NzI1ODY5OTQsIDM3LjAxMTYzMDk2NDg1NDUyNSwgMzYuMzAxMzgwMzgzNDY1NjU2LCAzNS42NDM5NTk0MzY0NjcxNSwgMzUuMDQzODYwODA3MzQ5ODk0XSwgIm9ic2pkIjogWzI0NTkxMzYuNDcwOTcxMzA2LCAyNDU5MTM3LjQ3MDk3MTMwNiwgMjQ1OTEzOC40NzA5NzEzMDYsIDI0NTkxMzkuNDcwOTcxMzA2LCAyNDU5MTQwLjQ3MDk3MTMwNiwgMjQ1OTE0MS40NzA5NzEzMDYsIDI0NTkxNDIuNDcwOTcxMzA2LCAyNDU5MTQzLjQ3MDk3MTMwNiwgMjQ1OTE0NC40NzA5NzEzMDYsIDI0NTkxNDUuNDcwOTcxMzA2LCAyNDU5MTQ2LjQ3MDk3MTMwNiwgMjQ1OTE0Ny40NzA5NzEzMDYsIDI0NTkxNDguNDcwOTcxMzA2LCAyNDU5MTQ5LjQ3MDk3MTMwNiwgMjQ1OTE1MC40NzA5NzEzMDYsIDI0NTkxNTEuNDcwOTcxMzA2LCAyNDU5MTUyLjQ3MDk3MTMwNiwgMjQ1OTE1My40NzA5NzEzMDYsIDI0NTkxNTQuNDcwOTcxMzA2LCAyNDU5MTU1LjQ3MDk3MTMwNiwgMjQ1OTE1Ni40NzA5NzEzMDYsIDI0NTkxNTcuNDcwOTcxMzA2LCAyNDU5MTU4LjQ3MDk3MTMwNiwgMjQ1OTE1OS40NzA5NzEzMDYsIDI0NTkxNjAuNDcwOTcxMzA2LCAyNDU5MTYxLjQ3MDk3MTMwNiwgMjQ1OTE2Mi40NzA5NzEzMDYsIDI0NTkxNjMuNDcwOTcxMzA2LCAyNDU5MTY0LjQ3MDk3MTMwNiwgMjQ1OTE2NS40NzA5NzEzMDYsIDI0NTkxNjYuNDcwOTcxMzA2LCAyNDU5MTY3LjQ3MDk3MTMwNiwgMjQ1OTE2OC40NzA5NzEzMDYsIDI0NTkxNjkuNDcwOTcxMzA2LCAyNDU5MTcwLjQ3MDk3MTMwNiwgMjQ1OTE3MS40NzA5NzEzMDYsIDI0NTkxNzIuNDcwOTcxMzA2LCAyNDU5MTczLjQ3MDk3MTMwNiwgMjQ1OTE3NC40NzA5NzEzMDYsIDI0NTkxNzUuNDcwOTcxMzA2LCAyNDU5MTc2LjQ3MDk3MTMwNiwgMjQ1OTE3Ny40NzA5NzEzMDYsIDI0NTkxNzguNDcwOTcxMzA2LCAyNDU5MTc5LjQ3MDk3MTMwNiwgMjQ1OTE4MC40NzA5NzEzMDYsIDI0NTkxODEuNDcwOTcxMzA2LCAyNDU5MTgyLjQ3MDk3MTMwNiwgMjQ1OTE4My40NzA5NzEzMDYsIDI0NTkxODQuNDcwOTcxMzA2LCAyNDU5MTg1LjQ3MDk3MTMwNiwgMjQ1OTE4Ni40NzA5NzEzMDYsIDI0NTkxODcuNDcwOTcxMzA2LCAyNDU5MTg4LjQ3MDk3MTMwNiwgMjQ1OTE4OS40NzA5NzEzMDYsIDI0NTkxOTAuNDcwOTcxMzA2LCAyNDU5MTkxLjQ3MDk3MTMwNiwgMjQ1OTE5Mi40NzA5NzEzMDYsIDI0NTkxOTMuNDcwOTcxMzA2LCAyNDU5MTk0LjQ3MDk3MTMwNiwgMjQ1OTE5NS40NzA5NzEzMDYsIDI0NTkxOTYuNDcwOTcxMzA2LCAyNDU5MTk3LjQ3MDk3MTMwNiwgMjQ1OTE5OC40NzA5NzEzMDYsIDI0NTkxOTkuNDcwOTcxMzA2LCAyNDU5MjAwLjQ3MDk3MTMwNiwgMjQ1OTIwMS40NzA5NzEzMDYsIDI0NTkyMDIuNDcwOTcxMzA2LCAyNDU5MjAzLjQ3MDk3MTMwNiwgMjQ1OTIwNC40NzA5NzEzMDYsIDI0NTkyMDUuNDcwOTcxMzA2LCAyNDU5MjA2LjQ3MDk3MTMwNiwgMjQ1OTIwNy40NzA5NzEzMDYsIDI0NTkyMDguNDcwOTcxMzA2LCAyNDU5MjA5LjQ3MDk3MTMwNiwgMjQ1OTIxMC40NzA5NzEzMDYsIDI0NTkyMTEuNDcwOTcxMzA2LCAyNDU5MjEyLjQ3MDk3MTMwNiwgMjQ1OTIxMy40NzA5NzEzMDYsIDI0NTkyMTQuNDcwOTcxMzA2XX19fQ==",
         "name": "ampel_test.json",
     }
     # note: the attachment_bytes is base64 encoded. The values are a json with a fit to a lightcurve: {"timestamp": "2020-11-04T12:00:03", "run": 1839, "duration": 0.146, "result": {"model": "salt2", "fit_lc_parameters": {"bounds": {"c": [-2, 5], "x1": [-5, 5], "z": [0, 0.2]}}, "fit_acceptable": false, "plot_info": "salt2 chisq 20.29 ndof 1 ok fit False", "model_analysis": {"has_premax_data": true, "has_postmax_data": false, "x1_in_range": true, "_x1_range": [-4, 4], "c_ok": true, "_c_range": [-1, 2]}, "fit_results": {"z": 0.11743956051701065, "t0": 2459158.8197625163, "x0": 0.0006085587726229467, "x1": -0.8735839568199673, "c": -0.05985581166006315, "mwebv": 0.09956195603903112, "mwr_v": 3.1, "z.err": 0.021552540312395424, "t0.err": 0.9573493564967066, "x0.err": 6.746016946789949e-05, "x1.err": 0.6478509759869966, "c.err": 0.13441303639641355}, "sncosmo_info": {"success": true, "chisq": 20.294017910112313, "ndof": 1, "chisqdof": 20.294017910112313}, "flux_dict": {"ztfg": [0.0, -0.04260585575047336, -0.15976361246431942, -0.5059839853552485, -0.10597904547829083, 3.822308947484571, 12.196754867100147, 23.88354491353415, 38.22323282037752, 55.01546727827308, 74.34254141634922, 96.32745393316009, 121.23085521718683, 149.67197334583886, 178.58713367255027, 205.07205565878846, 228.055316068424, 247.35232398087857, 262.6092519634573, 273.960191191851, 282.016391751773, 286.37262876586163, 286.68870101813445, 283.5545671173481, 277.6926455246088, 269.4835459846133, 259.1014121912208, 246.96912944976515, 233.89916873691928, 220.13227246260834, 205.71668739341314, 190.59715200394385, 175.55384144022622, 161.16599396445432, 147.51051782262417, 134.44622046218694, 121.89425017001439, 109.90492674308672, 98.85858205599014, 88.82224924498806, 79.85546579979393, 72.0957233314672, 65.30282339443757, 59.253128203636344, 53.92626603229452, 49.41979031775328, 45.67854825903064, 42.31292073534097, 39.13504249266131, 36.1755465721297, 33.42898795818345, 30.928719726233187, 28.75228186158564, 26.902478590030096, 25.33397834831236, 24.011056239382935, 22.903882222640554, 21.985521103960558, 21.183615798259172, 20.452263069130467, 19.784648140823755, 19.175559755403427, 18.62037487657529, 18.115085014172315, 17.65627039976832, 17.24032085612599, 16.859113035014577, 16.486188766741698, 16.118940802977047, 15.758473743647862, 15.405745704001246, 15.061723334246043, 14.727381022979804, 14.40369531565953, 14.091639911177353, 13.792181144905058, 13.506273869935807, 13.234868483767539, 12.981573318789627], "ztfr": [0.0, 0.2090292759377349, 0.7887464988107039, 1.7225720490024614, 3.6929293270041432, 8.790715650854805, 17.632454021162335, 29.250018351092617, 43.06962940203071, 58.82721079098557, 76.48663042438139, 96.19948398810972, 118.2043531796085, 143.00763850651066, 168.31296079567204, 191.94315051545507, 213.1124920184503, 231.70586709452542, 247.4778402032156, 260.56639507687237, 271.4781846619027, 279.88995582585454, 285.53637206609505, 288.56043234810784, 289.2091803834655, 287.6502117554417, 284.0123913503557, 278.4012742990645, 270.74784523583617, 261.2093367641972, 249.96542520909364, 236.99608084174656, 223.8221883025723, 211.60223019395332, 200.5768848516765, 190.59497704310533, 181.58622220425553, 173.41804171877473, 165.73070457689184, 158.48229532486502, 151.69958908533786, 145.45181494290867, 139.5840753333532, 133.95918683286877, 128.5735130683405, 123.5116847305524, 118.72179052112413, 113.80440771664829, 108.60835586471713, 103.24138668302145, 97.76524682254008, 92.33371416772081, 87.19749220219904, 82.42831046478832, 77.97792527637088, 73.81007156568363, 69.891944326849, 66.1993381916304, 62.814068298745696, 59.77509113972063, 57.05107267689715, 54.614319764565344, 52.44133768365566, 50.51152762252092, 48.80688504102122, 47.309219888691615, 45.98551564214617, 44.74140069344704, 43.562709928609166, 42.44799099342699, 41.3954501168835, 40.40343076096168, 39.47040612822724, 38.5949607206674, 37.77577772586994, 37.011630964854525, 36.301380383465656, 35.64395943646715, 35.043860807349894], "obsjd": [2459136.470971306, 2459137.470971306, 2459138.470971306, 2459139.470971306, 2459140.470971306, 2459141.470971306, 2459142.470971306, 2459143.470971306, 2459144.470971306, 2459145.470971306, 2459146.470971306, 2459147.470971306, 2459148.470971306, 2459149.470971306, 2459150.470971306, 2459151.470971306, 2459152.470971306, 2459153.470971306, 2459154.470971306, 2459155.470971306, 2459156.470971306, 2459157.470971306, 2459158.470971306, 2459159.470971306, 2459160.470971306, 2459161.470971306, 2459162.470971306, 2459163.470971306, 2459164.470971306, 2459165.470971306, 2459166.470971306, 2459167.470971306, 2459168.470971306, 2459169.470971306, 2459170.470971306, 2459171.470971306, 2459172.470971306, 2459173.470971306, 2459174.470971306, 2459175.470971306, 2459176.470971306, 2459177.470971306, 2459178.470971306, 2459179.470971306, 2459180.470971306, 2459181.470971306, 2459182.470971306, 2459183.470971306, 2459184.470971306, 2459185.470971306, 2459186.470971306, 2459187.470971306, 2459188.470971306, 2459189.470971306, 2459190.470971306, 2459191.470971306, 2459192.470971306, 2459193.470971306, 2459194.470971306, 2459195.470971306, 2459196.470971306, 2459197.470971306, 2459198.470971306, 2459199.470971306, 2459200.470971306, 2459201.470971306, 2459202.470971306, 2459203.470971306, 2459204.470971306, 2459205.470971306, 2459206.470971306, 2459207.470971306, 2459208.470971306, 2459209.470971306, 2459210.470971306, 2459211.470971306, 2459212.470971306, 2459213.470971306, 2459214.470971306]}}}
+    comment_id = sp.post_comment_with_attachment(
+        spectrum_id,
+        "Looks like Ia",
+        payload["name"],
+        payload["body"],
+        resource_type="spectra",
+        group_ids=[public_group.id],
+    ).comment_id
 
-    status, data = api(
-        "POST",
-        f"spectra/{spectrum_id}/comments",
-        data={
-            "text": "Looks like Ia",
-            "group_ids": [public_group.id],
-            "attachment": payload,
-        },
-        token=super_admin_token,
+    comment = sp.fetch_comment(spectrum_id, comment_id, resource_type="spectra")
+    assert comment.text == "Looks like Ia"
+    assert comment.attachment_name == payload["name"]
+
+    attachment = sp.fetch_comment_attachment(
+        spectrum_id, comment_id, resource_type="spectra"
     )
-    assert status == 200
-    assert data["status"] == "success"
-    comment_id = data["data"]["comment_id"]
-
-    status, data = api(
-        "GET",
-        f"spectra/{spectrum_id}/comments/{comment_id}",
-        token=super_admin_token,
+    assert json.loads(attachment) == json.loads(
+        base64.b64decode(payload["body"]).decode()
     )
-    assert status == 200
-    assert data["status"] == "success"
-
-    assert data["data"]["text"] == "Looks like Ia"
-    assert data["data"]["attachment_name"] == payload["name"]
-
-    status, data = api(
-        "GET",
-        f"spectra/{spectrum_id}/comments/{comment_id}/attachment",
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data == json.loads(base64.b64decode(payload["body"]).decode())
 
 
 def test_fetch_all_comments_on_spectrum(
     upload_data_token, comment_token, public_source, lris
 ):
-    status, data = api(
-        "POST",
-        "spectrum",
-        data={
-            "obj_id": str(public_source.id),
-            "observed_at": str(datetime.datetime.now()),
-            "instrument_id": lris.id,
-            "wavelengths": [664, 665, 666],
-            "fluxes": [234.2, 232.1, 235.3],
-            "group_ids": "all",
-        },
-        token=upload_data_token,
+    spectrum_id = (
+        client(upload_data_token)
+        .post_spectrum(
+            SpectrumPost(
+                obj_id=str(public_source.id),
+                observed_at=str(datetime.datetime.now()),
+                instrument_id=lris.id,
+                wavelengths=[664, 665, 666],
+                fluxes=[234.2, 232.1, 235.3],
+                group_ids="all",
+            )
+        )
+        .id
     )
-    assert status == 200
-    assert data["status"] == "success"
-    spectrum_id = data["data"]["id"]
 
     comment_text = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        f"spectra/{spectrum_id}/comments",
-        data={"text": comment_text},
-        token=comment_token,
+    client(comment_token).post_comment(
+        spectrum_id, comment_text, resource_type="spectra"
     )
-    assert status == 200
 
-    status, data = api("GET", f"spectra/{spectrum_id}/comments", token=comment_token)
-
-    assert status == 200
-    assert any(comment["text"] == comment_text for comment in data["data"])
+    comments = client(comment_token).fetch_comments(
+        spectrum_id, resource_type="spectra"
+    )
+    assert any(comment.text == comment_text for comment in comments)

--- a/skyportal/tests/api_tests/groups_users_analysis/test_group_admission_requests.py
+++ b/skyportal/tests/api_tests/groups_users_analysis/test_group_admission_requests.py
@@ -1,13 +1,13 @@
-from skyportal.tests import api, assert_api, assert_api_fail
+import pytest
+from skyportal_py import SkyPortalError
+
+from skyportal.tests import client
 
 
 def test_group_admission_existing_member(user, public_group, upload_data_token):
-    request_data = {"groupID": public_group.id, "userID": user.id}
-
-    status, data = api(
-        "POST", "group_admission_requests", data=request_data, token=upload_data_token
-    )
-    assert_api_fail(status, data, 400, "already a member of group")
+    with pytest.raises(SkyPortalError, match="already a member of group") as err:
+        client(upload_data_token).post_group_admission_request(public_group.id, user.id)
+    assert err.value.status_code == 400
 
 
 def test_group_admission_read_access(
@@ -19,72 +19,52 @@ def test_group_admission_read_access(
     view_only_token,
 ):
     # Have user_group2 request access to public_group
-    request_data = {"groupID": public_group.id, "userID": user_group2.id}
-
-    status, data = api(
-        "POST",
-        "group_admission_requests",
-        data=request_data,
-        token=upload_data_token_group2,
+    request_id = (
+        client(upload_data_token_group2)
+        .post_group_admission_request(public_group.id, user_group2.id)
+        .id
     )
-    assert_api(status, data)
-    request_id = data["data"]["id"]
 
     # user_group2 can read their own request
-    status, data = api(
-        "GET",
-        f"group_admission_requests/{request_id}",
-        token=upload_data_token_group2,
-    )
-    assert_api(status, data)
+    client(upload_data_token_group2).fetch_group_admission_request(request_id)
 
     # group_admin_user is associated with the manages_sources_token and
     # should be able to see the request just submitted
-    status, data = api(
-        "GET",
-        f"group_admission_requests/{request_id}",
-        token=manage_sources_token,
-    )
-    assert_api(status, data)
+    client(manage_sources_token).fetch_group_admission_request(request_id)
 
     # Regular user (view_only_token) should not be able to see the request
     # as they are neither a group admin nor the requesting user. RLS now
     # filters them out at the .select() layer, so the handler reports the
     # request as not found rather than running its explicit visibility
     # check.
-    status, data = api(
-        "GET",
-        f"group_admission_requests/{request_id}",
-        token=view_only_token,
-    )
-    assert_api_fail(
-        status, data, 400, "Could not find an admission request with the ID"
-    )
+    with pytest.raises(
+        SkyPortalError, match="Could not find an admission request with the ID"
+    ) as err:
+        client(view_only_token).fetch_group_admission_request(request_id)
+    assert err.value.status_code == 400
 
 
 # test get doesn't exist
 def test_group_admission_read_nonexistent(upload_data_token):
     request_id = 9999999
-    status, data = api(
-        "GET",
-        f"group_admission_requests/{request_id}",
-        token=upload_data_token,
-    )
-    assert status == 400
-    assert "Could not find an admission request with the ID" in data["message"]
+    with pytest.raises(
+        SkyPortalError, match="Could not find an admission request with the ID"
+    ) as err:
+        client(upload_data_token).fetch_group_admission_request(request_id)
+    assert err.value.status_code == 400
 
 
 # test post for someone not me
 def test_group_admission_post_for_another_user(
     user_group2, public_group, upload_data_token
 ):
-    request_data = {"groupID": public_group.id, "userID": user_group2.id}
-
-    status, data = api(
-        "POST", "group_admission_requests", data=request_data, token=upload_data_token
-    )
-    assert status == 400
-    assert "cannot be made on behalf of others" in data["message"]
+    with pytest.raises(
+        SkyPortalError, match="cannot be made on behalf of others"
+    ) as err:
+        client(upload_data_token).post_group_admission_request(
+            public_group.id, user_group2.id
+        )
+    assert err.value.status_code == 400
 
 
 # test patch non-admin
@@ -96,56 +76,35 @@ def test_group_admission_patch_permissions(
     group_admin_token,
 ):
     # Have user_group2 request access to public_group
-    request_data = {"groupID": public_group.id, "userID": user_group2.id}
-
-    status, data = api(
-        "POST",
-        "group_admission_requests",
-        data=request_data,
-        token=upload_data_token_group2,
+    request_id = (
+        client(upload_data_token_group2)
+        .post_group_admission_request(public_group.id, user_group2.id)
+        .id
     )
-    assert status == 200
-    assert data["status"] == "success"
-    request_id = data["data"]["id"]
 
     # Regular user is not a group admin and cannot approve the request.
     # RLS filters the request out at the .select(mode="update") layer, so
     # the handler reports it as not updatable (same code path as the
     # requesting user trying to approve themselves below).
-    status, data = api(
-        "PATCH",
-        f"group_admission_requests/{request_id}",
-        data={"status": "accepted"},
-        token=upload_data_token,
-    )
-    assert status == 400
-    assert (
-        "Insufficient permissions: group admission request status can only be changed by group admins."
-        in data["message"]
-    )
+    with pytest.raises(
+        SkyPortalError,
+        match="Insufficient permissions: group admission request status can only be changed by group admins",
+    ) as err:
+        client(upload_data_token).update_group_admission_request(request_id, "accepted")
+    assert err.value.status_code == 400
 
     # Nor can the requesting user do so
-    status, data = api(
-        "PATCH",
-        f"group_admission_requests/{request_id}",
-        data={"status": "accepted"},
-        token=upload_data_token_group2,
-    )
-    assert status == 400
-    assert (
-        "Insufficient permissions: group admission request status can only be changed by group admins."
-        in data["message"]
-    )
+    with pytest.raises(
+        SkyPortalError,
+        match="Insufficient permissions: group admission request status can only be changed by group admins",
+    ) as err:
+        client(upload_data_token_group2).update_group_admission_request(
+            request_id, "accepted"
+        )
+    assert err.value.status_code == 400
 
     # The group admin can approve the request
-    status, data = api(
-        "PATCH",
-        f"group_admission_requests/{request_id}",
-        data={"status": "accepted"},
-        token=group_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    client(group_admin_token).update_group_admission_request(request_id, "accepted")
 
 
 # test delete someone else
@@ -157,53 +116,30 @@ def test_group_admission_delete_permissions(
     group_admin_token,
 ):
     # Have user_group2 request access to public_group
-    request_data = {"groupID": public_group.id, "userID": user_group2.id}
-
-    status, data = api(
-        "POST",
-        "group_admission_requests",
-        data=request_data,
-        token=upload_data_token_group2,
+    request_id = (
+        client(upload_data_token_group2)
+        .post_group_admission_request(public_group.id, user_group2.id)
+        .id
     )
-    assert status == 200
-    assert data["status"] == "success"
-    request_id = data["data"]["id"]
 
     # Regular user cannot delete the request
-    status, data = api(
-        "DELETE",
-        f"group_admission_requests/{request_id}",
-        data={"status": "accepted"},
-        token=upload_data_token,
-    )
-    assert status == 400
-    assert (
-        "Insufficient permissions: only the requester can delete a group admission request."
-        in data["message"]
-    )
+    with pytest.raises(
+        SkyPortalError,
+        match="Insufficient permissions: only the requester can delete a group admission request",
+    ) as err:
+        client(upload_data_token).delete_group_admission_request(request_id)
+    assert err.value.status_code == 400
 
     # Nor can the group admin do so
-    status, data = api(
-        "DELETE",
-        f"group_admission_requests/{request_id}",
-        data={"status": "accepted"},
-        token=group_admin_token,
-    )
-    assert status == 400
-    assert (
-        "Insufficient permissions: only the requester can delete a group admission request."
-        in data["message"]
-    )
+    with pytest.raises(
+        SkyPortalError,
+        match="Insufficient permissions: only the requester can delete a group admission request",
+    ) as err:
+        client(group_admin_token).delete_group_admission_request(request_id)
+    assert err.value.status_code == 400
 
     # The requester can approve the request
-    status, data = api(
-        "DELETE",
-        f"group_admission_requests/{request_id}",
-        data={"status": "accepted"},
-        token=upload_data_token_group2,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    client(upload_data_token_group2).delete_group_admission_request(request_id)
 
 
 def test_group_admission_auto_accept(
@@ -213,37 +149,24 @@ def test_group_admission_auto_accept(
     group_admin_token,
 ):
     # A group admin enables auto-accept on the group
-    status, data = api(
-        "PUT",
-        f"groups/{public_group.id}",
-        data={"name": public_group.name, "auto_accept_requests": True},
-        token=group_admin_token,
+    client(group_admin_token).update_group(
+        public_group.id, public_group.name, auto_accept_requests=True
     )
-    assert_api(status, data)
 
     # A non-member requests to join -> should be accepted immediately
-    status, data = api(
-        "POST",
-        "group_admission_requests",
-        data={"groupID": public_group.id, "userID": user_group2.id},
-        token=upload_data_token_group2,
+    request_id = (
+        client(upload_data_token_group2)
+        .post_group_admission_request(public_group.id, user_group2.id)
+        .id
     )
-    assert_api(status, data)
-    request_id = data["data"]["id"]
 
     # The request is recorded as accepted rather than pending
-    status, data = api(
-        "GET",
-        f"group_admission_requests/{request_id}",
-        token=upload_data_token_group2,
-    )
-    assert_api(status, data)
-    assert data["data"]["status"] == "accepted"
+    request = client(upload_data_token_group2).fetch_group_admission_request(request_id)
+    assert request.status == "accepted"
 
     # ...and the user is now a member of the group
-    status, data = api("GET", f"groups/{public_group.id}", token=group_admin_token)
-    assert_api(status, data)
-    assert user_group2.id in [u["id"] for u in data["data"]["users"]]
+    group = client(group_admin_token).fetch_group(public_group.id)
+    assert user_group2.id in [u.id for u in group.users]
 
 
 def test_group_admission_no_auto_accept_leaves_pending(
@@ -253,24 +176,15 @@ def test_group_admission_no_auto_accept_leaves_pending(
     group_admin_token,
 ):
     # public_group does not auto-accept by default
-    status, data = api(
-        "POST",
-        "group_admission_requests",
-        data={"groupID": public_group.id, "userID": user_group2.id},
-        token=upload_data_token_group2,
+    request_id = (
+        client(upload_data_token_group2)
+        .post_group_admission_request(public_group.id, user_group2.id)
+        .id
     )
-    assert_api(status, data)
-    request_id = data["data"]["id"]
 
-    status, data = api(
-        "GET",
-        f"group_admission_requests/{request_id}",
-        token=upload_data_token_group2,
-    )
-    assert_api(status, data)
-    assert data["data"]["status"] == "pending"
+    request = client(upload_data_token_group2).fetch_group_admission_request(request_id)
+    assert request.status == "pending"
 
     # ...and the user has not been added to the group
-    status, data = api("GET", f"groups/{public_group.id}", token=group_admin_token)
-    assert_api(status, data)
-    assert user_group2.id not in [u["id"] for u in data["data"]["users"]]
+    group = client(group_admin_token).fetch_group(public_group.id)
+    assert user_group2.id not in [u.id for u in group.users]

--- a/skyportal/tests/api_tests/groups_users_analysis/test_groups.py
+++ b/skyportal/tests/api_tests/groups_users_analysis/test_groups.py
@@ -1,59 +1,51 @@
 import uuid
 
+import pytest
+from skyportal_py import SkyPortalError
+from skyportal_py.filters import FilterPost
+from skyportal_py.groups import GroupPost
+
 from baselayer.app.env import load_env
 from skyportal.model_util import create_token
-from skyportal.tests import api
+from skyportal.tests import api, client
 
 _, cfg = load_env()
 
 
 def test_token_user_create_new_group(super_admin_token, super_admin_user):
+    sp = client(super_admin_token)
     group_name = str(uuid.uuid4())
     group_description = "Group description"
-    status, data = api(
-        "POST",
-        "groups",
-        data={
-            "name": group_name,
-            "description": group_description,
-            "group_admins": [super_admin_user.id],
-        },
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    new_group_id = data["data"]["id"]
+    new_group_id = sp.post_group(
+        GroupPost(
+            name=group_name,
+            description=group_description,
+            group_admins=[super_admin_user.id],
+        )
+    ).id
 
-    status, data = api("GET", f"groups/{new_group_id}", token=super_admin_token)
-    assert data["status"] == "success"
-    assert data["data"]["name"] == group_name
-    assert data["data"]["description"] == group_description
+    group = sp.fetch_group(new_group_id)
+    assert group.name == group_name
+    assert group.description == group_description
 
 
 def test_cannot_create_group_empty_string_name(manage_groups_token, super_admin_user):
-    group_name = ""
-    status, data = api(
-        "POST",
-        "groups",
-        data={"name": group_name, "group_admins": [super_admin_user.id]},
-        token=manage_groups_token,
-    )
-    assert status == 400
-    assert "Missing required parameter" in data["message"]
+    with pytest.raises(SkyPortalError, match="Missing required parameter") as err:
+        client(manage_groups_token).post_group(
+            GroupPost(name="", group_admins=[super_admin_user.id])
+        )
+    assert err.value.status_code == 400
 
 
 def test_fetch_group_by_name(super_admin_token, super_admin_user):
     group_name = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "groups",
-        data={"name": group_name, "group_admins": [super_admin_user.id]},
-        token=super_admin_token,
+    new_group_id = (
+        client(super_admin_token)
+        .post_group(GroupPost(name=group_name, group_admins=[super_admin_user.id]))
+        .id
     )
-    assert status == 200
-    assert data["status"] == "success"
-    new_group_id = data["data"]["id"]
 
+    # skyportal-py gap: fetch_groups has no name= filter
     status, data = api("GET", f"groups?name={group_name}", token=super_admin_token)
     assert data["status"] == "success"
     assert len(data["data"]) == 1
@@ -62,6 +54,7 @@ def test_fetch_group_by_name(super_admin_token, super_admin_user):
 
 
 def test_fetch_group_exclude_users(super_admin_token, public_group):
+    # skyportal-py gap: fetch_group has no includeGroupUsers= parameter
     status, data = api(
         "GET",
         f"groups/{public_group.id}?includeGroupUsers=False",
@@ -72,243 +65,156 @@ def test_fetch_group_exclude_users(super_admin_token, public_group):
 
 
 def test_token_user_request_all_groups(super_admin_token, super_admin_user):
+    sp = client(super_admin_token)
     group_name = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "groups",
-        data={"name": group_name, "group_admins": [super_admin_user.id]},
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp.post_group(GroupPost(name=group_name, group_admins=[super_admin_user.id]))
 
-    status, data = api("GET", "groups", token=super_admin_token)
-    assert data["status"] == "success"
+    groups = sp.fetch_groups()
+    assert any(user_group.name == group_name for user_group in groups.user_groups)
     assert any(
-        user_group["name"] == group_name for user_group in data["data"]["user_groups"]
+        group.single_user_group is True and group.name == super_admin_user.username
+        for group in groups.user_groups
     )
     assert any(
-        group["single_user_group"] is True
-        and group["name"] == super_admin_user.username
-        for group in data["data"]["user_groups"]
-    )
-    assert any(
-        user_group["name"] == group_name
-        for user_group in data["data"]["user_accessible_groups"]
+        user_group.name == group_name for user_group in groups.user_accessible_groups
     )
     assert not any(
-        group["single_user_group"] is True
-        and group["name"] == super_admin_user.username
-        for group in data["data"]["user_accessible_groups"]
+        group.single_user_group is True and group.name == super_admin_user.username
+        for group in groups.user_accessible_groups
     )
 
 
 def test_token_user_update_group(super_admin_token, public_group):
+    sp = client(super_admin_token)
     new_name = str(uuid.uuid4())
-    status, data = api(
-        "PUT",
-        f"groups/{public_group.id}",
-        data={"name": new_name},
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp.update_group(public_group.id, new_name)
 
-    status, data = api("GET", f"groups/{public_group.id}", token=super_admin_token)
-    assert data["status"] == "success"
-    assert data["data"]["name"] == new_name
+    assert sp.fetch_group(public_group.id).name == new_name
 
 
 def test_token_user_delete_group(super_admin_token, public_group):
-    status, data = api("DELETE", f"groups/{public_group.id}", token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
+    sp = client(super_admin_token)
+    sp.delete_group(public_group.id)
 
-    status, data = api("GET", f"groups/{public_group.id}", token=super_admin_token)
-    assert status == 400
+    with pytest.raises(SkyPortalError) as err:
+        sp.fetch_group(public_group.id)
+    assert err.value.status_code == 400
 
 
 def test_manage_groups_token_get_unowned_group(
     super_admin_token, user, super_admin_user
 ):
     group_name = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "groups",
-        data={"name": group_name, "group_admins": [user.id]},
-        token=super_admin_token,
+    new_group_id = (
+        client(super_admin_token)
+        .post_group(GroupPost(name=group_name, group_admins=[user.id]))
+        .id
     )
-    assert status == 200
-    assert data["status"] == "success"
-    new_group_id = data["data"]["id"]
 
     token_name = str(uuid.uuid4())
     token_id = create_token(
         ACLs=["Manage groups"], user_id=super_admin_user.id, name=token_name
     )
 
-    status, data = api("GET", f"groups/{new_group_id}", token=token_id)
-    assert data["status"] == "success"
-    assert data["data"]["name"] == group_name
+    assert client(token_id).fetch_group(new_group_id).name == group_name
 
 
 def test_public_group(view_only_token):
-    status, response = api("GET", "groups/public", token=view_only_token)
-    assert status == 200
-    assert response["status"] == "success"
-    int(response["data"]["id"])
+    group = client(view_only_token).fetch_public_group()
+    assert isinstance(group.id, int)
 
 
 def test_add_delete_stream_group(
     super_admin_token, public_group_no_streams, public_stream
 ):
-    status, data = api(
-        "POST",
-        f"groups/{public_group_no_streams.id}/streams",
-        data={"stream_id": public_stream.id},
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["data"]["stream_id"] == public_stream.id
+    sp = client(super_admin_token)
+    added = sp.post_group_stream(public_group_no_streams.id, public_stream.id)
+    assert added.stream_id == public_stream.id
 
-    status, data = api(
-        "DELETE",
-        f"groups/{public_group_no_streams.id}/streams/{public_stream.id}",
-        token=super_admin_token,
-    )
-    assert status == 200
+    sp.delete_group_stream(public_group_no_streams.id, public_stream.id)
 
 
 def test_non_su_add_stream_to_group(
     manage_groups_token, public_group_no_streams, public_stream
 ):
-    status, data = api(
-        "POST",
-        f"groups/{public_group_no_streams.id}/streams",
-        data={"stream_id": public_stream.id},
-        token=manage_groups_token,
-    )
-    assert status == 400
+    with pytest.raises(SkyPortalError) as err:
+        client(manage_groups_token).post_group_stream(
+            public_group_no_streams.id, public_stream.id
+        )
+    assert err.value.status_code == 400
 
 
 def test_add_already_added_stream_to_group(
     super_admin_token, public_group_no_streams, public_stream
 ):
-    status, data = api(
-        "POST",
-        f"groups/{public_group_no_streams.id}/streams",
-        data={"stream_id": public_stream.id},
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["data"]["stream_id"] == public_stream.id
+    sp = client(super_admin_token)
+    added = sp.post_group_stream(public_group_no_streams.id, public_stream.id)
+    assert added.stream_id == public_stream.id
 
-    status, data = api(
-        "POST",
-        f"groups/{public_group_no_streams.id}/streams",
-        data={"stream_id": public_stream.id},
-        token=super_admin_token,
-    )
-    assert status == 400
-    assert data["message"] == "Specified stream is already associated with this group."
+    with pytest.raises(
+        SkyPortalError, match="Specified stream is already associated with this group."
+    ) as err:
+        sp.post_group_stream(public_group_no_streams.id, public_stream.id)
+    assert err.value.status_code == 400
 
 
 def test_add_stream_to_group_delete_stream(
     super_admin_token, public_group_no_streams, public_stream
 ):
-    status, data = api(
-        "POST",
-        f"groups/{public_group_no_streams.id}/streams",
-        data={"stream_id": public_stream.id},
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["data"]["stream_id"] == public_stream.id
+    sp = client(super_admin_token)
+    added = sp.post_group_stream(public_group_no_streams.id, public_stream.id)
+    assert added.stream_id == public_stream.id
 
     # check stream is there
-    status, data = api(
-        "GET",
-        f"groups/{public_group_no_streams.id}",
-        token=super_admin_token,
-    )
-    assert data["data"]["streams"][0]["id"] == public_stream.id
+    assert sp.fetch_group(public_group_no_streams.id).streams[0].id == public_stream.id
 
     # delete stream
-    status, data = api(
-        "DELETE",
-        f"streams/{public_stream.id}",
-        token=super_admin_token,
-    )
-    assert status == 200
+    sp.delete_stream(public_stream.id)
 
     # check group still exists and stream is not there
-    status, data = api(
-        "GET",
-        f"groups/{public_group_no_streams.id}",
-        token=super_admin_token,
-    )
-    assert len(data["data"]["streams"]) == 0
+    assert len(sp.fetch_group(public_group_no_streams.id).streams) == 0
 
 
 def test_post_new_filter_delete_group_deletes_filter(
     super_admin_token, group_with_stream, public_stream
 ):
-    status, data = api(
-        "POST",
-        "filters",
-        data={
-            "name": str(uuid.uuid4()),
-            "stream_id": public_stream.id,
-            "group_id": group_with_stream.id,
-        },
-        token=super_admin_token,
-    )
-    assert status == 200
-    filter_id = data["data"]["id"]
+    sp = client(super_admin_token)
+    filter_id = sp.post_filter(
+        FilterPost(
+            name=str(uuid.uuid4()),
+            stream_id=public_stream.id,
+            group_id=group_with_stream.id,
+        )
+    ).id
+    assert sp.fetch_filter(filter_id).id == filter_id
 
-    status, data = api("GET", f"filters/{filter_id}", token=super_admin_token)
-    assert status == 200
-    assert data["data"]["id"] == filter_id
+    sp.delete_group(group_with_stream.id)
 
-    status, data = api(
-        "DELETE", f"groups/{group_with_stream.id}", token=super_admin_token
-    )
-    assert status == 200
-
-    status, data = api("GET", f"filters/{filter_id}", token=super_admin_token)
-    assert status == 400
-    assert "Cannot find a filter with ID" in data["message"]
+    with pytest.raises(SkyPortalError, match="Cannot find a filter with ID"):
+        sp.fetch_filter(filter_id)
 
 
 def test_post_new_filter_delete_stream_deletes_filter(
     super_admin_token, group_with_stream, public_stream
 ):
-    status, data = api(
-        "POST",
-        "filters",
-        data={
-            "name": str(uuid.uuid4()),
-            "stream_id": public_stream.id,
-            "group_id": group_with_stream.id,
-        },
-        token=super_admin_token,
-    )
-    assert status == 200
-    filter_id = data["data"]["id"]
+    sp = client(super_admin_token)
+    filter_id = sp.post_filter(
+        FilterPost(
+            name=str(uuid.uuid4()),
+            stream_id=public_stream.id,
+            group_id=group_with_stream.id,
+        )
+    ).id
+    assert sp.fetch_filter(filter_id).id == filter_id
 
-    status, data = api("GET", f"filters/{filter_id}", token=super_admin_token)
-    assert status == 200
-    assert data["data"]["id"] == filter_id
+    sp.delete_stream(public_stream.id)
 
-    status, data = api("DELETE", f"streams/{public_stream.id}", token=super_admin_token)
-    assert status == 200
-
-    status, data = api("GET", f"filters/{filter_id}", token=super_admin_token)
-    assert status == 400
-    assert "Cannot find a filter with ID" in data["message"]
+    with pytest.raises(SkyPortalError, match="Cannot find a filter with ID"):
+        sp.fetch_filter(filter_id)
 
 
 def test_cannot_delete_sitewide_public_group(super_admin_token):
+    # skyportal-py gap: fetch_groups has no name= filter
     status, data = api(
         "GET", f"groups?name={cfg['misc.public_group_name']}", token=super_admin_token
     )
@@ -317,65 +223,44 @@ def test_cannot_delete_sitewide_public_group(super_admin_token):
     assert data["data"][0]["name"] == cfg["misc.public_group_name"]
     group_id = data["data"][0]["id"]
 
-    status, data = api("DELETE", f"groups/{group_id}", token=super_admin_token)
-    assert data["status"] == "error"
-    assert "Cannot find Group with id" in data["message"]
+    with pytest.raises(SkyPortalError, match="Cannot find Group with id"):
+        client(super_admin_token).delete_group(group_id)
 
 
 def test_obj_groups(public_source, public_group, super_admin_token):
-    status, data = api(
-        "GET", f"sources/{public_source.id}/groups", token=super_admin_token
-    )
-    assert status == 200
-    assert data["data"][0]["id"] == public_group.id
+    saved_groups = client(super_admin_token).fetch_source_saved_groups(public_source.id)
+    assert saved_groups[0].id == public_group.id
 
 
 def test_add_user_to_group(public_group, user_group2, super_admin_token):
-    status, data = api(
-        "POST",
-        f"groups/{public_group.id}/users",
-        data={"userID": user_group2.id, "admin": False, "canSave": False},
-        token=super_admin_token,
-    )
-    assert status == 200
+    sp = client(super_admin_token)
+    sp.post_group_user(public_group.id, user_group2.id, admin=False, can_save=False)
 
-    status, data = api(
-        "GET",
-        f"groups/{public_group.id}?includeGroupUsers=true",
-        token=super_admin_token,
-    )
-    group_user = None
-    for gu in data["data"]["users"]:
-        if gu["id"] == user_group2.id:
-            group_user = gu
+    group = sp.fetch_group(public_group.id)
+    group_user = next((gu for gu in group.users if gu.id == user_group2.id), None)
     assert group_user is not None
-    assert not group_user["can_save"]
-    assert not group_user["admin"]
+    assert not group_user.can_save
+    assert not group_user.admin
 
 
 def test_cannot_add_user_to_group_wout_stream_access(
     public_group_stream2, super_admin_token, user
 ):
-    status, data = api(
-        "POST",
-        f"groups/{public_group_stream2.id}/users",
-        data={"userID": user.id, "admin": False},
-        token=super_admin_token,
-    )
-    assert status == 403
-    assert "does not have stream access with ID" in data["message"]
+    with pytest.raises(
+        SkyPortalError, match="does not have stream access with ID"
+    ) as err:
+        client(super_admin_token).post_group_user(
+            public_group_stream2.id, user.id, admin=False
+        )
+    assert err.value.status_code == 403
 
 
 def test_cannot_delete_stream_actively_filtered(
     public_group, public_stream, public_filter, super_admin_token
 ):
-    status, data = api(
-        "DELETE",
-        f"groups/{public_group.id}/streams/{public_stream.id}",
-        token=super_admin_token,
-    )
-    assert status == 400
-    assert "No stream IDs with" in data["message"]
+    with pytest.raises(SkyPortalError, match="No stream IDs with") as err:
+        client(super_admin_token).delete_group_stream(public_group.id, public_stream.id)
+    assert err.value.status_code == 400
 
 
 def test_delete_stream_not_actively_filtered(
@@ -386,199 +271,123 @@ def test_delete_stream_not_actively_filtered(
     public_filter,
     super_admin_token,
 ):
+    sp = client(super_admin_token)
     # public_stream is actively filtered by public_filter on public_group;
     # the .select(mode="delete") predicate now correctly excludes the row
     # at query time (rather than letting it through and failing at
     # commit-time bulk_verify), so the handler's early return fires.
     # Matches `test_cannot_delete_stream_actively_filtered` above.
-    status, data = api(
-        "DELETE",
-        f"groups/{public_group.id}/streams/{public_stream.id}",
-        token=super_admin_token,
-    )
-    assert status == 400
-    assert "No stream IDs with" in data["message"]
+    with pytest.raises(SkyPortalError, match="No stream IDs with") as err:
+        sp.delete_group_stream(public_group.id, public_stream.id)
+    assert err.value.status_code == 400
 
-    status, data = api(
-        "DELETE",
-        f"groups/{public_group_two_streams.id}/streams/{public_stream2.id}",
-        token=super_admin_token,
-    )
-    assert status == 200
+    sp.delete_group_stream(public_group_two_streams.id, public_stream2.id)
 
 
 def test_update_group_user_admin_status(public_group, group_admin_token, user):
-    status, data = api(
-        "PATCH",
-        f"groups/{public_group.id}/users",
-        data={"userID": user.id, "admin": True},
-        token=group_admin_token,
-    )
-    assert status == 200
+    sp = client(group_admin_token)
+    sp.update_group_user(public_group.id, user.id, admin=True)
 
-    status, data = api(
-        "GET",
-        f"groups/{public_group.id}?includeGroupUsers=true",
-        token=group_admin_token,
-    )
-    group_user = None
-    for gu in data["data"]["users"]:
-        if gu["id"] == user.id:
-            group_user = gu
+    group = sp.fetch_group(public_group.id)
+    group_user = next((gu for gu in group.users if gu.id == user.id), None)
     assert group_user is not None
-    assert group_user["admin"]
-    assert group_user["can_save"]
+    assert group_user.admin
+    assert group_user.can_save
 
 
 def test_update_group_user_save_access_status(public_group, group_admin_token, user):
-    status, data = api(
-        "PATCH",
-        f"groups/{public_group.id}/users",
-        data={"userID": user.id, "canSave": False},
-        token=group_admin_token,
-    )
-    assert status == 200
+    sp = client(group_admin_token)
+    sp.update_group_user(public_group.id, user.id, can_save=False)
 
-    status, data = api(
-        "GET",
-        f"groups/{public_group.id}?includeGroupUsers=true",
-        token=group_admin_token,
-    )
-    group_user = None
-    for gu in data["data"]["users"]:
-        if gu["id"] == user.id:
-            group_user = gu
+    group = sp.fetch_group(public_group.id)
+    group_user = next((gu for gu in group.users if gu.id == user.id), None)
     assert group_user is not None
-    assert not group_user["can_save"]
+    assert not group_user.can_save
 
 
 def test_non_group_admin_cannot_update_group_user_admin_status(
     public_group, manage_users_token, user
 ):
-    status, data = api(
-        "PATCH",
-        f"groups/{public_group.id}/users",
-        data={"userID": user.id, "admin": True},
-        token=manage_users_token,
-    )
-    assert status == 400
+    with pytest.raises(SkyPortalError) as err:
+        client(manage_users_token).update_group_user(
+            public_group.id, user.id, admin=True
+        )
+    assert err.value.status_code == 400
 
 
 def test_remove_self_from_group(public_group, view_only_token, user):
-    status, data = api(
-        "DELETE",
-        f"groups/{public_group.id}/users/{user.id}",
-        token=view_only_token,
-    )
-    assert status == 200
+    client(view_only_token).delete_group_user(public_group.id, user.id)
 
 
 def test_super_admin_remove_user_from_group(public_group, super_admin_token, user):
-    status, data = api(
-        "DELETE",
-        f"groups/{public_group.id}/users/{user.id}",
-        token=super_admin_token,
-    )
-    assert status == 200
+    client(super_admin_token).delete_group_user(public_group.id, user.id)
 
 
 def test_group_admin_remove_user_from_group(public_group, group_admin_token, user):
-    status, data = api(
-        "DELETE",
-        f"groups/{public_group.id}/users/{user.id}",
-        token=group_admin_token,
-    )
-    assert status == 200
+    client(group_admin_token).delete_group_user(public_group.id, user.id)
 
 
 def test_non_group_admin_cannot_remove_user_from_group(
     public_group, view_only_token2, user
 ):
-    status, data = api(
-        "DELETE",
-        f"groups/{public_group.id}/users/{user.id}",
-        token=view_only_token2,
-    )
-    assert status == 403
+    with pytest.raises(SkyPortalError) as err:
+        client(view_only_token2).delete_group_user(public_group.id, user.id)
+    assert err.value.status_code == 403
 
 
 def test_cannot_add_self_to_group(public_group2, view_only_token, user):
-    status, data = api(
-        "POST",
-        f"groups/{public_group2.id}/users",
-        data={"userID": user.id, "admin": False},
-        token=view_only_token,
-    )
-    assert status == 401
-    assert "Unauthorized" in data["message"]
+    with pytest.raises(SkyPortalError, match="Unauthorized") as err:
+        client(view_only_token).post_group_user(public_group2.id, user.id, admin=False)
+    assert err.value.status_code == 401
 
 
 def test_group_admin_add_user_to_group(public_group, group_admin_token, user_group2):
-    status, data = api(
-        "POST",
-        f"groups/{public_group.id}/users",
-        data={"userID": user_group2.id, "admin": False, "canSave": True},
-        token=group_admin_token,
+    client(group_admin_token).post_group_user(
+        public_group.id, user_group2.id, admin=False, can_save=True
     )
-    assert status == 200
 
 
 def test_non_group_admin_cannot_add_user_to_group(
     public_group2, group_admin_token, user
 ):
-    status, data = api(
-        "POST",
-        f"groups/{public_group2.id}/users",
-        data={"userID": user.id, "admin": False},
-        token=group_admin_token,
-    )
-    assert status == 400
-    assert "not accessible" in data["message"]
+    with pytest.raises(SkyPortalError, match="not accessible") as err:
+        client(group_admin_token).post_group_user(
+            public_group2.id, user.id, admin=False
+        )
+    assert err.value.status_code == 400
 
 
 def test_cannot_add_stream_to_single_user_group(super_admin_token, user, public_stream):
     single_user_group = user.single_user_group
     assert single_user_group is not None
-    status, data = api(
-        "POST",
-        f"groups/{single_user_group.id}/streams",
-        data={"stream_id": public_stream.id},
-        token=super_admin_token,
-    )
-    assert status == 400
-    assert "It is a single user group" in data["message"]
+    with pytest.raises(SkyPortalError, match="It is a single user group") as err:
+        client(super_admin_token).post_group_stream(
+            single_user_group.id, public_stream.id
+        )
+    assert err.value.status_code == 400
 
 
 def test_cannot_add_another_user_to_single_user_group(user2, super_admin_token, user):
     single_user_group = user2.single_user_group
     assert single_user_group is not None
-    status, data = api(
-        "POST",
-        f"groups/{single_user_group.id}/users",
-        data={"userID": user.id, "admin": False},
-        token=super_admin_token,
-    )
-    assert status == 400
-    assert "It is a single user group" in data["message"]
+    with pytest.raises(SkyPortalError, match="It is a single user group") as err:
+        client(super_admin_token).post_group_user(
+            single_user_group.id, user.id, admin=False
+        )
+    assert err.value.status_code == 400
 
 
 def test_cannot_remove_user_from_single_user_group(super_admin_token, user):
     single_user_group = user.single_user_group
     assert single_user_group is not None
-    status, data = api(
-        "DELETE",
-        f"groups/{single_user_group.id}/users/{user.id}",
-        token=super_admin_token,
-    )
-    assert status == 403
+    with pytest.raises(SkyPortalError) as err:
+        client(super_admin_token).delete_group_user(single_user_group.id, user.id)
+    assert err.value.status_code == 403
 
 
 def test_user_cannot_remove_self_from_single_user_group(view_only_token, user):
     single_user_group = user.single_user_group
     assert single_user_group is not None
-    status, data = api(
-        "DELETE",
-        f"groups/{single_user_group.id}/users/{user.id}",
-        token=view_only_token,
-    )
-    assert status == 403
+    with pytest.raises(SkyPortalError) as err:
+        client(view_only_token).delete_group_user(single_user_group.id, user.id)
+    assert err.value.status_code == 403

--- a/skyportal/tests/api_tests/groups_users_analysis/test_groups.py
+++ b/skyportal/tests/api_tests/groups_users_analysis/test_groups.py
@@ -45,23 +45,17 @@ def test_fetch_group_by_name(super_admin_token, super_admin_user):
         .id
     )
 
-    # skyportal-py gap: fetch_groups has no name= filter
-    status, data = api("GET", f"groups?name={group_name}", token=super_admin_token)
-    assert data["status"] == "success"
-    assert len(data["data"]) == 1
-    assert data["data"][0]["name"] == group_name
-    assert data["data"][0]["id"] == new_group_id
+    matches = client(super_admin_token).fetch_groups_by_name(group_name)
+    assert len(matches) == 1
+    assert matches[0].name == group_name
+    assert matches[0].id == new_group_id
 
 
 def test_fetch_group_exclude_users(super_admin_token, public_group):
-    # skyportal-py gap: fetch_group has no includeGroupUsers= parameter
-    status, data = api(
-        "GET",
-        f"groups/{public_group.id}?includeGroupUsers=False",
-        token=super_admin_token,
+    group = client(super_admin_token).fetch_group(
+        public_group.id, include_group_users=False
     )
-    assert data["status"] == "success"
-    assert "users" not in data["data"]
+    assert group.users is None
 
 
 def test_token_user_request_all_groups(super_admin_token, super_admin_user):
@@ -214,17 +208,13 @@ def test_post_new_filter_delete_stream_deletes_filter(
 
 
 def test_cannot_delete_sitewide_public_group(super_admin_token):
-    # skyportal-py gap: fetch_groups has no name= filter
-    status, data = api(
-        "GET", f"groups?name={cfg['misc.public_group_name']}", token=super_admin_token
-    )
-    assert data["status"] == "success"
-    assert len(data["data"]) == 1
-    assert data["data"][0]["name"] == cfg["misc.public_group_name"]
-    group_id = data["data"][0]["id"]
+    sp = client(super_admin_token)
+    matches = sp.fetch_groups_by_name(cfg["misc.public_group_name"])
+    assert len(matches) == 1
+    assert matches[0].name == cfg["misc.public_group_name"]
 
     with pytest.raises(SkyPortalError, match="Cannot find Group with id"):
-        client(super_admin_token).delete_group(group_id)
+        sp.delete_group(matches[0].id)
 
 
 def test_obj_groups(public_source, public_group, super_admin_token):

--- a/skyportal/tests/api_tests/groups_users_analysis/test_instrument.py
+++ b/skyportal/tests/api_tests/groups_users_analysis/test_instrument.py
@@ -3,238 +3,172 @@ import time
 import uuid
 
 import pandas as pd
+import pytest
 from regions import Regions
+from skyportal_py import SkyPortalError
+from skyportal_py.instruments import InstrumentPost, InstrumentPut
+from skyportal_py.telescopes import TelescopePost
 
-from skyportal.tests import api
+from skyportal.tests import api, client
 
 
 def test_token_user_post_get_instrument(super_admin_token):
+    sp = client(super_admin_token)
     name = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "telescope",
-        data={
-            "name": name,
-            "nickname": name,
-            "lat": 0.0,
-            "lon": 0.0,
-            "elevation": 0.0,
-            "diameter": 10.0,
-        },
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    telescope_id = data["data"]["id"]
+    telescope_id = sp.post_telescope(
+        TelescopePost(
+            name=name,
+            nickname=name,
+            lat=0.0,
+            lon=0.0,
+            elevation=0.0,
+            diameter=10.0,
+        )
+    ).id
 
     fielddatafile = f"{os.path.dirname(__file__)}/../../../../data/ZTF_Fields.csv"
     regionsdatafile = f"{os.path.dirname(__file__)}/../../../../data/ZTF_Region.reg"
 
     instrument_name = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "instrument",
-        data={
-            "name": instrument_name,
-            "type": "imager",
-            "band": "NIR",
-            "filters": ["f110w"],
-            "telescope_id": telescope_id,
-            "field_data": pd.read_csv(fielddatafile)[:5].to_dict(orient="list"),
-            "field_region": Regions.read(regionsdatafile).serialize(format="ds9"),
-        },
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    instrument_id = data["data"]["id"]
-
-    params = {"includeGeoJSON": True}
+    instrument_id = sp.post_instrument(
+        InstrumentPost(
+            name=instrument_name,
+            type="imager",
+            band="NIR",
+            filters=["f110w"],
+            telescope_id=telescope_id,
+            field_data=pd.read_csv(fielddatafile)[:5].to_dict(orient="list"),
+            field_region=Regions.read(regionsdatafile).serialize(format="ds9"),
+        )
+    ).id
 
     # wait for the fields to populate
     nretries = 0
     fields_loaded = False
     while not fields_loaded and nretries < 5:
         try:
-            status, data = api(
-                "GET",
-                f"instrument/{instrument_id}",
-                params=params,
-                token=super_admin_token,
-            )
-            assert status == 200
-            assert data["status"] == "success"
-            assert data["data"]["band"] == "NIR"
-            assert len(data["data"]["fields"]) == 5
+            instrument = sp.fetch_instrument(instrument_id, include_geojson=True)
+            assert instrument.band == "NIR"
+            assert len(instrument.fields) == 5
             fields_loaded = True
         except AssertionError:
             nretries = nretries + 1
             time.sleep(3)
 
-    params = {"includeGeoJSON": True}
+    instrument_id = instrument.id
+    instrument = sp.fetch_instrument(instrument_id, include_geojson=True)
+    assert instrument.band == "NIR"
 
-    instrument_id = data["data"]["id"]
-    status, data = api(
-        "GET", f"instrument/{instrument_id}", params=params, token=super_admin_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    assert data["data"]["band"] == "NIR"
-
-    assert len(data["data"]["fields"]) == 5
+    assert len(instrument.fields) == 5
 
     assert any(
-        d["field_id"] == 1
-        and d["contour"]["features"][0]["geometry"]["coordinates"][0][0]
+        d.field_id == 1
+        and d.contour["features"][0]["geometry"]["coordinates"][0][0]
         == [110.84791974982103, -87.01522999646508]
-        for d in data["data"]["fields"]
+        for d in instrument.fields
     )
 
-    params = {"includeGeoJSONSummary": True}
+    instrument_id = instrument.id
+    instrument = sp.fetch_instrument(instrument_id, include_geojson_summary=True)
+    assert instrument.band == "NIR"
 
-    instrument_id = data["data"]["id"]
-    status, data = api(
-        "GET", f"instrument/{instrument_id}", params=params, token=super_admin_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    assert data["data"]["band"] == "NIR"
-
-    assert len(data["data"]["fields"]) == 5
+    assert len(instrument.fields) == 5
 
     assert any(
-        d["field_id"] == 1
-        and d["contour_summary"]["features"][0]["geometry"]["coordinates"][0]
+        d.field_id == 1
+        and d.contour_summary["features"][0]["geometry"]["coordinates"][0]
         == [1.0238351746164418, -89.93777511600825]
-        for d in data["data"]["fields"]
+        for d in instrument.fields
     )
 
 
 def test_fetch_instrument_by_name(super_admin_token):
+    sp = client(super_admin_token)
     tel_name = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "telescope",
-        data={
-            "name": tel_name,
-            "nickname": tel_name,
-            "lat": 0.0,
-            "lon": 0.0,
-            "elevation": 0.0,
-            "diameter": 10.0,
-        },
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    telescope_id = data["data"]["id"]
+    telescope_id = sp.post_telescope(
+        TelescopePost(
+            name=tel_name,
+            nickname=tel_name,
+            lat=0.0,
+            lon=0.0,
+            elevation=0.0,
+            diameter=10.0,
+        )
+    ).id
 
     instrument_name = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "instrument",
-        data={
-            "name": instrument_name,
-            "type": "imager",
-            "band": "V",
-            "telescope_id": telescope_id,
-        },
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    instrument_id = sp.post_instrument(
+        InstrumentPost(
+            name=instrument_name,
+            type="imager",
+            band="V",
+            telescope_id=telescope_id,
+        )
+    ).id
 
-    instrument_id = data["data"]["id"]
-    status, data = api(
-        "GET", f"instrument?name={instrument_name}", token=super_admin_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]) == 1
-    assert data["data"][0]["band"] == "V"
-    assert data["data"][0]["id"] == instrument_id
-    assert data["data"][0]["name"] == instrument_name
+    matches = sp.fetch_instruments(name=instrument_name)
+    assert len(matches) == 1
+    assert matches[0].band == "V"
+    assert matches[0].id == instrument_id
+    assert matches[0].name == instrument_name
 
 
 def test_token_user_update_instrument(
     super_admin_token, manage_sources_token, view_only_token
 ):
+    sp = client(super_admin_token)
     name = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "telescope",
-        data={
-            "name": name,
-            "nickname": name,
-            "lat": 0.0,
-            "lon": 0.0,
-            "elevation": 0.0,
-            "diameter": 10.0,
-        },
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    telescope_id = data["data"]["id"]
+    telescope_id = sp.post_telescope(
+        TelescopePost(
+            name=name,
+            nickname=name,
+            lat=0.0,
+            lon=0.0,
+            elevation=0.0,
+            diameter=10.0,
+        )
+    ).id
 
     instrument_name = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "instrument",
-        data={
-            "name": instrument_name,
-            "type": "imager",
-            "band": "NIR",
-            "filters": ["f110w"],
-            "telescope_id": telescope_id,
-        },
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    instrument_id = sp.post_instrument(
+        InstrumentPost(
+            name=instrument_name,
+            type="imager",
+            band="NIR",
+            filters=["f110w"],
+            telescope_id=telescope_id,
+        )
+    ).id
 
-    instrument_id = data["data"]["id"]
-    status, data = api("GET", f"instrument/{instrument_id}", token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-    assert data["data"]["band"] == "NIR"
+    assert sp.fetch_instrument(instrument_id).band == "NIR"
 
     new_name = f"Gattini2_{uuid.uuid4()}"
 
-    status, data = api(
-        "PUT",
-        f"instrument/{instrument_id}",
-        data={
-            "name": new_name,
-            "type": "imager",
-            "band": "NIR",
-            "filters": ["f110w"],
-            "telescope_id": telescope_id,
-        },
-        token=manage_sources_token,
-    )
-    assert status == 401
-    assert data["status"] == "error"
+    with pytest.raises(SkyPortalError) as err:
+        client(manage_sources_token).update_instrument(
+            instrument_id,
+            InstrumentPut(
+                name=new_name,
+                type="imager",
+                band="NIR",
+                filters=["f110w"],
+                telescope_id=telescope_id,
+            ),
+        )
+    assert err.value.status_code == 401
 
-    status, data = api(
-        "PUT",
-        f"instrument/{instrument_id}",
-        data={
-            "name": new_name,
-            "type": "imager",
-            "band": "NIR",
-            "filters": ["f110w"],
-            "telescope_id": telescope_id,
-        },
-        token=super_admin_token,
+    sp.update_instrument(
+        instrument_id,
+        InstrumentPut(
+            name=new_name,
+            type="imager",
+            band="NIR",
+            filters=["f110w"],
+            telescope_id=telescope_id,
+        ),
     )
-    assert status == 200
-    assert data["status"] == "success"
 
-    status, data = api("GET", f"instrument/{instrument_id}", token=view_only_token)
-    assert status == 200
-    assert data["status"] == "success"
-    assert data["data"]["name"] == new_name
+    assert client(view_only_token).fetch_instrument(instrument_id).name == new_name
 
 
 def test_update_instrument_across_id(super_admin_token):
@@ -242,204 +176,142 @@ def test_update_instrument_across_id(super_admin_token):
     # The instrument is given a region so the update exercises both async
     # lazy-load traps: the deferred `region` column and the load_instance
     # schema's sync instance fetch.
+    sp = client(super_admin_token)
     name = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "telescope",
-        data={"name": name, "nickname": name, "diameter": 0.0, "fixed_location": False},
-        token=super_admin_token,
-    )
-    assert status == 200
-    telescope_id = data["data"]["id"]
+    telescope_id = sp.post_telescope(
+        TelescopePost(name=name, nickname=name, diameter=0.0, fixed_location=False)
+    ).id
 
-    status, data = api(
-        "POST",
-        "instrument",
-        data={
-            "name": str(uuid.uuid4()),
-            "type": "imager",
-            "filters": ["f110w"],
-            "telescope_id": telescope_id,
-            "field_fov_type": "circle",
-            "field_fov_attributes": 3.0,
-        },
-        token=super_admin_token,
-    )
-    assert status == 200
-    instrument_id = data["data"]["id"]
+    instrument_id = sp.post_instrument(
+        InstrumentPost(
+            name=str(uuid.uuid4()),
+            type="imager",
+            filters=["f110w"],
+            telescope_id=telescope_id,
+            field_fov_type="circle",
+            field_fov_attributes=3.0,
+        )
+    ).id
 
     across_id = str(uuid.uuid4())
-    status, data = api(
-        "PUT",
-        f"instrument/{instrument_id}",
-        data={"across_id": across_id},
-        token=super_admin_token,
-    )
-    assert status == 200, data
-    assert data["status"] == "success"
+    sp.update_instrument(instrument_id, InstrumentPut(across_id=across_id))
 
-    status, data = api("GET", f"instrument/{instrument_id}", token=super_admin_token)
-    assert status == 200
-    assert data["data"]["across_id"] == across_id
+    assert sp.fetch_instrument(instrument_id).across_id == across_id
 
 
 def test_token_user_delete_instrument(super_admin_token, view_only_token):
+    sp = client(super_admin_token)
     name = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "telescope",
-        data={
-            "name": name,
-            "nickname": name,
-            "lat": 0.0,
-            "lon": 0.0,
-            "elevation": 0.0,
-            "diameter": 10.0,
-        },
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    telescope_id = data["data"]["id"]
+    telescope_id = sp.post_telescope(
+        TelescopePost(
+            name=name,
+            nickname=name,
+            lat=0.0,
+            lon=0.0,
+            elevation=0.0,
+            diameter=10.0,
+        )
+    ).id
 
     instrument_name = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "instrument",
-        data={
-            "name": instrument_name,
-            "type": "imager",
-            "band": "NIR",
-            "filters": ["f110w"],
-            "telescope_id": telescope_id,
-        },
-        token=super_admin_token,
-    )
+    instrument_id = sp.post_instrument(
+        InstrumentPost(
+            name=instrument_name,
+            type="imager",
+            band="NIR",
+            filters=["f110w"],
+            telescope_id=telescope_id,
+        )
+    ).id
 
-    assert status == 200
-    assert data["status"] == "success"
-    instrument_id = data["data"]["id"]
+    sp.delete_instrument(instrument_id)
 
-    status, data = api("DELETE", f"instrument/{instrument_id}", token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-
-    status, data = api("GET", f"instrument/{instrument_id}", token=view_only_token)
-    assert status == 400
+    with pytest.raises(SkyPortalError) as err:
+        client(view_only_token).fetch_instrument(instrument_id)
+    assert err.value.status_code == 400
 
 
 def test_post_instrument_fov(super_admin_token):
+    sp = client(super_admin_token)
     telescope_name = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "telescope",
-        data={
-            "name": telescope_name,
-            "nickname": telescope_name,
-            "lat": 0.0,
-            "lon": 0.0,
-            "elevation": 0.0,
-            "diameter": 10.0,
-        },
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    telescope_id = data["data"]["id"]
+    telescope_id = sp.post_telescope(
+        TelescopePost(
+            name=telescope_name,
+            nickname=telescope_name,
+            lat=0.0,
+            lon=0.0,
+            elevation=0.0,
+            diameter=10.0,
+        )
+    ).id
 
     instrument_name = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "instrument",
-        data={
-            "name": instrument_name,
-            "type": "imager",
-            "band": "NIR",
-            "filters": ["f110w"],
-            "telescope_id": telescope_id,
-            "field_fov_type": "circle",
-            "field_fov_attributes": 3.0,
-        },
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    instrument_id = data["data"]["id"]
-
-    params = {"includeRegion": True}
+    instrument_id = sp.post_instrument(
+        InstrumentPost(
+            name=instrument_name,
+            type="imager",
+            band="NIR",
+            filters=["f110w"],
+            telescope_id=telescope_id,
+            field_fov_type="circle",
+            field_fov_attributes=3.0,
+        )
+    ).id
 
     # wait for the fields to populate
     nretries = 0
     fields_loaded = False
     while not fields_loaded and nretries < 5:
         try:
-            status, data = api(
-                "GET",
-                f"instrument/{instrument_id}",
-                token=super_admin_token,
-                params=params,
-            )
-            assert status == 200
-            assert data["status"] == "success"
-            assert data["data"]["band"] == "NIR"
+            instrument = sp.fetch_instrument(instrument_id, include_region=True)
+            assert instrument.band == "NIR"
             fields_loaded = True
         except AssertionError:
             nretries = nretries + 1
             time.sleep(3)
 
-    assert status == 200
-    assert data["status"] == "success"
-
     region_str = """# Region file format: DS9 astropy/regions
 icrs
 circle(0.00000000,0.00000000,3.00000000)"""
 
-    assert data["data"]["region"].strip() == region_str.strip()
+    assert instrument.region.strip() == region_str.strip()
 
 
 def test_token_user_post_sensitivity_data(super_admin_token):
+    sp = client(super_admin_token)
     name = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "telescope",
-        data={
-            "name": name,
-            "nickname": name,
-            "lat": 0.0,
-            "lon": 0.0,
-            "elevation": 0.0,
-            "diameter": 10.0,
-        },
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    telescope_id = data["data"]["id"]
+    telescope_id = sp.post_telescope(
+        TelescopePost(
+            name=name,
+            nickname=name,
+            lat=0.0,
+            lon=0.0,
+            elevation=0.0,
+            diameter=10.0,
+        )
+    ).id
 
     instrument_name = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "instrument",
-        data={
-            "name": instrument_name,
-            "type": "imager",
-            "band": "NIR",
-            "filters": ["f110w"],
-            "sensitivity_data": {
-                "wrong_filter_name": {
-                    "limiting_magnitude": 20.5,
-                    "magsys": "ab",
-                    "exposure_time": 30,
-                }
-            },
-            "telescope_id": telescope_id,
-        },
-        token=super_admin_token,
-    )
-    assert status == 400
-    assert data["status"] == "error"
+    with pytest.raises(SkyPortalError) as err:
+        sp.post_instrument(
+            InstrumentPost(
+                name=instrument_name,
+                type="imager",
+                band="NIR",
+                filters=["f110w"],
+                sensitivity_data={
+                    "wrong_filter_name": {
+                        "limiting_magnitude": 20.5,
+                        "magsys": "ab",
+                        "exposure_time": 30,
+                    }
+                },
+                telescope_id=telescope_id,
+            )
+        )
+    assert err.value.status_code == 400
     assert (
-        data["message"]
+        str(err.value)
         == "Sensitivity_data filters must be a subset of the instrument filters"
     )
 
@@ -450,40 +322,32 @@ def test_instrument_forms_api_classname_reads_telescope(super_admin_token):
     instrument.telescope (next_twilight_morning_nautical), which lazy-loads under
     the async handler unless the telescope relationship is eager-loaded.
     """
+    sp = client(super_admin_token)
     name = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "telescope",
-        data={
-            "name": name,
-            "nickname": name,
-            "lat": 0.0,
-            "lon": 0.0,
-            "elevation": 0.0,
-            "diameter": 10.0,
-        },
-        token=super_admin_token,
-    )
-    assert status == 200
-    telescope_id = data["data"]["id"]
+    telescope_id = sp.post_telescope(
+        TelescopePost(
+            name=name,
+            nickname=name,
+            lat=0.0,
+            lon=0.0,
+            elevation=0.0,
+            diameter=10.0,
+        )
+    ).id
 
     instrument_name = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "instrument",
-        data={
-            "name": instrument_name,
-            "type": "imager",
-            "band": "optical",
-            "filters": ["ztfg"],
-            "telescope_id": telescope_id,
-            "api_classname": "ZTFAPI",
-        },
-        token=super_admin_token,
-    )
-    assert status == 200
-    instrument_id = data["data"]["id"]
+    instrument_id = sp.post_instrument(
+        InstrumentPost(
+            name=instrument_name,
+            type="imager",
+            band="optical",
+            filters=["ztfg"],
+            telescope_id=telescope_id,
+            api_classname="ZTFAPI",
+        )
+    ).id
 
+    # raw api: internal form-schema endpoint, outside skyportal-py's scope
     status, data = api(
         "GET",
         "internal/instrument_forms",

--- a/skyportal/tests/api_tests/groups_users_analysis/test_invitations.py
+++ b/skyportal/tests/api_tests/groups_users_analysis/test_invitations.py
@@ -1,81 +1,60 @@
 import uuid
 
-from skyportal.tests import api
+import pytest
+from skyportal_py import SkyPortalError
+from skyportal_py.invitations import InvitationPost
+
+from skyportal.tests import client
 
 
 def test_invite_new_user(manage_users_token, public_stream, public_group):
-    status, data = api(
-        "POST",
-        "invitations",
-        data={
-            "userEmail": "string",
-            "streamIDs": [public_stream.id],
-            "groupIDs": [public_group.id],
-            "groupAdmin": [True],
-        },
-        token=manage_users_token,
+    client(manage_users_token).post_invitation(
+        InvitationPost(
+            user_email="string",
+            stream_ids=[public_stream.id],
+            group_ids=[public_group.id],
+            group_admin=[True],
+        )
     )
-    print(status)
-    print(data)
-    assert status == 200
 
 
 def test_invite_new_user_forbidden(view_only_token, public_stream, public_group):
-    status, data = api(
-        "POST",
-        "invitations",
-        data={
-            "userEmail": "string",
-            "streamIDs": [public_stream.id],
-            "groupIDs": [public_group.id],
-            "groupAdmin": [True],
-        },
-        token=view_only_token,
-    )
-
-    assert status == 401
-    assert "Unauthorized" in data["message"]
+    with pytest.raises(SkyPortalError, match="Unauthorized") as err:
+        client(view_only_token).post_invitation(
+            InvitationPost(
+                user_email="string",
+                stream_ids=[public_stream.id],
+                group_ids=[public_group.id],
+                group_admin=[True],
+            )
+        )
+    assert err.value.status_code == 401
 
 
 def test_get_invitations(
     manage_users_token, manage_users_token_group2, public_stream, public_group
 ):
-    status, data = api(
-        "POST",
-        "invitations",
-        data={
-            "userEmail": "string",
-            "streamIDs": [public_stream.id],
-            "groupIDs": [public_group.id],
-            "groupAdmin": [True],
-        },
-        token=manage_users_token,
+    invitation_id = (
+        client(manage_users_token)
+        .post_invitation(
+            InvitationPost(
+                user_email="string",
+                stream_ids=[public_stream.id],
+                group_ids=[public_group.id],
+                group_admin=[True],
+            )
+        )
+        .id
     )
-    print(status)
-    print(data)
-    assert status == 200
-    invitation_id = data["data"]["id"]
 
     # Whoever created the invitation can fetch it
-    status, data = api(
-        "GET",
-        "invitations",
-        params={"group": public_group.name},
-        token=manage_users_token,
-    )
-    assert status == 200
-    assert data["data"]["totalMatches"] == 1
-    assert data["data"]["invitations"][0]["id"] == invitation_id
+    page = client(manage_users_token).fetch_invitations(group=public_group.name)
+    assert page.total_matches == 1
+    assert page.invitations[0].id == invitation_id
 
     # Only invitors can see the invitation
-    status, data = api(
-        "GET",
-        "invitations",
-        params={"group": public_group.name},
-        token=manage_users_token_group2,
-    )
-    assert status == 200
-    assert data["data"]["totalMatches"] == 0
+    page = client(manage_users_token_group2).fetch_invitations(group=public_group.name)
+    assert page.total_matches == 0
 
 
 def test_patch_invitation(
@@ -86,53 +65,36 @@ def test_patch_invitation(
     public_group2,
 ):
     user_email = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "invitations",
-        data={
-            "userEmail": user_email,
-            "streamIDs": [public_stream.id],
-            "groupIDs": [public_group.id],
-            "groupAdmin": [True],
-        },
-        token=manage_users_token,
+    invitation_id = (
+        client(manage_users_token)
+        .post_invitation(
+            InvitationPost(
+                user_email=user_email,
+                stream_ids=[public_stream.id],
+                group_ids=[public_group.id],
+                group_admin=[True],
+            )
+        )
+        .id
     )
-    print(status)
-    print(data)
-    assert status == 200
-    invitation_id = data["data"]["id"]
 
     # Only the invitor should be able to patch
-    status, data = api(
-        "PATCH", f"invitations/{invitation_id}", token=manage_users_token_group2
-    )
-    assert status == 400
-    assert "Insufficient permissions" in data["message"]
+    with pytest.raises(SkyPortalError, match="Insufficient permissions") as err:
+        client(manage_users_token_group2).update_invitation(invitation_id)
+    assert err.value.status_code == 400
 
     # Need one of groupIDs or streamIDs
-    status, data = api(
-        "PATCH", f"invitations/{invitation_id}", token=manage_users_token
-    )
-    assert status == 400
-    assert "At least one of" in data["message"]
+    with pytest.raises(SkyPortalError, match="At least one of") as err:
+        client(manage_users_token).update_invitation(invitation_id)
+    assert err.value.status_code == 400
 
     # Try adding group2 to the invited user
-    status, _ = api(
-        "PATCH",
-        f"invitations/{invitation_id}",
-        data={"groupIDs": [public_group2.id]},
-        token=manage_users_token,
+    client(manage_users_token).update_invitation(
+        invitation_id, group_ids=[public_group2.id]
     )
-    assert status == 200
 
     # Try updating role to View only
-    status, _ = api(
-        "PATCH",
-        f"invitations/{invitation_id}",
-        data={"role": "View only"},
-        token=manage_users_token,
-    )
-    assert status == 200
+    client(manage_users_token).update_invitation(invitation_id, role="View only")
 
 
 def test_delete_invitation(
@@ -143,36 +105,23 @@ def test_delete_invitation(
     public_group2,
 ):
     user_email = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "invitations",
-        data={
-            "userEmail": user_email,
-            "streamIDs": [public_stream.id],
-            "groupIDs": [public_group.id],
-            "groupAdmin": [True],
-        },
-        token=manage_users_token,
+    invitation_id = (
+        client(manage_users_token)
+        .post_invitation(
+            InvitationPost(
+                user_email=user_email,
+                stream_ids=[public_stream.id],
+                group_ids=[public_group.id],
+                group_admin=[True],
+            )
+        )
+        .id
     )
-    print(status)
-    print(data)
-    assert status == 200
-    invitation_id = data["data"]["id"]
 
     # Only the invitor should be able to delete
-    status, data = api(
-        "DELETE", f"invitations/{invitation_id}", token=manage_users_token_group2
-    )
-    print("-------")
-    print(status)
-    print(data)
-    assert status == 400
-    assert "Insufficient permissions" in data["message"]
+    with pytest.raises(SkyPortalError, match="Insufficient permissions") as err:
+        client(manage_users_token_group2).delete_invitation(invitation_id)
+    assert err.value.status_code == 400
 
     # Try deleting invitation
-    status, _ = api(
-        "DELETE",
-        f"invitations/{invitation_id}",
-        token=manage_users_token,
-    )
-    assert status == 200
+    client(manage_users_token).delete_invitation(invitation_id)

--- a/skyportal/tests/api_tests/groups_users_analysis/test_listener.py
+++ b/skyportal/tests/api_tests/groups_users_analysis/test_listener.py
@@ -1,95 +1,59 @@
-from skyportal.tests import api
+import pytest
+from skyportal_py import SkyPortalError
+
+from skyportal.tests import client
 
 
 def test_post_status_update_to_sedm_request(
     public_source_followup_request, sedm_listener_token, view_only_token
 ):
     new_status = "observed successfully"
-    status, data = api(
-        "POST",
-        "facility",
-        data={
-            "followup_request_id": public_source_followup_request.id,
-            "new_status": new_status,
-        },
-        token=sedm_listener_token,
+    client(sedm_listener_token).post_facility_message(
+        public_source_followup_request.id, {"new_status": new_status}
     )
 
-    assert status == 200
-
-    status, data = api(
-        "GET",
-        f"followup_request/{public_source_followup_request.id}",
-        token=view_only_token,
+    followup_request = client(view_only_token).fetch_followup_request(
+        public_source_followup_request.id
     )
-
-    assert status == 200
-    assert data["data"]["status"] == new_status
+    assert followup_request.status == new_status
 
 
 def test_post_status_update_to_request_without_listener_acl(
     public_source_followup_request, view_only_token
 ):
-    status, data = api(
-        "POST",
-        "facility",
-        data={
-            "followup_request_id": public_source_followup_request.id,
-            "new_status": "status that should be rejected due to lack of ACL",
-        },
-        token=view_only_token,
+    with pytest.raises(SkyPortalError) as err:
+        client(view_only_token).post_facility_message(
+            public_source_followup_request.id,
+            {"new_status": "status that should be rejected due to lack of ACL"},
+        )
+    assert err.value.status_code == 400
+
+    followup_request = client(view_only_token).fetch_followup_request(
+        public_source_followup_request.id
     )
-
-    assert status == 400
-
-    status, data = api(
-        "GET",
-        f"followup_request/{public_source_followup_request.id}",
-        token=view_only_token,
-    )
-
-    assert status == 200
-    assert data["data"]["status"] == public_source_followup_request.status
+    assert followup_request.status == public_source_followup_request.status
 
 
 def test_post_poorly_formatted_sedm_message(
     public_source_followup_request, sedm_listener_token
 ):
     new_status = "observed successfully"
-    status, data = api(
-        "POST",
-        "facility",
-        data={
-            "followup_request_id": public_source_followup_request.id,
-            "new_status": new_status,
-            "superfluous_field": "abcd",
-        },
-        token=sedm_listener_token,
-    )
-
-    assert status == 500
+    with pytest.raises(SkyPortalError) as err:
+        client(sedm_listener_token).post_facility_message(
+            public_source_followup_request.id,
+            {"new_status": new_status, "superfluous_field": "abcd"},
+        )
+    assert err.value.status_code == 500
 
 
 def test_post_message_about_unowned_request(
     public_source_group2_followup_request, sedm_listener_token, super_admin_token
 ):
-    status, data = api(
-        "POST",
-        "facility",
-        data={
-            "followup_request_id": public_source_group2_followup_request.id,
-            "new_status": "ok",
-        },
-        token=sedm_listener_token,
+    client(sedm_listener_token).post_facility_message(
+        public_source_group2_followup_request.id, {"new_status": "ok"}
     )
 
-    assert status == 200
-
-    status, data = api(
-        "GET",
-        f"followup_request/{public_source_group2_followup_request.id}",
-        token=super_admin_token,
+    followup_request = client(super_admin_token).fetch_followup_request(
+        public_source_group2_followup_request.id
     )
-
-    assert status == 200
-    assert data["data"]["status"] == "ok"
+    assert followup_request.status == "ok"

--- a/skyportal/tests/api_tests/groups_users_analysis/test_listings.py
+++ b/skyportal/tests/api_tests/groups_users_analysis/test_listings.py
@@ -1,141 +1,106 @@
 import uuid
 
+import pytest
+from skyportal_py import SkyPortalError
+from skyportal_py.listings import ListingPost
+
 from skyportal.model_util import create_token
-from skyportal.tests import api, assert_api, assert_api_fail
+from skyportal.tests import client
 
 
 def test_add_objects_to_list(user, public_candidate, public_candidate2):
     token_id = create_token(
         ACLs=["Upload data"], user_id=user.id, name=str(uuid.uuid4())
     )
+    sp = client(token_id)
 
-    status, data = api(
-        "POST",
-        "listing",
-        data={
-            "user_id": user.id,
-            "obj_id": public_candidate.id,
-            "list_name": "favorites",
-        },
-        token=token_id,
-    )
+    item1 = sp.post_listing(
+        ListingPost(
+            user_id=user.id,
+            obj_id=public_candidate.id,
+            list_name="favorites",
+        )
+    ).id  # get the list item ID
 
-    assert status == 200
-    item1 = data["data"]["id"]  # get the list item ID
-
-    status, data = api(
-        "POST",
-        "listing",
-        data={
-            "user_id": user.id,
-            "obj_id": public_candidate2.id,
-            "list_name": "favorites",
-        },
-        token=token_id,
-    )
-
-    assert status == 200
-    item2 = data["data"]["id"]  # get the list item ID
+    item2 = sp.post_listing(
+        ListingPost(
+            user_id=user.id,
+            obj_id=public_candidate2.id,
+            list_name="favorites",
+        )
+    ).id  # get the list item ID
 
     # get the list back, should include only two items
-    status, data = api("GET", f"listing/{user.id}?listName=favorites", token=token_id)
+    new_list = sp.fetch_listings(user_id=user.id, list_name="favorites")
 
-    assert status == 200
-    new_list = data["data"]
-
-    items = [item["id"] for item in new_list]
+    items = [item.id for item in new_list]
 
     assert set(items) == {item1, item2}
 
     # try to post a listing to a non-existing object
     fake_obj_id = str(uuid.uuid4())
 
-    status, data = api(
-        "POST",
-        "listing",
-        data={"user_id": user.id, "obj_id": fake_obj_id, "list_name": "favorites"},
-        token=token_id,
-    )
-
-    assert status == 400
+    with pytest.raises(SkyPortalError) as err:
+        sp.post_listing(
+            ListingPost(user_id=user.id, obj_id=fake_obj_id, list_name="favorites")
+        )
+    assert err.value.status_code == 400
 
 
 def test_double_posting(user, public_candidate):
     token_id = create_token(
         ACLs=["Upload data"], user_id=user.id, name=str(uuid.uuid4())
     )
+    sp = client(token_id)
 
-    status, data = api(
-        "POST",
-        "listing",
-        data={
-            "user_id": user.id,
-            "obj_id": public_candidate.id,
-            "list_name": "favorites",
-        },
-        token=token_id,
+    sp.post_listing(
+        ListingPost(
+            user_id=user.id,
+            obj_id=public_candidate.id,
+            list_name="favorites",
+        )
     )
-
-    assert status == 200
 
     # try posting the same listing again!
-    status, data = api(
-        "POST",
-        "listing",
-        data={
-            "user_id": user.id,
-            "obj_id": public_candidate.id,
-            "list_name": "favorites",
-        },
-        token=token_id,
-    )
-
-    assert status == 400
+    with pytest.raises(SkyPortalError) as err:
+        sp.post_listing(
+            ListingPost(
+                user_id=user.id,
+                obj_id=public_candidate.id,
+                list_name="favorites",
+            )
+        )
+    assert err.value.status_code == 400
 
 
 def test_add_remove_objects(user, public_candidate, public_candidate2):
     token_id = create_token(
         ACLs=["Upload data"], user_id=user.id, name=str(uuid.uuid4())
     )
+    sp = client(token_id)
 
-    status, data = api(
-        "POST",
-        "listing",
-        data={
-            "user_id": user.id,
-            "obj_id": public_candidate.id,
-            "list_name": "favorites",
-        },
-        token=token_id,
-    )
-    assert status == 200
-    item1 = data["data"]["id"]  # get the list item ID
+    item1 = sp.post_listing(
+        ListingPost(
+            user_id=user.id,
+            obj_id=public_candidate.id,
+            list_name="favorites",
+        )
+    ).id  # get the list item ID
 
-    status, data = api(
-        "POST",
-        "listing",
-        data={
-            "user_id": user.id,
-            "obj_id": public_candidate2.id,
-            "list_name": "favorites",
-        },
-        token=token_id,
-    )
+    item2 = sp.post_listing(
+        ListingPost(
+            user_id=user.id,
+            obj_id=public_candidate2.id,
+            list_name="favorites",
+        )
+    ).id  # get the list item ID
 
-    assert status == 200
-    item2 = data["data"]["id"]  # get the list item ID
-
-    status, data = api("DELETE", f"listing/{item1}", token=token_id)
-
-    assert status == 200
+    sp.delete_listing(item1)
 
     # get the list back, should include only one item
-    status, data = api("GET", f"listing/{user.id}?listName=favorites", token=token_id)
+    new_list = sp.fetch_listings(user_id=user.id, list_name="favorites")
 
-    assert status == 200
-    new_list = data["data"]
-
-    items = [item["id"] for item in new_list]
+    items = [item.id for item in new_list]
 
     assert set(items) == {item2}
 
@@ -144,36 +109,23 @@ def test_add_objects_to_different_lists(user, public_candidate, public_candidate
     token_id = create_token(
         ACLs=["Upload data"], user_id=user.id, name=str(uuid.uuid4())
     )
+    sp = client(token_id)
 
     list1 = str(uuid.uuid4())
 
-    status, data = api(
-        "POST",
-        "listing",
-        data={"user_id": user.id, "obj_id": public_candidate.id, "list_name": list1},
-        token=token_id,
-    )
-
-    assert status == 200
-    item1 = data["data"]["id"]  # get the list item ID
+    item1 = sp.post_listing(
+        ListingPost(user_id=user.id, obj_id=public_candidate.id, list_name=list1)
+    ).id  # get the list item ID
 
     list2 = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "listing",
-        data={"user_id": user.id, "obj_id": public_candidate2.id, "list_name": list2},
-        token=token_id,
+    sp.post_listing(
+        ListingPost(user_id=user.id, obj_id=public_candidate2.id, list_name=list2)
     )
 
-    assert status == 200
-
     # get the list back, should include only one item that matches list1
-    status, data = api("GET", f"listing/{user.id}?listName={list1}", token=token_id)
+    new_list = sp.fetch_listings(user_id=user.id, list_name=list1)
 
-    assert status == 200
-    new_list = data["data"]
-
-    items = [item["id"] for item in new_list]
+    items = [item.id for item in new_list]
 
     assert set(items) == {item1}
 
@@ -182,63 +134,41 @@ def test_patching_listing(user, user2, public_candidate, public_candidate2):
     token_id = create_token(
         ACLs=["Upload data"], user_id=user.id, name=str(uuid.uuid4())
     )
+    sp = client(token_id)
 
     list1 = str(uuid.uuid4())
 
-    status, data = api(
-        "POST",
-        "listing",
-        data={"user_id": user.id, "obj_id": public_candidate.id, "list_name": list1},
-        token=token_id,
-    )
+    item1 = sp.post_listing(
+        ListingPost(user_id=user.id, obj_id=public_candidate.id, list_name=list1)
+    ).id  # get the list item ID
 
-    assert status == 200
-    item1 = data["data"]["id"]  # get the list item ID
-
-    status, data = api(
-        "POST",
-        "listing",
-        data={"user_id": user.id, "obj_id": public_candidate2.id, "list_name": list1},
-        token=token_id,
-    )
-
-    assert status == 200
-    item2 = data["data"]["id"]  # get the list item ID
+    item2 = sp.post_listing(
+        ListingPost(user_id=user.id, obj_id=public_candidate2.id, list_name=list1)
+    ).id  # get the list item ID
 
     list2 = str(uuid.uuid4())
-    status, data = api(
-        "PATCH",
-        f"listing/{item2}",
-        data={"user_id": user.id, "obj_id": public_candidate2.id, "list_name": list2},
-        token=token_id,
+    sp.update_listing(
+        item2, user_id=user.id, obj_id=public_candidate2.id, list_name=list2
     )
 
-    assert status == 200
-
     # get the list back, should include only one item that matches list2
-    status, data = api("GET", f"listing/{user.id}?listName={list2}", token=token_id)
-    print(data["data"])
-    assert status == 200
-    new_list = data["data"]
+    new_list = sp.fetch_listings(user_id=user.id, list_name=list2)
+    print(new_list)
 
     assert len(new_list) == 1
 
-    assert new_list[0]["id"] == item2  # the listing ID is the same
+    assert new_list[0].id == item2  # the listing ID is the same
 
-    assert new_list[0]["user_id"] == user.id  # user stays the same
-    assert new_list[0]["obj_id"] == public_candidate2.id  # obj id is new
-    assert new_list[0]["list_name"] == list2  # list name is new
+    assert new_list[0].user_id == user.id  # user stays the same
+    assert new_list[0].obj_id == public_candidate2.id  # obj id is new
+    assert new_list[0].list_name == list2  # list name is new
 
     # try to patch with an invalid user id
-    status, data = api(
-        "PATCH",
-        f"listing/{item1}",
-        data={"user_id": user2.id, "obj_id": public_candidate2.id, "list_name": list2},
-        token=token_id,
-    )
-
-    assert status == 400
-    assert "Insufficient permission" in data["message"]
+    with pytest.raises(SkyPortalError, match="Insufficient permission") as err:
+        sp.update_listing(
+            item1, user_id=user2.id, obj_id=public_candidate2.id, list_name=list2
+        )
+    assert err.value.status_code == 400
 
 
 def test_listings_user_permissions(
@@ -250,177 +180,119 @@ def test_listings_user_permissions(
     public_candidate,
     public_candidate2,
 ):
-    status, data = api(
-        "POST",
-        "listing",
-        data={
-            "user_id": user.id,
-            "obj_id": public_candidate.id,
-            "list_name": "favorites",
-        },
-        token=upload_data_token,
-    )
+    sp = client(upload_data_token)
+    sp_admin = client(super_admin_token)
 
-    assert_api(status, data)
-    item1 = data["data"]["id"]  # get the list item ID
+    item1 = sp.post_listing(
+        ListingPost(
+            user_id=user.id,
+            obj_id=public_candidate.id,
+            list_name="favorites",
+        )
+    ).id  # get the list item ID
 
     # try to transfer ownership to a different user
-    status, data = api(
-        "PATCH",
-        f"listing/{item1}",
-        data={
-            "user_id": user2.id,
-            "obj_id": public_candidate.id,
-            "list_name": "favorites",
-        },
-        token=upload_data_token,
-    )
-
-    assert_api_fail(status, data, 400, "Insufficient permissions")
+    with pytest.raises(SkyPortalError, match="Insufficient permissions") as err:
+        sp.update_listing(
+            item1,
+            user_id=user2.id,
+            obj_id=public_candidate.id,
+            list_name="favorites",
+        )
+    assert err.value.status_code == 400
 
     # try to post to a different user
-    status, data = api(
-        "POST",
-        "listing",
-        data={
-            "user_id": user2.id,
-            "obj_id": public_candidate.id,
-            "list_name": "favorites",
-        },
-        token=upload_data_token,
-    )
-    assert_api_fail(
-        status, data, 400, "Only admins can add listings to other users' accounts"
-    )
+    with pytest.raises(
+        SkyPortalError, match="Only admins can add listings to other users' accounts"
+    ) as err:
+        sp.post_listing(
+            ListingPost(
+                user_id=user2.id,
+                obj_id=public_candidate.id,
+                list_name="favorites",
+            )
+        )
+    assert err.value.status_code == 400
 
     # try to add this to a different user, but with super admin privileges
-    status, data = api(
-        "PATCH",
-        f"listing/{item1}",
-        data={
-            "user_id": user2.id,
-            "obj_id": public_candidate.id,
-            "list_name": "favorites",
-        },
-        token=super_admin_token,
+    sp_admin.update_listing(
+        item1,
+        user_id=user2.id,
+        obj_id=public_candidate.id,
+        list_name="favorites",
     )
-
-    assert_api(status, data)
 
     # get the list back, should include only one item that matches user2
-    status, data = api(
-        "GET", f"listing/{user2.id}?listName=favorites", token=super_admin_token
-    )
-
-    assert_api(status, data)
-    new_list = data["data"]
+    new_list = sp_admin.fetch_listings(user_id=user2.id, list_name="favorites")
 
     assert len(new_list) == 1
-    assert new_list[0]["id"] == item1  # the listing ID is the same
-    assert new_list[0]["obj_id"] == public_candidate.id  # obj stays the same
+    assert new_list[0].id == item1  # the listing ID is the same
+    assert new_list[0].obj_id == public_candidate.id  # obj stays the same
 
     # try to patch with only partial data inputs
     # bring this listing back to first user with super token permission
-    status, data = api(
-        "PATCH",
-        f"listing/{item1}",
-        data={"user_id": user.id},
-        token=super_admin_token,
-    )
-
-    assert_api(status, data)
+    sp_admin.update_listing(item1, user_id=user.id)
 
     # change the object id only
-    status, data = api(
-        "PATCH",
-        f"listing/{item1}",
-        data={"obj_id": public_candidate2.id},
-        token=upload_data_token,
-    )
-
-    assert_api(status, data)
+    sp.update_listing(item1, obj_id=public_candidate2.id)
 
     # change the list name only
-    status, data = api(
-        "PATCH",
-        f"listing/{item1}",
-        data={"list_name": "new_listing"},
-        token=upload_data_token,
-    )
-
-    assert_api(status, data)
+    sp.update_listing(item1, list_name="new_listing")
 
     # get the list back, should include only one item that matches user2
-    status, data = api(
-        "GET", f"listing/{user.id}?listName=new_listing", token=super_admin_token
-    )
-
-    assert_api(status, data)
-    new_list = data["data"]
+    new_list = sp_admin.fetch_listings(user_id=user.id, list_name="new_listing")
 
     assert len(new_list) == 1
-    assert new_list[0]["id"] == item1  # the listing ID is the same
-    assert new_list[0]["obj_id"] == public_candidate2.id  # obj was updated
-    assert new_list[0]["user_id"] == user.id  # user was returned to original
-    assert new_list[0]["list_name"] == "new_listing"  # new listing name
+    assert new_list[0].id == item1  # the listing ID is the same
+    assert new_list[0].obj_id == public_candidate2.id  # obj was updated
+    assert new_list[0].user_id == user.id  # user was returned to original
+    assert new_list[0].list_name == "new_listing"  # new listing name
 
 
 def test_invalid_listing_name_fails(user, upload_data_token, public_candidate):
+    sp = client(upload_data_token)
+
     # we cannot post a listing with an empty string
-    status, data = api(
-        "POST",
-        "listing",
-        data={"user_id": user.id, "obj_id": public_candidate.id, "list_name": ""},
-        token=upload_data_token,
-    )
-
-    assert status == 400
-    assert "must begin with alphanumeric/underscore" in data["message"]
+    with pytest.raises(
+        SkyPortalError, match="must begin with alphanumeric/underscore"
+    ) as err:
+        sp.post_listing(
+            ListingPost(user_id=user.id, obj_id=public_candidate.id, list_name="")
+        )
+    assert err.value.status_code == 400
 
     # we cannot post a listing with a non-alphanumeric first letter
-    status, data = api(
-        "POST",
-        "listing",
-        data={"user_id": user.id, "obj_id": public_candidate.id, "list_name": " "},
-        token=upload_data_token,
-    )
-
-    assert status == 400
-    assert "must begin with alphanumeric/underscore" in data["message"]
+    with pytest.raises(
+        SkyPortalError, match="must begin with alphanumeric/underscore"
+    ) as err:
+        sp.post_listing(
+            ListingPost(user_id=user.id, obj_id=public_candidate.id, list_name=" ")
+        )
+    assert err.value.status_code == 400
 
     # we cannot post a listing with a non-alphanumeric first letter
-    status, data = api(
-        "POST",
-        "listing",
-        data={"user_id": user.id, "obj_id": public_candidate.id, "list_name": "-"},
-        token=upload_data_token,
-    )
-
-    assert status == 400
-    assert "must begin with alphanumeric/underscore" in data["message"]
+    with pytest.raises(
+        SkyPortalError, match="must begin with alphanumeric/underscore"
+    ) as err:
+        sp.post_listing(
+            ListingPost(user_id=user.id, obj_id=public_candidate.id, list_name="-")
+        )
+    assert err.value.status_code == 400
 
     # this is ok
-    status, data = api(
-        "POST",
-        "listing",
-        data={
-            "user_id": user.id,
-            "obj_id": public_candidate.id,
-            "list_name": "favorites",
-        },
-        token=upload_data_token,
-    )
-
-    assert status == 200
-    listing_id = data["data"]["id"]
+    listing_id = sp.post_listing(
+        ListingPost(
+            user_id=user.id,
+            obj_id=public_candidate.id,
+            list_name="favorites",
+        )
+    ).id
 
     # we cannot post a listing with a non-alphanumeric first letter
-    status, data = api(
-        "PATCH",
-        f"listing/{listing_id}",
-        data={"user_id": user.id, "obj_id": public_candidate.id, "list_name": ""},
-        token=upload_data_token,
-    )
-
-    assert status == 400
-    assert "must begin with alphanumeric/underscore" in data["message"]
+    with pytest.raises(
+        SkyPortalError, match="must begin with alphanumeric/underscore"
+    ) as err:
+        sp.update_listing(
+            listing_id, user_id=user.id, obj_id=public_candidate.id, list_name=""
+        )
+    assert err.value.status_code == 400

--- a/skyportal/tests/api_tests/groups_users_analysis/test_mmadetector.py
+++ b/skyportal/tests/api_tests/groups_users_analysis/test_mmadetector.py
@@ -2,138 +2,109 @@ import os
 import uuid
 
 import numpy as np
+import pytest
 from astropy.time import Time
+from skyportal_py import SkyPortalError
+from skyportal_py.mmadetectors import MMADetectorPost, MMADetectorSpectrumPost
 
-from skyportal.tests import api
+from skyportal.tests import client
 
 
 def test_token_user_post_get_mmadetector(super_admin_token):
+    sp = client(super_admin_token)
     name = str(uuid.uuid4())
-    post_data = {
-        "name": name,
-        "nickname": name,
-        "type": "gravitational-wave",
-        "fixed_location": True,
-        "lat": 0.0,
-        "lon": 0.0,
-    }
+    post_data = MMADetectorPost(
+        name=name,
+        nickname=name,
+        type="gravitational-wave",
+        fixed_location=True,
+        lat=0.0,
+        lon=0.0,
+    )
 
-    status, data = api("POST", "mmadetector", data=post_data, token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
+    mmadetector_id = sp.post_mmadetector(post_data).id
 
-    mmadetector_id = data["data"]["id"]
-    status, data = api("GET", f"mmadetector/{mmadetector_id}", token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-    for key in post_data:
-        assert data["data"][key] == post_data[key]
+    fetched = sp.fetch_mmadetector(mmadetector_id)
+    for key, value in post_data.model_dump(exclude_none=True).items():
+        assert getattr(fetched, key) == value
 
 
 def test_fetch_mmadetector_by_name(super_admin_token):
+    sp = client(super_admin_token)
     name = str(uuid.uuid4())
-    post_data = {
-        "name": name,
-        "nickname": name,
-        "type": "gravitational-wave",
-        "fixed_location": True,
-        "lat": 0.0,
-        "lon": 0.0,
-    }
+    post_data = MMADetectorPost(
+        name=name,
+        nickname=name,
+        type="gravitational-wave",
+        fixed_location=True,
+        lat=0.0,
+        lon=0.0,
+    )
 
-    status, data = api("POST", "mmadetector", data=post_data, token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
+    sp.post_mmadetector(post_data)
 
-    status, data = api("GET", f"mmadetector?name={name}", token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]) == 1
-    for key in post_data:
-        assert data["data"][0][key] == post_data[key]
+    matches = sp.fetch_mmadetectors(name=name)
+    assert len(matches) == 1
+    for key, value in post_data.model_dump(exclude_none=True).items():
+        assert getattr(matches[0], key) == value
 
 
 def test_token_user_update_mmadetector(super_admin_token):
+    sp = client(super_admin_token)
     name = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "mmadetector",
-        data={
-            "name": name,
-            "nickname": name,
-            "type": "gravitational-wave",
-            "fixed_location": True,
-            "lat": 0.0,
-            "lon": 0.0,
-        },
-        token=super_admin_token,
+    mmadetector_id = sp.post_mmadetector(
+        MMADetectorPost(
+            name=name,
+            nickname=name,
+            type="gravitational-wave",
+            fixed_location=True,
+            lat=0.0,
+            lon=0.0,
+        )
+    ).id
+
+    assert sp.fetch_mmadetector(mmadetector_id).lon == 0.0
+
+    sp.update_mmadetector(
+        mmadetector_id,
+        name=name,
+        nickname=name,
+        type="neutrino",
+        fixed_location=True,
+        lat=0.0,
+        lon=20.0,
     )
-    assert status == 200
-    assert data["status"] == "success"
 
-    mmadetector_id = data["data"]["id"]
-    status, data = api("GET", f"mmadetector/{mmadetector_id}", token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-    assert data["data"]["lon"] == 0.0
-
-    status, data = api(
-        "PATCH",
-        f"mmadetector/{mmadetector_id}",
-        data={
-            "name": name,
-            "nickname": name,
-            "type": "neutrino",
-            "fixed_location": True,
-            "lat": 0.0,
-            "lon": 20.0,
-        },
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-
-    status, data = api("GET", f"mmadetector/{mmadetector_id}", token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-    assert data["data"]["lon"] == 20.0
-    assert data["data"]["type"] == "neutrino"
+    fetched = sp.fetch_mmadetector(mmadetector_id)
+    assert fetched.lon == 20.0
+    assert fetched.type == "neutrino"
 
 
 def test_token_user_delete_mmadetector(super_admin_token):
+    sp = client(super_admin_token)
     name = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "mmadetector",
-        data={
-            "name": name,
-            "nickname": name,
-            "type": "gravitational-wave",
-            "fixed_location": True,
-            "lat": 0.0,
-            "lon": 0.0,
-        },
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    mmadetector_id = sp.post_mmadetector(
+        MMADetectorPost(
+            name=name,
+            nickname=name,
+            type="gravitational-wave",
+            fixed_location=True,
+            lat=0.0,
+            lon=0.0,
+        )
+    ).id
 
-    mmadetector_id = data["data"]["id"]
-    status, data = api("GET", f"mmadetector/{mmadetector_id}", token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
+    sp.fetch_mmadetector(mmadetector_id)
 
-    status, data = api(
-        "DELETE", f"mmadetector/{mmadetector_id}", token=super_admin_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp.delete_mmadetector(mmadetector_id)
 
-    status, data = api("GET", f"mmadetector/{mmadetector_id}", token=super_admin_token)
-    assert status == 400
+    with pytest.raises(SkyPortalError) as err:
+        sp.fetch_mmadetector(mmadetector_id)
+    assert err.value.status_code == 400
 
 
 def test_mmadetector_spectrum(super_admin_token):
+    sp = client(super_admin_token)
     datafile = f"{os.path.dirname(__file__)}/../../data/aligo_O4high_noise_spectrum.txt"
     data_out = np.loadtxt(datafile)
     frequencies = data_out[:, 0]
@@ -143,76 +114,50 @@ def test_mmadetector_spectrum(super_admin_token):
     end_time = Time("2024-06-01T00:00:00", format="isot")
 
     name = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "mmadetector",
-        data={
-            "name": name,
-            "nickname": name,
-            "type": "gravitational-wave",
-            "fixed_location": True,
-            "lat": 0.0,
-            "lon": 0.0,
-        },
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    detector_id = sp.post_mmadetector(
+        MMADetectorPost(
+            name=name,
+            nickname=name,
+            type="gravitational-wave",
+            fixed_location=True,
+            lat=0.0,
+            lon=0.0,
+        )
+    ).id
 
-    detector_id = data["data"]["id"]
+    spectrum_id = sp.post_mmadetector_spectrum(
+        MMADetectorSpectrumPost(
+            frequencies=frequencies.tolist(),
+            amplitudes=amplitudes.tolist(),
+            start_time=start_time.isot,
+            end_time=end_time.isot,
+            detector_id=detector_id,
+        )
+    ).id
 
-    data = {
-        "frequencies": frequencies.tolist(),
-        "amplitudes": amplitudes.tolist(),
-        "start_time": start_time.isot,
-        "end_time": end_time.isot,
-        "detector_id": detector_id,
-    }
+    spectrum = sp.fetch_mmadetector_spectrum(spectrum_id)
 
-    status, data = api(
-        "POST",
-        "mmadetector/spectra",
-        data=data,
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    spectrum_id = data["data"]["id"]
+    assert np.array_equal(frequencies, spectrum.frequencies)
+    assert np.array_equal(amplitudes, spectrum.amplitudes)
+    assert start_time == Time(spectrum.start_time)
+    assert end_time == Time(spectrum.end_time)
 
-    status, data = api(
-        "GET", f"mmadetector/spectra/{spectrum_id}", token=super_admin_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    spectrum = sp.fetch_mmadetector_spectra()[0]
 
-    assert np.array_equal(frequencies, data["data"]["frequencies"])
-    assert np.array_equal(amplitudes, data["data"]["amplitudes"])
-    assert start_time == Time(data["data"]["start_time"], format="isot")
-    assert end_time == Time(data["data"]["end_time"], format="isot")
+    assert np.array_equal(frequencies, spectrum.frequencies)
+    assert np.array_equal(amplitudes, spectrum.amplitudes)
+    assert start_time == Time(spectrum.start_time)
+    assert end_time == Time(spectrum.end_time)
 
-    status, data = api("GET", "mmadetector/spectra", token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-    data = data["data"][0]
+    sp.delete_mmadetector_spectrum(spectrum_id)
 
-    assert np.array_equal(frequencies, data["frequencies"])
-    assert np.array_equal(amplitudes, data["amplitudes"])
-    assert start_time == Time(data["start_time"], format="isot")
-    assert end_time == Time(data["end_time"], format="isot")
-
-    status, data = api(
-        "DELETE", f"mmadetector/spectra/{spectrum_id}", token=super_admin_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
-
-    status, data = api(
-        "GET", f"mmadetector/spectra/{spectrum_id}", token=super_admin_token
-    )
-    assert status == 403
+    with pytest.raises(SkyPortalError) as err:
+        sp.fetch_mmadetector_spectrum(spectrum_id)
+    assert err.value.status_code == 403
 
 
 def test_mmadetector_time_intervals(super_admin_token):
+    sp = client(super_admin_token)
     datafile = f"{os.path.dirname(__file__)}/../../data/H1L1_O3_time_intervals.txt"
     data_out = np.loadtxt(datafile)
     time_intervals = []
@@ -227,90 +172,43 @@ def test_mmadetector_time_intervals(super_admin_token):
     test_time_interval_2 = [seg.replace(".000", "") for seg in test_time_interval_2]
 
     name = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "mmadetector",
-        data={
-            "name": name,
-            "nickname": name,
-            "type": "gravitational-wave",
-            "fixed_location": True,
-            "lat": 0.0,
-            "lon": 0.0,
-        },
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    detector_id = sp.post_mmadetector(
+        MMADetectorPost(
+            name=name,
+            nickname=name,
+            type="gravitational-wave",
+            fixed_location=True,
+            lat=0.0,
+            lon=0.0,
+        )
+    ).id
 
-    detector_id = data["data"]["id"]
-
-    data = {
-        "time_intervals": time_intervals,
-        "detector_id": detector_id,
-    }
-
-    status, data = api(
-        "POST",
-        "mmadetector/time_intervals",
-        data=data,
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    time_interval_ids = data["data"]["ids"]
+    time_interval_ids = sp.post_mmadetector_time_intervals(
+        detector_id, time_intervals
+    ).ids
 
     time_interval_id = time_interval_ids[0]
-    status, data = api(
-        "GET", f"mmadetector/time_intervals/{time_interval_id}", token=super_admin_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    assert data["data"]["time_interval"] == test_time_interval
+    interval = sp.fetch_mmadetector_time_interval(time_interval_id)
+    assert [t.isoformat() for t in interval.time_interval] == test_time_interval
 
-    params = {"detectorIDs": [detector_id]}
-    status, data = api(
-        "GET", "mmadetector/time_intervals", params=params, token=super_admin_token
+    intervals = sp.fetch_mmadetector_time_intervals(detector_ids=[detector_id])
+    assert any(
+        [t.isoformat() for t in seg.time_interval] == test_time_interval
+        for seg in intervals
     )
-    assert status == 200
-    assert data["status"] == "success"
-    assert any(seg["time_interval"] == test_time_interval for seg in data["data"])
-    assert all(seg["id"] in time_interval_ids for seg in data["data"])
+    assert all(seg.id in time_interval_ids for seg in intervals)
 
-    data = {
-        "time_interval": time_intervals[1],
-        "detector_id": detector_id,
-    }
-
-    status, data = api(
-        "PATCH",
-        f"mmadetector/time_intervals/{time_interval_id}",
-        data=data,
-        token=super_admin_token,
+    sp.update_mmadetector_time_interval(
+        time_interval_id, time_interval=time_intervals[1]
     )
-    assert status == 200
-    assert data["status"] == "success"
 
     time_interval_id = time_interval_ids[0]
-    status, data = api(
-        "GET", f"mmadetector/time_intervals/{time_interval_id}", token=super_admin_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    assert data["data"]["time_interval"] == test_time_interval_2
+    interval = sp.fetch_mmadetector_time_interval(time_interval_id)
+    assert [t.isoformat() for t in interval.time_interval] == test_time_interval_2
 
     for time_interval_id in time_interval_ids:
-        status, data = api(
-            "DELETE",
-            f"mmadetector/time_intervals/{time_interval_id}",
-            token=super_admin_token,
-        )
-        assert status == 200
-        assert data["status"] == "success"
+        sp.delete_mmadetector_time_interval(time_interval_id)
 
-        status, data = api(
-            "GET",
-            f"mmadetector/time_intervals/{time_interval_id}",
-            token=super_admin_token,
-        )
-        assert status == 403
+        with pytest.raises(SkyPortalError) as err:
+            sp.fetch_mmadetector_time_interval(time_interval_id)
+        assert err.value.status_code == 403

--- a/skyportal/tests/api_tests/groups_users_analysis/test_newsfeed.py
+++ b/skyportal/tests/api_tests/groups_users_analysis/test_newsfeed.py
@@ -1,38 +1,35 @@
 import uuid
 
-from skyportal.tests import api
+import pytest
+from skyportal_py import SkyPortalError
+from skyportal_py.sources import SourcePost
+
+from skyportal.tests import client
 
 
 def test_retrieve_newsfeed(view_only_token, public_group, upload_data_token):
     obj_id = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id,
-            "ra": 235.22,
-            "dec": -23.33,
-            "redshift": 3,
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    client(upload_data_token).post_source(
+        SourcePost(
+            id=obj_id,
+            ra=235.22,
+            dec=-23.33,
+            redshift=3,
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
 
-    params = {"numItems": 1000}
-    status, data = api("GET", "newsfeed", token=view_only_token, params=params)
-
-    assert status == 200
-    data = data["data"]
-    assert any(d["type"] == "source" for d in data)
-    assert any(d["message"] == "New source saved" for d in data)
-    assert any(d["source_id"] == obj_id for d in data)
+    items = client(view_only_token).fetch_news_feed(num_items=1000)
+    assert any(d.type == "source" for d in items)
+    assert any(d.message == "New source saved" for d in items)
+    assert any(d.source_id == obj_id for d in items)
 
 
 def test_fail_newsfeed_request_too_many(
     view_only_token,
 ):
-    params = {"numItems": 1001}
-    status, data = api("GET", "newsfeed", token=view_only_token, params=params)
-    assert status == 400
-    assert data["message"] == "numItems should be no larger than 1000."
+    with pytest.raises(
+        SkyPortalError, match="numItems should be no larger than 1000"
+    ) as err:
+        client(view_only_token).fetch_news_feed(num_items=1001)
+    assert err.value.status_code == 400

--- a/skyportal/tests/api_tests/groups_users_analysis/test_observation_plan.py
+++ b/skyportal/tests/api_tests/groups_users_analysis/test_observation_plan.py
@@ -3,8 +3,12 @@ import uuid
 
 import numpy as np
 from astropy.table import Table
+from skyportal_py import SkyPortalError
+from skyportal_py.allocations import AllocationPost
+from skyportal_py.galaxies import GalaxyCatalogPost
+from skyportal_py.observation_plans import ObservationPlanPost
 
-from skyportal.tests import api, retry_until
+from skyportal.tests import client, retry_until
 from skyportal.tests.external.test_moving_objects import (
     add_telescope_and_instrument,
     remove_telescope_and_instrument,
@@ -12,6 +16,7 @@ from skyportal.tests.external.test_moving_objects import (
 
 
 def test_observation_plan_tiling(super_admin_token, public_group, gcn_GW190814):
+    sp = client(super_admin_token)
     dateobs = gcn_GW190814.dateobs.strftime("%Y-%m-%dT%H:%M:%S")
     gcnevent_id = gcn_GW190814.id
     localization_id = gcn_GW190814.localizations[0].id
@@ -20,32 +25,29 @@ def test_observation_plan_tiling(super_admin_token, public_group, gcn_GW190814):
         "ZTF", super_admin_token, list(range(200, 250))
     )
 
-    request_data = {
-        "group_id": public_group.id,
-        "instrument_id": instrument_id,
-        "pi": "Shri Kulkarni",
-        "hours_allocated": 200,
-        "validity_ranges": [
-            {
-                "start_date": "2021-02-27T00:00:00.000Z",
-                "end_date": "3021-07-20T00:00:00.000Z",
-            }
-        ],
-        "proposal_id": "COO-2020A-P01",
-        "types": ["observation_plan"],
-    }
-
-    status, data = api("POST", "allocation", data=request_data, token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-    allocation_id = data["data"]["id"]
+    allocation_id = sp.post_allocation(
+        AllocationPost(
+            group_id=public_group.id,
+            instrument_id=instrument_id,
+            pi="Shri Kulkarni",
+            hours_allocated=200,
+            validity_ranges=[
+                {
+                    "start_date": "2021-02-27T00:00:00.000Z",
+                    "end_date": "3021-07-20T00:00:00.000Z",
+                }
+            ],
+            proposal_id="COO-2020A-P01",
+            types=["observation_plan"],
+        )
+    ).id
 
     requests_data = [
-        {
-            "allocation_id": allocation_id,
-            "gcnevent_id": gcnevent_id,
-            "localization_id": localization_id,
-            "payload": {
+        ObservationPlanPost(
+            allocation_id=allocation_id,
+            gcnevent_id=gcnevent_id,
+            localization_id=localization_id,
+            payload={
                 "start_date": "2020-07-16 01:01:01",
                 "end_date": "2020-07-17 01:01:01",
                 "filter_strategy": "block",
@@ -61,96 +63,73 @@ def test_observation_plan_tiling(super_admin_token, public_group, gcn_GW190814):
                 "subprogram_name": "GRB",
                 "galactic_latitude": 10,
             },
-        }
+        )
         for _ in range(2)
     ]
 
     for request_data in requests_data:
-        status, data = api(
-            "POST", "observation_plan", data=request_data, token=super_admin_token
-        )
-        assert status == 200
-        assert data["status"] == "success"
+        sp.post_observation_plan(request_data)
 
     def plans_ready():
-        status, data = api(
-            "GET",
-            "observation_plan",
-            params={
-                "includePlannedObservations": "true",
-                "dateobs": dateobs,
-                "instrumentID": instrument_id,
-            },
-            token=super_admin_token,
+        page = sp.fetch_observation_plans(
+            include_planned_observations=True,
+            dateobs=dateobs,
+            instrument_id=instrument_id,
         )
-        assert status == 200
-        assert data["status"] == "success"
 
         # get those which have been created on the right event
         requests = [
             d
-            for d in data["data"]["requests"]
-            if d["gcnevent_id"] == gcnevent_id and d["allocation_id"] == allocation_id
+            for d in page.requests
+            if d.gcnevent_id == gcnevent_id and d.allocation_id == allocation_id
         ]
         assert len(requests) == len(requests_data)
         for d in requests:
             assert any(
-                d["payload"] == request_data["payload"]
-                for request_data in requests_data
+                d.payload == request_data.payload for request_data in requests_data
             )
-            observation_plans = d["observation_plans"]
+            observation_plans = d.observation_plans
             assert len(observation_plans) == 1
             observation_plan = observation_plans[0]
 
             assert any(
-                observation_plan["plan_name"] == request_data["payload"]["queue_name"]
+                observation_plan.plan_name == request_data.payload["queue_name"]
                 for request_data in requests_data
             )
             assert any(
-                observation_plan["validity_window_start"]
-                == request_data["payload"]["start_date"].replace(" ", "T")
+                observation_plan.validity_window_start.isoformat()
+                == request_data.payload["start_date"].replace(" ", "T")
                 for request_data in requests_data
             )
             assert any(
-                observation_plan["validity_window_end"]
-                == request_data["payload"]["end_date"].replace(" ", "T")
+                observation_plan.validity_window_end.isoformat()
+                == request_data.payload["end_date"].replace(" ", "T")
                 for request_data in requests_data
             )
 
-            planned_observations = observation_plan["planned_observations"]
+            planned_observations = observation_plan.planned_observations
 
             assert all(
-                obs["filt"] == requests_data[0]["payload"]["filters"]
+                obs.filt == requests_data[0].payload["filters"]
                 for obs in planned_observations
             )
             assert all(
-                obs["exposure_time"]
-                == int(requests_data[0]["payload"]["exposure_time"])
+                obs.exposure_time == int(requests_data[0].payload["exposure_time"])
                 for obs in planned_observations
             )
-        return [d["id"] for d in requests]
+        return [d.id for d in requests]
 
     request_ids = retry_until(plans_ready, timeout=60)
 
     # exercise the (async) delete path: DELETE each request and verify it is gone
     for request_id in request_ids:
-        status, data = api(
-            "DELETE", f"observation_plan/{request_id}", token=super_admin_token
-        )
-        assert status == 200, data
-        assert data["status"] == "success"
+        sp.delete_observation_plan(request_id)
 
-    status, data = api(
-        "GET",
-        "observation_plan",
-        params={"dateobs": dateobs, "instrumentID": instrument_id},
-        token=super_admin_token,
-    )
-    assert status == 200
+    page = sp.fetch_observation_plans(dateobs=dateobs, instrument_id=instrument_id)
     remaining = [
         d
-        for d in data["data"]["requests"]
-        if d["gcnevent_id"] == gcnevent_id and d["allocation_id"] == allocation_id
+        for d in page.requests
+        if d.gcnevent_id == gcnevent_id and d.allocation_id == allocation_id
     ]
     assert len(remaining) == 0
 
@@ -159,6 +138,7 @@ def test_observation_plan_tiling(super_admin_token, public_group, gcn_GW190814):
 
 def test_observation_plan_combined(super_admin_token, public_group, gcn_GW190814):
     """Exercise the combined (submit_multiple) plan-generation path and delete."""
+    sp = client(super_admin_token)
     dateobs = gcn_GW190814.dateobs.strftime("%Y-%m-%dT%H:%M:%S")
     gcnevent_id = gcn_GW190814.id
     localization_id = gcn_GW190814.localizations[0].id
@@ -167,34 +147,29 @@ def test_observation_plan_combined(super_admin_token, public_group, gcn_GW190814
         "ZTF", super_admin_token, list(range(200, 250))
     )
 
-    allocation_data = {
-        "group_id": public_group.id,
-        "instrument_id": instrument_id,
-        "pi": "Shri Kulkarni",
-        "hours_allocated": 200,
-        "validity_ranges": [
-            {
-                "start_date": "2021-02-27T00:00:00.000Z",
-                "end_date": "3021-07-20T00:00:00.000Z",
-            }
-        ],
-        "proposal_id": "COO-2020A-P01",
-        "types": ["observation_plan"],
-    }
-
-    status, data = api(
-        "POST", "allocation", data=allocation_data, token=super_admin_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    allocation_id = data["data"]["id"]
+    allocation_id = sp.post_allocation(
+        AllocationPost(
+            group_id=public_group.id,
+            instrument_id=instrument_id,
+            pi="Shri Kulkarni",
+            hours_allocated=200,
+            validity_ranges=[
+                {
+                    "start_date": "2021-02-27T00:00:00.000Z",
+                    "end_date": "3021-07-20T00:00:00.000Z",
+                }
+            ],
+            proposal_id="COO-2020A-P01",
+            types=["observation_plan"],
+        )
+    ).id
 
     observation_plans = [
-        {
-            "allocation_id": allocation_id,
-            "gcnevent_id": gcnevent_id,
-            "localization_id": localization_id,
-            "payload": {
+        ObservationPlanPost(
+            allocation_id=allocation_id,
+            gcnevent_id=gcnevent_id,
+            localization_id=localization_id,
+            payload={
                 "start_date": "2020-07-16 01:01:01",
                 "end_date": "2020-07-17 01:01:01",
                 "filter_strategy": "block",
@@ -210,56 +185,38 @@ def test_observation_plan_combined(super_admin_token, public_group, gcn_GW190814
                 "subprogram_name": "GRB",
                 "galactic_latitude": 10,
             },
-        }
+        )
         for _ in range(2)
     ]
 
     # combine_plans=True groups the requests so the queue calls submit_multiple
-    status, data = api(
-        "POST",
-        "observation_plan",
-        data={"observation_plans": observation_plans, "combine_plans": True},
-        token=super_admin_token,
-    )
-    assert status == 200, data
-    assert data["status"] == "success"
+    sp.post_observation_plans(observation_plans, combine_plans=True)
 
     def combined_plans_ready():
-        status, data = api(
-            "GET",
-            "observation_plan",
-            params={
-                "includePlannedObservations": "true",
-                "dateobs": dateobs,
-                "instrumentID": instrument_id,
-            },
-            token=super_admin_token,
+        page = sp.fetch_observation_plans(
+            include_planned_observations=True,
+            dateobs=dateobs,
+            instrument_id=instrument_id,
         )
-        assert status == 200
-        assert data["status"] == "success"
 
         requests = [
             d
-            for d in data["data"]["requests"]
-            if d["gcnevent_id"] == gcnevent_id and d["allocation_id"] == allocation_id
+            for d in page.requests
+            if d.gcnevent_id == gcnevent_id and d.allocation_id == allocation_id
         ]
         assert len(requests) == len(observation_plans)
         # every request should be combined (share a combined_id) and complete
-        assert all(d["combined_id"] is not None for d in requests)
-        assert all(d["status"] == "complete" for d in requests)
+        assert all(d.combined_id is not None for d in requests)
+        assert all(d.status == "complete" for d in requests)
         for d in requests:
-            assert len(d["observation_plans"]) == 1
-        return [d["id"] for d in requests]
+            assert len(d.observation_plans) == 1
+        return [d.id for d in requests]
 
     request_ids = retry_until(combined_plans_ready, timeout=60)
 
     # exercise the (async) delete path on the combined requests
     for request_id in request_ids:
-        status, data = api(
-            "DELETE", f"observation_plan/{request_id}", token=super_admin_token
-        )
-        assert status == 200, data
-        assert data["status"] == "success"
+        sp.delete_observation_plan(request_id)
 
     remove_telescope_and_instrument(telescope_id, instrument_id, super_admin_token)
 
@@ -267,75 +224,67 @@ def test_observation_plan_combined(super_admin_token, public_group, gcn_GW190814
 def test_observation_plan_galaxy(
     super_admin_token, view_only_token, public_group, gcn_GW190814
 ):
+    sp = client(super_admin_token)
     gcnevent_id = gcn_GW190814.id
     localization_id = gcn_GW190814.localizations[0].id
 
     catalog_name = "test_galaxy_catalog"
     # in case the catalog already exists, delete it.
-    status, data = api(
-        "DELETE", f"galaxy_catalog/{catalog_name}", token=super_admin_token
-    )
+    try:
+        sp.delete_galaxy_catalog(catalog_name)
+    except SkyPortalError:
+        pass
 
     datafile = f"{os.path.dirname(__file__)}/../../../../data/CLU_mini.hdf5"
-    data = {
-        "catalog_name": catalog_name,
-        "catalog_data": Table.read(datafile)
-        .to_pandas()
-        .replace({np.nan: None})
-        .to_dict(orient="list"),
-    }
-
-    status, data = api("POST", "galaxy_catalog", data=data, token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
+    sp.post_galaxy_catalog(
+        GalaxyCatalogPost(
+            catalog_name=catalog_name,
+            catalog_data=Table.read(datafile)
+            .to_pandas()
+            .replace({np.nan: None})
+            .to_dict(orient="list"),
+        )
+    )
 
     telescope_id, instrument_id, _, _ = add_telescope_and_instrument(
         "ZTF", super_admin_token, list(range(200, 250))
     )
 
     def galaxies_loaded():
-        status, data = api(
-            "GET",
-            "galaxy_catalog",
-            token=view_only_token,
-            params={"catalog_name": catalog_name},
+        galaxies = (
+            client(view_only_token).fetch_galaxies(catalog_name=catalog_name).galaxies
         )
-        assert status == 200
-        galaxies = data["data"]["galaxies"]
         assert len(galaxies) == 92
         assert any(
-            d["name"] == "6dFgs gJ0001313-055904" and d["mstar"] == 336.60756522868667
+            d.name == "6dFgs gJ0001313-055904" and d.mstar == 336.60756522868667
             for d in galaxies
         )
 
     retry_until(galaxies_loaded, timeout=50)
 
-    request_data = {
-        "group_id": public_group.id,
-        "instrument_id": instrument_id,
-        "pi": "Shri Kulkarni",
-        "hours_allocated": 200,
-        "validity_ranges": [
-            {
-                "start_date": "2021-02-27T00:00:00.000Z",
-                "end_date": "3021-07-20T00:00:00.000Z",
-            }
-        ],
-        "proposal_id": "COO-2020A-P01",
-        "types": ["observation_plan"],
-    }
-
-    status, data = api("POST", "allocation", data=request_data, token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-    allocation_id = data["data"]["id"]
+    allocation_id = sp.post_allocation(
+        AllocationPost(
+            group_id=public_group.id,
+            instrument_id=instrument_id,
+            pi="Shri Kulkarni",
+            hours_allocated=200,
+            validity_ranges=[
+                {
+                    "start_date": "2021-02-27T00:00:00.000Z",
+                    "end_date": "3021-07-20T00:00:00.000Z",
+                }
+            ],
+            proposal_id="COO-2020A-P01",
+            types=["observation_plan"],
+        )
+    ).id
 
     requests_data = [
-        {
-            "allocation_id": allocation_id,
-            "gcnevent_id": gcnevent_id,
-            "localization_id": localization_id,
-            "payload": {
+        ObservationPlanPost(
+            allocation_id=allocation_id,
+            gcnevent_id=gcnevent_id,
+            localization_id=localization_id,
+            payload={
                 "start_date": "2020-07-16 01:01:01",
                 "end_date": "2020-07-17 01:01:01",
                 "filter_strategy": "block",
@@ -352,65 +301,53 @@ def test_observation_plan_galaxy(
                 "subprogram_name": "GRB",
                 "galactic_latitude": 10,
             },
-        }
+        )
         for _ in range(2)
     ]
 
     for request_data in requests_data:
-        status, data = api(
-            "POST", "observation_plan", data=request_data, token=super_admin_token
-        )
-        assert status == 200
-        assert data["status"] == "success"
+        sp.post_observation_plan(request_data)
 
     def galaxy_plans_ready():
-        status, data = api(
-            "GET",
-            "observation_plan",
-            params={"includePlannedObservations": "true"},
-            token=super_admin_token,
-        )
-        assert status == 200
-        assert data["status"] == "success"
+        page = sp.fetch_observation_plans(include_planned_observations=True)
 
         # get those which have been created on the right event
         requests = [
             d
-            for d in data["data"]["requests"]
-            if d["gcnevent_id"] == gcnevent_id and d["allocation_id"] == allocation_id
+            for d in page.requests
+            if d.gcnevent_id == gcnevent_id and d.allocation_id == allocation_id
         ]
         assert len(requests) == len(requests_data)
 
         for i, d in enumerate(requests):
             assert any(
-                d["payload"]["queue_name"] == request_data["payload"]["queue_name"]
+                d.payload["queue_name"] == request_data.payload["queue_name"]
                 for request_data in requests_data
             )
-            observation_plans = d["observation_plans"]
+            observation_plans = d.observation_plans
             assert len(observation_plans) == 1
             observation_plan = observation_plans[0]
 
             assert any(
-                observation_plan["plan_name"] == request_data["payload"]["queue_name"]
+                observation_plan.plan_name == request_data.payload["queue_name"]
                 for request_data in requests_data
             )
-            assert observation_plan["validity_window_start"] == requests_data[0][
-                "payload"
-            ]["start_date"].replace(" ", "T")
-            assert observation_plan["validity_window_end"] == requests_data[0][
-                "payload"
-            ]["end_date"].replace(" ", "T")
+            assert observation_plan.validity_window_start.isoformat() == requests_data[
+                0
+            ].payload["start_date"].replace(" ", "T")
+            assert observation_plan.validity_window_end.isoformat() == requests_data[
+                0
+            ].payload["end_date"].replace(" ", "T")
 
-            planned_observations = observation_plan["planned_observations"]
+            planned_observations = observation_plan.planned_observations
             assert len(planned_observations) >= 2
 
             assert all(
-                obs["filt"] == requests_data[i]["payload"]["filters"]
+                obs.filt == requests_data[i].payload["filters"]
                 for obs in planned_observations
             )
             assert all(
-                obs["exposure_time"]
-                == int(requests_data[i]["payload"]["exposure_time"])
+                obs.exposure_time == int(requests_data[i].payload["exposure_time"])
                 for obs in planned_observations
             )
 

--- a/skyportal/tests/api_tests/groups_users_analysis/test_reminders.py
+++ b/skyportal/tests/api_tests/groups_users_analysis/test_reminders.py
@@ -2,103 +2,86 @@ import time
 import uuid
 from datetime import UTC, datetime, timedelta
 
-from skyportal.tests import api
+from skyportal_py.reminders import ReminderPost
+from skyportal_py.shifts import ShiftPost
+from skyportal_py.sources import SourcePost
+from skyportal_py.spectra import SpectrumPost
+
+from skyportal.tests import client
 
 from ....utils.naive_datetime import utcnow_naive
 
 
-def post_and_verify_reminder(endpoint, token):
+def post_and_verify_reminder(resource_type, resource_id, token):
+    sp = client(token)
     reminder_text = str(uuid.uuid4())
     next_reminder = utcnow_naive() + timedelta(seconds=2)
     next_reminder = next_reminder.replace(microsecond=0)
     reminder_delay = 1
     number_of_reminders = 1
-    request_data = {
-        "text": reminder_text,
-        "next_reminder": next_reminder.strftime("%Y-%m-%dT%H:%M:%S"),
-        "reminder_delay": reminder_delay,
-        "number_of_reminders": number_of_reminders,
-    }
 
-    status, data = api(
-        "POST",
-        endpoint,
-        data=request_data,
-        token=token,
+    sp.post_reminder(
+        resource_id,
+        ReminderPost(
+            text=reminder_text,
+            next_reminder=next_reminder.strftime("%Y-%m-%dT%H:%M:%S"),
+            reminder_delay=reminder_delay,
+            number_of_reminders=number_of_reminders,
+        ),
+        resource_type=resource_type,
     )
-    assert status == 200
-    assert data["status"] == "success"
 
-    status, data = api("GET", endpoint, token=token)
-    assert status == 200
-    assert data["status"] == "success"
-    data = data["data"]["reminders"]
+    reminders = sp.fetch_reminders(resource_id, resource_type=resource_type).reminders
     # find the index of reminder we just created using the text
     reminder_index = next(
         index
-        for index, reminder in enumerate(data)
-        if reminder["text"] == reminder_text
+        for index, reminder in enumerate(reminders)
+        if reminder.text == reminder_text
     )
     assert reminder_index != -1
-    assert data[reminder_index]["reminder_delay"] == reminder_delay
-    assert data[reminder_index]["number_of_reminders"] <= number_of_reminders
-    assert (
-        datetime.strptime(data[reminder_index]["next_reminder"], "%Y-%m-%dT%H:%M:%S")
-        >= next_reminder
-    )
+    assert reminders[reminder_index].reminder_delay == reminder_delay
+    assert reminders[reminder_index].number_of_reminders <= number_of_reminders
+    assert reminders[reminder_index].next_reminder >= next_reminder
 
     n_retries = 0
     while n_retries < 5:
-        status, data = api(
-            "GET",
-            endpoint,
-            token=token,
+        reminders = sp.fetch_reminders(
+            resource_id, resource_type=resource_type
+        ).reminders
+        # find the index of reminder we just created using the text
+        reminder_index = next(
+            index
+            for index, reminder in enumerate(reminders)
+            if reminder.text == reminder_text
         )
-        if data["status"] == "success":
-            data = data["data"]["reminders"]
-            # find the index of reminder we just created using the text
-            reminder_index = next(
-                index
-                for index, reminder in enumerate(data)
-                if reminder["text"] == reminder_text
-            )
-            if data[reminder_index]["number_of_reminders"] < number_of_reminders:
-                break
+        if reminders[reminder_index].number_of_reminders < number_of_reminders:
+            break
         time.sleep(2)
         n_retries += 1
     assert n_retries < 10
-    assert status == 200
-    assert len(data) == 1
-    assert data[reminder_index]["text"] == reminder_text
-    assert data[reminder_index]["reminder_delay"] == reminder_delay
-    assert data[reminder_index]["number_of_reminders"] == number_of_reminders - 1
-    assert (
-        datetime.strptime(data[reminder_index]["next_reminder"], "%Y-%m-%dT%H:%M:%S")
-        > next_reminder
-    )
+    assert len(reminders) == 1
+    assert reminders[reminder_index].text == reminder_text
+    assert reminders[reminder_index].reminder_delay == reminder_delay
+    assert reminders[reminder_index].number_of_reminders == number_of_reminders - 1
+    assert reminders[reminder_index].next_reminder > next_reminder
     return reminder_text
 
 
 def test_reminder_on_source(super_admin_token):
+    sp = client(super_admin_token)
     obj_id = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id,
-            "ra": 24.6258,
-            "dec": -32.9024,
-            "redshift": 3,
-        },
-        token=super_admin_token,
+    sp.post_source(
+        SourcePost(
+            id=obj_id,
+            ra=24.6258,
+            dec=-32.9024,
+            redshift=3,
+        )
     )
-    assert status == 200
 
-    status, data = api("GET", f"sources/{obj_id}", token=super_admin_token)
-    assert status == 200
+    source = sp.fetch_source(obj_id)
 
-    endpoint = f"source/{data['data']['id']}/reminders"
-    post_and_verify_reminder(endpoint, super_admin_token)
+    post_and_verify_reminder("source", source.id, super_admin_token)
 
 
 def test_reminder_on_shift(
@@ -109,61 +92,50 @@ def test_reminder_on_shift(
     shift_name = str(uuid.uuid4())
     start_date = (datetime.now(UTC) - timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%S")
     end_date = (datetime.now(UTC) + timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%S")
-    request_data = {
-        "name": shift_name,
-        "group_id": public_group.id,
-        "start_date": start_date,
-        "end_date": end_date,
-        "description": "Shift during GCN",
-        "shift_admins": [super_admin_user.id],
-    }
+    shift_id = (
+        client(super_admin_token)
+        .post_shift(
+            ShiftPost(
+                name=shift_name,
+                group_id=public_group.id,
+                start_date=start_date,
+                end_date=end_date,
+                description="Shift during GCN",
+                shift_admins=[super_admin_user.id],
+            )
+        )
+        .id
+    )
 
-    status, data = api("POST", "shifts", data=request_data, token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-
-    endpoint = f"shift/{data['data']['id']}/reminders"
-    post_and_verify_reminder(endpoint, super_admin_token)
+    post_and_verify_reminder("shift", shift_id, super_admin_token)
 
 
 def test_reminder_on_spectra(super_admin_token, lris):
+    sp = client(super_admin_token)
     obj_id = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id,
-            "ra": 24.6258,
-            "dec": -32.9024,
-            "redshift": 3,
-        },
-        token=super_admin_token,
+    sp.post_source(
+        SourcePost(
+            id=obj_id,
+            ra=24.6258,
+            dec=-32.9024,
+            redshift=3,
+        )
     )
-    assert status == 200
 
-    status, data = api("GET", f"sources/{obj_id}", token=super_admin_token)
-    assert status == 200
+    sp.fetch_source(obj_id)
 
-    status, data = api(
-        "POST",
-        "spectrum",
-        data={
-            "obj_id": obj_id,
-            "observed_at": "2020-01-10T00:00:00",
-            "instrument_id": lris.id,
-            "wavelengths": [664, 665, 666],
-            "fluxes": [234.3, 232.1, 235.3],
-        },
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    spectrum_id = data["data"]["id"]
+    spectrum_id = sp.post_spectrum(
+        SpectrumPost(
+            obj_id=obj_id,
+            observed_at="2020-01-10T00:00:00",
+            instrument_id=lris.id,
+            wavelengths=[664, 665, 666],
+            fluxes=[234.3, 232.1, 235.3],
+        )
+    ).id
 
-    endpoint = f"spectra/{spectrum_id}/reminders"
-    post_and_verify_reminder(endpoint, super_admin_token)
+    post_and_verify_reminder("spectra", spectrum_id, super_admin_token)
 
 
 def test_reminder_on_gcn(super_admin_token, gcn_GW190814):
-    endpoint = f"gcn_event/{gcn_GW190814.id}/reminders"
-    post_and_verify_reminder(endpoint, super_admin_token)
+    post_and_verify_reminder("gcn_event", gcn_GW190814.id, super_admin_token)

--- a/skyportal/tests/api_tests/groups_users_analysis/test_shifts.py
+++ b/skyportal/tests/api_tests/groups_users_analysis/test_shifts.py
@@ -1,160 +1,124 @@
 import uuid
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta
 
-from skyportal.tests import api
+import pytest
+from skyportal_py import SkyPortalError
+from skyportal_py.shifts import ShiftPost
+
+from skyportal.tests import client
 
 
 def test_shift(public_group, super_admin_token, view_only_token, super_admin_user):
     name = str(uuid.uuid4())
     start_date = date.today().strftime("%Y-%m-%dT%H:%M:%S")
     end_date = (date.today() + timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%S")
-    request_data = {
-        "name": name,
-        "group_id": public_group.id,
-        "start_date": start_date,
-        "end_date": end_date,
-        "description": "the Night Shift",
-        "shift_admins": [super_admin_user.id],
-        "required_users_number": 2,
-    }
-    status, data = api("POST", "shifts", data=request_data, token=view_only_token)
-    assert status == 401
-    assert data["status"] == "error"
-
-    status, data = api("POST", "shifts", data=request_data, token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-
-    shift_id = data["data"]["id"]
-
-    status, data = api(
-        "GET", f"shifts/{shift_id}", data=request_data, token=super_admin_token
+    shift_post = ShiftPost(
+        name=name,
+        group_id=public_group.id,
+        start_date=start_date,
+        end_date=end_date,
+        description="the Night Shift",
+        shift_admins=[super_admin_user.id],
+        required_users_number=2,
     )
-    assert status == 200
-    assert data["status"] == "success"
+    with pytest.raises(SkyPortalError) as err:
+        client(view_only_token).post_shift(shift_post)
+    assert err.value.status_code == 401
 
-    status, data = api(
-        "GET", f"shifts?group_id={public_group.id}", token=super_admin_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp = client(super_admin_token)
+    shift_id = sp.post_shift(shift_post).id
 
-    assert any(request_data["name"] == s["name"] for s in data["data"])
-    assert any(request_data["start_date"] == s["start_date"] for s in data["data"])
-    assert any(request_data["end_date"] == s["end_date"] for s in data["data"])
+    sp.fetch_shift(shift_id)
+
+    shifts = sp.fetch_shifts(group_id=public_group.id)
+
+    assert any(shift_post.name == s.name for s in shifts)
     assert any(
-        request_data["required_users_number"] == s["required_users_number"]
-        for s in data["data"]
+        datetime.fromisoformat(shift_post.start_date) == s.start_date for s in shifts
+    )
+    assert any(
+        datetime.fromisoformat(shift_post.end_date) == s.end_date for s in shifts
+    )
+    assert any(
+        shift_post.required_users_number == s.required_users_number for s in shifts
     )
 
     assert any(
-        len([s for s in shift["shift_users_ids"] if s == super_admin_user.id]) == 1
-        for shift in data["data"]
+        len([s for s in shift.shift_users_ids if s == super_admin_user.id]) == 1
+        for shift in shifts
     )
 
     name2 = str(uuid.uuid4())
-    request_data = {
-        "name": name2,
-        "description": "the Day Shift",
-        "required_users_number": 3,
-    }
+    description2 = "the Day Shift"
+    required_users_number2 = 3
 
-    status, data = api(
-        "PATCH", f"shifts/{shift_id}", data=request_data, token=super_admin_token
+    sp.update_shift(
+        shift_id,
+        name=name2,
+        description=description2,
+        required_users_number=required_users_number2,
     )
-    assert status == 200
-    assert data["status"] == "success"
 
-    status, data = api(
-        "GET", f"shifts/{shift_id}", data=request_data, token=super_admin_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    shift = sp.fetch_shift(shift_id)
 
-    assert request_data["name"] == data["data"]["name"]
-    assert request_data["description"] == data["data"]["description"]
-    assert (
-        request_data["required_users_number"] == data["data"]["required_users_number"]
-    )
+    assert shift.name == name2
+    assert shift.description == description2
+    assert shift.required_users_number == required_users_number2
 
 
 def test_shift_summary(
     public_group, super_admin_token, super_admin_user, gcn_GRB180116A
 ):
+    sp = client(super_admin_token)
     # add a shift to the group, with a start day one day before today,
     # and an end day one day after today
     shift_name_1 = str(uuid.uuid4())
     start_date = "2018-01-15T12:00:00"
     end_date = "2018-01-17T12:00:00"
-    request_data = {
-        "name": shift_name_1,
-        "group_id": public_group.id,
-        "start_date": start_date,
-        "end_date": end_date,
-        "description": "Shift during GCN",
-        "shift_admins": [super_admin_user.id],
-    }
+    shift_id = sp.post_shift(
+        ShiftPost(
+            name=shift_name_1,
+            group_id=public_group.id,
+            start_date=start_date,
+            end_date=end_date,
+            description="Shift during GCN",
+            shift_admins=[super_admin_user.id],
+        )
+    ).id
 
-    status, data = api("POST", "shifts", data=request_data, token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-
-    shift_id = data["data"]["id"]
-
-    status, data = api(
-        "GET", f"shifts/{shift_id}", data=request_data, token=super_admin_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp.fetch_shift(shift_id)
 
     shift_name_2 = str(uuid.uuid4())
     start_date = "2018-01-17T12:00:00"
     end_date = "2018-01-18T12:00:00"
-    request_data = {
-        "name": shift_name_2,
-        "group_id": public_group.id,
-        "start_date": start_date,
-        "end_date": end_date,
-        "description": "Shift not during GCN",
-        "shift_admins": [super_admin_user.id],
-    }
+    shift_id_2 = sp.post_shift(
+        ShiftPost(
+            name=shift_name_2,
+            group_id=public_group.id,
+            start_date=start_date,
+            end_date=end_date,
+            description="Shift not during GCN",
+            shift_admins=[super_admin_user.id],
+        )
+    ).id
 
-    status, data = api("POST", "shifts", data=request_data, token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-
-    shift_id_2 = data["data"]["id"]
-
-    status, data = api(
-        "GET", f"shifts?group_id={public_group.id}", token=super_admin_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp.fetch_shifts(group_id=public_group.id)
 
     dateobs = gcn_GRB180116A.dateobs.strftime("%Y-%m-%dT%H:%M:%S")
 
-    status, data = api("GET", f"shifts/summary/{shift_id}", token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-    assert int(data["data"]["shifts"]["total"]) == 1
-    assert int(data["data"]["gcns"]["total"]) == 1
-    assert data["data"]["shifts"]["data"][0]["name"] == shift_name_1
-    assert data["data"]["gcns"]["data"][0]["dateobs"] == dateobs
-    assert shift_id in data["data"]["gcns"]["data"][0]["shift_ids"]
-    assert shift_id_2 not in data["data"]["gcns"]["data"][0]["shift_ids"]
+    report = sp.fetch_shift_summary(shift_id)
+    assert int(report.shifts.total) == 1
+    assert int(report.gcns.total) == 1
+    assert report.shifts.data[0]["name"] == shift_name_1
+    assert report.gcns.data[0]["dateobs"] == dateobs
+    assert shift_id in report.gcns.data[0]["shift_ids"]
+    assert shift_id_2 not in report.gcns.data[0]["shift_ids"]
 
-    request_data = {
-        "startDate": "2018-01-14T12:00:00",
-        "endDate": "2018-01-19T12:00:00",
-    }
-
-    status, data = api(
-        "GET", "shifts/summary", params=request_data, token=super_admin_token
+    report = sp.fetch_shift_summary(
+        start_date="2018-01-14T12:00:00", end_date="2018-01-19T12:00:00"
     )
 
-    assert status == 200
-    assert data["status"] == "success"
-    assert int(data["data"]["shifts"]["total"]) == 2
-    assert int(data["data"]["gcns"]["total"]) == 1
-    assert shift_id in data["data"]["gcns"]["data"][0]["shift_ids"]
-    assert shift_id_2 not in data["data"]["gcns"]["data"][0]["shift_ids"]
+    assert int(report.shifts.total) == 2
+    assert int(report.gcns.total) == 1
+    assert shift_id in report.gcns.data[0]["shift_ids"]
+    assert shift_id_2 not in report.gcns.data[0]["shift_ids"]

--- a/skyportal/tests/api_tests/groups_users_analysis/test_standards.py
+++ b/skyportal/tests/api_tests/groups_users_analysis/test_standards.py
@@ -2,6 +2,7 @@ from skyportal.tests import api
 
 
 def test_standards(view_only_token):
+    # raw api: internal endpoint outside skyportal-py's scope
     status, data = api(
         "GET",
         "internal/standards",
@@ -23,6 +24,7 @@ def test_standards(view_only_token):
 
 
 def test_standards_bad_standard_list(view_only_token):
+    # raw api: internal endpoint outside skyportal-py's scope
     status, data = api(
         "GET",
         "internal/standards",
@@ -40,6 +42,7 @@ def test_standards_bad_standard_list(view_only_token):
 
 
 def test_standards_bad_range(view_only_token):
+    # raw api: internal endpoint outside skyportal-py's scope
     status, data = api(
         "GET",
         "internal/standards",
@@ -72,6 +75,7 @@ def test_standards_bad_range(view_only_token):
 
 
 def test_standards_filter(view_only_token):
+    # raw api: internal endpoint outside skyportal-py's scope
     status, data = api(
         "GET",
         "internal/standards",

--- a/skyportal/tests/api_tests/groups_users_analysis/test_tag.py
+++ b/skyportal/tests/api_tests/groups_users_analysis/test_tag.py
@@ -1,27 +1,19 @@
 import uuid
 
 import pytest
-from sqlalchemy import select
-from sqlalchemy.orm import Session
+from skyportal_py import SkyPortalError
 
-from skyportal.models import ObjTagOption
-from skyportal.tests import api
+from skyportal.tests import api, client
 
 
 # --- Testing ObjTagOption API
 def test_get_tag(super_admin_token):
-    tag_to_create = {"name": f"TestTag{uuid.uuid4().hex}"}
-    status, data = api(
-        "POST", "objtagoption", data=tag_to_create, token=super_admin_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp = client(super_admin_token)
+    tag_name = f"TestTag{uuid.uuid4().hex}"
+    sp.post_obj_tag_option(tag_name)
 
-    status, data = api("GET", "objtagoption", token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-    tag_names = [tag["name"] for tag in data["data"]]
-    assert tag_to_create["name"] in tag_names
+    tag_names = [tag.name for tag in sp.fetch_obj_tag_options()]
+    assert tag_name in tag_names
 
 
 @pytest.mark.parametrize(
@@ -33,13 +25,11 @@ def test_get_tag(super_admin_token):
     ],
 )
 def test_add_tag_case_sensitive(super_admin_token, invalid_tag_name):
-    status, data = api(
-        "POST", "objtagoption", data={"name": invalid_tag_name}, token=super_admin_token
-    )
-
-    assert status == 400
-    assert data["status"] == "error"
-    assert "must contain only letters and numbers" in data["message"]
+    with pytest.raises(
+        SkyPortalError, match="must contain only letters and numbers"
+    ) as err:
+        client(super_admin_token).post_obj_tag_option(invalid_tag_name)
+    assert err.value.status_code == 400
 
 
 @pytest.mark.parametrize(
@@ -69,38 +59,34 @@ def test_tag_color_validation(
     super_admin_token, color, expected_status, should_be_valid
 ):
     """Test creating tags with valid and invalid color values"""
-    tag_data = {"name": f"TestTag{uuid.uuid4().hex}", "color": color}
-
-    status, data = api("POST", "objtagoption", data=tag_data, token=super_admin_token)
-    assert status == expected_status
+    sp = client(super_admin_token)
+    tag_name = f"TestTag{uuid.uuid4().hex}"
 
     if should_be_valid:
-        assert data["status"] == "success"
-        assert data["data"]["name"] == tag_data["name"]
-        assert data["data"]["color"] == color
+        tag = sp.post_obj_tag_option(tag_name, color=color)
+        assert tag.name == tag_name
+        assert tag.color == color
     else:
-        assert data["status"] == "error"
-        assert "must be a valid hex color code" in data["message"]
+        with pytest.raises(
+            SkyPortalError, match="must be a valid hex color code"
+        ) as err:
+            sp.post_obj_tag_option(tag_name, color=color)
+        assert err.value.status_code == expected_status
 
 
 def test_add_tag(super_admin_token):
-    tag_to_create = {"name": f"TagAdded{uuid.uuid4().hex}"}
-    status, data = api(
-        "POST", "objtagoption", data=tag_to_create, token=super_admin_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    assert data["data"]["name"] == tag_to_create["name"]
+    sp = client(super_admin_token)
+    tag_name = f"TagAdded{uuid.uuid4().hex}"
+    tag = sp.post_obj_tag_option(tag_name)
+    assert tag.name == tag_name
 
     # Verification that we can't create the same tag twice
-    status, data = api(
-        "POST", "objtagoption", data=tag_to_create, token=super_admin_token
-    )
-    assert status == 409
-    assert data["status"] == "error"
-    assert "already exists" in data["message"]
+    with pytest.raises(SkyPortalError, match="already exists") as err:
+        sp.post_obj_tag_option(tag_name)
+    assert err.value.status_code == 409
 
     # Verification that we can't create a tag without a name
+    # raw api: intentionally malformed payload the typed client can't produce
     status, data = api("POST", "objtagoption", data="", token=super_admin_token)
     assert status == 500
     assert data["status"] == "error"
@@ -108,39 +94,24 @@ def test_add_tag(super_admin_token):
 
 
 def test_modify_tag(super_admin_token):
+    sp = client(super_admin_token)
     # Creation of a tag to modify
-    tag_data = {"name": f"TagToModify{uuid.uuid4().hex}"}
-    create_status, created_tag = api(
-        "POST", "objtagoption", data=tag_data, token=super_admin_token
-    )
-    assert create_status == 200
-    assert created_tag["status"] == "success"
-
-    tag_id = created_tag["data"]["id"]
-    tag_to_rename = {"name": f"TagRenamed{uuid.uuid4().hex}"}
+    tag_id = sp.post_obj_tag_option(f"TagToModify{uuid.uuid4().hex}").id
 
     # Testing nominal case
-    status, data = api(
-        "PATCH", f"objtagoption/{tag_id}", data=tag_to_rename, token=super_admin_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp.update_obj_tag_option(tag_id, f"TagRenamed{uuid.uuid4().hex}")
 
     # Testing to rename a tag with an existing name
-    tag_to_create = {"name": f"TagAdded{uuid.uuid4().hex}"}
-    status, data = api(
-        "POST", "objtagoption", data=tag_to_create, token=super_admin_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    status, data = api(
-        "PATCH", f"objtagoption/{tag_id}", data=tag_to_create, token=super_admin_token
-    )
-    assert status == 400
-    assert data["status"] == "error"
-    assert "This tag name already exists for another tag" in data["message"]
+    existing_name = f"TagAdded{uuid.uuid4().hex}"
+    sp.post_obj_tag_option(existing_name)
+    with pytest.raises(
+        SkyPortalError, match="This tag name already exists for another tag"
+    ) as err:
+        sp.update_obj_tag_option(tag_id, existing_name)
+    assert err.value.status_code == 400
 
     # Testing to rename a tag without name
+    # raw api: intentionally malformed payload the typed client can't produce
     status, data = api(
         "PATCH", f"objtagoption/{tag_id}", data="", token=super_admin_token
     )
@@ -149,154 +120,88 @@ def test_modify_tag(super_admin_token):
     assert "Please ensure posted data is of type application/json" in data["message"]
 
     # Testing to rename a non existing tag
-    data = {"name": f"TagNotFound{uuid.uuid4().hex}"}
-    status, data = api(
-        "PATCH", "objtagoption/9999999", data=data, token=super_admin_token
-    )
-    assert status == 404
-    assert data["status"] == "error"
-    assert "Tag not found" in data["message"]
+    with pytest.raises(SkyPortalError, match="Tag not found") as err:
+        sp.update_obj_tag_option(9999999, f"TagNotFound{uuid.uuid4().hex}")
+    assert err.value.status_code == 404
 
 
 def test_modify_tag_without_providing_color(super_admin_token):
     """Test setting tag color back to null"""
-    tag_data = {"name": f"TagColorToNull{uuid.uuid4().hex}", "color": "#3a87ad"}
-    create_status, created_tag = api(
-        "POST", "objtagoption", data=tag_data, token=super_admin_token
-    )
-    assert create_status == 200
-    tag_id = created_tag["data"]["id"]
+    sp = client(super_admin_token)
+    tag_name = f"TagColorToNull{uuid.uuid4().hex}"
+    tag_id = sp.post_obj_tag_option(tag_name, color="#3a87ad").id
 
     # Update without providing color (should keep existing color)
-    update_data = {"name": tag_data["name"]}
-    status, data = api(
-        "PATCH", f"objtagoption/{tag_id}", data=update_data, token=super_admin_token
-    )
-    assert status == 200
+    sp.update_obj_tag_option(tag_id, tag_name)
 
-    status, data = api("GET", "objtagoption", token=super_admin_token)
-    updated_tag = next((tag for tag in data["data"] if tag["id"] == tag_id), None)
-    assert updated_tag["color"] == "#3a87ad"
+    updated_tag = next(
+        (tag for tag in sp.fetch_obj_tag_options() if tag.id == tag_id), None
+    )
+    assert updated_tag.color == "#3a87ad"
 
 
 def test_change_tag_color(super_admin_token):
     """Test changing the color of an existing tag"""
+    sp = client(super_admin_token)
     initial_color = "#ff0000"
-    tag_data = {"name": f"TagColorChange{uuid.uuid4().hex}", "color": initial_color}
-    create_status, created_tag = api(
-        "POST", "objtagoption", data=tag_data, token=super_admin_token
-    )
-    assert create_status == 200
-    assert created_tag["status"] == "success"
-    assert created_tag["data"]["color"] == initial_color
+    tag_name = f"TagColorChange{uuid.uuid4().hex}"
+    created_tag = sp.post_obj_tag_option(tag_name, color=initial_color)
+    assert created_tag.color == initial_color
 
-    tag_id = created_tag["data"]["id"]
+    tag_id = created_tag.id
 
     new_color = "#3a87ad"
-    update_data = {"name": tag_data["name"], "color": new_color}
-    status, data = api(
-        "PATCH", f"objtagoption/{tag_id}", data=update_data, token=super_admin_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp.update_obj_tag_option(tag_id, tag_name, color=new_color)
 
     # Verify the color was changed
-    status, data = api("GET", "objtagoption", token=super_admin_token)
-    assert status == 200
-    updated_tag = next((tag for tag in data["data"] if tag["id"] == tag_id), None)
+    updated_tag = next(
+        (tag for tag in sp.fetch_obj_tag_options() if tag.id == tag_id), None
+    )
     assert updated_tag is not None
-    assert updated_tag["color"] == new_color
+    assert updated_tag.color == new_color
 
 
 def test_delete_tag(super_admin_token):
+    sp = client(super_admin_token)
     # Creation of a tag to delete
-    tag_data = {"name": f"TagToDelete{uuid.uuid4().hex}"}
-    create_status, created_tag = api(
-        "POST", "objtagoption", data=tag_data, token=super_admin_token
-    )
-    assert create_status == 200
-    assert created_tag["status"] == "success"
-
-    tag_id = created_tag["data"]["id"]
+    tag_id = sp.post_obj_tag_option(f"TagToDelete{uuid.uuid4().hex}").id
 
     # Delete the tag
-    delete_status, data = api(
-        "DELETE", f"objtagoption/{tag_id}", token=super_admin_token
-    )
-    assert delete_status == 200
-    assert created_tag["status"] == "success"
-    assert "Successfully deleted tag" in data["data"]
+    sp.delete_obj_tag_option(tag_id)
 
     # Verification that we can't delete a tag that doesn't exist
-    delete_status, data = api(
-        "DELETE", f"objtagoption/{tag_id}", token=super_admin_token
-    )
-    assert delete_status == 404
-    assert data["status"] == "error"
-    assert "Tag not found" in data["message"]
+    with pytest.raises(SkyPortalError, match="Tag not found") as err:
+        sp.delete_obj_tag_option(tag_id)
+    assert err.value.status_code == 404
 
 
 # --- Testing ObjTag API
 def test_create_tag_obj_association(super_admin_token, public_source, public_group):
+    sp = client(super_admin_token)
     # Create a tag option
-    tag_data = {"name": f"Tag{uuid.uuid4().hex}"}
-    status, tag = api("POST", "objtagoption", data=tag_data, token=super_admin_token)
-    assert status == 200
-    assert tag["status"] == "success"
+    tag = sp.post_obj_tag_option(f"Tag{uuid.uuid4().hex}")
 
-    assoc_data = {
-        "objtagoption_id": tag["data"]["id"],
-        "obj_id": public_source.id,
-        "group_ids": [public_group.id],
-    }
-
-    status, data = api("POST", "objtag", data=assoc_data, token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-    assoc_id = data["data"]["id"]
-
-    status, data = api("GET", "objtag", token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
+    assoc_id = sp.post_obj_tag(public_source.id, tag.id, group_ids=[public_group.id]).id
 
     created_assoc = next(
-        (assoc for assoc in data["data"] if assoc["id"] == assoc_id), None
+        (assoc for assoc in sp.fetch_obj_tags() if assoc.id == assoc_id), None
     )
     assert created_assoc is not None
 
-    assert created_assoc["objtagoption_id"] == tag["data"]["id"]
-    assert created_assoc["obj_id"] == public_source.id
+    assert created_assoc.objtagoption_id == tag.id
+    assert created_assoc.obj_id == public_source.id
 
-    status, data = api("POST", "objtag", data=assoc_data, token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
+    sp.post_obj_tag(public_source.id, tag.id, group_ids=[public_group.id])
 
 
 def test_delete_association(super_admin_token, public_source, public_group):
-    tag_data = {"name": f"TagDeleteAssociation{uuid.uuid4().hex}"}
-    status, tag = api("POST", "objtagoption", data=tag_data, token=super_admin_token)
-    assert status == 200
-    assert tag["status"] == "success"
+    sp = client(super_admin_token)
+    tag = sp.post_obj_tag_option(f"TagDeleteAssociation{uuid.uuid4().hex}")
 
-    assoc_data = {
-        "objtagoption_id": tag["data"]["id"],
-        "obj_id": public_source.id,
-        "group_ids": [public_group.id],
-    }
-    status, assoc = api("POST", "objtag", data=assoc_data, token=super_admin_token)
-    assert status == 200
-    assert assoc["status"] == "success"
+    assoc_id = sp.post_obj_tag(public_source.id, tag.id, group_ids=[public_group.id]).id
 
-    status, data = api(
-        "DELETE", f"objtag/{assoc['data']['id']}", token=super_admin_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    assert "Successfully deleted association" in data["data"]
+    sp.delete_obj_tag(assoc_id)
 
-    status, data = api(
-        "DELETE", f"objtag/{assoc['data']['id']}", token=super_admin_token
-    )
-    assert status == 404
-    assert data["status"] == "error"
-    assert "Association not found" in data["message"]
+    with pytest.raises(SkyPortalError, match="Association not found") as err:
+        sp.delete_obj_tag(assoc_id)
+    assert err.value.status_code == 404

--- a/skyportal/tests/api_tests/groups_users_analysis/test_taxonomy.py
+++ b/skyportal/tests/api_tests/groups_users_analysis/test_taxonomy.py
@@ -1,220 +1,175 @@
 import uuid
 
+import pytest
+from skyportal_py import SkyPortalError
+from skyportal_py.taxonomies import TaxonomyPost, TaxonomyPut
 from tdtax import __version__, taxonomy
 
-from skyportal.tests import api
+from skyportal.tests import api, client
 
 
 def test_add_retrieve_delete_taxonomy(taxonomy_token, public_group):
+    sp = client(taxonomy_token)
     name = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "taxonomy",
-        data={
-            "name": name,
-            "hierarchy": taxonomy,
-            "group_ids": [public_group.id],
-            "provenance": f"tdtax_{__version__}",
-            "version": __version__,
-            "isLatest": True,
-        },
-        token=taxonomy_token,
-    )
-    assert status == 200
-    taxonomy_id = data["data"]["taxonomy_id"]
+    taxonomy_id = sp.post_taxonomy(
+        TaxonomyPost(
+            name=name,
+            hierarchy=taxonomy,
+            group_ids=[public_group.id],
+            provenance=f"tdtax_{__version__}",
+            version=__version__,
+            is_latest=True,
+        )
+    ).taxonomy_id
 
-    status, data = api("GET", f"taxonomy/{taxonomy_id}", token=taxonomy_token)
+    fetched = sp.fetch_taxonomy(taxonomy_id)
+    assert fetched.name == name
+    assert fetched.version == __version__
 
-    assert status == 200
-    assert data["data"]["name"] == name
-    assert data["data"]["version"] == __version__
+    sp.delete_taxonomy(taxonomy_id)
 
-    status, data = api("DELETE", f"taxonomy/{taxonomy_id}", token=taxonomy_token)
-    assert status == 200
-
-    status, data = api("GET", f"taxonomy/{taxonomy_id}", token=taxonomy_token)
-    assert status == 400
+    with pytest.raises(SkyPortalError) as err:
+        sp.fetch_taxonomy(taxonomy_id)
+    assert err.value.status_code == 400
 
 
 def test_add_bad_taxonomy(taxonomy_token, public_group):
-    status, data = api(
-        "POST",
-        "taxonomy",
-        data={
-            "name": str(uuid.uuid4()),
-            "hierarchy": {"Silly": "taxonomy", "bad": True},
-            "group_ids": [public_group.id],
-            "provenance": "Nope",
-            "version": "0.0.1bad",
-            "isLatest": True,
-        },
-        token=taxonomy_token,
-    )
-
-    assert status == 400
-    assert data["message"] == "Hierarchy does not validate against the schema."
+    with pytest.raises(
+        SkyPortalError, match="Hierarchy does not validate against the schema."
+    ) as err:
+        client(taxonomy_token).post_taxonomy(
+            TaxonomyPost(
+                name=str(uuid.uuid4()),
+                hierarchy={"Silly": "taxonomy", "bad": True},
+                group_ids=[public_group.id],
+                provenance="Nope",
+                version="0.0.1bad",
+                is_latest=True,
+            )
+        )
+    assert err.value.status_code == 400
 
 
 def test_latest_taxonomy(taxonomy_token, public_group):
+    sp = client(taxonomy_token)
     # add one, then add another with the same name
     name = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "taxonomy",
-        data={
-            "name": name,
-            "hierarchy": taxonomy,
-            "group_ids": [public_group.id],
-            "provenance": f"tdtax_{__version__}",
-            "version": __version__,
-        },
-        token=taxonomy_token,
-    )
-    assert status == 200
-    old_taxonomy_id = data["data"]["taxonomy_id"]
-    status, data = api("GET", f"taxonomy/{old_taxonomy_id}", token=taxonomy_token)
-    assert status == 200
-    assert data["data"]["isLatest"]
+    old_taxonomy_id = sp.post_taxonomy(
+        TaxonomyPost(
+            name=name,
+            hierarchy=taxonomy,
+            group_ids=[public_group.id],
+            provenance=f"tdtax_{__version__}",
+            version=__version__,
+        )
+    ).taxonomy_id
+    assert sp.fetch_taxonomy(old_taxonomy_id).is_latest
 
-    status, data = api(
-        "POST",
-        "taxonomy",
-        data={
-            "name": name,
-            "hierarchy": taxonomy,
-            "group_ids": [public_group.id],
-            "provenance": f"tdtax_{__version__}",
-            "version": "new version",
-        },
-        token=taxonomy_token,
-    )
-    assert status == 200
-    new_taxonomy_id = data["data"]["taxonomy_id"]
-    status, data = api("GET", f"taxonomy/{new_taxonomy_id}", token=taxonomy_token)
-    assert status == 200
-    assert data["data"]["isLatest"]
+    new_taxonomy_id = sp.post_taxonomy(
+        TaxonomyPost(
+            name=name,
+            hierarchy=taxonomy,
+            group_ids=[public_group.id],
+            provenance=f"tdtax_{__version__}",
+            version="new version",
+        )
+    ).taxonomy_id
+    assert sp.fetch_taxonomy(new_taxonomy_id).is_latest
 
     # the first one we added should now have isLatest == False
-    status, data = api("GET", f"taxonomy/{old_taxonomy_id}", token=taxonomy_token)
-    assert status == 200
-    assert not data["data"]["isLatest"]
+    assert not sp.fetch_taxonomy(old_taxonomy_id).is_latest
 
-    status, data = api("DELETE", f"taxonomy/{new_taxonomy_id}", token=taxonomy_token)
-    status, data = api("DELETE", f"taxonomy/{old_taxonomy_id}", token=taxonomy_token)
+    sp.delete_taxonomy(new_taxonomy_id)
+    sp.delete_taxonomy(old_taxonomy_id)
 
 
 def test_get_many_taxonomies(taxonomy_token, public_group):
+    sp = client(taxonomy_token)
     n_tax = 5
     ids = []
     names = []
     for _ in range(n_tax):
         name = "test taxonomy" + str(uuid.uuid4())
-        status, data = api(
-            "POST",
-            "taxonomy",
-            data={
-                "name": name,
-                "hierarchy": taxonomy,
-                "group_ids": [public_group.id],
-                "provenance": f"tdtax_{__version__}",
-                "version": __version__,
-                "isLatest": True,
-            },
-            token=taxonomy_token,
+        ids.append(
+            sp.post_taxonomy(
+                TaxonomyPost(
+                    name=name,
+                    hierarchy=taxonomy,
+                    group_ids=[public_group.id],
+                    provenance=f"tdtax_{__version__}",
+                    version=__version__,
+                    is_latest=True,
+                )
+            ).taxonomy_id
         )
-        assert status == 200
-        ids.append(data["data"]["taxonomy_id"])
         names.append(name)
 
-    status, data = api("GET", "taxonomy", token=taxonomy_token)
-    assert status == 200
-    assert isinstance(data["data"], list)
-
     # make sure we can retrieve those taxonomies
-    for _taxonomy in data["data"]:
-        assert _taxonomy["id"] in ids
-        assert _taxonomy["name"] == names[ids.index(_taxonomy["id"])]
+    for _taxonomy in sp.fetch_taxonomies():
+        assert _taxonomy.id in ids
+        assert _taxonomy.name == names[ids.index(_taxonomy.id)]
 
 
 def test_taxonomy_group_view(
     taxonomy_token_two_groups, taxonomy_token, public_group, public_group2
 ):
     name = "test taxonomy" + str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "taxonomy",
-        data={
-            "name": name,
-            "hierarchy": taxonomy,
-            "group_ids": [public_group2.id],
-            "provenance": f"tdtax_{__version__}",
-            "version": __version__,
-            "isLatest": True,
-        },
-        token=taxonomy_token_two_groups,
+    taxonomy_id = (
+        client(taxonomy_token_two_groups)
+        .post_taxonomy(
+            TaxonomyPost(
+                name=name,
+                hierarchy=taxonomy,
+                group_ids=[public_group2.id],
+                provenance=f"tdtax_{__version__}",
+                version=__version__,
+                is_latest=True,
+            )
+        )
+        .taxonomy_id
     )
-    assert status == 200
-    taxonomy_id = data["data"]["taxonomy_id"]
 
-    status, data = api(
-        "GET", f"taxonomy/{taxonomy_id}", token=taxonomy_token_two_groups
+    assert client(taxonomy_token_two_groups).fetch_taxonomy(taxonomy_id).id == (
+        taxonomy_id
     )
-    assert status == 200
 
     # this token is not apart of group 2
-    status, data = api("GET", f"taxonomy/{taxonomy_id}", token=taxonomy_token)
-    assert status == 400
-    assert "is not available to user" in data["message"]
+    with pytest.raises(SkyPortalError, match="is not available to user") as err:
+        client(taxonomy_token).fetch_taxonomy(taxonomy_id)
+    assert err.value.status_code == 400
 
 
 def test_update_taxonomy(taxonomy_token, public_group):
+    sp = client(taxonomy_token)
     name = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "taxonomy",
-        data={
-            "name": name,
-            "hierarchy": taxonomy,
-            "group_ids": [public_group.id],
-            "provenance": f"tdtax_{__version__}",
-            "version": __version__,
-            "isLatest": True,
-        },
-        token=taxonomy_token,
-    )
-    assert status == 200
-    taxonomy_id = data["data"]["taxonomy_id"]
+    taxonomy_id = sp.post_taxonomy(
+        TaxonomyPost(
+            name=name,
+            hierarchy=taxonomy,
+            group_ids=[public_group.id],
+            provenance=f"tdtax_{__version__}",
+            version=__version__,
+            is_latest=True,
+        )
+    ).taxonomy_id
 
-    status, data = api("GET", f"taxonomy/{taxonomy_id}", token=taxonomy_token)
-
-    assert status == 200
-    assert data["data"]["name"] == name
-    assert data["data"]["version"] == __version__
+    fetched = sp.fetch_taxonomy(taxonomy_id)
+    assert fetched.name == name
+    assert fetched.version == __version__
 
     name2 = str(uuid.uuid4())
+    sp.update_taxonomy(taxonomy_id, TaxonomyPut(name=name2))
+
+    fetched = sp.fetch_taxonomy(taxonomy_id)
+    assert fetched.name == name2
+    assert fetched.version == __version__
+
+    # raw api: TaxonomyPut has no hierarchy field by design (the hierarchy
+    # cannot be edited); this asserts the server rejects such an attempt
     status, data = api(
         "PUT",
         f"taxonomy/{taxonomy_id}",
-        data={
-            "name": name2,
-        },
-        token=taxonomy_token,
-    )
-    assert status == 200
-
-    status, data = api("GET", f"taxonomy/{taxonomy_id}", token=taxonomy_token)
-
-    assert status == 200
-    assert data["data"]["name"] == name2
-    assert data["data"]["version"] == __version__
-
-    name2 = str(uuid.uuid4())
-    status, data = api(
-        "PUT",
-        f"taxonomy/{taxonomy_id}",
-        data={
-            "hierarchy": taxonomy,
-        },
+        data={"hierarchy": taxonomy},
         token=taxonomy_token,
     )
     assert status == 400

--- a/skyportal/tests/api_tests/groups_users_analysis/test_teams.py
+++ b/skyportal/tests/api_tests/groups_users_analysis/test_teams.py
@@ -1,104 +1,78 @@
 import uuid
 
-from skyportal.tests import api
+import pytest
+from skyportal_py import SkyPortalError
+from skyportal_py.teams import TeamPost, TeamPut
+
+from skyportal.tests import api, client
 
 
 def test_manage_teams_create_get_update_delete_team(
     manage_teams_token, group_admin_user, public_group
 ):
+    sp = client(manage_teams_token)
     name = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "teams",
-        data={
-            "name": name,
-            "description": "A team",
-            "primary_color": "#123456",
-            "logo_url": "/static/images/team_logos/ZTF.png",
-            "group_ids": [public_group.id],
-        },
-        token=manage_teams_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    team_id = data["data"]["id"]
+    team_id = sp.post_team(
+        TeamPost(
+            name=name,
+            description="A team",
+            primary_color="#123456",
+            logo_url="/static/images/team_logos/ZTF.png",
+            group_ids=[public_group.id],
+        )
+    ).id
 
     # Fetch it back: groups and derived roster are included.
-    status, data = api("GET", f"teams/{team_id}", token=manage_teams_token)
-    assert status == 200
-    assert data["data"]["name"] == name
-    assert data["data"]["primary_color"] == "#123456"
-    group_ids = [g["id"] for g in data["data"]["groups"]]
-    assert public_group.id in group_ids
-    member_ids = [u["id"] for u in data["data"]["users"]]
-    assert group_admin_user.id in member_ids
+    team = sp.fetch_team(team_id)
+    assert team.name == name
+    assert team.primary_color == "#123456"
+    assert public_group.id in [g.id for g in team.groups]
+    assert group_admin_user.id in [u.id for u in team.users]
 
     # Update name + color.
     new_name = str(uuid.uuid4())
-    status, data = api(
-        "PUT",
-        f"teams/{team_id}",
-        data={"name": new_name, "primary_color": "#abcdef"},
-        token=manage_teams_token,
-    )
-    assert status == 200
+    sp.update_team(team_id, TeamPut(name=new_name, primary_color="#abcdef"))
 
-    status, data = api("GET", f"teams/{team_id}", token=manage_teams_token)
-    assert data["data"]["name"] == new_name
-    assert data["data"]["primary_color"] == "#abcdef"
+    team = sp.fetch_team(team_id)
+    assert team.name == new_name
+    assert team.primary_color == "#abcdef"
 
     # Delete it.
-    status, data = api("DELETE", f"teams/{team_id}", token=manage_teams_token)
-    assert status == 200
+    sp.delete_team(team_id)
 
-    status, data = api("GET", f"teams/{team_id}", token=manage_teams_token)
-    assert status == 400
+    with pytest.raises(SkyPortalError) as err:
+        sp.fetch_team(team_id)
+    assert err.value.status_code == 400
 
 
 def test_team_appears_in_list(manage_teams_token, public_group):
-    name = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "teams",
-        data={"name": name, "group_ids": [public_group.id]},
-        token=manage_teams_token,
-    )
-    assert status == 200
-    team_id = data["data"]["id"]
+    sp = client(manage_teams_token)
+    team_id = sp.post_team(
+        TeamPost(name=str(uuid.uuid4()), group_ids=[public_group.id])
+    ).id
 
-    status, data = api("GET", "teams", token=manage_teams_token)
-    assert status == 200
-    ids = [t["id"] for t in data["data"]["teams"]]
-    assert team_id in ids
+    assert team_id in [t.id for t in sp.fetch_teams()]
 
 
 def test_team_list_reports_num_members(
     manage_teams_token, group_admin_user, public_group
 ):
-    name = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "teams",
-        data={"name": name, "group_ids": [public_group.id]},
-        token=manage_teams_token,
-    )
-    assert status == 200
-    team_id = data["data"]["id"]
+    sp = client(manage_teams_token)
+    team_id = sp.post_team(
+        TeamPost(name=str(uuid.uuid4()), group_ids=[public_group.id])
+    ).id
 
     # Detail view exposes the full roster; num_members matches its length.
-    status, data = api("GET", f"teams/{team_id}", token=manage_teams_token)
-    assert status == 200
-    member_ids = {u["id"] for u in data["data"]["users"]}
+    detail = sp.fetch_team(team_id)
+    member_ids = {u.id for u in detail.users}
     assert group_admin_user.id in member_ids
-    assert data["data"]["num_members"] == len(member_ids)
+    assert detail.num_members == len(member_ids)
 
     # List view omits the roster but still reports the count (regression: it
     # previously rendered 0 members because `users` was absent from the list).
-    status, data = api("GET", "teams", token=manage_teams_token)
-    assert status == 200
-    team = next(t for t in data["data"]["teams"] if t["id"] == team_id)
-    assert "users" not in team
-    assert team["num_members"] == len(member_ids)
+    team = next(t for t in sp.fetch_teams() if t.id == team_id)
+    assert team.users is None
+    assert team.num_members == len(member_ids)
 
 
 def test_recent_sources_scoped_to_team(
@@ -106,15 +80,13 @@ def test_recent_sources_scoped_to_team(
 ):
     # public_source is saved only to public_group; public_source_group2 only to
     # public_group2. A team on public_group2 must scope the widget to that group.
-    status, data = api(
-        "POST",
-        "teams",
-        data={"name": str(uuid.uuid4()), "group_ids": [public_group2.id]},
-        token=super_admin_token,
+    team_id = (
+        client(super_admin_token)
+        .post_team(TeamPost(name=str(uuid.uuid4()), group_ids=[public_group2.id]))
+        .id
     )
-    assert status == 200
-    team_id = data["data"]["id"]
 
+    # raw api: internal dashboard-widget endpoint, outside skyportal-py's scope
     status, data = api(
         "GET",
         "internal/recent_sources",
@@ -141,15 +113,13 @@ def test_source_counts_scoped_to_team(
 ):
     # public_group2 is a fresh group holding exactly one source, so a team on it
     # should count exactly that one source.
-    status, data = api(
-        "POST",
-        "teams",
-        data={"name": str(uuid.uuid4()), "group_ids": [public_group2.id]},
-        token=super_admin_token,
+    team_id = (
+        client(super_admin_token)
+        .post_team(TeamPost(name=str(uuid.uuid4()), group_ids=[public_group2.id]))
+        .id
     )
-    assert status == 200
-    team_id = data["data"]["id"]
 
+    # raw api: internal dashboard-widget endpoint, outside skyportal-py's scope
     status, data = api(
         "GET",
         "internal/source_counts",
@@ -161,6 +131,7 @@ def test_source_counts_scoped_to_team(
 
 
 def test_cannot_create_team_without_name(manage_teams_token, public_group):
+    # raw api: intentionally malformed payload the typed client can't produce
     status, data = api(
         "POST",
         "teams",
@@ -173,29 +144,17 @@ def test_cannot_create_team_without_name(manage_teams_token, public_group):
 
 def test_manage_teams_acl_required_to_create(group_admin_token, public_group):
     # group_admin_token lacks the "Manage teams" ACL.
-    status, data = api(
-        "POST",
-        "teams",
-        data={"name": str(uuid.uuid4()), "group_ids": [public_group.id]},
-        token=group_admin_token,
-    )
-    assert status in (401, 403)
+    with pytest.raises(SkyPortalError) as err:
+        client(group_admin_token).post_team(
+            TeamPost(name=str(uuid.uuid4()), group_ids=[public_group.id])
+        )
+    assert err.value.status_code in (401, 403)
 
 
 def test_newsfeed_accepts_team_scope(manage_teams_token, public_group):
-    name = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "teams",
-        data={"name": name, "group_ids": [public_group.id]},
-        token=manage_teams_token,
-    )
-    assert status == 200
-    team_id = data["data"]["id"]
+    sp = client(manage_teams_token)
+    team_id = sp.post_team(
+        TeamPost(name=str(uuid.uuid4()), group_ids=[public_group.id])
+    ).id
 
-    status, data = api(
-        "GET", "newsfeed", params={"teamID": team_id}, token=manage_teams_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    assert isinstance(data["data"], list)
+    assert isinstance(sp.fetch_news_feed(team_id=team_id), list)

--- a/skyportal/tests/api_tests/groups_users_analysis/test_telescope.py
+++ b/skyportal/tests/api_tests/groups_users_analysis/test_telescope.py
@@ -1,184 +1,141 @@
 import uuid
 
-from skyportal.tests import api
+import pytest
+from skyportal_py import SkyPortalError
+from skyportal_py.telescopes import TelescopePost, TelescopePut
+
+from skyportal.tests import client
 
 
 def test_get_telescope_longitude_longitude_box(super_admin_token):
+    sp = client(super_admin_token)
     name = str(uuid.uuid4())
-    post_data = {
-        "name": name,
-        "nickname": name,
-        "lat": 0.0,
-        "lon": 0.0,
-        "elevation": 0.0,
-        "diameter": 10.0,
-        "skycam_link": "http://www.lulin.ncu.edu.tw/wea/cur_sky.jpg",
-        "robotic": True,
-    }
-
-    status, data = api("POST", "telescope", data=post_data, token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-
-    telescope_id_1 = data["data"]["id"]
+    telescope_id_1 = sp.post_telescope(
+        TelescopePost(
+            name=name,
+            nickname=name,
+            lat=0.0,
+            lon=0.0,
+            elevation=0.0,
+            diameter=10.0,
+            skycam_link="http://www.lulin.ncu.edu.tw/wea/cur_sky.jpg",
+            robotic=True,
+        )
+    ).id
 
     name = str(uuid.uuid4())
-    post_data = {
-        "name": name,
-        "nickname": name,
-        "lat": -30.0,
-        "lon": 60.0,
-        "elevation": 0.0,
-        "diameter": 10.0,
-        "skycam_link": "http://www.lulin.ncu.edu.tw/wea/cur_sky.jpg",
-        "robotic": True,
-    }
+    telescope_id_2 = sp.post_telescope(
+        TelescopePost(
+            name=name,
+            nickname=name,
+            lat=-30.0,
+            lon=60.0,
+            elevation=0.0,
+            diameter=10.0,
+            skycam_link="http://www.lulin.ncu.edu.tw/wea/cur_sky.jpg",
+            robotic=True,
+        )
+    ).id
 
-    status, data = api("POST", "telescope", data=post_data, token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-
-    telescope_id_2 = data["data"]["id"]
-
-    params = {
-        "latitudeMin": -45.0,
-        "latitudeMax": -15.0,
-        "longitudeMin": 45.0,
-        "longitudeMax": 75.0,
-    }
-
-    status, data = api("GET", "telescope", token=super_admin_token, params=params)
-    assert status == 200
-    assert data["status"] == "success"
-
-    assert telescope_id_2 in [tel["id"] for tel in data["data"]]
-    assert telescope_id_1 not in [tel["id"] for tel in data["data"]]
+    in_box = sp.fetch_telescopes(
+        latitude_min=-45.0,
+        latitude_max=-15.0,
+        longitude_min=45.0,
+        longitude_max=75.0,
+    )
+    assert telescope_id_2 in [tel.id for tel in in_box]
+    assert telescope_id_1 not in [tel.id for tel in in_box]
 
 
 def test_token_user_post_get_telescope(super_admin_token):
+    sp = client(super_admin_token)
     name = str(uuid.uuid4())
-    post_data = {
-        "name": name,
-        "nickname": name,
-        "lat": 0.0,
-        "lon": 0.0,
-        "elevation": 0.0,
-        "diameter": 10.0,
-        "skycam_link": "http://www.lulin.ncu.edu.tw/wea/cur_sky.jpg",
-        "robotic": True,
-    }
+    post_data = TelescopePost(
+        name=name,
+        nickname=name,
+        lat=0.0,
+        lon=0.0,
+        elevation=0.0,
+        diameter=10.0,
+        skycam_link="http://www.lulin.ncu.edu.tw/wea/cur_sky.jpg",
+        robotic=True,
+    )
 
-    status, data = api("POST", "telescope", data=post_data, token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-
-    telescope_id = data["data"]["id"]
-    status, data = api("GET", f"telescope/{telescope_id}", token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-    for key in post_data:
-        assert data["data"][key] == post_data[key]
+    telescope_id = sp.post_telescope(post_data).id
+    fetched = sp.fetch_telescope(telescope_id)
+    for key, value in post_data.model_dump(exclude_none=True).items():
+        assert getattr(fetched, key) == value
 
 
 def test_fetch_telescope_by_name(super_admin_token):
+    sp = client(super_admin_token)
     name = str(uuid.uuid4())
-    post_data = {
-        "name": name,
-        "nickname": name,
-        "lat": 0.0,
-        "lon": 0.0,
-        "elevation": 0.0,
-        "diameter": 10.0,
-        "skycam_link": "http://www.lulin.ncu.edu.tw/wea/cur_sky.jpg",
-    }
+    post_data = TelescopePost(
+        name=name,
+        nickname=name,
+        lat=0.0,
+        lon=0.0,
+        elevation=0.0,
+        diameter=10.0,
+        skycam_link="http://www.lulin.ncu.edu.tw/wea/cur_sky.jpg",
+    )
 
-    status, data = api("POST", "telescope", data=post_data, token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
+    sp.post_telescope(post_data)
 
-    status, data = api("GET", f"telescope?name={name}", token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]) == 1
-    for key in post_data:
-        assert data["data"][0][key] == post_data[key]
+    matches = sp.fetch_telescopes(name=name)
+    assert len(matches) == 1
+    for key, value in post_data.model_dump(exclude_none=True).items():
+        assert getattr(matches[0], key) == value
 
 
 def test_token_user_update_telescope(super_admin_token):
+    sp = client(super_admin_token)
     name = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "telescope",
-        data={
-            "name": name,
-            "nickname": name,
-            "lat": 0.0,
-            "lon": 0.0,
-            "elevation": 0.0,
-            "diameter": 10.0,
-            "robotic": True,
-        },
-        token=super_admin_token,
+    telescope_id = sp.post_telescope(
+        TelescopePost(
+            name=name,
+            nickname=name,
+            lat=0.0,
+            lon=0.0,
+            elevation=0.0,
+            diameter=10.0,
+            robotic=True,
+        )
+    ).id
+    assert sp.fetch_telescope(telescope_id).diameter == 10.0
+
+    sp.update_telescope(
+        telescope_id,
+        TelescopePut(
+            name=name,
+            nickname=name,
+            lat=0.0,
+            lon=0.0,
+            elevation=0.0,
+            diameter=12.0,
+        ),
     )
-    assert status == 200
-    assert data["status"] == "success"
-
-    telescope_id = data["data"]["id"]
-    status, data = api("GET", f"telescope/{telescope_id}", token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-    assert data["data"]["diameter"] == 10.0
-
-    status, data = api(
-        "PUT",
-        f"telescope/{telescope_id}",
-        data={
-            "name": name,
-            "nickname": name,
-            "lat": 0.0,
-            "lon": 0.0,
-            "elevation": 0.0,
-            "diameter": 12.0,
-        },
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-
-    status, data = api("GET", f"telescope/{telescope_id}", token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-    assert data["data"]["diameter"] == 12.0
+    assert sp.fetch_telescope(telescope_id).diameter == 12.0
 
 
 def test_token_user_delete_telescope(super_admin_token):
+    sp = client(super_admin_token)
     name = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "telescope",
-        data={
-            "name": name,
-            "nickname": name,
-            "lat": 0.0,
-            "lon": 0.0,
-            "elevation": 0.0,
-            "diameter": 10.0,
-            "robotic": False,
-        },
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    telescope_id = sp.post_telescope(
+        TelescopePost(
+            name=name,
+            nickname=name,
+            lat=0.0,
+            lon=0.0,
+            elevation=0.0,
+            diameter=10.0,
+            robotic=False,
+        )
+    ).id
+    assert sp.fetch_telescope(telescope_id).diameter == 10.0
 
-    telescope_id = data["data"]["id"]
-    status, data = api("GET", f"telescope/{telescope_id}", token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-    assert data["data"]["diameter"] == 10.0
+    sp.delete_telescope(telescope_id)
 
-    status, data = api("DELETE", f"telescope/{telescope_id}", token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-
-    status, data = api("GET", f"telescope/{telescope_id}", token=super_admin_token)
-    assert status == 400
+    with pytest.raises(SkyPortalError) as err:
+        sp.fetch_telescope(telescope_id)
+    assert err.value.status_code == 400

--- a/skyportal/tests/api_tests/groups_users_analysis/test_thumbnail.py
+++ b/skyportal/tests/api_tests/groups_users_analysis/test_thumbnail.py
@@ -7,30 +7,30 @@ import uuid
 
 import pytest
 import sqlalchemy as sa
+from skyportal_py import SkyPortalError
+from skyportal_py.sources import SourcePost
+from skyportal_py.thumbnails import ThumbnailPost
 
 from baselayer.app.models import async_plain_session_factory
 from skyportal.models import DBSession, Obj, Thumbnail
-from skyportal.tests import api, assert_api
+from skyportal.tests import api, client
 
 
 def test_token_user_post_get_thumbnail(upload_data_token, public_group, ztf_camera):
+    sp = client(upload_data_token)
     obj_id = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id,
-            "ra": 234.22,
-            "dec": -22.33,
-            "redshift": 3,
-            "transient": False,
-            "ra_dis": 2.3,
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    saved = sp.post_source(
+        SourcePost(
+            id=obj_id,
+            ra=234.22,
+            dec=-22.33,
+            redshift=3,
+            transient=False,
+            ra_dis=2.3,
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
-    assert data["data"]["id"] == obj_id
+    assert saved.id == obj_id
 
     # Don't wait for the thumbnail_queue background service — it fetches the
     # most-recent unprocessed obj and a busy test suite keeps pushing newer
@@ -42,41 +42,26 @@ def test_token_user_post_get_thumbnail(upload_data_token, public_group, ztf_came
 
     asyncio.run(_backfill_thumbnails())
 
-    status, data = api(
-        "GET", f"sources/{obj_id}?includeThumbnails=true", token=upload_data_token
-    )
-    thumbnails = data.get("data", {}).get("thumbnails", [])
+    thumbnails = sp.fetch_source(obj_id, include_thumbnails=True).thumbnails
     assert isinstance(thumbnails, list) and len(thumbnails) == 3
 
     orig_source_thumbnail_count = len(thumbnails)
     data = base64.b64encode(
         open(os.path.abspath("skyportal/tests/data/14gqr_new.png"), "rb").read()
-    )
+    ).decode()
     ttype = "new"
-    status, data = api(
-        "POST",
-        "thumbnail",
-        data={"obj_id": obj_id, "data": data, "ttype": ttype},
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    thumbnail_id = data["data"]["id"]
+    thumbnail_id = sp.post_thumbnail(
+        ThumbnailPost(obj_id=obj_id, data=data, ttype=ttype)
+    ).id
     assert isinstance(thumbnail_id, int)
 
-    status, data = api("GET", f"thumbnail/{thumbnail_id}", token=upload_data_token)
-    assert status == 200
-    assert data["status"] == "success"
-    assert data["data"]["type"] == "new"
+    assert sp.fetch_thumbnail(thumbnail_id).type == "new"
 
     # POST/thumbnail is synchronous; this short poll only guards read-after-write.
     nretries = 0
     thumbnails_loaded = False
     while nretries < 5:
-        status, data = api(
-            "GET", f"sources/{obj_id}?includeThumbnails=true", token=upload_data_token
-        )
-        thumbnails = data.get("data", {}).get("thumbnails", [])
+        thumbnails = sp.fetch_source(obj_id, include_thumbnails=True).thumbnails
         if (
             isinstance(thumbnails, list)
             and len(thumbnails) == orig_source_thumbnail_count + 1
@@ -98,18 +83,9 @@ def test_thumbnail_queue_fetch_obj_finds_unprocessed_source(
     from services.thumbnail_queue.thumbnail_queue import fetch_obj
 
     obj_id = str(uuid.uuid4())
-    status, _ = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id,
-            "ra": 234.22,
-            "dec": -22.33,
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    client(upload_data_token).post_source(
+        SourcePost(id=obj_id, ra=234.22, dec=-22.33, group_ids=[public_group.id])
     )
-    assert status == 200
 
     async def _fetch_backfill_fetch():
         async with async_plain_session_factory() as session:
@@ -139,18 +115,9 @@ def test_thumbnail_queue_classifies_remote_grayscale(
     from services.thumbnail_queue import thumbnail_queue as tq
 
     obj_id = str(uuid.uuid4())
-    status, _ = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id,
-            "ra": 234.22,
-            "dec": -22.33,
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    client(upload_data_token).post_source(
+        SourcePost(id=obj_id, ra=234.22, dec=-22.33, group_ids=[public_group.id])
     )
-    assert status == 200
 
     async def _values():
         async with async_plain_session_factory() as session:
@@ -210,27 +177,24 @@ def test_cannot_post_thumbnail_invalid_ttype(
     upload_data_token, public_group, ztf_camera
 ):
     obj_id = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id,
-            "ra": 234.22,
-            "dec": -22.33,
-            "redshift": 3,
-            "transient": False,
-            "ra_dis": 2.3,
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    saved = client(upload_data_token).post_source(
+        SourcePost(
+            id=obj_id,
+            ra=234.22,
+            dec=-22.33,
+            redshift=3,
+            transient=False,
+            ra_dis=2.3,
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
-    assert data["data"]["id"] == obj_id
+    assert saved.id == obj_id
 
     data = base64.b64encode(
         open(os.path.abspath("skyportal/tests/data/14gqr_new.png"), "rb").read()
     )
     ttype = "invalid_ttype"
+    # raw api: intentionally malformed payload the typed client can't produce
     status, data = api(
         "POST",
         "thumbnail",
@@ -245,222 +209,172 @@ def test_cannot_post_thumbnail_invalid_ttype(
 def test_cannot_post_thumbnail_invalid_image_type(
     upload_data_token, public_group, ztf_camera
 ):
+    sp = client(upload_data_token)
     obj_id = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id,
-            "ra": 234.22,
-            "dec": -22.33,
-            "redshift": 3,
-            "transient": False,
-            "ra_dis": 2.3,
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    saved = sp.post_source(
+        SourcePost(
+            id=obj_id,
+            ra=234.22,
+            dec=-22.33,
+            redshift=3,
+            transient=False,
+            ra_dis=2.3,
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
-    assert data["data"]["id"] == obj_id
+    assert saved.id == obj_id
 
     data = base64.b64encode(
         open(
             os.path.abspath("skyportal/tests/data/candid-87704463155000_ref.jpg"), "rb"
         ).read()
-    )
+    ).decode()
     ttype = "ref"
-    status, data = api(
-        "POST",
-        "thumbnail",
-        data={"obj_id": obj_id, "data": data, "ttype": ttype},
-        token=upload_data_token,
-    )
-    assert status == 400
-    assert data["status"] == "error"
-    assert "Invalid thumbnail image type. Only PNG are supported." in data["message"]
+    with pytest.raises(
+        SkyPortalError,
+        match=re.escape("Invalid thumbnail image type. Only PNG are supported."),
+    ) as err:
+        sp.post_thumbnail(ThumbnailPost(obj_id=obj_id, data=data, ttype=ttype))
+    assert err.value.status_code == 400
 
 
 def test_cannot_post_thumbnail_invalid_size(
     upload_data_token, public_group, ztf_camera
 ):
+    sp = client(upload_data_token)
     obj_id = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id,
-            "ra": 234.22,
-            "dec": -22.33,
-            "redshift": 3,
-            "transient": False,
-            "ra_dis": 2.3,
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    saved = sp.post_source(
+        SourcePost(
+            id=obj_id,
+            ra=234.22,
+            dec=-22.33,
+            redshift=3,
+            transient=False,
+            ra_dis=2.3,
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
-    assert data["data"]["id"] == obj_id
+    assert saved.id == obj_id
 
     data = base64.b64encode(
         open(os.path.abspath("skyportal/tests/data/14gqr_new_13px.png"), "rb").read()
-    )
+    ).decode()
     ttype = "ref"
-    status, data = api(
-        "POST",
-        "thumbnail",
-        data={"obj_id": obj_id, "data": data, "ttype": ttype},
-        token=upload_data_token,
-    )
-    assert status == 400
-    assert data["status"] == "error"
-    assert "Invalid thumbnail size." in data["message"]
+    with pytest.raises(
+        SkyPortalError, match=re.escape("Invalid thumbnail size.")
+    ) as err:
+        sp.post_thumbnail(ThumbnailPost(obj_id=obj_id, data=data, ttype=ttype))
+    assert err.value.status_code == 400
 
 
 def test_cannot_post_thumbnail_invalid_file_type(
     upload_data_token, public_group, ztf_camera
 ):
+    sp = client(upload_data_token)
     obj_id = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id,
-            "ra": 234.22,
-            "dec": -22.33,
-            "redshift": 3,
-            "transient": False,
-            "ra_dis": 2.3,
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    saved = sp.post_source(
+        SourcePost(
+            id=obj_id,
+            ra=234.22,
+            dec=-22.33,
+            redshift=3,
+            transient=False,
+            ra_dis=2.3,
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
-    assert data["data"]["id"] == obj_id
+    assert saved.id == obj_id
 
-    data = base64.b64encode(os.urandom(2048))  # invalid image data
+    data = base64.b64encode(os.urandom(2048)).decode()  # invalid image data
     ttype = "ref"
-    status, data = api(
-        "POST",
-        "thumbnail",
-        data={"obj_id": obj_id, "data": data, "ttype": ttype},
-        token=upload_data_token,
-    )
-    assert status == 400
-    assert data["status"] == "error"
-    assert "cannot identify image file" in data["message"]
+    with pytest.raises(SkyPortalError, match="cannot identify image file") as err:
+        sp.post_thumbnail(ThumbnailPost(obj_id=obj_id, data=data, ttype=ttype))
+    assert err.value.status_code == 400
 
 
 def test_delete_thumbnail_deletes_file_on_disk(
     upload_data_token, super_admin_token, public_group
 ):
+    sp = client(upload_data_token)
     obj_id = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id,
-            "ra": 234.22,
-            "dec": -22.33,
-            "redshift": 3,
-            "transient": False,
-            "ra_dis": 2.3,
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    saved = sp.post_source(
+        SourcePost(
+            id=obj_id,
+            ra=234.22,
+            dec=-22.33,
+            redshift=3,
+            transient=False,
+            ra_dis=2.3,
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
-    assert data["data"]["id"] == obj_id
+    assert saved.id == obj_id
 
     thumbnail_data = base64.b64encode(
         open(os.path.abspath("skyportal/tests/data/14gqr_new.png"), "rb").read()
-    )
+    ).decode()
     ttype = "new"
-    status, data = api(
-        "POST",
-        "thumbnail",
-        data={"obj_id": obj_id, "data": thumbnail_data, "ttype": ttype},
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    thumbnail_id = data["data"]["id"]
+    thumbnail_id = sp.post_thumbnail(
+        ThumbnailPost(obj_id=obj_id, data=thumbnail_data, ttype=ttype)
+    ).id
     assert isinstance(thumbnail_id, int)
 
-    status, data = api("GET", f"thumbnail/{thumbnail_id}", token=upload_data_token)
-    assert status == 200
-    assert data["status"] == "success"
-    assert data["data"]["type"] == ttype
+    assert sp.fetch_thumbnail(thumbnail_id).type == ttype
 
     nretries = 0
     thumbnail = None
     # look for the newly created thumbnail
     while nretries < 5:
-        status, data = api(
-            "GET", f"sources/{obj_id}?includeThumbnails=true", token=upload_data_token
-        )
-        thumbnails = data.get("data", {}).get("thumbnails", [])
+        thumbnails = sp.fetch_source(obj_id, include_thumbnails=True).thumbnails
         if isinstance(thumbnails, list) and any(
-            t["id"] == thumbnail_id for t in thumbnails
+            t.id == thumbnail_id for t in thumbnails
         ):
-            thumbnail = next((t for t in thumbnails if t["id"] == thumbnail_id), None)
+            thumbnail = next((t for t in thumbnails if t.id == thumbnail_id), None)
             break
         nretries += 1
         time.sleep(2)
 
     assert thumbnail is not None
 
-    fpath = thumbnail["file_uri"]
+    fpath = thumbnail.file_uri
     assert os.path.exists(fpath)
 
-    status, data = api("DELETE", f"thumbnail/{thumbnail_id}", token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
+    client(super_admin_token).delete_thumbnail(thumbnail_id)
 
     assert not os.path.exists(fpath)
 
 
 def test_change_thumbnail_folder(upload_data_token, super_admin_token, public_group):
+    sp = client(upload_data_token)
+    admin = client(super_admin_token)
     obj_id = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id,
-            "ra": 234.22,
-            "dec": -22.33,
-            "redshift": 3,
-            "transient": False,
-            "ra_dis": 2.3,
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    saved = sp.post_source(
+        SourcePost(
+            id=obj_id,
+            ra=234.22,
+            dec=-22.33,
+            redshift=3,
+            transient=False,
+            ra_dis=2.3,
+            group_ids=[public_group.id],
+        )
     )
-    assert_api(status, data)
-    assert data["data"]["id"] == obj_id
+    assert saved.id == obj_id
 
     thumbnail_data = base64.b64encode(
         open(os.path.abspath("skyportal/tests/data/14gqr_new.png"), "rb").read()
-    )
+    ).decode()
     ttype = "new"
-    status, data = api(
-        "POST",
-        "thumbnail",
-        data={"obj_id": obj_id, "data": thumbnail_data, "ttype": ttype},
-        token=upload_data_token,
-    )
-    assert_api(status, data)
-    thumbnail_id = data["data"]["id"]
+    thumbnail_id = sp.post_thumbnail(
+        ThumbnailPost(obj_id=obj_id, data=thumbnail_data, ttype=ttype)
+    ).id
     assert isinstance(thumbnail_id, int)
 
-    status, data = api("GET", f"thumbnail/{thumbnail_id}", token=upload_data_token)
-    assert_api(status, data)
-    assert data["data"]["type"] == ttype
+    assert sp.fetch_thumbnail(thumbnail_id).type == ttype
 
-    status, data = api("GET", f"thumbnail/{thumbnail_id}", token=upload_data_token)
-    assert_api(status, data)
-    thumbnail = data["data"]
-    assert thumbnail["obj_id"] == obj_id
-    fpath = thumbnail["file_uri"]
+    thumbnail = sp.fetch_thumbnail(thumbnail_id)
+    assert thumbnail.obj_id == obj_id
+    fpath = thumbnail.file_uri
     assert os.path.exists(fpath)
 
     # check there are exactly two subfolders of two letters
@@ -469,53 +383,31 @@ def test_change_thumbnail_folder(upload_data_token, super_admin_token, public_gr
     assert bool(re.match(r"^[a-f0-9]{2}/[a-f-0-9]{2}$", subfolders2))
 
     # now push the thumbnails to 3 levels deep
-    status, data = api(
-        "PATCH",
-        "thumbnailPath",
-        params={
-            "type": ttype,
-            "requiredDepth": 3,
-            "numPerPage": 500,
-        },
-        token=super_admin_token,
-    )
+    # (this always sent a `type` param the server ignores — it reads `types` —
+    # so the server-default types are checked, which include "new")
+    report = admin.update_thumbnail_paths(required_depth=3, num_per_page=500)
 
-    assert_api(status, data)
-    assert data["data"]["totalMatches"] < 500  # otherwise some are not moved!
-    assert data["data"]["inWrongFolder"] == 0  # all thumbnails are updated
+    assert report.total_matches < 500  # otherwise some are not moved!
+    assert report.in_wrong_folder == 0  # all thumbnails are updated
 
     # check the new folder structure
-    status, data = api("GET", f"thumbnail/{thumbnail_id}", token=upload_data_token)
-    assert_api(status, data)
-    thumbnail = data["data"]
-    assert thumbnail["obj_id"] == obj_id
-    fpath = thumbnail["file_uri"]
+    thumbnail = sp.fetch_thumbnail(thumbnail_id)
+    assert thumbnail.obj_id == obj_id
+    fpath = thumbnail.file_uri
     assert os.path.exists(fpath)
     subfolders3 = os.path.dirname(fpath.split("thumbnails/")[1])
     assert bool(re.match(r"^[a-f0-9]{2}/[a-f-0-9]{2}/[a-f-0-9]{2}$", subfolders3))
 
     # return the thumbnails to 2 levels deep
-    status, data = api(
-        "PATCH",
-        "thumbnailPath",
-        params={
-            "type": ttype,
-            "requiredDepth": 2,
-            "numPerPage": 500,
-        },
-        token=super_admin_token,
-    )
+    report = admin.update_thumbnail_paths(required_depth=2, num_per_page=500)
 
-    assert_api(status, data)
-    assert data["data"]["totalMatches"] < 500  # otherwise some are not moved!
-    assert data["data"]["inWrongFolder"] == 0  # all thumbnails are updated
+    assert report.total_matches < 500  # otherwise some are not moved!
+    assert report.in_wrong_folder == 0  # all thumbnails are updated
 
     # make sure the new folder structure is back to normal
-    status, data = api("GET", f"thumbnail/{thumbnail_id}", token=upload_data_token)
-    assert_api(status, data)
-    thumbnail = data["data"]
-    assert thumbnail["obj_id"] == obj_id
-    fpath = thumbnail["file_uri"]
+    thumbnail = sp.fetch_thumbnail(thumbnail_id)
+    assert thumbnail.obj_id == obj_id
+    fpath = thumbnail.file_uri
     assert os.path.exists(fpath)
 
     subfolders4 = os.path.dirname(fpath.split("thumbnails/")[1])
@@ -528,8 +420,7 @@ def test_change_thumbnail_folder(upload_data_token, super_admin_token, public_gr
     assert len(os.listdir(old_folder)) == 0
 
     # delete empty folders
-    status, data = api("DELETE", "thumbnailPath", token=super_admin_token)
-    assert_api(status, data)
+    admin.delete_thumbnail_folders()
 
     assert not os.path.exists(old_folder)
 
@@ -538,46 +429,34 @@ def test_change_thumbnail_folder(upload_data_token, super_admin_token, public_gr
 def test_token_user_delete_thumbnail_cascade_source(
     upload_data_token, super_admin_token, public_group, ztf_camera
 ):
+    sp = client(upload_data_token)
     obj_id = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id,
-            "ra": 234.22,
-            "dec": -22.33,
-            "redshift": 3,
-            "transient": False,
-            "ra_dis": 2.3,
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    saved = sp.post_source(
+        SourcePost(
+            id=obj_id,
+            ra=234.22,
+            dec=-22.33,
+            redshift=3,
+            transient=False,
+            ra_dis=2.3,
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
-    assert data["data"]["id"] == obj_id
+    assert saved.id == obj_id
 
     orig_source_thumbnail_count = len(
         DBSession.query(Obj).filter(Obj.id == obj_id).first().thumbnails
     )
     data = base64.b64encode(
         open(os.path.abspath("skyportal/tests/data/14gqr_new.png"), "rb").read()
-    )
+    ).decode()
     ttype = "new"
-    status, data = api(
-        "POST",
-        "thumbnail",
-        data={"obj_id": obj_id, "data": data, "ttype": ttype},
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    thumbnail_id = data["data"]["id"]
+    thumbnail_id = sp.post_thumbnail(
+        ThumbnailPost(obj_id=obj_id, data=data, ttype=ttype)
+    ).id
     assert isinstance(thumbnail_id, int)
 
-    status, data = api("GET", f"thumbnail/{thumbnail_id}", token=upload_data_token)
-    assert status == 200
-    assert data["status"] == "success"
-    assert data["data"]["type"] == "new"
+    assert sp.fetch_thumbnail(thumbnail_id).type == "new"
 
     assert (
         DBSession.query(Thumbnail).filter(Thumbnail.id == thumbnail_id).first().obj.id
@@ -587,9 +466,7 @@ def test_token_user_delete_thumbnail_cascade_source(
         == orig_source_thumbnail_count + 1
     )
 
-    status, data = api("DELETE", f"thumbnail/{thumbnail_id}", token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
+    client(super_admin_token).delete_thumbnail(thumbnail_id)
 
     assert (
         len(DBSession.query(Obj).filter(Obj.id == obj_id).first().thumbnails)
@@ -600,22 +477,15 @@ def test_token_user_delete_thumbnail_cascade_source(
 def test_survey_thumbnail_skymapper_and_on_demand(
     upload_data_token, super_admin_token, public_group
 ):
+    sp = client(upload_data_token)
     obj_id = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id,
-            "ra": 234.22,
-            "dec": -22.33,
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    sp.post_source(
+        SourcePost(id=obj_id, ra=234.22, dec=-22.33, group_ids=[public_group.id])
     )
-    assert status == 200
 
     # Default survey-thumbnail generation is SDSS/PS1/LS only; SkyMapper and the
     # pointed instruments (HST/Chandra/JWST) are on-demand.
+    # raw api: internal endpoint outside skyportal-py's scope
     status, data = api(
         "POST",
         "internal/survey_thumbnail",
@@ -624,14 +494,14 @@ def test_survey_thumbnail_skymapper_and_on_demand(
     )
     assert status == 200
 
-    status, data = api(
-        "GET", f"sources/{obj_id}?includeThumbnails=true", token=upload_data_token
-    )
-    types = {t["type"] for t in data["data"]["thumbnails"]}
+    types = {
+        t.type for t in sp.fetch_source(obj_id, include_thumbnails=True).thumbnails
+    }
     assert {"sdss", "ls", "ps1"} <= types
     assert not ({"sm", "hst", "chandra", "jwst"} & types)
 
     # Unknown thumbnail types are rejected.
+    # raw api: internal endpoint outside skyportal-py's scope
     status, data = api(
         "POST",
         "internal/survey_thumbnail",
@@ -643,6 +513,7 @@ def test_survey_thumbnail_skymapper_and_on_demand(
 
     # SkyMapper is available on-demand (placeholder here since the cutout service
     # is disabled in test config, but the thumbnail is created).
+    # raw api: internal endpoint outside skyportal-py's scope
     status, data = api(
         "POST",
         "internal/survey_thumbnail",
@@ -650,7 +521,6 @@ def test_survey_thumbnail_skymapper_and_on_demand(
         token=super_admin_token,
     )
     assert status == 200
-    status, data = api(
-        "GET", f"sources/{obj_id}?includeThumbnails=true", token=upload_data_token
-    )
-    assert "sm" in {t["type"] for t in data["data"]["thumbnails"]}
+    assert "sm" in {
+        t.type for t in sp.fetch_source(obj_id, include_thumbnails=True).thumbnails
+    }

--- a/skyportal/tests/api_tests/groups_users_analysis/test_user.py
+++ b/skyportal/tests/api_tests/groups_users_analysis/test_user.py
@@ -1,14 +1,17 @@
 import uuid
 
+import pytest
+from skyportal_py import SkyPortalError
+from skyportal_py.profile import ProfilePatch
+from skyportal_py.users import UserPost
+
 from skyportal.model_util import create_token
 from skyportal.models import DBSession, Token
-from skyportal.tests import api
+from skyportal.tests import api, client
 
 
 def test_get_user_info(manage_users_token, user):
-    status, data = api("GET", f"user/{user.id}", token=manage_users_token)
-    assert status == 200
-    assert data["data"]["id"] == user.id
+    assert client(manage_users_token).fetch_user(user.id).id == user.id
 
 
 def test_delete_user_cascades_to_tokens(super_admin_token, user, public_group):
@@ -19,11 +22,12 @@ def test_delete_user_cascades_to_tokens(super_admin_token, user, public_group):
     # end the transaction on the test-side
     DBSession().commit()
 
-    status, data = api("DELETE", f"user/{user.id}", token=super_admin_token)
-    assert status == 200
+    sp = client(super_admin_token)
+    sp.delete_user(user.id)
 
-    status, data = api("GET", f"user/{user.id}", token=super_admin_token)
-    assert status == 400
+    with pytest.raises(SkyPortalError) as err:
+        sp.fetch_user(user.id)
+    assert err.value.status_code == 400
 
     assert not Token.query.get(token_id)
 
@@ -31,84 +35,61 @@ def test_delete_user_cascades_to_tokens(super_admin_token, user, public_group):
 def test_delete_user_cascades_to_groupuser(
     super_admin_token, manage_groups_token, user, public_group
 ):
-    status, data = api("GET", f"groups/{public_group.id}", token=manage_groups_token)
-    orig_num_users = len(data["data"]["users"])
+    orig_num_users = len(client(manage_groups_token).fetch_group(public_group.id).users)
 
-    status, data = api("DELETE", f"user/{user.id}", token=super_admin_token)
-    assert status == 200
+    client(super_admin_token).delete_user(user.id)
 
-    status, data = api("GET", f"user/{user.id}", token=super_admin_token)
-    assert status == 400
+    with pytest.raises(SkyPortalError) as err:
+        client(super_admin_token).fetch_user(user.id)
+    assert err.value.status_code == 400
 
-    status, data = api("GET", f"groups/{public_group.id}", token=manage_groups_token)
-    assert len(data["data"]["users"]) == orig_num_users - 1
+    group = client(manage_groups_token).fetch_group(public_group.id)
+    assert len(group.users) == orig_num_users - 1
 
 
 def test_add_basic_user_info(manage_groups_token, super_admin_token):
+    sp = client(super_admin_token)
     username = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "user",
-        data={
-            "username": username,
-            "first_name": "Fritz",
-            "last_name": "Marshal",
-            "affiliations": ["Caltech"],
-        },
-        token=super_admin_token,
-    )
-    assert status == 200
-    new_user_id = data["data"]["id"]
-    status, data = api("GET", f"user/{new_user_id}", token=super_admin_token)
-    assert status == 200
-    assert data["data"]["first_name"] == "Fritz"
-    assert data["data"]["last_name"] == "Marshal"
-    assert data["data"]["affiliations"] == ["Caltech"]
+    new_user_id = sp.post_user(
+        UserPost(
+            username=username,
+            first_name="Fritz",
+            last_name="Marshal",
+            affiliations=["Caltech"],
+        )
+    ).id
 
-    status, data = api("DELETE", f"user/{new_user_id}", token=super_admin_token)
-    assert status == 200
+    fetched = sp.fetch_user(new_user_id)
+    assert fetched.first_name == "Fritz"
+    assert fetched.last_name == "Marshal"
+    assert fetched.affiliations == ["Caltech"]
+
+    sp.delete_user(new_user_id)
 
     # add a bad phone number, expecting an error
-    status, data = api(
-        "POST",
-        "user",
-        data={"username": username, "contact_phone": "blah"},
-        token=super_admin_token,
-    )
-    assert status == 400
-    assert "Could not parse input" in data["message"]
+    with pytest.raises(SkyPortalError, match="Could not parse input") as err:
+        sp.post_user(UserPost(username=username, contact_phone="blah"))
+    assert err.value.status_code == 400
 
 
 def test_add_delete_user_adds_deletes_single_user_group(
     manage_groups_token, super_admin_user_two_groups, super_admin_token
 ):
     username = str(uuid.uuid4())
-    status, data = api(
-        "POST", "user", data={"username": username}, token=super_admin_token
-    )
-    assert status == 200
-    new_user_id = data["data"]["id"]
+    new_user_id = client(super_admin_token).post_user(UserPost(username=username)).id
 
-    status, data = api(
-        "GET", "groups?includeSingleUserGroups=true", token=manage_groups_token
-    )
-    assert data["status"] == "success"
+    groups = client(manage_groups_token).fetch_groups(include_single_user_groups=True)
     assert any(
-        group["single_user_group"] and group["name"] == username
-        for group in data["data"]["all_groups"]
+        group.single_user_group and group.name == username
+        for group in groups.all_groups
     )
 
-    status, data = api("DELETE", f"user/{new_user_id}", token=super_admin_token)
-    assert status == 200
+    client(super_admin_token).delete_user(new_user_id)
 
-    status, data = api(
-        "GET", "groups?includeSingleUserGroups=true", token=manage_groups_token
-    )
-    assert data["status"] == "success"
-
+    groups = client(manage_groups_token).fetch_groups(include_single_user_groups=True)
     assert not any(
-        group["single_user_group"] and group["name"] == username
-        for group in data["data"]["all_groups"]
+        group.single_user_group and group.name == username
+        for group in groups.all_groups
     )
 
 
@@ -117,98 +98,60 @@ def test_add_modify_user_adds_modifies_single_user_group(
 ):
     username = str(uuid.uuid4())
     token_name = str(uuid.uuid4())
-    status, data = api(
-        "POST", "user", data={"username": username}, token=super_admin_token
-    )
-    assert status == 200
-    new_user_id = data["data"]["id"]
+    new_user_id = client(super_admin_token).post_user(UserPost(username=username)).id
 
-    status, data = api(
-        "GET", "groups?includeSingleUserGroups=true", token=manage_groups_token
-    )
-    assert data["status"] == "success"
+    groups = client(manage_groups_token).fetch_groups(include_single_user_groups=True)
     assert any(
-        group["single_user_group"] and group["name"] == username
-        for group in data["data"]["all_groups"]
+        group.single_user_group and group.name == username
+        for group in groups.all_groups
     )
 
     token_id = create_token(ACLs=[], user_id=new_user_id, name=token_name)
     new_username = str(uuid.uuid4())
 
-    status, data = api(
-        "PATCH", "internal/profile", data={"username": new_username}, token=token_id
-    )
-    assert status == 200
+    client(token_id).update_profile(ProfilePatch(username=new_username))
 
-    status, data = api(
-        "GET", "groups?includeSingleUserGroups=true", token=manage_groups_token
-    )
-    assert data["status"] == "success"
+    groups = client(manage_groups_token).fetch_groups(include_single_user_groups=True)
     assert any(
-        group["single_user_group"] and group["name"] == new_username
-        for group in data["data"]["all_groups"]
+        group.single_user_group and group.name == new_username
+        for group in groups.all_groups
     )
 
 
 def test_user_list(view_only_token):
-    status, data = api("GET", "user", token=view_only_token)
-    assert status == 200
-    assert data["status"] == "success"
+    client(view_only_token).fetch_users()
 
 
 def test_user_list_filtering(view_only_token, user, view_only_user):
     # Try some simple filtering options - other options follow very similar
     # logic so just these should be decent coverage
+    sp = client(view_only_token)
 
     # Username
-    status, data = api(
-        "GET",
-        f"user/?username={user.username}",
-        token=view_only_token,
-    )
-    assert status == 200
-    assert len(data["data"]["users"]) == 1
-    assert data["data"]["users"][0]["id"] == user.id
+    page = sp.fetch_users(username=user.username)
+    assert len(page.users) == 1
+    assert page.users[0].id == user.id
 
     # Role
     # Make sure the result shows up among all the view_only_users provisioned across tests
     # by returning a huge page
-    status, data = api(
-        "GET",
-        "user/?role=View+only&numPerPage=300",
-        token=view_only_token,
-    )
-    assert status == 200
-    result_user_ids = [user["id"] for user in data["data"]["users"]]
+    page = sp.fetch_users(role="View only", num_per_page=300)
+    result_user_ids = [u.id for u in page.users]
     assert view_only_user.id in result_user_ids
     assert user.id not in result_user_ids
 
 
 def test_patch_user_expiration_date(super_admin_token, user):
-    status, data = api(
-        "PATCH",
-        f"user/{user.id}",
-        data={"expirationDate": "2030-01-02"},
-        token=super_admin_token,
-    )
-    assert status == 200, data
+    sp = client(super_admin_token)
+    sp.update_user(user.id, expiration_date="2030-01-02")
 
-    status, data = api("GET", f"user/{user.id}", token=super_admin_token)
-    assert status == 200
-    assert data["data"]["expiration_date"].startswith("2030-01-02")
-    # The parsed date is the only thing that lands: the camelCase key must not
-    # also be assigned verbatim (to_dict serializes the instance __dict__).
-    assert "expirationDate" not in data["data"]
+    # extra="forbid" also verifies the camelCase key is not assigned verbatim
+    # alongside the parsed date (to_dict serializes the instance __dict__).
+    fetched = sp.fetch_user(user.id)
+    assert fetched.expiration_date.date().isoformat() == "2030-01-02"
 
-    status, data = api(
-        "PATCH",
-        f"user/{user.id}",
-        data={"expirationDate": None},
-        token=super_admin_token,
-    )
-    assert status == 200, data
-    status, data = api("GET", f"user/{user.id}", token=super_admin_token)
-    assert data["data"]["expiration_date"] is None
+    sp.update_user(user.id, expiration_date=None)
+    assert sp.fetch_user(user.id).expiration_date is None
 
 
 def test_patch_user_cannot_rewrite_identity_columns(super_admin_token, user):
@@ -216,6 +159,7 @@ def test_patch_user_cannot_rewrite_identity_columns(super_admin_token, user):
     identity columns have to be refused explicitly."""
     original_uid = user.oauth_uid
 
+    # raw api: intentionally hostile payload the typed client can't produce
     status, data = api(
         "PATCH",
         f"user/{user.id}",
@@ -224,7 +168,6 @@ def test_patch_user_cannot_rewrite_identity_columns(super_admin_token, user):
     )
     assert status == 200, data
 
-    status, data = api("GET", f"user/{user.id}", token=super_admin_token)
-    assert status == 200, data
-    assert data["data"]["id"] == user.id
-    assert data["data"]["oauth_uid"] == original_uid
+    fetched = client(super_admin_token).fetch_user(user.id)
+    assert fetched.id == user.id
+    assert fetched.oauth_uid == original_uid

--- a/skyportal/tests/api_tests/photometry_followup/test_bulk_delete_photometry.py
+++ b/skyportal/tests/api_tests/photometry_followup/test_bulk_delete_photometry.py
@@ -1,31 +1,25 @@
-from skyportal.tests import api
+from skyportal_py.photometry import PhotometryPost
+
+from skyportal.tests import client
 
 
 def test_bulk_delete_photometry(
     super_admin_token, upload_data_token, public_source, public_group, ztf_camera
 ):
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": [58000.0, 58001.0, 58002.0],
-            "instrument_id": ztf_camera.id,
-            "flux": [12.24, 12.52, 12.70],
-            "fluxerr": [0.031, 0.029, 0.030],
-            "filter": ["ztfg", "ztfg", "ztfg"],
-            "zp": [25.0, 25.0, 25.0],
-            "magsys": ["ab", "ab", "ab"],
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    resp = client(upload_data_token).post_photometry(
+        PhotometryPost(
+            obj_id=str(public_source.id),
+            mjd=[58000.0, 58001.0, 58002.0],
+            instrument_id=ztf_camera.id,
+            flux=[12.24, 12.52, 12.70],
+            fluxerr=[0.031, 0.029, 0.030],
+            filter=["ztfg", "ztfg", "ztfg"],
+            zp=[25.0, 25.0, 25.0],
+            magsys=["ab", "ab", "ab"],
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
-    assert data["status"] == "success"
-    upload_id = data["data"]["upload_id"]
+    upload_id = resp.upload_id
 
-    status, data = api(
-        "DELETE", f"photometry/bulk_delete/{upload_id}", token=super_admin_token
-    )
-    assert status == 200
-    assert data["data"] == "Deleted 3 photometry point(s)."
+    result = client(super_admin_token).bulk_delete_photometry(upload_id)
+    assert result == "Deleted 3 photometry point(s)."

--- a/skyportal/tests/api_tests/photometry_followup/test_default_observation_plan.py
+++ b/skyportal/tests/api_tests/photometry_followup/test_default_observation_plan.py
@@ -4,8 +4,12 @@ import uuid
 
 import numpy as np
 import pytest
+from skyportal_py import SkyPortalError
+from skyportal_py.allocations import AllocationPost
+from skyportal_py.gcn_events import GcnEventPost
+from skyportal_py.observation_plans import DefaultObservationPlanPost
 
-from skyportal.tests import api
+from skyportal.tests import client
 from skyportal.tests.external.test_moving_objects import (
     add_telescope_and_instrument,
     remove_telescope_and_instrument,
@@ -14,35 +18,33 @@ from skyportal.tests.external.test_moving_objects import (
 
 @pytest.mark.flaky(reruns=2)
 def test_default_observation_plan_tiling(super_admin_token, public_group):
+    sp = client(super_admin_token)
     telescope_id, instrument_id, _, _ = add_telescope_and_instrument(
         "ZTF", super_admin_token, list(range(200, 250))
     )
 
-    request_data = {
-        "group_id": public_group.id,
-        "instrument_id": instrument_id,
-        "pi": "Shri Kulkarni",
-        "hours_allocated": 200,
-        "validity_ranges": [
-            {
-                "start_date": "2021-02-27T00:00:00.000Z",
-                "end_date": "3021-07-20T00:00:00.000Z",
-            }
-        ],
-        "proposal_id": "COO-2020A-P01",
-    }
-
-    status, data = api("POST", "allocation", data=request_data, token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-    allocation_id = data["data"]["id"]
+    allocation_id = sp.post_allocation(
+        AllocationPost(
+            group_id=public_group.id,
+            instrument_id=instrument_id,
+            pi="Shri Kulkarni",
+            hours_allocated=200,
+            validity_ranges=[
+                {
+                    "start_date": "2021-02-27T00:00:00.000Z",
+                    "end_date": "3021-07-20T00:00:00.000Z",
+                }
+            ],
+            proposal_id="COO-2020A-P01",
+        )
+    ).id
 
     default_plan_name = str(uuid.uuid4())
 
-    request_data = {
-        "allocation_id": allocation_id,
-        "default_plan_name": default_plan_name,
-        "payload": {
+    request_data = DefaultObservationPlanPost(
+        allocation_id=allocation_id,
+        default_plan_name=default_plan_name,
+        payload={
             "filter_strategy": "block",
             "schedule_strategy": "tiling",
             "schedule_type": "greedy_slew",
@@ -54,98 +56,56 @@ def test_default_observation_plan_tiling(super_admin_token, public_group):
             "program_id": "Partnership",
             "subprogram_name": "GRB",
         },
-    }
-
-    status, data = api(
-        "POST", "default_observation_plan", data=request_data, token=super_admin_token
     )
-    assert status == 200
-    assert data["status"] == "success"
-    id = data["data"]["id"]
 
-    status, data = api(
-        "GET",
-        f"default_observation_plan/{id}",
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    assert data["data"]["allocation_id"] == allocation_id
+    id = sp.post_default_observation_plan(request_data).id
+
+    assert sp.fetch_default_observation_plan(id).allocation_id == allocation_id
 
     # we create a second plan, to see if generating both at the same time works
     default_plan_name_2 = str(uuid.uuid4())
-    request_data["default_plan_name"] = default_plan_name_2
-    status, data = api(
-        "POST", "default_observation_plan", data=request_data, token=super_admin_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    request_data.default_plan_name = default_plan_name_2
+    id = sp.post_default_observation_plan(request_data).id
 
-    id = data["data"]["id"]
-
-    status, data = api(
-        "GET",
-        f"default_observation_plan/{id}",
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    assert data["data"]["allocation_id"] == allocation_id
+    assert sp.fetch_default_observation_plan(id).allocation_id == allocation_id
 
     datafile = f"{os.path.dirname(__file__)}/../../../../data/GW190814.xml"
     with open(datafile, "rb") as fid:
         payload = fid.read()
-    event_data = {"xml": payload}
+    event_data = GcnEventPost(xml=payload)
 
     dateobs = "2019-08-14T21:10:39"
-    status, data = api("GET", f"gcn_event/{dateobs}", token=super_admin_token)
-
-    if status == 404:
-        status, data = api(
-            "POST", "gcn_event", data=event_data, token=super_admin_token
-        )
-        assert status == 200
-        assert data["status"] == "success"
+    try:
+        sp.fetch_gcn_event(dateobs)
+    except SkyPortalError:
+        gcnevent_id = sp.post_gcn_event(event_data).gcnevent_id
     else:
         # we delete the event and re-add it
-        status, data = api("DELETE", f"gcn_event/{dateobs}", token=super_admin_token)
-        assert status == 200
-        assert data["status"] == "success"
-
-        status, data = api(
-            "POST", "gcn_event", data=event_data, token=super_admin_token
-        )
-        assert status == 200
-        assert data["status"] == "success"
-
-    gcnevent_id = data["data"]["gcnevent_id"]
+        sp.delete_gcn_event(dateobs)
+        gcnevent_id = sp.post_gcn_event(event_data).gcnevent_id
 
     # wait for event to load
     for n_times in range(26):
-        status, data = api("GET", f"gcn_event/{dateobs}", token=super_admin_token)
-        if data["status"] == "success":
+        try:
+            sp.fetch_gcn_event(dateobs)
             break
-        time.sleep(2)
+        except SkyPortalError:
+            time.sleep(2)
     assert n_times < 25
 
     # wait for the localization to load
-    params = {"include2DMap": True}
     for n_times_2 in range(26):
-        status, data = api(
-            "GET",
-            "localization/2019-08-14T21:10:39/name/LALInference.v1.fits.gz",
-            token=super_admin_token,
-            params=params,
-        )
-
-        if data["status"] == "success":
-            data = data["data"]
-            assert data["dateobs"] == dateobs
-            assert data["localization_name"] == "LALInference.v1.fits.gz"
-            assert np.isclose(np.sum(data["flat_2d"]), 1)
-            break
-        else:
+        try:
+            localization = sp.fetch_localization(
+                "2019-08-14T21:10:39", "LALInference.v1.fits.gz", include_2d_map=True
+            )
+        except SkyPortalError:
             time.sleep(2)
+        else:
+            assert localization.dateobs.isoformat() == dateobs
+            assert localization.localization_name == "LALInference.v1.fits.gz"
+            assert np.isclose(np.sum(localization.flat_2d), 1)
+            break
     assert n_times_2 < 25
 
     # wait for the plans to be processed
@@ -155,30 +115,17 @@ def test_default_observation_plan_tiling(super_admin_token, public_group):
     while n_retries < 10:
         try:
             # now we want to see if any observation plans were created
-            status, data = api(
-                "GET",
-                f"gcn_event/{gcnevent_id}/observation_plan_requests",
-                token=super_admin_token,
-            )
-            assert status == 200
-            assert data["status"] == "success"
-            assert len(data["data"]) > 0
-            generated_by_default = [
-                d["allocation_id"] == allocation_id for d in data["data"]
-            ]
+            requests = sp.fetch_gcn_event_observation_plan_requests(gcnevent_id)
+            assert len(requests) > 0
+            generated_by_default = [d.allocation_id == allocation_id for d in requests]
             assert sum(generated_by_default) == 2
             break
-        except AssertionError:
+        except (AssertionError, SkyPortalError):
             n_retries += 1
             time.sleep(5)
 
     assert n_retries < 10
 
-    status, data = api(
-        "DELETE",
-        f"default_observation_plan/{id}",
-        token=super_admin_token,
-    )
-    assert status == 200
+    sp.delete_default_observation_plan(id)
 
     remove_telescope_and_instrument(telescope_id, instrument_id, super_admin_token)

--- a/skyportal/tests/api_tests/photometry_followup/test_followup_requests_api.py
+++ b/skyportal/tests/api_tests/photometry_followup/test_followup_requests_api.py
@@ -1,9 +1,15 @@
 import asyncio
 import uuid
 
+import pytest
 import sqlalchemy as sa
+from skyportal_py import SkyPortalError
+from skyportal_py.followup_requests import (
+    DefaultFollowupRequestPost,
+    FollowupRequestPost,
+)
 
-from skyportal.tests import api
+from skyportal.tests import client
 
 from ....utils.naive_datetime import utcnow_naive
 
@@ -25,19 +31,13 @@ def test_token_user_post_robotic_followup_request(
         },
     }
 
-    status, data = api(
-        "POST", "followup_request", data=request_data, token=upload_data_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    id = data["data"]["id"]
+    sp = client(upload_data_token)
+    id = sp.post_followup_request(FollowupRequestPost(**request_data)).id
 
-    status, data = api("GET", f"followup_request/{id}", token=upload_data_token)
-    assert status == 200
-    assert data["status"] == "success"
+    followup_request = sp.fetch_followup_request(id)
 
     for key in request_data:
-        assert data["data"][key] == request_data[key]
+        assert getattr(followup_request, key) == request_data[key]
 
 
 def test_gemini_followup_blank_note_title(
@@ -59,11 +59,7 @@ def test_gemini_followup_blank_note_title(
         },
     }
 
-    status, data = api(
-        "POST", "followup_request", data=request_data, token=upload_data_token
-    )
-    assert status == 200, data
-    assert data["status"] == "success"
+    client(upload_data_token).post_followup_request(FollowupRequestPost(**request_data))
 
 
 def test_winter_followup_submit(
@@ -81,11 +77,7 @@ def test_winter_followup_submit(
         },
     }
 
-    status, data = api(
-        "POST", "followup_request", data=request_data, token=upload_data_token
-    )
-    assert status == 200, data
-    assert data["status"] == "success"
+    client(upload_data_token).post_followup_request(FollowupRequestPost(**request_data))
 
 
 def test_token_user_delete_owned_followup_request(
@@ -108,16 +100,10 @@ def test_token_user_delete_owned_followup_request(
         },
     }
 
-    status, data = api(
-        "POST", "followup_request", data=request_data, token=upload_data_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    id = data["data"]["id"]
+    sp = client(upload_data_token)
+    id = sp.post_followup_request(FollowupRequestPost(**request_data)).id
 
-    status, data = api("DELETE", f"followup_request/{id}", token=upload_data_token)
-    assert status == 200
-    assert data["status"] == "success"
+    sp.delete_followup_request(id)
 
 
 def test_token_user_modify_owned_followup_request(
@@ -137,12 +123,8 @@ def test_token_user_modify_owned_followup_request(
         },
     }
 
-    status, data = api(
-        "POST", "followup_request", data=request_data, token=upload_data_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    id = data["data"]["id"]
+    sp = client(upload_data_token)
+    id = sp.post_followup_request(FollowupRequestPost(**request_data)).id
 
     new_request_data = {
         "allocation_id": public_group_sedm_allocation.id,
@@ -158,17 +140,12 @@ def test_token_user_modify_owned_followup_request(
         },
     }
 
-    status, data = api(
-        "PUT", f"followup_request/{id}", data=new_request_data, token=upload_data_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp.update_followup_request(id, **new_request_data)
 
-    status, data = api("GET", f"followup_request/{id}", token=upload_data_token)
-    assert status == 200
+    followup_request = sp.fetch_followup_request(id)
 
     for k in new_request_data:
-        assert data["data"][k] == new_request_data[k]
+        assert getattr(followup_request, k) == new_request_data[k]
 
 
 def test_regular_user_delete_super_admin_followup_request(
@@ -194,16 +171,13 @@ def test_regular_user_delete_super_admin_followup_request(
         },
     }
 
-    status, data = api(
-        "POST", "followup_request", data=request_data, token=super_admin_token
+    id = (
+        client(super_admin_token)
+        .post_followup_request(FollowupRequestPost(**request_data))
+        .id
     )
-    assert status == 200
-    assert data["status"] == "success"
-    id = data["data"]["id"]
 
-    status, data = api("DELETE", f"followup_request/{id}", token=upload_data_token)
-    assert status == 200
-    assert data["status"] == "success"
+    client(upload_data_token).delete_followup_request(id)
 
 
 def test_group1_user_cannot_see_group2_followup_request(
@@ -226,20 +200,18 @@ def test_group1_user_cannot_see_group2_followup_request(
         },
     }
 
-    status, data = api(
-        "POST", "followup_request", data=request_data, token=super_admin_token
+    id = (
+        client(super_admin_token)
+        .post_followup_request(FollowupRequestPost(**request_data))
+        .id
     )
-    assert status == 200
-    assert data["status"] == "success"
-    id = data["data"]["id"]
 
-    status, data = api("GET", f"followup_request/{id}", token=view_only_token)
-    assert status == 400
-    assert data["status"] == "error"
+    with pytest.raises(SkyPortalError) as err:
+        client(view_only_token).fetch_followup_request(id)
+    assert err.value.status_code == 400
 
-    status, data = api("GET", "followup_request/", token=view_only_token)
-    assert status == 200
-    assert id not in [a["id"] for a in data["data"]["followup_requests"]]
+    page = client(view_only_token).fetch_followup_requests()
+    assert id not in [a.id for a in page.followup_requests]
 
 
 def test_filter_followup_request(
@@ -263,55 +235,18 @@ def test_filter_followup_request(
     }
 
     time_before_post = utcnow_naive().isoformat()
-    status, data = api(
-        "POST", "followup_request", data=request_data, token=upload_data_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    client(upload_data_token).post_followup_request(FollowupRequestPost(**request_data))
 
-    params = {"startDate": time_before_post}
-
-    status, data = api(
-        "GET",
-        "followup_request",
-        params=params,
-        token=view_only_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    assert any(
-        s["obj_id"] == public_source.id for s in data["data"]["followup_requests"]
-    )
+    page = client(view_only_token).fetch_followup_requests(start_date=time_before_post)
+    assert any(s.obj_id == public_source.id for s in page.followup_requests)
 
     time_after_post = utcnow_naive().isoformat()
 
-    params = {"startDate": time_after_post}
+    page = client(view_only_token).fetch_followup_requests(start_date=time_after_post)
+    assert not any(s.obj_id == public_source.id for s in page.followup_requests)
 
-    status, data = api(
-        "GET",
-        "followup_request",
-        params=params,
-        token=view_only_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    assert not any(
-        s["obj_id"] == public_source.id for s in data["data"]["followup_requests"]
-    )
-
-    params = {"sourceID": public_source.id}
-
-    status, data = api(
-        "GET",
-        "followup_request",
-        params=params,
-        token=view_only_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    assert any(
-        s["obj_id"] == public_source.id for s in data["data"]["followup_requests"]
-    )
+    page = client(view_only_token).fetch_followup_requests(source_id=public_source.id)
+    assert any(s.obj_id == public_source.id for s in page.followup_requests)
 
 
 def _default_followup_payload(public_group, allocation, **extra):
@@ -347,19 +282,14 @@ def test_default_followup_request_stores_constraints(
         implements_update=False,
     )
 
-    status, data = api(
-        "POST",
-        "default_followup_request",
-        data=request_data,
-        token=super_admin_token,
-    )
-    assert status == 200, data
-    new_id = data["data"]["id"]
+    sp = client(super_admin_token)
+    new_id = sp.post_default_followup_request(
+        DefaultFollowupRequestPost(**request_data)
+    ).id
 
-    status, data = api("GET", "default_followup_request", token=super_admin_token)
-    assert status == 200
-    match = next(r for r in data["data"] if r["id"] == new_id)
-    constraints = match["constraints"]
+    requests = sp.fetch_default_followup_requests()
+    match = next(r for r in requests if r.id == new_id)
+    constraints = match.constraints
     assert constraints is not None
     assert constraints["not_if_classified"] is True
     assert constraints["not_if_duplicates"] is True
@@ -368,62 +298,44 @@ def test_default_followup_request_stores_constraints(
     # constraints not supplied are absent (not defaulted)
     assert "not_if_spectra_exist" not in constraints
     # priority_order / validity_days / comment are stored for the auto-trigger path
-    assert match["priority_order"] == "desc"
-    assert match["validity_days"] == 3
-    assert match["comment"] == "auto-trigger test"
-    assert match["implements_update"] is False
+    assert match.priority_order == "desc"
+    assert match.validity_days == 3
+    assert match.comment == "auto-trigger test"
+    assert match.implements_update is False
 
 
 def test_default_followup_request_source_filter_regex_validation(
     public_group, public_group_sedm_allocation, super_admin_token
 ):
     def make(name):
-        return _default_followup_payload(
-            public_group,
-            public_group_sedm_allocation,
-            source_filter={"name": name, "group_id": public_group.id},
+        return DefaultFollowupRequestPost(
+            **_default_followup_payload(
+                public_group,
+                public_group_sedm_allocation,
+                source_filter={"name": name, "group_id": public_group.id},
+            )
         )
 
+    sp = client(super_admin_token)
+
     # A valid regex is accepted.
-    status, data = api(
-        "POST",
-        "default_followup_request",
-        data=make("^ZTF2[0-9].*"),
-        token=super_admin_token,
-    )
-    assert status == 200, data
-    assert data["status"] == "success"
+    sp.post_default_followup_request(make("^ZTF2[0-9].*"))
 
     # A malformed regex is rejected at creation (would otherwise error in
     # Postgres on every source save).
-    status, data = api(
-        "POST",
-        "default_followup_request",
-        data=make("([unterminated"),
-        token=super_admin_token,
-    )
-    assert status == 400
-    assert "valid regular expression" in data["message"]
+    with pytest.raises(SkyPortalError, match="valid regular expression") as err:
+        sp.post_default_followup_request(make("([unterminated"))
+    assert err.value.status_code == 400
 
     # A catastrophic-backtracking pattern is rejected at creation (ReDoS guard).
-    status, data = api(
-        "POST",
-        "default_followup_request",
-        data=make("(a+)+$"),
-        token=super_admin_token,
-    )
-    assert status == 400
-    assert "catastrophic backtracking" in data["message"]
+    with pytest.raises(SkyPortalError, match="catastrophic backtracking") as err:
+        sp.post_default_followup_request(make("(a+)+$"))
+    assert err.value.status_code == 400
 
     # An oversized pattern is rejected.
-    status, data = api(
-        "POST",
-        "default_followup_request",
-        data=make("a" * 1001),
-        token=super_admin_token,
-    )
-    assert status == 400
-    assert "at most" in data["message"]
+    with pytest.raises(SkyPortalError, match="at most") as err:
+        sp.post_default_followup_request(make("a" * 1001))
+    assert err.value.status_code == 400
 
 
 def test_default_followup_request_without_constraints_is_null(
@@ -431,20 +343,15 @@ def test_default_followup_request_without_constraints_is_null(
 ):
     request_data = _default_followup_payload(public_group, public_group_sedm_allocation)
 
-    status, data = api(
-        "POST",
-        "default_followup_request",
-        data=request_data,
-        token=super_admin_token,
-    )
-    assert status == 200, data
-    new_id = data["data"]["id"]
+    sp = client(super_admin_token)
+    new_id = sp.post_default_followup_request(
+        DefaultFollowupRequestPost(**request_data)
+    ).id
 
-    status, data = api("GET", "default_followup_request", token=super_admin_token)
-    assert status == 200
-    match = next(r for r in data["data"] if r["id"] == new_id)
+    requests = sp.fetch_default_followup_requests()
+    match = next(r for r in requests if r.id == new_id)
     # no constraint keys supplied -> stored as null (always submit)
-    assert match["constraints"] is None
+    assert match.constraints is None
 
 
 def test_auto_followup_request_flushes_before_submit(

--- a/skyportal/tests/api_tests/photometry_followup/test_followup_requests_reprioritize.py
+++ b/skyportal/tests/api_tests/photometry_followup/test_followup_requests_reprioritize.py
@@ -1,4 +1,6 @@
-from skyportal.tests import api
+from skyportal_py.followup_requests import FollowupRequestPost
+
+from skyportal.tests import client
 
 
 def test_reprioritize_followup_request(
@@ -9,46 +11,31 @@ def test_reprioritize_followup_request(
 ):
     localization_id = gcn_GW190425.localizations[0].id
 
-    request_data = {
-        "allocation_id": public_group_generic_allocation.id,
-        "obj_id": public_source.id,
-        "payload": {
-            "priority": 1,
-            "start_date": "3010-09-01",
-            "end_date": "3012-09-01",
-            "observation_choices": public_group_generic_allocation.instrument.to_dict()[
-                "filters"
-            ],
-            "exposure_time": 300,
-            "exposure_counts": 1,
-            "maximum_airmass": 2,
-            "minimum_lunar_distance": 30,
-        },
-    }
+    sp = client(upload_data_token)
+    id = sp.post_followup_request(
+        FollowupRequestPost(
+            allocation_id=public_group_generic_allocation.id,
+            obj_id=public_source.id,
+            payload={
+                "priority": 1,
+                "start_date": "3010-09-01",
+                "end_date": "3012-09-01",
+                "observation_choices": public_group_generic_allocation.instrument.to_dict()[
+                    "filters"
+                ],
+                "exposure_time": 300,
+                "exposure_counts": 1,
+                "maximum_airmass": 2,
+                "minimum_lunar_distance": 30,
+            },
+        )
+    ).id
 
-    status, data = api(
-        "POST", "followup_request", data=request_data, token=upload_data_token
+    sp.update_followup_request_prioritization(
+        request_ids=[id],
+        priority_type="localization",
+        localization_id=localization_id,
     )
-    assert status == 200
-    assert data["status"] == "success"
-    id = data["data"]["id"]
 
-    new_request_data = {
-        "localizationId": localization_id,
-        "requestIds": [id],
-        "priorityType": "localization",
-    }
-
-    status, data = api(
-        "PUT",
-        "followup_request/prioritization",
-        data=new_request_data,
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-
-    status, data = api("GET", f"followup_request/{id}", token=upload_data_token)
-    assert status == 200
-
-    assert data["data"]["payload"]["priority"] == 5
+    followup_request = sp.fetch_followup_request(id)
+    assert followup_request.payload["priority"] == 5

--- a/skyportal/tests/api_tests/photometry_followup/test_gcn_event_obj.py
+++ b/skyportal/tests/api_tests/photometry_followup/test_gcn_event_obj.py
@@ -1,6 +1,11 @@
 import uuid
 
-from skyportal.tests import api
+import pytest
+from skyportal_py import SkyPortalError
+from skyportal_py.gcn_events import GcnEventObjPost
+from skyportal_py.sources import SourcePost
+
+from skyportal.tests import api, client
 
 # gcn_GW190814 fixture: dateobs 2019-08-14 21:10:39, localization
 # "LALInference.v1.fits.gz".
@@ -13,13 +18,7 @@ def _dateobs(gcn_event):
 
 def _post_source(token, ra=24.6258, dec=-32.9024):
     obj_id = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "sources",
-        data={"id": obj_id, "ra": ra, "dec": dec, "redshift": 3},
-        token=token,
-    )
-    assert status == 200, data
+    client(token).post_source(SourcePost(id=obj_id, ra=ra, dec=dec, redshift=3))
     return obj_id
 
 
@@ -33,7 +32,7 @@ def _confirm(token, dateobs, source_id, gcn_status="confirmed", **extra):
         "end_date": "2019-08-16T00:00:00",
         **extra,
     }
-    return api("POST", f"sources_in_gcn/{dateobs}", data=body, token=token)
+    return client(token).post_gcn_event_source(dateobs, GcnEventObjPost(**body))
 
 
 def test_confirm_get_patch_delete_lifecycle(
@@ -43,7 +42,7 @@ def test_confirm_get_patch_delete_lifecycle(
     source_id = _post_source(upload_data_token)
 
     # confirm the source in the GCN
-    status, data = _confirm(
+    result = _confirm(
         super_admin_token,
         dateobs,
         source_id,
@@ -51,62 +50,39 @@ def test_confirm_get_patch_delete_lifecycle(
         explanation="in localization",
         notes="looks real",
     )
-    assert status == 200, data
-    assert data["data"]["id"] is not None
+    assert result.id is not None
 
     # GET single via path
-    status, data = api(
-        "GET", f"sources_in_gcn/{dateobs}/{source_id}", token=view_only_token
-    )
-    assert status == 200, data
-    entries = data["data"]
+    entries = client(view_only_token).fetch_gcn_event_source(dateobs, source_id)
     assert len(entries) == 1
-    assert entries[0]["obj_id"] == source_id
-    assert entries[0]["status"] == "confirmed"
-    assert entries[0]["explanation"] == "in localization"
-    assert entries[0]["notes"] == "looks real"
+    assert entries[0].obj_id == source_id
+    assert entries[0].status == "confirmed"
+    assert entries[0].explanation == "in localization"
+    assert entries[0].notes == "looks real"
 
     # GET list (no source filter) includes it
-    status, data = api("GET", f"sources_in_gcn/{dateobs}", token=view_only_token)
-    assert status == 200, data
-    assert any(e["obj_id"] == source_id for e in data["data"])
+    entries = client(view_only_token).fetch_gcn_event_sources(dateobs)
+    assert any(e.obj_id == source_id for e in entries)
 
     # associated_gcns lists the event while confirmed
-    status, data = api("GET", f"associated_gcns/{source_id}", token=view_only_token)
-    assert status == 200, data
-    assert dateobs in [d.replace(" ", "T") for d in data["data"]["gcns"]]
+    gcns = client(view_only_token).fetch_gcn_events_associated_with_source(source_id)
+    assert dateobs in [d.replace(" ", "T") for d in gcns]
 
     # PATCH to rejected
-    status, data = api(
-        "PATCH",
-        f"sources_in_gcn/{dateobs}/{source_id}",
-        data={"status": "rejected"},
-        token=super_admin_token,
-    )
-    assert status == 200, data
+    client(super_admin_token).update_gcn_event_source(dateobs, source_id, "rejected")
 
-    status, data = api(
-        "GET", f"sources_in_gcn/{dateobs}/{source_id}", token=view_only_token
-    )
-    assert status == 200, data
-    assert data["data"][0]["status"] == "rejected"
+    entries = client(view_only_token).fetch_gcn_event_source(dateobs, source_id)
+    assert entries[0].status == "rejected"
 
     # associated_gcns only returns confirmed associations -> now empty for it
-    status, data = api("GET", f"associated_gcns/{source_id}", token=view_only_token)
-    assert status == 200, data
-    assert dateobs not in [d.replace(" ", "T") for d in data["data"]["gcns"]]
+    gcns = client(view_only_token).fetch_gcn_events_associated_with_source(source_id)
+    assert dateobs not in [d.replace(" ", "T") for d in gcns]
 
     # DELETE
-    status, data = api(
-        "DELETE", f"sources_in_gcn/{dateobs}/{source_id}", token=super_admin_token
-    )
-    assert status == 200, data
+    client(super_admin_token).delete_gcn_event_source(dateobs, source_id)
 
-    status, data = api(
-        "GET", f"sources_in_gcn/{dateobs}/{source_id}", token=view_only_token
-    )
-    assert status == 200, data
-    assert data["data"] == []
+    entries = client(view_only_token).fetch_gcn_event_source(dateobs, source_id)
+    assert entries == []
 
 
 def test_list_filters_by_sources_id_list(
@@ -117,24 +93,18 @@ def test_list_filters_by_sources_id_list(
     source_b = _post_source(upload_data_token, ra=25.0, dec=-33.0)
 
     for sid in (source_a, source_b):
-        status, data = _confirm(super_admin_token, dateobs, sid, gcn_status="confirmed")
-        assert status == 200, data
+        _confirm(super_admin_token, dateobs, sid, gcn_status="confirmed")
 
     # full list has both
-    status, data = api("GET", f"sources_in_gcn/{dateobs}", token=view_only_token)
-    assert status == 200, data
-    returned = {e["obj_id"] for e in data["data"]}
+    entries = client(view_only_token).fetch_gcn_event_sources(dateobs)
+    returned = {e.obj_id for e in entries}
     assert {source_a, source_b}.issubset(returned)
 
     # filter to just one via sourcesIDList
-    status, data = api(
-        "GET",
-        f"sources_in_gcn/{dateobs}",
-        params={"sourcesIDList": source_a},
-        token=view_only_token,
+    entries = client(view_only_token).fetch_gcn_event_sources(
+        dateobs, source_ids=[source_a]
     )
-    assert status == 200, data
-    returned = {e["obj_id"] for e in data["data"]}
+    returned = {e.obj_id for e in entries}
     assert returned == {source_a}
 
 
@@ -143,15 +113,15 @@ def test_post_requires_existing_localization(
 ):
     dateobs = _dateobs(gcn_GW190814)
     source_id = _post_source(upload_data_token)
-    status, data = _confirm(
-        super_admin_token,
-        dateobs,
-        source_id,
-        gcn_status="confirmed",
-        localization_name="does-not-exist.fits.gz",
-    )
-    assert status == 400
-    assert "Localization not found" in data["message"]
+    with pytest.raises(SkyPortalError, match="Localization not found") as err:
+        _confirm(
+            super_admin_token,
+            dateobs,
+            source_id,
+            gcn_status="confirmed",
+            localization_name="does-not-exist.fits.gz",
+        )
+    assert err.value.status_code == 400
 
 
 def test_post_missing_required_fields(
@@ -160,6 +130,7 @@ def test_post_missing_required_fields(
     dateobs = _dateobs(gcn_GW190814)
     source_id = _post_source(upload_data_token)
     # omit localization_name/cumprob/dates -> validation error
+    # raw api: intentionally incomplete payload the typed model can't produce
     status, data = api(
         "POST",
         f"sources_in_gcn/{dateobs}",
@@ -173,14 +144,11 @@ def test_patch_unknown_source(super_admin_token, upload_data_token, gcn_GW190814
     dateobs = _dateobs(gcn_GW190814)
     source_id = _post_source(upload_data_token)
     # never confirmed -> PATCH should fail
-    status, data = api(
-        "PATCH",
-        f"sources_in_gcn/{dateobs}/{source_id}",
-        data={"status": "rejected"},
-        token=super_admin_token,
-    )
-    assert status == 400
-    assert "not confirmed/rejected" in data["message"]
+    with pytest.raises(SkyPortalError, match="not confirmed/rejected") as err:
+        client(super_admin_token).update_gcn_event_source(
+            dateobs, source_id, "rejected"
+        )
+    assert err.value.status_code == 400
 
 
 def test_vetting_needs_only_access_to_the_event(
@@ -192,19 +160,12 @@ def test_vetting_needs_only_access_to_the_event(
     source_id = _post_source(upload_data_token)
 
     # a token that can post data, with no GCN-specific ACL, can vet
-    status, data = _confirm(
-        upload_data_token, dateobs, source_id, gcn_status="confirmed"
-    )
-    assert status == 200, data
+    _confirm(upload_data_token, dateobs, source_id, gcn_status="confirmed")
 
-    status, data = api(
-        "GET", f"sources_in_gcn/{dateobs}/{source_id}", token=view_only_token
-    )
-    assert status == 200, data
-    assert data["data"][0]["status"] == "confirmed"
+    entries = client(view_only_token).fetch_gcn_event_source(dateobs, source_id)
+    assert entries[0].status == "confirmed"
 
     # read-only remains read-only
-    status, _ = api(
-        "DELETE", f"sources_in_gcn/{dateobs}/{source_id}", token=view_only_token
-    )
-    assert status == 401
+    with pytest.raises(SkyPortalError) as err:
+        client(view_only_token).delete_gcn_event_source(dateobs, source_id)
+    assert err.value.status_code == 401

--- a/skyportal/tests/api_tests/photometry_followup/test_obj_photometry.py
+++ b/skyportal/tests/api_tests/photometry_followup/test_obj_photometry.py
@@ -1,26 +1,22 @@
 import uuid
 
-from skyportal.tests import api
+import pytest
+from skyportal_py import SkyPortalError
+
+from skyportal.tests import client
 
 
 def test_obj_photometry(upload_data_token, public_source):
-    status, data = api(
-        "GET",
-        f"sources/{public_source.id}/photometry",
-        token=upload_data_token,
-    )
-    assert status == 200
+    sp = client(upload_data_token)
+    sp.fetch_photometry(public_source.id)
 
     obj_id = str(uuid.uuid4())
 
     # try a non-existent source
-    status, data = api(
-        "GET",
-        f"sources/{obj_id}/photometry",
-        token=upload_data_token,
-    )
-    assert status == 403
+    with pytest.raises(SkyPortalError) as err:
+        sp.fetch_photometry(obj_id)
+    assert err.value.status_code == 403
     assert (
-        data["message"]
+        str(err.value)
         == f"Insufficient permissions for User {upload_data_token} to read Obj {obj_id}"
     )

--- a/skyportal/tests/api_tests/photometry_followup/test_observation.py
+++ b/skyportal/tests/api_tests/photometry_followup/test_observation.py
@@ -1,11 +1,14 @@
+import contextlib
 import os
 import time
 
 import numpy as np
 import pandas as pd
 import pytest
+from skyportal_py import SkyPortalError
+from skyportal_py.observations import ObservationPost
 
-from skyportal.tests import api
+from skyportal.tests import api, client
 from skyportal.tests.external.test_moving_objects import (
     add_telescope_and_instrument,
     remove_telescope_and_instrument,
@@ -22,95 +25,78 @@ def test_observation(super_admin_token, gcn_GW190425):
     datafile = (
         f"{os.path.dirname(__file__)}/../../../../data/sample_observation_data.csv"
     )
-    data = {
-        "telescopeName": telescope_name,
-        "instrumentName": instrument_name,
-        "observationData": pd.read_csv(datafile).to_dict(orient="list"),
-    }
 
-    status, data = api("POST", "observation", data=data, token=super_admin_token)
-
-    assert status == 200
-    assert data["status"] == "success"
+    sp = client(super_admin_token)
+    sp.post_observation(
+        ObservationPost(
+            telescope_name=telescope_name,
+            instrument_name=instrument_name,
+            observation_data=pd.read_csv(datafile).to_dict(orient="list"),
+        )
+    )
 
     # wait for the executed observations to populate
     time.sleep(15)
 
-    data = {
-        "telescopeName": telescope_name,
-        "instrumentName": instrument_name,
-        "startDate": "2019-04-25 08:18:05",
-        "endDate": "2019-04-28 08:18:05",
-        "localizationDateobs": dateobs,
-        "localizationName": "bayestar.fits.gz",
-        "localizationCumprob": 1.01,
-        "returnStatistics": True,
-        "numPerPage": 1000,
-    }
+    page = sp.fetch_observations(
+        telescope_name=telescope_name,
+        instrument_name=instrument_name,
+        start_date="2019-04-25 08:18:05",
+        end_date="2019-04-28 08:18:05",
+        localization_dateobs=dateobs,
+        localization_name="bayestar.fits.gz",
+        localization_cumprob=1.01,
+        return_statistics=True,
+        num_per_page=1000,
+    )
 
-    status, data = api("GET", "observation", params=data, token=super_admin_token)
-
-    assert status == 200
-    data = data["data"]
-    assert len(data["observations"]) == 10
-    assert np.isclose(data["probability"], 2.582514047833091e-05)
+    assert len(page.observations) == 10
+    assert np.isclose(page.probability, 2.582514047833091e-05)
     assert any(
-        d["obstime"] == "2019-04-25T08:18:18.002909" and d["observation_id"] == 84434604
-        for d in data["observations"]
+        d.obstime.isoformat() == "2019-04-25T08:18:18.002909"
+        and d.observation_id == 84434604
+        for d in page.observations
     )
 
     observation_id = None
-    for d in data["observations"]:
-        if d["observation_id"] == 84434604:
-            observation_id = d["id"]
+    for d in page.observations:
+        if d.observation_id == 84434604:
+            observation_id = d.id
             break
 
-    data = {
-        "startDate": "2019-04-25 08:18:05",
-        "endDate": "2019-04-28 08:18:05",
-        "localizationDateobs": "2019-04-25T08:18:05",
-        "localizationName": "bayestar.fits.gz",
-        "localizationCumprob": 1.01,
-    }
-    status, data = api(
-        "GET",
-        f"observation/simsurvey/{instrument_id}",
-        params=data,
-        token=super_admin_token,
+    sp.fetch_observation_simsurvey(
+        instrument_id,
+        start_date="2019-04-25 08:18:05",
+        end_date="2019-04-28 08:18:05",
+        localization_dateobs="2019-04-25T08:18:05",
+        localization_name="bayestar.fits.gz",
+        localization_cumprob=1.01,
     )
-    assert status == 200
 
-    status, data = api(
-        "DELETE", f"observation/{observation_id}", token=super_admin_token
+    sp.delete_observation(observation_id)
+
+    page = sp.fetch_observations(
+        telescope_name=telescope_name,
+        instrument_name=instrument_name,
+        start_date="2019-04-25 08:18:05",
+        end_date="2019-04-28 08:18:05",
+        localization_dateobs="2019-04-25T08:18:05",
+        localization_name="bayestar.fits.gz",
+        localization_cumprob=1.01,
+        return_statistics=True,
+        num_per_page=1000,
     )
-    assert status == 200
 
-    data = {
-        "telescopeName": telescope_name,
-        "instrumentName": instrument_name,
-        "startDate": "2019-04-25 08:18:05",
-        "endDate": "2019-04-28 08:18:05",
-        "localizationDateobs": "2019-04-25T08:18:05",
-        "localizationName": "bayestar.fits.gz",
-        "localizationCumprob": 1.01,
-        "returnStatistics": True,
-        "numPerPage": 1000,
-    }
-
-    status, data = api("GET", "observation", params=data, token=super_admin_token)
-    assert status == 200
-    data = data["data"]
-
-    assert len(data["observations"]) == 9
+    assert len(page.observations) == 9
     assert not any(
-        d["obstime"] == "2019-04-25T08:18:18.002909" and d["observation_id"] == 84434604
-        for d in data["observations"]
+        d.obstime.isoformat() == "2019-04-25T08:18:18.002909"
+        and d.observation_id == 84434604
+        for d in page.observations
     )
 
-    # delete the event
-    status, data = api(
-        "DELETE", "gcn_event/2019-04-25T08:18:05", token=super_admin_token
-    )
+    # delete the event; original test issues this DELETE without checking the response
+    with contextlib.suppress(SkyPortalError):
+        sp.delete_gcn_event("2019-04-25T08:18:05")
 
     remove_telescope_and_instrument(telescope_id, instrument_id, super_admin_token)
 
@@ -122,16 +108,14 @@ def test_observation_radec(super_admin_token):
     )
 
     datafile = f"{os.path.dirname(__file__)}/../../../../data/sample_observation_data_radec.csv"
-    data = {
-        "telescopeName": telescope_name,
-        "instrumentName": instrument_name,
-        "observationData": pd.read_csv(datafile).to_dict(orient="list"),
-    }
 
-    status, data = api("POST", "observation", data=data, token=super_admin_token)
-
-    assert status == 200
-    assert data["status"] == "success"
+    client(super_admin_token).post_observation(
+        ObservationPost(
+            telescope_name=telescope_name,
+            instrument_name=instrument_name,
+            observation_data=pd.read_csv(datafile).to_dict(orient="list"),
+        )
+    )
 
     params = {
         "startDate": "2019-04-25 08:18:05",
@@ -143,6 +127,7 @@ def test_observation_radec(super_admin_token):
     observations_loaded = False
     while not observations_loaded and nretries < 5:
         try:
+            # raw api: raw-JSON shape assertion (len of the response dict) the typed model would mask
             status, data = api(
                 "GET", "observation", params=params, token=super_admin_token
             )
@@ -171,16 +156,14 @@ def test_observation_isot(super_admin_token):
     datafile = (
         f"{os.path.dirname(__file__)}/../../../../data/sample_observation_data_isot.csv"
     )
-    data = {
-        "telescopeName": telescope_name,
-        "instrumentName": instrument_name,
-        "observationData": pd.read_csv(datafile).to_dict(orient="list"),
-    }
 
-    status, data = api("POST", "observation", data=data, token=super_admin_token)
-
-    assert status == 200
-    assert data["status"] == "success"
+    client(super_admin_token).post_observation(
+        ObservationPost(
+            telescope_name=telescope_name,
+            instrument_name=instrument_name,
+            observation_data=pd.read_csv(datafile).to_dict(orient="list"),
+        )
+    )
 
     params = {
         "startDate": "2019-04-25 08:18:05",
@@ -192,6 +175,7 @@ def test_observation_isot(super_admin_token):
     observations_loaded = False
     while not observations_loaded and nretries < 5:
         try:
+            # raw api: raw-JSON shape assertion (len of the response dict) the typed model would mask
             status, data = api(
                 "GET", "observation", params=params, token=super_admin_token
             )

--- a/skyportal/tests/api_tests/photometry_followup/test_observing_runs.py
+++ b/skyportal/tests/api_tests/photometry_followup/test_observing_runs.py
@@ -1,6 +1,10 @@
 import pytest
+from skyportal_py import SkyPortalError
+from skyportal_py.observing_runs import ObservingRunPost, ObservingRunUpdate
+from skyportal_py.photometry import PhotometryPost
+from skyportal_py.sources import SourcePost
 
-from skyportal.tests import api
+from skyportal.tests import client
 
 
 def test_token_user_add_new_observing_run(
@@ -14,19 +18,15 @@ def test_token_user_add_new_observing_run(
         "calendar_date": "2020-02-16",
     }
 
-    status, data = api(
-        "POST", "observing_run", data=run_details, token=observing_run_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    run_id = data["data"]["id"]
+    sp = client(observing_run_token)
+    run_id = sp.post_observing_run(ObservingRunPost(**run_details)).id
 
-    status, data = api("GET", f"observing_run/{run_id}", token=observing_run_token)
-
-    assert status == 200
-    assert data["status"] == "success"
+    run = sp.fetch_observing_run(run_id)
     for key in run_details:
-        assert data["data"][key] == run_details[key]
+        value = getattr(run, key)
+        if key == "calendar_date":
+            value = value.isoformat()
+        assert value == run_details[key]
 
 
 def test_super_admin_user_delete_nonowned_observing_run(
@@ -40,17 +40,13 @@ def test_super_admin_user_delete_nonowned_observing_run(
         "calendar_date": "2020-02-16",
     }
 
-    status, data = api(
-        "POST", "observing_run", data=run_details, token=observing_run_token
+    run_id = (
+        client(observing_run_token)
+        .post_observing_run(ObservingRunPost(**run_details))
+        .id
     )
-    assert status == 200
-    assert data["status"] == "success"
-    run_id = data["data"]["id"]
 
-    status, data = api("DELETE", f"observing_run/{run_id}", token=super_admin_token)
-
-    assert status == 200
-    assert data["status"] == "success"
+    client(super_admin_token).delete_observing_run(run_id)
 
 
 def test_unauthorized_user_delete_nonowned_observing_run(
@@ -64,17 +60,15 @@ def test_unauthorized_user_delete_nonowned_observing_run(
         "calendar_date": "2020-02-16",
     }
 
-    status, data = api(
-        "POST", "observing_run", data=run_details, token=observing_run_token
+    run_id = (
+        client(observing_run_token)
+        .post_observing_run(ObservingRunPost(**run_details))
+        .id
     )
-    assert status == 200
-    assert data["status"] == "success"
-    run_id = data["data"]["id"]
 
-    status, data = api("DELETE", f"observing_run/{run_id}", token=manage_sources_token)
-
-    assert status == 400
-    assert data["status"] == "error"
+    with pytest.raises(SkyPortalError) as err:
+        client(manage_sources_token).delete_observing_run(run_id)
+    assert err.value.status_code == 400
 
 
 def test_authorized_user_modify_owned_observing_run(
@@ -88,29 +82,20 @@ def test_authorized_user_modify_owned_observing_run(
         "calendar_date": "2020-02-16",
     }
 
-    status, data = api(
-        "POST", "observing_run", data=run_details, token=observing_run_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    run_id = data["data"]["id"]
+    sp = client(observing_run_token)
+    run_id = sp.post_observing_run(ObservingRunPost(**run_details)).id
 
     new_date = {"calendar_date": "2020-02-17"}
     run_details.update(new_date)
 
-    status, data = api(
-        "PUT", f"observing_run/{run_id}", data=new_date, token=observing_run_token
-    )
+    sp.update_observing_run(run_id, ObservingRunUpdate(**new_date))
 
-    assert status == 200
-    assert data["status"] == "success"
-
-    status, data = api("GET", f"observing_run/{run_id}", token=observing_run_token)
-
-    assert status == 200
-    assert data["status"] == "success"
+    run = sp.fetch_observing_run(run_id)
     for key in run_details:
-        assert data["data"][key] == run_details[key]
+        value = getattr(run, key)
+        if key == "calendar_date":
+            value = value.isoformat()
+        assert value == run_details[key]
 
 
 def test_unauthorized_user_modify_unowned_observing_run(
@@ -124,22 +109,20 @@ def test_unauthorized_user_modify_unowned_observing_run(
         "calendar_date": "2020-02-16",
     }
 
-    status, data = api(
-        "POST", "observing_run", data=run_details, token=observing_run_token
+    run_id = (
+        client(observing_run_token)
+        .post_observing_run(ObservingRunPost(**run_details))
+        .id
     )
-    assert status == 200
-    assert data["status"] == "success"
-    run_id = data["data"]["id"]
 
     new_date = {"calendar_date": "2020-02-17"}
     run_details.update(new_date)
 
-    status, data = api(
-        "PUT", f"observing_run/{run_id}", data=new_date, token=manage_sources_token
-    )
-
-    assert status == 401
-    assert data["status"] == "error"
+    with pytest.raises(SkyPortalError) as err:
+        client(manage_sources_token).update_observing_run(
+            run_id, ObservingRunUpdate(**new_date)
+        )
+    assert err.value.status_code == 401
 
 
 def test_observing_run_assignment_group_names(
@@ -152,36 +135,24 @@ def test_observing_run_assignment_group_names(
 ):
     # Save the obj associated with the public_assignment to a group the run
     # owner is not a part of
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": public_source.id,
-            "ra": 234.22,
-            "dec": -22.33,
-            "redshift": 3,
-            "transient": False,
-            "ra_dis": 2.3,
-            "group_ids": [public_group2.id],
-        },
-        token=upload_data_token_two_groups,
+    client(upload_data_token_two_groups).post_source(
+        SourcePost(
+            id=public_source.id,
+            ra=234.22,
+            dec=-22.33,
+            redshift=3,
+            transient=False,
+            ra_dis=2.3,
+            group_ids=[public_group2.id],
+        )
     )
-    assert status == 200
-    assert data["status"] == "success"
 
     # Get the observing run and associated assignments and check that public_group2
     # is not in the accessible_group_ids
-    status, data = api(
-        "GET", f"observing_run/{public_assignment.run.id}", token=view_only_token
-    )
+    run = client(view_only_token).fetch_observing_run(public_assignment.run.id)
 
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]["assignments"]) == 1
-    assert (
-        public_group2.name
-        not in data["data"]["assignments"][0]["accessible_group_names"]
-    )
+    assert len(run.assignments) == 1
+    assert public_group2.name not in run.assignments[0].accessible_group_names
 
 
 def test_observing_run_assignment_last_detection(
@@ -194,29 +165,22 @@ def test_observing_run_assignment_last_detection(
 ):
     """Facilities size exposures from the target's brightness, so the run
     payload carries the last detection alongside each assignment."""
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 61254.4,
-            "instrument_id": ztf_camera.id,
-            "mag": 18.9,
-            "magerr": 0.07,
-            "limiting_mag": 22.3,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    client(upload_data_token).post_photometry(
+        PhotometryPost(
+            obj_id=str(public_source.id),
+            mjd=61254.4,
+            instrument_id=ztf_camera.id,
+            mag=18.9,
+            magerr=0.07,
+            limiting_mag=22.3,
+            magsys="ab",
+            filter="ztfg",
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200, data
 
-    status, data = api(
-        "GET", f"observing_run/{public_assignment.run.id}", token=view_only_token
-    )
-    assert status == 200
-    assignment = data["data"]["assignments"][0]
-    assert assignment["last_detected_mag"] == pytest.approx(18.9, abs=0.01)
-    assert assignment["last_detected_filter"] == "ztfg"
-    assert assignment["last_detected_mjd"] == pytest.approx(61254.4)
+    run = client(view_only_token).fetch_observing_run(public_assignment.run.id)
+    assignment = run.assignments[0]
+    assert assignment.last_detected_mag == pytest.approx(18.9, abs=0.01)
+    assert assignment.last_detected_filter == "ztfg"
+    assert assignment.last_detected_mjd == pytest.approx(61254.4)

--- a/skyportal/tests/api_tests/photometry_followup/test_phot_stats.py
+++ b/skyportal/tests/api_tests/photometry_followup/test_phot_stats.py
@@ -5,6 +5,9 @@ import uuid
 import numpy as np
 import pytest
 import sqlalchemy as sa
+from skyportal_py import SkyPortalError
+from skyportal_py.photometry import PhotometryPost, PhotometryUpdate
+from skyportal_py.sources import SourcePost
 
 from baselayer.app import models as baselayer_models
 from baselayer.app.env import load_env
@@ -12,7 +15,7 @@ from skyportal.handlers.api.photometry import add_external_photometry
 from skyportal.models import User
 from skyportal.models.phot_stat import PhotStat
 from skyportal.models.photometry import PHOT_ZP, Photometry
-from skyportal.tests import api
+from skyportal.tests import client
 
 from ....utils.naive_datetime import utcnow_naive
 
@@ -21,132 +24,69 @@ PHOT_DETECTION_THRESHOLD = cfg["misc.photometry_detection_threshold_nsigma"]
 
 
 def test_phot_stats_permissions(upload_data_token, super_admin_token, public_source):
+    sp_user = client(upload_data_token)
+    sp_admin = client(super_admin_token)
+
     # normal user cannot delete or update the phot stats
-    status, data = api(
-        "DELETE", f"sources/{public_source.id}/phot_stat", token=upload_data_token
-    )
-    assert status == 401
-    assert "Unauthorized" in data["message"]
+    with pytest.raises(SkyPortalError, match="Unauthorized") as err:
+        sp_user.delete_source_phot_stat(public_source.id)
+    assert err.value.status_code == 401
 
-    status, data = api(
-        "PUT",
-        f"sources/{public_source.id}/phot_stat",
-        token=upload_data_token,
-        data={},
-    )
-    assert status == 401
-    assert "Unauthorized" in data["message"]
+    with pytest.raises(SkyPortalError, match="Unauthorized") as err:
+        sp_user.update_source_phot_stat(public_source.id)
+    assert err.value.status_code == 401
 
-    status, data = api(
-        "GET",
-        f"sources/{public_source.id}/phot_stat",
-        token=upload_data_token,
-        data={},
-    )
-    assert status == 200
+    sp_user.fetch_source_phot_stat(public_source.id)
     # super user can delete the phot stats
-    status, data = api(
-        "DELETE", f"sources/{public_source.id}/phot_stat", token=super_admin_token
-    )
-    assert status == 200
+    sp_admin.delete_source_phot_stat(public_source.id)
 
     # normal user cannot post a phot stat
-    status, data = api(
-        "POST",
-        f"sources/{public_source.id}/phot_stat",
-        token=upload_data_token,
-        data={},
-    )
-    assert status == 401
-    assert "Unauthorized" in data["message"]
+    with pytest.raises(SkyPortalError, match="Unauthorized") as err:
+        sp_user.post_source_phot_stat(public_source.id)
+    assert err.value.status_code == 401
 
     # super user can post a phot stat
-    status, data = api(
-        "POST",
-        f"sources/{public_source.id}/phot_stat",
-        token=super_admin_token,
-        data={},
-    )
-    assert status == 200
+    sp_admin.post_source_phot_stat(public_source.id)
 
-    status, data = api(
-        "GET",
-        f"sources/{public_source.id}/phot_stat",
-        token=upload_data_token,
-        data={},
-    )
-    assert status == 200
+    sp_user.fetch_source_phot_stat(public_source.id)
     # super admin cannot re-post a phot stat
 
-    status, data = api(
-        "POST",
-        f"sources/{public_source.id}/phot_stat",
-        token=super_admin_token,
-        data={},
-    )
-    assert status == 400
-    assert "already exists" in data["message"]
+    with pytest.raises(SkyPortalError, match="already exists") as err:
+        sp_admin.post_source_phot_stat(public_source.id)
+    assert err.value.status_code == 400
 
 
 def test_delete_phot_stat_does_not_cascade(
     upload_data_token, super_admin_token, public_source
 ):
-    status, data = api(
-        "GET",
-        f"sources/{public_source.id}/photometry",
-        token=upload_data_token,
-    )
-    assert status == 200
-    phot_ids = [p["id"] for p in data["data"]]
+    sp_user = client(upload_data_token)
+    phot_ids = [p.id for p in sp_user.fetch_photometry(public_source.id)]
 
-    status, data = api(
-        "DELETE", f"sources/{public_source.id}/phot_stat", token=super_admin_token
-    )
-    assert status == 200
+    client(super_admin_token).delete_source_phot_stat(public_source.id)
 
-    status, data = api(
-        "GET",
-        f"sources/{public_source.id}/phot_stat",
-        token=upload_data_token,
-        data={},
-    )
-    assert status == 400
+    with pytest.raises(SkyPortalError) as err:
+        sp_user.fetch_source_phot_stat(public_source.id)
+    assert err.value.status_code == 400
 
-    status, data = api(
-        "GET",
-        f"sources/{public_source.id}",
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert data["data"]["id"] == public_source.id
+    assert sp_user.fetch_source(public_source.id).id == public_source.id
 
-    status, data = api(
-        "GET",
-        f"sources/{public_source.id}/photometry",
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert {p["id"] for p in data["data"]} == set(phot_ids)
+    assert {p.id for p in sp_user.fetch_photometry(public_source.id)} == set(phot_ids)
 
 
 def test_phot_stats_simple_lightcurve(
     upload_data_token, super_admin_token, public_source, public_group, ztf_camera
 ):
+    sp = client(upload_data_token)
     source_id = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": source_id,
-            "ra": np.random.uniform(0, 360),
-            "dec": np.random.uniform(-90, 90),
-            "redshift": np.random.uniform(0, 1),
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    sp.post_source(
+        SourcePost(
+            id=source_id,
+            ra=np.random.uniform(0, 360),
+            dec=np.random.uniform(-90, 90),
+            redshift=np.random.uniform(0, 1),
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
-    assert data["status"] == "success"
 
     mjd = np.linspace(57000, 57100, 5)
     flux = np.array([10.0, 110.0, 170.0, 180.0, 100.0])
@@ -155,49 +95,36 @@ def test_phot_stats_simple_lightcurve(
 
     # post all these points
     for i in range(len(mjd)):
-        status, data = api(
-            "POST",
-            "photometry",
-            data={
-                "obj_id": source_id,
-                "mjd": mjd[i],
-                "instrument_id": ztf_camera.id,
-                "flux": flux[i],
-                "fluxerr": 10.0,
-                "zp": 25.0,
-                "magsys": "ab",
-                "filter": "ztfr",
-                "group_ids": [public_group.id],
-                "altdata": {"some_key": str(uuid.uuid4())},
-            },
-            token=upload_data_token,
+        sp.post_photometry(
+            PhotometryPost(
+                obj_id=source_id,
+                mjd=mjd[i],
+                instrument_id=ztf_camera.id,
+                flux=flux[i],
+                fluxerr=10.0,
+                zp=25.0,
+                magsys="ab",
+                filter="ztfr",
+                group_ids=[public_group.id],
+                altdata={"some_key": str(uuid.uuid4())},
+            )
         )
-        if status != 200:
-            print(data)
-        assert status == 200
-        assert data["status"] == "success"
 
-    status, data = api(
-        "GET",
-        f"sources/{source_id}/photometry",
-        token=upload_data_token,
-    )
-    assert status == 200
-    photometry = data["data"]
+    photometry = sp.fetch_photometry(source_id)
 
     # get the magnitudes, detections, and limits
     # in the order of MJD, not the order they were posted
-    phot_dict = {p["mjd"]: p for p in photometry}
+    phot_dict = {p.mjd: p for p in photometry}
     mag = []
     det = []
     lim = []
     filt = []
     for j in mjd:
         assert j in phot_dict
-        mag.append(phot_dict[j]["mag"])
-        det.append(phot_dict[j]["snr"] > PHOT_DETECTION_THRESHOLD)
-        lim.append(phot_dict[j]["limiting_mag"])
-        filt.append(phot_dict[j]["filter"])
+        mag.append(phot_dict[j].mag)
+        det.append(phot_dict[j].snr > PHOT_DETECTION_THRESHOLD)
+        lim.append(phot_dict[j].limiting_mag)
+        filt.append(phot_dict[j].filter)
 
     mag = np.array(mag)
     det = np.array(det)
@@ -207,61 +134,41 @@ def test_phot_stats_simple_lightcurve(
     print(f"mags: {mag}")
 
     # get the photometry stats
-    status, data = api(
-        "GET",
-        f"sources/{source_id}/phot_stat",
-        token=upload_data_token,
-    )
-    assert status == 200
-    phot_stat = data["data"]
+    phot_stat = sp.fetch_source_phot_stat(source_id).model_dump()
 
     check_phot_stat_is_consistent(phot_stat, mjd, mag, filt, det, lim)
 
 
 def test_phot_stats_for_public_source(upload_data_token, public_source):
-    status, data = api(
-        "GET",
-        f"sources/{public_source.id}/photometry",
-        token=upload_data_token,
-    )
-    assert status == 200
-    photometry = data["data"]
-    mag = [p["mag"] for p in photometry]
+    sp = client(upload_data_token)
+    photometry = sp.fetch_photometry(public_source.id)
+    mag = [p.mag for p in photometry]
     assert all(isinstance(m, float) and not np.isnan(m) for m in mag)
     mag = np.array(mag)
-    mjd = np.array([p["mjd"] for p in photometry])
-    filt = np.array([p["filter"] for p in photometry])
-    det = np.array([p["snr"] > PHOT_DETECTION_THRESHOLD for p in photometry])
-    lim = np.array([p["limiting_mag"] for p in photometry])
+    mjd = np.array([p.mjd for p in photometry])
+    filt = np.array([p.filter for p in photometry])
+    det = np.array([p.snr > PHOT_DETECTION_THRESHOLD for p in photometry])
+    lim = np.array([p.limiting_mag for p in photometry])
 
-    status, data = api(
-        "GET",
-        f"sources/{public_source.id}/phot_stat",
-        token=upload_data_token,
-        data={},
-    )
-    assert status == 200
-    check_phot_stat_is_consistent(data["data"], mjd, mag, filt, det, lim)
+    phot_stat = sp.fetch_source_phot_stat(public_source.id).model_dump()
+    check_phot_stat_is_consistent(phot_stat, mjd, mag, filt, det, lim)
 
 
 def test_phot_stat_consistent(
     upload_data_token, super_admin_token, public_group, ztf_camera
 ):
+    sp = client(upload_data_token)
+    sp_admin = client(super_admin_token)
     source_id = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": source_id,
-            "ra": np.random.uniform(0, 360),
-            "dec": np.random.uniform(-90, 90),
-            "redshift": np.random.uniform(0, 1),
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    sp.post_source(
+        SourcePost(
+            id=source_id,
+            ra=np.random.uniform(0, 360),
+            dec=np.random.uniform(-90, 90),
+            redshift=np.random.uniform(0, 1),
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
-    assert data["status"] == "success"
 
     num_points = 20
     mjd = np.random.uniform(55000, 56000, num_points)
@@ -278,49 +185,36 @@ def test_phot_stat_consistent(
     np.random.shuffle(insert_idx)  # input data in random order
 
     for i in insert_idx:
-        status, data = api(
-            "POST",
-            "photometry",
-            data={
-                "obj_id": source_id,
-                "mjd": mjd[i],
-                "instrument_id": ztf_camera.id,
-                "flux": flux[i],
-                "fluxerr": 10.0,
-                "zp": 25.0,
-                "magsys": "ab",
-                "filter": filt[i],
-                "group_ids": [public_group.id],
-                "altdata": {"some_key": str(uuid.uuid4())},
-            },
-            token=upload_data_token,
+        resp = sp.post_photometry(
+            PhotometryPost(
+                obj_id=source_id,
+                mjd=mjd[i],
+                instrument_id=ztf_camera.id,
+                flux=flux[i],
+                fluxerr=10.0,
+                zp=25.0,
+                magsys="ab",
+                filter=filt[i],
+                group_ids=[public_group.id],
+                altdata={"some_key": str(uuid.uuid4())},
+            )
         )
-        if status != 200:
-            print(data)
-        assert status == 200
-        assert data["status"] == "success"
-        phot_ids.append(data["data"]["ids"][0])
+        phot_ids.append(resp.ids[0])
 
-    status, data = api(
-        "GET",
-        f"sources/{source_id}/photometry",
-        token=upload_data_token,
-    )
-    assert status == 200
-    photometry = data["data"]
+    photometry = sp.fetch_photometry(source_id)
     assert len(photometry) == num_points
 
     # get the magnitudes, detections, and limits
     # in the order of MJD, not the order they were posted
-    phot_dict = {p["mjd"]: p for p in photometry}
+    phot_dict = {p.mjd: p for p in photometry}
     mag = []
     det = []
     lim = []
     for j in mjd:
         assert j in phot_dict
-        mag.append(phot_dict[j]["mag"])
-        det.append(phot_dict[j]["snr"] > PHOT_DETECTION_THRESHOLD)
-        lim.append(phot_dict[j]["limiting_mag"])
+        mag.append(phot_dict[j].mag)
+        det.append(phot_dict[j].snr > PHOT_DETECTION_THRESHOLD)
+        lim.append(phot_dict[j].limiting_mag)
 
     mag = np.array(mag)
     det = np.array(det)
@@ -328,41 +222,21 @@ def test_phot_stat_consistent(
     assert all(isinstance(m, float) and not np.isnan(m) for m in mag)
     assert np.sum(det) == num_points - 5
 
-    status, data = api(
-        "GET",
-        f"sources/{source_id}/phot_stat",
-        token=upload_data_token,
-    )
-    assert status == 200
-    phot_stat = data["data"]
+    phot_stat = sp.fetch_source_phot_stat(source_id).model_dump()
 
     check_phot_stat_is_consistent(phot_stat, mjd, mag, filt, det, lim)
 
     # now re-calculate the points
-    status, data = api(
-        "DELETE", f"sources/{source_id}/phot_stat", token=super_admin_token
-    )
-    assert status == 200
+    sp_admin.delete_source_phot_stat(source_id)
 
-    status, data = api(
-        "POST", f"sources/{source_id}/phot_stat", token=super_admin_token
-    )
-    assert status == 200
+    sp_admin.post_source_phot_stat(source_id)
 
-    status, data = api(
-        "GET",
-        f"sources/{source_id}/phot_stat",
-        token=upload_data_token,
-    )
-    assert status == 200
-    phot_stat = data["data"]
+    phot_stat = sp.fetch_source_phot_stat(source_id).model_dump()
     check_phot_stat_is_consistent(phot_stat, mjd, mag, filt, det, lim)
 
     # now delete a point
-    status, data = api("DELETE", f"photometry/{phot_ids[6]}", token=upload_data_token)
+    sp.delete_photometry(phot_ids[6])
     phot_ids.pop(6)
-
-    assert status == 200
 
     idx = np.ones(num_points, dtype=bool)
     # point inserted at index 6 is some other index
@@ -374,76 +248,57 @@ def test_phot_stat_consistent(
     det_less = det[idx]
     lim_less = lim[idx]
 
-    status, data = api("GET", f"sources/{source_id}/phot_stat", token=upload_data_token)
-
-    assert status == 200
-    phot_stat = data["data"]
+    phot_stat = sp.fetch_source_phot_stat(source_id).model_dump()
 
     check_phot_stat_is_consistent(
         phot_stat, mjd_less, mag_less, filt_less, det_less, lim_less
     )
 
     # re-add that photometry point to check that the phot_stat updates
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": source_id,
-            "mjd": mjd[insert_idx[6]],
-            "instrument_id": ztf_camera.id,
-            "flux": flux[insert_idx[6]],
-            "fluxerr": 10.0,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": filt[insert_idx[6]],
-            "group_ids": [public_group.id],
-            "altdata": {"some_key": str(uuid.uuid4())},
-        },
-        token=upload_data_token,
+    resp = sp.post_photometry(
+        PhotometryPost(
+            obj_id=source_id,
+            mjd=mjd[insert_idx[6]],
+            instrument_id=ztf_camera.id,
+            flux=flux[insert_idx[6]],
+            fluxerr=10.0,
+            zp=25.0,
+            magsys="ab",
+            filter=filt[insert_idx[6]],
+            group_ids=[public_group.id],
+            altdata={"some_key": str(uuid.uuid4())},
+        )
     )
-    assert status == 200
-    assert data["status"] == "success"
-    phot_ids.insert(6, data["data"]["ids"][0])
+    phot_ids.insert(6, resp.ids[0])
 
-    status, data = api("GET", f"sources/{source_id}/phot_stat", token=upload_data_token)
-
-    assert status == 200
-    phot_stat = data["data"]
+    phot_stat = sp.fetch_source_phot_stat(source_id).model_dump()
 
     check_phot_stat_is_consistent(phot_stat, mjd, mag, filt, det, lim)
 
     # modify one of the points and see if it updates
     flux[2] = 700.2
-    status, data = api(
-        "PATCH",
-        f"photometry/{phot_ids[insert_idx.index(2)]}",
-        data={
-            "obj_id": source_id,
-            "mjd": mjd[2],
-            "instrument_id": ztf_camera.id,
-            "flux": flux[2],
-            "fluxerr": 10.0,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": filt[2],
-            "group_ids": [public_group.id],
-            "altdata": {"some_key": str(uuid.uuid4())},
-        },
-        token=upload_data_token,
+    sp.update_photometry(
+        phot_ids[insert_idx.index(2)],
+        PhotometryUpdate(
+            obj_id=source_id,
+            mjd=mjd[2],
+            instrument_id=ztf_camera.id,
+            flux=flux[2],
+            fluxerr=10.0,
+            zp=25.0,
+            magsys="ab",
+            filter=filt[2],
+            group_ids=[public_group.id],
+            altdata={"some_key": str(uuid.uuid4())},
+        ),
     )
-    assert status == 200
 
-    status, data = api(
-        "GET", f"photometry/{phot_ids[insert_idx.index(2)]}", token=upload_data_token
-    )
-    assert status == 200
-    assert mjd[2] == data["data"]["mjd"]
-    mag[2] = data["data"]["mag"]
-    det[2] = data["data"]["snr"] > PHOT_DETECTION_THRESHOLD
+    point = sp.fetch_photometry_point(phot_ids[insert_idx.index(2)])
+    assert mjd[2] == point.mjd
+    mag[2] = point.mag
+    det[2] = point.snr > PHOT_DETECTION_THRESHOLD
 
-    status, data = api("GET", f"sources/{source_id}/phot_stat", token=upload_data_token)
-    assert status == 200
-    phot_stat = data["data"]
+    phot_stat = sp.fetch_source_phot_stat(source_id).model_dump()
 
     check_phot_stat_is_consistent(phot_stat, mjd, mag, filt, det, lim)
 
@@ -451,37 +306,29 @@ def test_phot_stat_consistent(
     flux = np.append(flux, np.random.normal(500, 10, 1))
     filt = np.append(filt, np.random.choice(["ztfg", "ztfr", "ztfi"], 1))
 
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": source_id,
-            "mjd": 58000.0 + np.random.rand() * 100,
-            "instrument_id": ztf_camera.id,
-            "flux": flux[-1],
-            "fluxerr": 10.0,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": filt[-1],
-            "group_ids": [public_group.id],
-            "altdata": {"some_key": str(uuid.uuid4())},
-        },
-        token=upload_data_token,
+    resp = sp.post_photometry(
+        PhotometryPost(
+            obj_id=source_id,
+            mjd=58000.0 + np.random.rand() * 100,
+            instrument_id=ztf_camera.id,
+            flux=flux[-1],
+            fluxerr=10.0,
+            zp=25.0,
+            magsys="ab",
+            filter=filt[-1],
+            group_ids=[public_group.id],
+            altdata={"some_key": str(uuid.uuid4())},
+        )
     )
-    assert status == 200
-    assert data["status"] == "success"
-    phot_ids.append(data["data"]["ids"][0])
+    phot_ids.append(resp.ids[0])
 
-    status, data = api("GET", f"photometry/{phot_ids[-1]}", token=upload_data_token)
-    assert status == 200
-    mag = np.append(mag, data["data"]["mag"])
-    mjd = np.append(mjd, data["data"]["mjd"])
+    point = sp.fetch_photometry_point(phot_ids[-1])
+    mag = np.append(mag, point.mag)
+    mjd = np.append(mjd, point.mjd)
     det = np.append(det, True)
     lim = np.append(lim, mag[-1])
 
-    status, data = api("GET", f"sources/{source_id}/phot_stat", token=upload_data_token)
-    assert status == 200
-    phot_stat = data["data"]
+    phot_stat = sp.fetch_source_phot_stat(source_id).model_dump()
 
     check_phot_stat_is_consistent(phot_stat, mjd, mag, filt, det, lim)
 
@@ -489,6 +336,8 @@ def test_phot_stat_consistent(
 def test_phot_stats_update_handler(
     upload_data_token, super_admin_token, public_group, ztf_camera
 ):
+    sp = client(upload_data_token)
+    sp_admin = client(super_admin_token)
     num_sources = 4
     num_points = 5
     source_ids = []
@@ -498,20 +347,15 @@ def test_phot_stats_update_handler(
 
     for j in range(num_sources):
         source_ids.append(str(uuid.uuid4()))
-        status, data = api(
-            "POST",
-            "sources",
-            data={
-                "id": source_ids[-1],
-                "ra": np.random.uniform(0, 360),
-                "dec": np.random.uniform(-90, 90),
-                "redshift": np.random.uniform(0, 1),
-                "group_ids": [public_group.id],
-            },
-            token=upload_data_token,
+        sp.post_source(
+            SourcePost(
+                id=source_ids[-1],
+                ra=np.random.uniform(0, 360),
+                dec=np.random.uniform(-90, 90),
+                redshift=np.random.uniform(0, 1),
+                group_ids=[public_group.id],
+            )
         )
-        assert status == 200
-        assert data["status"] == "success"
 
         # post some photometry for each source
         mjd = np.random.uniform(55000, 56000, num_points)
@@ -523,236 +367,138 @@ def test_phot_stats_update_handler(
         filt = np.random.choice(["ztfg", "ztfr", "ztfi"], num_points)
 
         for i in range(num_points):
-            status, data = api(
-                "POST",
-                "photometry",
-                data={
-                    "obj_id": source_ids[-1],
-                    "mjd": mjd[i],
-                    "instrument_id": ztf_camera.id,
-                    "flux": flux[i],
-                    "fluxerr": 10.0,
-                    "zp": 25.0,
-                    "magsys": "ab",
-                    "filter": filt[i],
-                    "group_ids": [public_group.id],
-                    "altdata": {"some_key": str(uuid.uuid4())},
-                },
-                token=upload_data_token,
+            sp.post_photometry(
+                PhotometryPost(
+                    obj_id=source_ids[-1],
+                    mjd=mjd[i],
+                    instrument_id=ztf_camera.id,
+                    flux=flux[i],
+                    fluxerr=10.0,
+                    zp=25.0,
+                    magsys="ab",
+                    filter=filt[i],
+                    group_ids=[public_group.id],
+                    altdata={"some_key": str(uuid.uuid4())},
+                )
             )
-            if status != 200:
-                print(data)
-            assert status == 200
-            assert data["status"] == "success"
 
     # get all Objs with or without PhotStats
-    status, data = api(
-        "GET",
-        "phot_stats",
-        token=super_admin_token,
-    )
-    assert status == 200
-    num_sources_total = data["data"]["totalWithPhotStats"]
+    counts = sp_admin.fetch_phot_stats_counts()
+    num_sources_total = counts.total_with_phot_stats
 
     # get only the recent ones posted in this test
-    status, data = api(
-        "GET",
-        "phot_stats",
-        params={
-            "createdAtStartTime": t0.isoformat(),
-        },
-        token=super_admin_token,
+    counts = sp_admin.fetch_phot_stats_counts(
+        created_at_start_time=t0.isoformat(),
     )
-    assert status == 200
-    assert data["data"]["totalWithPhotStats"] == num_sources
-    assert data["data"]["totalWithoutPhotStats"] == 0
+    assert counts.total_with_phot_stats == num_sources
+    assert counts.total_without_phot_stats == 0
 
     # get only sources posted before this test
-    status, data = api(
-        "GET",
-        "phot_stats",
-        params={
-            "createdAtEndTime": t0.isoformat(),
-            "fullUpdateEndTime": t0.isoformat(),
-        },
-        token=super_admin_token,
+    counts = sp_admin.fetch_phot_stats_counts(
+        created_at_end_time=t0.isoformat(),
+        full_update_end_time=t0.isoformat(),
     )
-    assert status == 200
-    assert data["data"]["totalWithPhotStats"] == num_sources_total - num_sources
+    assert counts.total_with_phot_stats == num_sources_total - num_sources
 
     # delete the phot stats from one object
-    status, data = api(
-        "DELETE",
-        f"sources/{source_ids[0]}/phot_stat",
-        token=super_admin_token,
-    )
-    assert status == 200
+    sp_admin.delete_source_phot_stat(source_ids[0])
 
-    status, data = api(
-        "GET",
-        "phot_stats",
-        token=super_admin_token,
-    )
+    counts = sp_admin.fetch_phot_stats_counts()
 
-    assert status == 200
-    assert data["data"]["totalWithPhotStats"] == num_sources_total - 1
+    assert counts.total_with_phot_stats == num_sources_total - 1
 
     # get only the recent ones posted in this test
-    status, data = api(
-        "GET",
-        "phot_stats",
-        params={"createdAtStartTime": t0.isoformat()},
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["data"]["totalWithoutPhotStats"] == 1
+    counts = sp_admin.fetch_phot_stats_counts(created_at_start_time=t0.isoformat())
+    assert counts.total_without_phot_stats == 1
 
     # time before we re-calculate the missing PhotStats
     t1 = utcnow_naive()
 
     # only update sources from this test
     # that don't have PhotStats (the deleted one)
-    status, data = api(
-        "POST",
-        "phot_stats",
-        params={
-            "createdAtStartTime": t0.isoformat(),
-        },
-        token=super_admin_token,
+    batch = sp_admin.post_phot_stats(
+        created_at_start_time=t0.isoformat(),
     )
-    assert status == 200
-    assert data["data"]["totalMatches"] == 1
+    assert batch.total_matches == 1
 
     # the sources in this test should now all have phot stats
-    status, data = api(
-        "GET",
-        "phot_stats",
-        params={"createdAtStartTime": t0.isoformat()},
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["data"]["totalWithPhotStats"] == num_sources
-    assert data["data"]["totalWithoutPhotStats"] == 0
+    counts = sp_admin.fetch_phot_stats_counts(created_at_start_time=t0.isoformat())
+    assert counts.total_with_phot_stats == num_sources
+    assert counts.total_without_phot_stats == 0
 
     # Only one source has a phot stat updated after t1
-    status, data = api(
-        "GET",
-        "phot_stats",
-        params={
-            "createdAtStartTime": t0.isoformat(),
-            "fullUpdateStartTime": t1.isoformat(),
-        },
-        token=super_admin_token,
+    counts = sp_admin.fetch_phot_stats_counts(
+        created_at_start_time=t0.isoformat(),
+        full_update_start_time=t1.isoformat(),
     )
-    assert status == 200
-    assert data["data"]["totalWithPhotStats"] == 1
-    assert data["data"]["totalWithoutPhotStats"] == 0
+    assert counts.total_with_phot_stats == 1
+    assert counts.total_without_phot_stats == 0
 
     t2 = utcnow_naive()
 
     # no sources have had a quick update after t2
-    status, data = api(
-        "GET",
-        "phot_stats",
-        params={
-            "createdAtStartTime": t0.isoformat(),
-            "quickUpdateStartTime": t2.isoformat(),
-        },
-        token=super_admin_token,
+    counts = sp_admin.fetch_phot_stats_counts(
+        created_at_start_time=t0.isoformat(),
+        quick_update_start_time=t2.isoformat(),
     )
-    assert status == 200
-    assert data["data"]["totalWithPhotStats"] == 0
-    assert data["data"]["totalWithoutPhotStats"] == 0
+    assert counts.total_with_phot_stats == 0
+    assert counts.total_without_phot_stats == 0
 
     # all sources from this test have been updated before t2
-    status, data = api(
-        "GET",
-        "phot_stats",
-        params={
-            "createdAtStartTime": t0.isoformat(),
-            "fullUpdateEndTime": t2.isoformat(),
-        },
-        token=super_admin_token,
+    counts = sp_admin.fetch_phot_stats_counts(
+        created_at_start_time=t0.isoformat(),
+        full_update_end_time=t2.isoformat(),
     )
-    assert status == 200
-    assert data["data"]["totalWithPhotStats"] == num_sources
-    assert data["data"]["totalWithoutPhotStats"] == 0
+    assert counts.total_with_phot_stats == num_sources
+    assert counts.total_without_phot_stats == 0
 
     # post another photometry point to trigger quick update:
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": source_ids[1],
-            "mjd": np.random.uniform(55000, 56000),
-            "instrument_id": ztf_camera.id,
-            "flux": np.random.normal(300, 10),
-            "fluxerr": 10.0,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": np.random.choice(["ztfg", "ztfr", "ztfi"]),
-            "group_ids": [public_group.id],
-            "altdata": {"some_key": str(uuid.uuid4())},
-        },
-        token=upload_data_token,
+    sp.post_photometry(
+        PhotometryPost(
+            obj_id=source_ids[1],
+            mjd=np.random.uniform(55000, 56000),
+            instrument_id=ztf_camera.id,
+            flux=np.random.normal(300, 10),
+            fluxerr=10.0,
+            zp=25.0,
+            magsys="ab",
+            filter=np.random.choice(["ztfg", "ztfr", "ztfi"]),
+            group_ids=[public_group.id],
+            altdata={"some_key": str(uuid.uuid4())},
+        )
     )
-    assert status == 200
 
     # check that the quick update has changed the PhotStat on one object
-    status, data = api(
-        "GET",
-        "phot_stats",
-        params={
-            "createdAtStartTime": t0.isoformat(),
-            "quickUpdateStartTime": t2.isoformat(),
-        },
-        token=super_admin_token,
+    counts = sp_admin.fetch_phot_stats_counts(
+        created_at_start_time=t0.isoformat(),
+        quick_update_start_time=t2.isoformat(),
     )
-    assert status == 200
-    assert data["data"]["totalWithPhotStats"] == 1
-    assert data["data"]["totalWithoutPhotStats"] == 0
+    assert counts.total_with_phot_stats == 1
+    assert counts.total_without_phot_stats == 0
 
     # run a full update on all new sources
-    status, data = api(
-        "PATCH",
-        "phot_stats",
-        params={
-            "createdAtStartTime": t0.isoformat(),
-        },
-        token=super_admin_token,
+    batch = sp_admin.update_phot_stats(
+        created_at_start_time=t0.isoformat(),
     )
 
-    assert status == 200
-    assert data["data"]["totalMatches"] == num_sources
+    assert batch.total_matches == num_sources
 
     # make sure we recover all the sources with
     # a full update time after t2
-    status, data = api(
-        "GET",
-        "phot_stats",
-        params={
-            "createdAtStartTime": t0.isoformat(),
-            "fullUpdateStartTime": t2.isoformat(),
-        },
-        token=super_admin_token,
+    counts = sp_admin.fetch_phot_stats_counts(
+        created_at_start_time=t0.isoformat(),
+        full_update_start_time=t2.isoformat(),
     )
-    assert status == 200
-    assert data["data"]["totalWithPhotStats"] == num_sources
-    assert data["data"]["totalWithoutPhotStats"] == 0
+    assert counts.total_with_phot_stats == num_sources
+    assert counts.total_without_phot_stats == 0
 
     # no sources left updated before t2
-    status, data = api(
-        "GET",
-        "phot_stats",
-        params={
-            "createdAtStartTime": t0.isoformat(),
-            "fullUpdateEndTime": t2.isoformat(),
-        },
-        token=super_admin_token,
+    counts = sp_admin.fetch_phot_stats_counts(
+        created_at_start_time=t0.isoformat(),
+        full_update_end_time=t2.isoformat(),
     )
-    assert status == 200
-    assert data["data"]["totalWithPhotStats"] == 0
-    assert data["data"]["totalWithoutPhotStats"] == 0
+    assert counts.total_with_phot_stats == 0
+    assert counts.total_without_phot_stats == 0
 
 
 def test_phot_stats_bad_data(upload_data_token, public_group, ztf_camera):
@@ -977,18 +723,14 @@ def test_phot_stat_incremental_matches_full_recompute(
     detection and several re-detections, the maintained PhotStat must equal a
     from-scratch full_update over all of the object's photometry — no drift."""
     source_id = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": source_id,
-            "ra": np.random.uniform(0, 360),
-            "dec": np.random.uniform(-90, 90),
-            "group_ids": [public_group.id],
-        },
-        token=super_admin_token,
+    client(super_admin_token).post_source(
+        SourcePost(
+            id=source_id,
+            ra=np.random.uniform(0, 360),
+            dec=np.random.uniform(-90, 90),
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
 
     rounds = [
         # round 1: initial detection (object is new -> full_update)
@@ -1057,119 +799,79 @@ def test_phot_stat_incremental_matches_full_recompute(
 
 
 def test_phot_stat_aggregate(upload_data_token, public_group, ztf_camera):
+    sp = client(upload_data_token)
+
     # metadata-only request returns the plottable field list
-    status, data = api("GET", "phot_stats/aggregate", token=upload_data_token)
-    assert status == 200
-    field_values = {f["value"] for f in data["data"]["fields"]}
+    agg = sp.fetch_phot_stats_aggregate()
+    field_values = {f.value for f in agg.fields}
     assert "peak_mag_global" in field_values
     assert "rise_rate" in field_values
-    assert data["data"]["points"] == []
+    assert agg.points == []
 
     # a source with photometry gets a PhotStat and should appear
     source_id = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": source_id,
-            "ra": np.random.uniform(0, 360),
-            "dec": np.random.uniform(-90, 90),
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    sp.post_source(
+        SourcePost(
+            id=source_id,
+            ra=np.random.uniform(0, 360),
+            dec=np.random.uniform(-90, 90),
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
 
     for mjd, flux in zip(np.linspace(57000, 57100, 4), [10.0, 110.0, 170.0, 90.0]):
-        status, data = api(
-            "POST",
-            "photometry",
-            data={
-                "obj_id": source_id,
-                "mjd": mjd,
-                "instrument_id": ztf_camera.id,
-                "flux": flux,
-                "fluxerr": 10.0,
-                "zp": 25.0,
-                "magsys": "ab",
-                "filter": "ztfr",
-                "group_ids": [public_group.id],
-            },
-            token=upload_data_token,
+        sp.post_photometry(
+            PhotometryPost(
+                obj_id=source_id,
+                mjd=mjd,
+                instrument_id=ztf_camera.id,
+                flux=flux,
+                fluxerr=10.0,
+                zp=25.0,
+                magsys="ab",
+                filter="ztfr",
+                group_ids=[public_group.id],
+            )
         )
-        assert status == 200
 
-    status, data = api(
-        "GET",
-        "phot_stats/aggregate",
-        params={"xField": "num_obs_global", "yField": "num_det_global"},
-        token=upload_data_token,
+    agg = sp.fetch_phot_stats_aggregate(
+        x_field="num_obs_global", y_field="num_det_global"
     )
-    assert status == 200
-    ids = {p["id"] for p in data["data"]["points"]}
+    ids = {p.id for p in agg.points}
     assert source_id in ids
 
     # invalid field is rejected
-    status, data = api(
-        "GET",
-        "phot_stats/aggregate",
-        params={"xField": "not_a_field", "yField": "num_det_global"},
-        token=upload_data_token,
-    )
-    assert status == 400
-    assert "Invalid xField" in data["message"]
+    with pytest.raises(SkyPortalError, match="Invalid xField") as err:
+        sp.fetch_phot_stats_aggregate(x_field="not_a_field", y_field="num_det_global")
+    assert err.value.status_code == 400
 
     # down-selecting on a classification nothing has excludes the source
-    status, data = api(
-        "GET",
-        "phot_stats/aggregate",
-        params={
-            "xField": "num_obs_global",
-            "yField": "num_det_global",
-            "classifications": "not-a-real-classification",
-        },
-        token=upload_data_token,
+    agg = sp.fetch_phot_stats_aggregate(
+        x_field="num_obs_global",
+        y_field="num_det_global",
+        classifications=["not-a-real-classification"],
     )
-    assert status == 200
-    assert source_id not in {p["id"] for p in data["data"]["points"]}
+    assert source_id not in {p.id for p in agg.points}
 
     # selecting by group (instead of classification) includes the source
-    status, data = api(
-        "GET",
-        "phot_stats/aggregate",
-        params={
-            "xField": "num_obs_global",
-            "yField": "num_det_global",
-            "group_id": public_group.id,
-        },
-        token=upload_data_token,
+    agg = sp.fetch_phot_stats_aggregate(
+        x_field="num_obs_global",
+        y_field="num_det_global",
+        group_id=public_group.id,
     )
-    assert status == 200
-    assert source_id in {p["id"] for p in data["data"]["points"]}
+    assert source_id in {p.id for p in agg.points}
 
     # selecting by an explicit object list restricts to those objects
-    status, data = api(
-        "GET",
-        "phot_stats/aggregate",
-        params={
-            "xField": "num_obs_global",
-            "yField": "num_det_global",
-            "obj_ids": source_id,
-        },
-        token=upload_data_token,
+    agg = sp.fetch_phot_stats_aggregate(
+        x_field="num_obs_global",
+        y_field="num_det_global",
+        obj_ids=[source_id],
     )
-    assert status == 200
-    assert source_id in {p["id"] for p in data["data"]["points"]}
+    assert source_id in {p.id for p in agg.points}
 
-    status, data = api(
-        "GET",
-        "phot_stats/aggregate",
-        params={
-            "xField": "num_obs_global",
-            "yField": "num_det_global",
-            "obj_ids": "not-a-real-object",
-        },
-        token=upload_data_token,
+    agg = sp.fetch_phot_stats_aggregate(
+        x_field="num_obs_global",
+        y_field="num_det_global",
+        obj_ids=["not-a-real-object"],
     )
-    assert status == 200
-    assert source_id not in {p["id"] for p in data["data"]["points"]}
+    assert source_id not in {p.id for p in agg.points}

--- a/skyportal/tests/api_tests/photometry_followup/test_photometric_series.py
+++ b/skyportal/tests/api_tests/photometry_followup/test_photometric_series.py
@@ -1,5 +1,6 @@
 import hashlib
 import os
+import re
 import time
 import uuid
 
@@ -8,10 +9,12 @@ import pandas as pd
 import pytest
 import sqlalchemy as sa
 from astropy.time import Time
+from skyportal_py import SkyPortalError
+from skyportal_py.photometric_series import PhotometricSeriesPost
 from sqlalchemy.exc import IntegrityError
 
 from skyportal.models import DBSession, PhotometricSeries
-from skyportal.tests import api, assert_api, assert_api_fail
+from skyportal.tests import api, assert_api, assert_api_fail, client
 from skyportal.utils.hdf5_files import (
     dump_dataframe_to_bytestream,
     load_dataframe_from_bytestream,
@@ -65,49 +68,33 @@ def test_hdf5_file_vs_memory_hash():
 def test_post_retrieve_delete_series(
     phot_series_maker, upload_data_token, public_source, ztf_camera
 ):
+    sp = client(upload_data_token)
     filename = None
 
     try:  # cleanup file at the end
         input_data = phot_series_maker()
-        series_data = {
-            "data": input_data,
-            "obj_id": public_source.id,
-            "instrument_id": ztf_camera.id,
-            "ra": 234.22,
-            "dec": 52.31,
-            "series_name": "2020/summer",
-            "series_obj_id": np.random.randint(1e3, 1e4),
-            "exp_time": 30.0,
-            "filter": "ztfg",
-            "origin": "ZTF",
-        }
+        series_data = PhotometricSeriesPost(
+            data=input_data,
+            obj_id=public_source.id,
+            instrument_id=ztf_camera.id,
+            ra=234.22,
+            dec=52.31,
+            series_name="2020/summer",
+            series_obj_id=str(np.random.randint(1e3, 1e4)),
+            exp_time=30.0,
+            filter="ztfg",
+            origin="ZTF",
+        )
 
-        status, data = api(
-            "POST",
-            "photometric_series",
-            data=series_data,
-            token=upload_data_token,
-        )
-        assert_api(status, data)
-        ps_id = data["data"]["id"]
-        status, data = api(
-            "GET",
-            f"photometric_series/{ps_id}",
-            token=upload_data_token,
-        )
-        assert_api(status, data)
-        filename = data["data"]["filename"]
-        output_data = data["data"]["data"]
+        ps_id = sp.post_photometric_series(series_data).id
+        ps = sp.fetch_photometric_series(ps_id)
+        filename = ps.filename
+        output_data = ps.data
 
         # make sure the data is the same
         assert input_data == output_data
 
-        status, data = api(
-            "DELETE",
-            f"photometric_series/{ps_id}",
-            token=upload_data_token,
-        )
-        assert_api(status, data)
+        sp.delete_photometric_series(ps_id)
 
         assert not os.path.isfile(filename)
 
@@ -119,154 +106,132 @@ def test_post_retrieve_delete_series(
 def test_post_illegal_data_series(
     phot_series_maker, upload_data_token, public_source, ztf_camera
 ):
+    sp = client(upload_data_token)
     input_data = {}
-    series_data = {
-        "data": input_data,
-        "obj_id": public_source.id,
-        "instrument_id": ztf_camera.id,
-        "ra": 234.22,
-        "dec": 52.31,
-        "series_name": "2020/summer",
-        "series_obj_id": np.random.randint(1e3, 1e4),
-        "exp_time": 30.0,
-        "filter": "ztfg",
-        "origin": "ZTF",
-    }
-    status, data = api(
-        "POST",
-        "photometric_series",
-        data=series_data,
-        token=upload_data_token,
+    series_data = PhotometricSeriesPost(
+        data=input_data,
+        obj_id=public_source.id,
+        instrument_id=ztf_camera.id,
+        ra=234.22,
+        dec=52.31,
+        series_name="2020/summer",
+        series_obj_id=str(np.random.randint(1e3, 1e4)),
+        exp_time=30.0,
+        filter="ztfg",
+        origin="ZTF",
     )
-    assert_api_fail(status, data, 400, "Must supply a non-empty DataFrame.")
+    with pytest.raises(
+        SkyPortalError, match=re.escape("Must supply a non-empty DataFrame.")
+    ) as err:
+        sp.post_photometric_series(series_data)
+    assert err.value.status_code == 400
 
     input_data = phot_series_maker()
     input_data["mjddd"] = input_data.pop("mjd")
-    series_data = {
-        "data": input_data,
-        "obj_id": public_source.id,
-        "instrument_id": ztf_camera.id,
-        "ra": 234.22,
-        "dec": 52.31,
-        "series_name": "2020/summer",
-        "series_obj_id": np.random.randint(1e3, 1e4),
-        "exp_time": 30.0,
-        "filter": "ztfg",
-        "origin": "ZTF",
-    }
-    status, data = api(
-        "POST",
-        "photometric_series",
-        data=series_data,
-        token=upload_data_token,
+    series_data = PhotometricSeriesPost(
+        data=input_data,
+        obj_id=public_source.id,
+        instrument_id=ztf_camera.id,
+        ra=234.22,
+        dec=52.31,
+        series_name="2020/summer",
+        series_obj_id=str(np.random.randint(1e3, 1e4)),
+        exp_time=30.0,
+        filter="ztfg",
+        origin="ZTF",
     )
-    assert_api_fail(status, data, 400, "Input to photometric series must contain")
+    with pytest.raises(
+        SkyPortalError, match="Input to photometric series must contain"
+    ) as err:
+        sp.post_photometric_series(series_data)
+    assert err.value.status_code == 400
 
     input_data["mjds"] = input_data.pop("mjddd")
     input_data["magggg"] = input_data.pop("mag")
-    series_data = {
-        "data": input_data,
-        "obj_id": public_source.id,
-        "instrument_id": ztf_camera.id,
-        "ra": 234.22,
-        "dec": 52.31,
-        "series_name": "2020/summer",
-        "series_obj_id": np.random.randint(1e3, 1e4),
-        "exp_time": 30.0,
-        "filter": "ztfg",
-        "origin": "ZTF",
-    }
-    status, data = api(
-        "POST",
-        "photometric_series",
-        data=series_data,
-        token=upload_data_token,
+    series_data = PhotometricSeriesPost(
+        data=input_data,
+        obj_id=public_source.id,
+        instrument_id=ztf_camera.id,
+        ra=234.22,
+        dec=52.31,
+        series_name="2020/summer",
+        series_obj_id=str(np.random.randint(1e3, 1e4)),
+        exp_time=30.0,
+        filter="ztfg",
+        origin="ZTF",
     )
-    assert_api_fail(status, data, 400, "Input to photometric series must contain")
+    with pytest.raises(
+        SkyPortalError, match="Input to photometric series must contain"
+    ) as err:
+        sp.post_photometric_series(series_data)
+    assert err.value.status_code == 400
 
 
 def test_post_bad_metadata(
     phot_series_maker, upload_data_token, public_source, ztf_camera
 ):
+    sp = client(upload_data_token)
     input_data = phot_series_maker()
     series_data = {
         "data": input_data,
     }
-    status, data = api(
-        "POST",
-        "photometric_series",
-        data=series_data,
-        token=upload_data_token,
-    )
-    assert_api_fail(status, data, 400, "Must supply an obj_id")
+    with pytest.raises(SkyPortalError, match="Must supply an obj_id") as err:
+        sp.post_photometric_series(PhotometricSeriesPost(**series_data))
+    assert err.value.status_code == 400
 
     # add the object id
     series_data.update({"obj_id": public_source.id})
-    status, data = api(
-        "POST",
-        "photometric_series",
-        data=series_data,
-        token=upload_data_token,
-    )
-    assert_api_fail(status, data, 400, "Must supply an instrument_id")
+    with pytest.raises(SkyPortalError, match="Must supply an instrument_id") as err:
+        sp.post_photometric_series(PhotometricSeriesPost(**series_data))
+    assert err.value.status_code == 400
 
     # add the instrument id (this number is not legal!)
     series_data.update({"instrument_id": 123456778})
-    status, data = api(
-        "POST",
-        "photometric_series",
-        data=series_data,
-        token=upload_data_token,
-    )
-    assert_api_fail(status, data, 400, "Invalid instrument_id")
+    with pytest.raises(SkyPortalError, match="Invalid instrument_id") as err:
+        sp.post_photometric_series(PhotometricSeriesPost(**series_data))
+    assert err.value.status_code == 400
 
     # add the instrument id
     series_data.update({"instrument_id": ztf_camera.id})
-    status, data = api(
-        "POST",
-        "photometric_series",
-        data=series_data,
-        token=upload_data_token,
-    )
-    assert_api_fail(
-        status,
-        data,
-        400,
-        "The following keys are missing: "
-        "['series_name', 'series_obj_id', 'ra', 'dec', 'exp_time', 'filter']",
-    )
+    with pytest.raises(
+        SkyPortalError,
+        match=re.escape(
+            "The following keys are missing: "
+            "['series_name', 'series_obj_id', 'ra', 'dec', 'exp_time', 'filter']"
+        ),
+    ) as err:
+        sp.post_photometric_series(PhotometricSeriesPost(**series_data))
+    assert err.value.status_code == 400
 
     # add the series name and obj_id
     series_data.update(
-        {"series_name": "test_series_id", "series_obj_id": np.random.randint(1e3, 1e4)}
+        {
+            "series_name": "test_series_id",
+            "series_obj_id": str(np.random.randint(1e3, 1e4)),
+        }
     )
-    status, data = api(
-        "POST",
-        "photometric_series",
-        data=series_data,
-        token=upload_data_token,
-    )
-    assert_api_fail(
-        status,
-        data,
-        400,
-        "The following keys are missing: ['ra', 'dec', 'exp_time', 'filter']",
-    )
+    with pytest.raises(
+        SkyPortalError,
+        match=re.escape(
+            "The following keys are missing: ['ra', 'dec', 'exp_time', 'filter']"
+        ),
+    ) as err:
+        sp.post_photometric_series(PhotometricSeriesPost(**series_data))
+    assert err.value.status_code == 400
 
     # add everything else, but wrong filter
     series_data.update(
         {"ra": 234.22, "dec": 52.31, "exp_time": 30.0, "filter": "foobar"}
     )
-    status, data = api(
-        "POST",
-        "photometric_series",
-        data=series_data,
-        token=upload_data_token,
-    )
-    assert_api_fail(status, data, 400, "is not allowed. Allowed filters are:")
+    with pytest.raises(
+        SkyPortalError, match=re.escape("is not allowed. Allowed filters are:")
+    ) as err:
+        sp.post_photometric_series(PhotometricSeriesPost(**series_data))
+    assert err.value.status_code == 400
 
     # filter is ok, but exp time is not a number
     series_data.update({"exp_time": "foobar", "filter": "ztfg"})
+    # raw api: intentionally malformed payload the typed client can't produce
     status, data = api(
         "POST",
         "photometric_series",
@@ -277,6 +242,7 @@ def test_post_bad_metadata(
 
     # try to add some optional metadata but with wrong values
     series_data.update({"exp_time": 30.0, "magref": "foobar"})
+    # raw api: intentionally malformed payload the typed client can't produce
     status, data = api(
         "POST",
         "photometric_series",
@@ -286,6 +252,7 @@ def test_post_bad_metadata(
     assert_api_fail(status, data, 400, "Could not cast magref to the correct type")
 
     series_data.update({"magref": 17.1, "stream_ids": "foobar"})
+    # raw api: intentionally malformed payload the typed client can't produce
     status, data = api(
         "POST",
         "photometric_series",
@@ -295,6 +262,7 @@ def test_post_bad_metadata(
     assert_api_fail(status, data, 400, "Invalid stream_ids parameter value")
 
     series_data.update({"stream_ids": [], "altdata": "foobar"})
+    # raw api: intentionally malformed payload the typed client can't produce
     status, data = api(
         "POST",
         "photometric_series",
@@ -304,16 +272,13 @@ def test_post_bad_metadata(
     assert_api_fail(status, data, 400, "Could not cast altdata to the correct type")
 
     series_data.update({"altdata": {}, "followup_request_id": 123456789})
-    status, data = api(
-        "POST",
-        "photometric_series",
-        data=series_data,
-        token=upload_data_token,
-    )
-    assert_api_fail(status, data, 400, "Invalid followup_request_id")
+    with pytest.raises(SkyPortalError, match="Invalid followup_request_id") as err:
+        sp.post_photometric_series(PhotometricSeriesPost(**series_data))
+    assert err.value.status_code == 400
 
     series_data.pop("followup_request_id")
     series_data.update({"time_stamp_alignment": "foobar"})
+    # raw api: intentionally malformed payload the typed client can't produce
     status, data = api(
         "POST",
         "photometric_series",
@@ -324,6 +289,7 @@ def test_post_bad_metadata(
 
     # add keywords that are not familiar
     series_data.update({"time_stamp_alignment": "middle", "foo": "bar"})
+    # raw api: intentionally malformed payload the typed client can't produce
     status, data = api(
         "POST",
         "photometric_series",
@@ -336,78 +302,63 @@ def test_post_bad_metadata(
 def test_post_inferred_metadata(
     phot_series_maker, upload_data_token, public_source, ztf_camera
 ):
+    sp = client(upload_data_token)
     filename = None
 
     try:  # cleanup file at the end
         input_data = phot_series_maker(extra_columns=[])
-        series_data = {
-            "data": input_data,
-            "obj_id": public_source.id,
-            "instrument_id": ztf_camera.id,
-            "series_name": "2020/summer",
-            "series_obj_id": np.random.randint(1e3, 1e4),
-        }
-        status, data = api(
-            "POST",
-            "photometric_series",
-            data=series_data,
-            token=upload_data_token,
+        series_data = PhotometricSeriesPost(
+            data=input_data,
+            obj_id=public_source.id,
+            instrument_id=ztf_camera.id,
+            series_name="2020/summer",
+            series_obj_id=str(np.random.randint(1e3, 1e4)),
         )
-        assert_api_fail(
-            status,
-            data,
-            400,
-            "The following keys are missing: ['ra', 'dec', 'exp_time', 'filter']",
-        )
+        with pytest.raises(
+            SkyPortalError,
+            match=re.escape(
+                "The following keys are missing: ['ra', 'dec', 'exp_time', 'filter']"
+            ),
+        ) as err:
+            sp.post_photometric_series(series_data)
+        assert err.value.status_code == 400
 
         # should be able to get the RA/Dec from the data
         input_data = phot_series_maker(extra_columns=["ra", "dec"])
         assert "ra" in input_data
         assert "dec" in input_data
 
-        series_data = {
-            "data": input_data,
-            "obj_id": public_source.id,
-            "instrument_id": ztf_camera.id,
-            "series_name": "2020/summer",
-            "series_obj_id": np.random.randint(1e3, 1e4),
-        }
-        status, data = api(
-            "POST",
-            "photometric_series",
-            data=series_data,
-            token=upload_data_token,
+        series_data = PhotometricSeriesPost(
+            data=input_data,
+            obj_id=public_source.id,
+            instrument_id=ztf_camera.id,
+            series_name="2020/summer",
+            series_obj_id=str(np.random.randint(1e3, 1e4)),
         )
-        assert_api_fail(
-            status,
-            data,
-            400,
-            "The following keys are missing: ['exp_time', 'filter']",
-        )
+        with pytest.raises(
+            SkyPortalError,
+            match=re.escape("The following keys are missing: ['exp_time', 'filter']"),
+        ) as err:
+            sp.post_photometric_series(series_data)
+        assert err.value.status_code == 400
 
         # should be able to get the exposure time, too
         input_data = phot_series_maker(extra_columns=["ra", "dec", "exp_time"])
         assert "exp_time" in input_data
 
-        series_data = {
-            "data": input_data,
-            "obj_id": public_source.id,
-            "instrument_id": ztf_camera.id,
-            "series_name": "2020/summer",
-            "series_obj_id": np.random.randint(1e3, 1e4),
-        }
-        status, data = api(
-            "POST",
-            "photometric_series",
-            data=series_data,
-            token=upload_data_token,
+        series_data = PhotometricSeriesPost(
+            data=input_data,
+            obj_id=public_source.id,
+            instrument_id=ztf_camera.id,
+            series_name="2020/summer",
+            series_obj_id=str(np.random.randint(1e3, 1e4)),
         )
-        assert_api_fail(
-            status,
-            data,
-            400,
-            "The following keys are missing: ['filter']",
-        )
+        with pytest.raises(
+            SkyPortalError,
+            match=re.escape("The following keys are missing: ['filter']"),
+        ) as err:
+            sp.post_photometric_series(series_data)
+        assert err.value.status_code == 400
 
         # should be able to get the exposure time, too
         input_data = phot_series_maker(
@@ -415,40 +366,23 @@ def test_post_inferred_metadata(
         )
         assert "filter" in input_data
 
-        series_data = {
-            "data": input_data,
-            "obj_id": public_source.id,
-            "instrument_id": ztf_camera.id,
-            "series_name": "2020/summer",
-            "series_obj_id": np.random.randint(1e3, 1e4),
-        }
-        status, data = api(
-            "POST",
-            "photometric_series",
-            data=series_data,
-            token=upload_data_token,
+        series_data = PhotometricSeriesPost(
+            data=input_data,
+            obj_id=public_source.id,
+            instrument_id=ztf_camera.id,
+            series_name="2020/summer",
+            series_obj_id=str(np.random.randint(1e3, 1e4)),
         )
-        assert_api(status, data)
-        ps_id = data["data"]["id"]
+        ps_id = sp.post_photometric_series(series_data).id
 
-        status, data = api(
-            "GET",
-            f"photometric_series/{ps_id}",
-            token=upload_data_token,
-        )
-        assert_api(status, data)
-        filename = data["data"]["filename"]
-        output_data = data["data"]["data"]
+        ps = sp.fetch_photometric_series(ps_id)
+        filename = ps.filename
+        output_data = ps.data
 
         # make sure the data is the same
         assert input_data == output_data
 
-        status, data = api(
-            "DELETE",
-            f"photometric_series/{ps_id}",
-            token=upload_data_token,
-        )
-        assert_api(status, data)
+        sp.delete_photometric_series(ps_id)
 
         assert not os.path.isfile(filename)
 
@@ -460,6 +394,7 @@ def test_post_inferred_metadata(
 def test_post_dataframe_file(
     phot_series_maker, upload_data_token, public_source, ztf_camera
 ):
+    sp = client(upload_data_token)
     filename = None
 
     try:  # cleanup file at the end
@@ -468,45 +403,28 @@ def test_post_dataframe_file(
         byte_stream = dump_dataframe_to_bytestream(df)
         assert isinstance(byte_stream, bytes)
 
-        series_data = {
-            "data": byte_stream,
-            "obj_id": public_source.id,
-            "instrument_id": ztf_camera.id,
-            "ra": 234.22,
-            "dec": 52.31,
-            "series_name": "2020/summer",
-            "series_obj_id": np.random.randint(1e3, 1e4),
-            "exp_time": 30.0,
-            "filter": "ztfg",
-            "origin": "ZTF",
-        }
+        series_data = PhotometricSeriesPost(
+            data=byte_stream,
+            obj_id=public_source.id,
+            instrument_id=ztf_camera.id,
+            ra=234.22,
+            dec=52.31,
+            series_name="2020/summer",
+            series_obj_id=str(np.random.randint(1e3, 1e4)),
+            exp_time=30.0,
+            filter="ztfg",
+            origin="ZTF",
+        )
 
-        status, data = api(
-            "POST",
-            "photometric_series",
-            data=series_data,
-            token=upload_data_token,
-        )
-        assert_api(status, data)
-        ps_id = data["data"]["id"]
-        status, data = api(
-            "GET",
-            f"photometric_series/{ps_id}",
-            token=upload_data_token,
-        )
-        assert_api(status, data)
-        filename = data["data"]["filename"]
-        output_data = data["data"]["data"]
+        ps_id = sp.post_photometric_series(series_data).id
+        ps = sp.fetch_photometric_series(ps_id)
+        filename = ps.filename
+        output_data = ps.data
 
         # make sure the data is the same
         assert df.equals(pd.DataFrame(output_data))
 
-        status, data = api(
-            "DELETE",
-            f"photometric_series/{ps_id}",
-            token=upload_data_token,
-        )
-        assert_api(status, data)
+        sp.delete_photometric_series(ps_id)
 
         assert not os.path.isfile(filename)
 
@@ -520,6 +438,7 @@ def test_post_dataframe_file(
 def test_post_dataframe_file_with_metadata(
     phot_series_maker, upload_data_token, public_source, ztf_camera
 ):
+    sp = client(upload_data_token)
     filename = None
 
     try:  # cleanup file at the end
@@ -537,40 +456,23 @@ def test_post_dataframe_file_with_metadata(
         byte_stream = dump_dataframe_to_bytestream(df, metadata)
         assert isinstance(byte_stream, bytes)
 
-        series_data = {
-            "data": byte_stream,
-        }
+        series_data = PhotometricSeriesPost(
+            data=byte_stream,
+        )
 
-        status, data = api(
-            "POST",
-            "photometric_series",
-            data=series_data,
-            token=upload_data_token,
-        )
-        assert_api(status, data)
-        ps_id = data["data"]["id"]
-        status, data = api(
-            "GET",
-            f"photometric_series/{ps_id}",
-            token=upload_data_token,
-        )
-        assert_api(status, data)
-        filename = data["data"]["filename"]
-        output_data = data["data"]["data"]
-        output_ra = data["data"]["ra"]
-        output_dec = data["data"]["dec"]
+        ps_id = sp.post_photometric_series(series_data).id
+        ps = sp.fetch_photometric_series(ps_id)
+        filename = ps.filename
+        output_data = ps.data
+        output_ra = ps.ra
+        output_dec = ps.dec
 
         # make sure the data is the same
         assert df.equals(pd.DataFrame(output_data))
         assert abs(output_ra - 123) < 1e-3
         assert abs(output_dec + 45) < 1e-3
 
-        status, data = api(
-            "DELETE",
-            f"photometric_series/{ps_id}",
-            token=upload_data_token,
-        )
-        assert_api(status, data)
+        sp.delete_photometric_series(ps_id)
 
         assert not os.path.isfile(filename)
 
@@ -584,40 +486,29 @@ def test_post_dataframe_file_with_metadata(
 def test_read_file_after_posting(
     phot_series_maker, upload_data_token, public_source, ztf_camera
 ):
+    sp = client(upload_data_token)
     filename = None
 
     try:  # cleanup file at the end
         input_data = phot_series_maker()
-        series_data = {
-            "data": input_data,
-            "obj_id": public_source.id,
-            "instrument_id": ztf_camera.id,
-            "ra": 123.22,
-            "dec": -45.31,
-            "series_name": "2022/winter",
-            "series_obj_id": np.random.randint(1e3, 1e4),
-            "exp_time": 30.0,
-            "filter": "ztfg",
-            "origin": "ZTF",
-        }
+        series_data = PhotometricSeriesPost(
+            data=input_data,
+            obj_id=public_source.id,
+            instrument_id=ztf_camera.id,
+            ra=123.22,
+            dec=-45.31,
+            series_name="2022/winter",
+            series_obj_id=str(np.random.randint(1e3, 1e4)),
+            exp_time=30.0,
+            filter="ztfg",
+            origin="ZTF",
+        )
 
-        status, data = api(
-            "POST",
-            "photometric_series",
-            data=series_data,
-            token=upload_data_token,
-        )
-        assert_api(status, data)
-        ps_id = data["data"]["id"]
-        status, data = api(
-            "GET",
-            f"photometric_series/{ps_id}",
-            token=upload_data_token,
-        )
-        assert_api(status, data)
-        filename = data["data"]["filename"]
-        output_data = data["data"]["data"]
-        output_hash = data["data"]["hash"]
+        ps_id = sp.post_photometric_series(series_data).id
+        ps = sp.fetch_photometric_series(ps_id)
+        filename = ps.filename
+        output_data = ps.data
+        output_hash = ps.hash
 
         # make sure the data is the same
         assert input_data == output_data
@@ -640,19 +531,14 @@ def test_read_file_after_posting(
         assert abs(metadata["ra"] - 123.22) < 1e-3
         assert abs(metadata["dec"] + 45.31) < 1e-3
         assert metadata["series_name"] == "2022/winter"
-        assert metadata["series_obj_id"] == str(series_data["series_obj_id"])
+        assert metadata["series_obj_id"] == series_data.series_obj_id
 
         # check that the hash is the same!
         with open(filename, "rb") as f:
             file_hash = hashlib.md5(f.read()).hexdigest()
         assert file_hash == output_hash
 
-        status, data = api(
-            "DELETE",
-            f"photometric_series/{ps_id}",
-            token=upload_data_token,
-        )
-        assert_api(status, data)
+        sp.delete_photometric_series(ps_id)
 
         assert not os.path.isfile(filename)
 
@@ -664,72 +550,49 @@ def test_read_file_after_posting(
 def test_cannot_repost_series(
     phot_series_maker, upload_data_token, public_source, ztf_camera
 ):
+    sp = client(upload_data_token)
     filename = None
 
     try:  # cleanup file at the end
         input_data = phot_series_maker()
-        series_data = {
-            "data": input_data,
-            "obj_id": public_source.id,
-            "instrument_id": ztf_camera.id,
-            "ra": 234.22,
-            "dec": 52.31,
-            "series_name": "2020/summer",
-            "series_obj_id": np.random.randint(1e3, 1e4),
-            "exp_time": 30.0,
-            "filter": "ztfg",
-            "origin": "ZTF",
-        }
+        series_data = PhotometricSeriesPost(
+            data=input_data,
+            obj_id=public_source.id,
+            instrument_id=ztf_camera.id,
+            ra=234.22,
+            dec=52.31,
+            series_name="2020/summer",
+            series_obj_id=str(np.random.randint(1e3, 1e4)),
+            exp_time=30.0,
+            filter="ztfg",
+            origin="ZTF",
+        )
 
-        status, data = api(
-            "POST",
-            "photometric_series",
-            data=series_data,
-            token=upload_data_token,
-        )
-        assert_api(status, data)
-        ps_id = data["data"]["id"]
-        status, data = api(
-            "GET",
-            f"photometric_series/{ps_id}",
-            token=upload_data_token,
-        )
-        assert_api(status, data)
-        filename = data["data"]["filename"]
-        output_data = data["data"]["data"]
+        ps_id = sp.post_photometric_series(series_data).id
+        ps = sp.fetch_photometric_series(ps_id)
+        filename = ps.filename
+        output_data = ps.data
 
         # make sure the data is the same
         assert input_data == output_data
 
         # try to post the same data again
-        status, data = api(
-            "POST",
-            "photometric_series",
-            data=series_data,
-            token=upload_data_token,
-        )
-        assert_api_fail(status, data, 400, "already exists")
+        with pytest.raises(SkyPortalError, match="already exists") as err:
+            sp.post_photometric_series(series_data)
+        assert err.value.status_code == 400
 
         # delete the file then try again
         os.remove(filename)
 
         # try to post the same data again
-        status, data = api(
-            "POST",
-            "photometric_series",
-            data=series_data,
-            token=upload_data_token,
-        )
-        assert_api_fail(
-            status, data, 400, "A PhotometricSeries with the same hash already exists"
-        )
+        with pytest.raises(
+            SkyPortalError,
+            match="A PhotometricSeries with the same hash already exists",
+        ) as err:
+            sp.post_photometric_series(series_data)
+        assert err.value.status_code == 400
 
-        status, data = api(
-            "DELETE",
-            f"photometric_series/{ps_id}",
-            token=upload_data_token,
-        )
-        assert_api(status, data)
+        sp.delete_photometric_series(ps_id)
 
         assert not os.path.isfile(filename)
 
@@ -838,40 +701,28 @@ def test_no_autodelete_series(photometric_series):
 def test_patch_series_data(
     phot_series_maker, upload_data_token, public_source, ztf_camera
 ):
+    sp = client(upload_data_token)
     filename = None
     ps_id = None
 
     try:  # cleanup file at the end
         input_data = phot_series_maker()
-        series_data = {
-            "data": input_data,
-            "obj_id": public_source.id,
-            "instrument_id": ztf_camera.id,
-            "ra": 234.22,
-            "dec": 52.31,
-            "series_name": "2020/summer",
-            "series_obj_id": np.random.randint(1e3, 1e4),
-            "exp_time": 30.0,
-            "filter": "ztfg",
-            "origin": "ZTF",
-        }
-
-        status, data = api(
-            "POST",
-            "photometric_series",
-            data=series_data,
-            token=upload_data_token,
+        series_data = PhotometricSeriesPost(
+            data=input_data,
+            obj_id=public_source.id,
+            instrument_id=ztf_camera.id,
+            ra=234.22,
+            dec=52.31,
+            series_name="2020/summer",
+            series_obj_id=str(np.random.randint(1e3, 1e4)),
+            exp_time=30.0,
+            filter="ztfg",
+            origin="ZTF",
         )
-        assert_api(status, data)
-        ps_id = data["data"]["id"]
 
-        status, data = api(
-            "GET",
-            f"photometric_series/{ps_id}",
-            token=upload_data_token,
-        )
-        assert_api(status, data)
-        output_data = data["data"]["data"]
+        ps_id = sp.post_photometric_series(series_data).id
+
+        output_data = sp.fetch_photometric_series(ps_id).data
 
         # make sure the data is the same
         assert input_data == output_data
@@ -885,22 +736,13 @@ def test_patch_series_data(
         # pandas >= 3.0's Copy-on-Write, leaving the data unchanged.
         new_df.loc[3, "mjd"] += 1
 
-        status, data = api(
-            "PATCH",
-            f"photometric_series/{ps_id}",
-            data={"data": new_df.to_dict(orient="list")},
-            token=upload_data_token,
+        sp.update_photometric_series(
+            ps_id, PhotometricSeriesPost(data=new_df.to_dict(orient="list"))
         )
-        assert_api(status, data)
 
-        status, data = api(
-            "GET",
-            f"photometric_series/{ps_id}",
-            token=upload_data_token,
-        )
-        assert_api(status, data)
-        filename = data["data"]["filename"]
-        output_data = data["data"]["data"]
+        ps = sp.fetch_photometric_series(ps_id)
+        filename = ps.filename
+        output_data = ps.data
 
         # make sure the data is not the same
         assert input_data != output_data
@@ -908,12 +750,7 @@ def test_patch_series_data(
 
     finally:
         if ps_id is not None:
-            status, data = api(
-                "DELETE",
-                f"photometric_series/{ps_id}",
-                token=upload_data_token,
-            )
-            assert_api(status, data)
+            sp.delete_photometric_series(ps_id)
 
         if filename is not None and os.path.isfile(filename):
             os.remove(filename)
@@ -922,74 +759,48 @@ def test_patch_series_data(
 def test_patch_series_metadata(
     phot_series_maker, upload_data_token, public_source, ztf_camera
 ):
+    sp = client(upload_data_token)
     filename = None
     ps_id = None
 
     try:  # cleanup file at the end
         input_data = phot_series_maker()
-        series_data = {
-            "data": input_data,
-            "obj_id": public_source.id,
-            "instrument_id": ztf_camera.id,
-            "ra": 234.22,
-            "dec": 52.31,
-            "series_name": "2020/summer",
-            "series_obj_id": np.random.randint(1e3, 1e4),
-            "exp_time": 30.0,
-            "filter": "ztfg",
-            "origin": "ZTF",
-        }
-
-        status, data = api(
-            "POST",
-            "photometric_series",
-            data=series_data,
-            token=upload_data_token,
+        series_data = PhotometricSeriesPost(
+            data=input_data,
+            obj_id=public_source.id,
+            instrument_id=ztf_camera.id,
+            ra=234.22,
+            dec=52.31,
+            series_name="2020/summer",
+            series_obj_id=str(np.random.randint(1e3, 1e4)),
+            exp_time=30.0,
+            filter="ztfg",
+            origin="ZTF",
         )
-        assert_api(status, data)
-        ps_id = data["data"]["id"]
 
-        status, data = api(
-            "GET",
-            f"photometric_series/{ps_id}",
-            token=upload_data_token,
-        )
-        assert_api(status, data)
-        filename = data["data"]["filename"]
-        output_data = data["data"]["data"]
+        ps_id = sp.post_photometric_series(series_data).id
+
+        ps = sp.fetch_photometric_series(ps_id)
+        filename = ps.filename
+        output_data = ps.data
 
         # make sure the data is the same
         assert input_data == output_data
 
         # now change the metadata
-        status, data = api(
-            "PATCH",
-            f"photometric_series/{ps_id}",
-            data={"ra": series_data["ra"] + 1},
-            token=upload_data_token,
+        sp.update_photometric_series(
+            ps_id, PhotometricSeriesPost(ra=series_data.ra + 1)
         )
-        assert_api(status, data)
 
-        status, data = api(
-            "GET",
-            f"photometric_series/{ps_id}",
-            token=upload_data_token,
-        )
-        assert_api(status, data)
-        output_metadata = data["data"]
+        output_metadata = sp.fetch_photometric_series(ps_id)
 
         # make sure the data is not the same
         assert series_data != output_metadata
-        assert series_data["ra"] == output_metadata["ra"] - 1
+        assert series_data.ra == output_metadata.ra - 1
 
     finally:
         if ps_id is not None:
-            status, data = api(
-                "DELETE",
-                f"photometric_series/{ps_id}",
-                token=upload_data_token,
-            )
-            assert_api(status, data)
+            sp.delete_photometric_series(ps_id)
 
         if filename is not None and os.path.isfile(filename):
             os.remove(filename)
@@ -998,6 +809,7 @@ def test_patch_series_metadata(
 def test_patch_series_data_file_and_metadata(
     phot_series_maker, upload_data_token, public_source, ztf_camera
 ):
+    sp = client(upload_data_token)
     filename = None
     ps_id = None
 
@@ -1009,32 +821,20 @@ def test_patch_series_data_file_and_metadata(
             "ra": 234.22,
             "dec": 52.31,
             "series_name": "2020/summer",
-            "series_obj_id": np.random.randint(1e3, 1e4),
+            "series_obj_id": str(np.random.randint(1e3, 1e4)),
             "exp_time": 30.0,
             "filter": "ztfg",
             "origin": "ZTF",
         }
         byte_data = dump_dataframe_to_bytestream(pd.DataFrame(input_data), metadata)
-        series_data = {**metadata, "data": byte_data}
+        series_data = PhotometricSeriesPost(**metadata, data=byte_data)
 
-        status, data = api(
-            "POST",
-            "photometric_series",
-            data=series_data,
-            token=upload_data_token,
-        )
-        assert_api(status, data)
-        ps_id = data["data"]["id"]
+        ps_id = sp.post_photometric_series(series_data).id
 
-        status, data = api(
-            "GET",
-            f"photometric_series/{ps_id}",
-            token=upload_data_token,
-        )
-        assert_api(status, data)
+        ps = sp.fetch_photometric_series(ps_id)
 
-        filename = data["data"]["filename"]
-        output_data = data["data"]["data"]
+        filename = ps.filename
+        output_data = ps.data
 
         # make sure the data is the same
         assert input_data == output_data
@@ -1043,83 +843,44 @@ def test_patch_series_data_file_and_metadata(
         metadata["dec"] += 1
         byte_data = dump_dataframe_to_bytestream(pd.DataFrame(input_data), metadata)
 
-        status, data = api(
-            "PATCH",
-            f"photometric_series/{ps_id}",
-            data={"data": byte_data},
-            token=upload_data_token,
-        )
-        assert_api(status, data)
+        sp.update_photometric_series(ps_id, PhotometricSeriesPost(data=byte_data))
 
-        status, data = api(
-            "GET",
-            f"photometric_series/{ps_id}",
-            token=upload_data_token,
-        )
-        assert_api(status, data)
-        output_metadata = data["data"]
+        output_metadata = sp.fetch_photometric_series(ps_id)
 
         # make sure the data is not the same
         assert series_data != output_metadata
-        assert series_data["dec"] == output_metadata["dec"] - 1
+        assert series_data.dec == output_metadata.dec - 1
 
         # now change the metadata, both in file and in direct input
         metadata["exp_time"] += 10
         byte_data = dump_dataframe_to_bytestream(pd.DataFrame(input_data), metadata)
 
-        status, data = api(
-            "PATCH",
-            f"photometric_series/{ps_id}",
-            data={"data": byte_data, "exp_time": 20},
-            token=upload_data_token,
+        sp.update_photometric_series(
+            ps_id, PhotometricSeriesPost(data=byte_data, exp_time=20)
         )
-        assert_api(status, data)
 
-        status, data = api(
-            "GET",
-            f"photometric_series/{ps_id}",
-            token=upload_data_token,
-        )
-        assert_api(status, data)
-        output_metadata = data["data"]
+        output_metadata = sp.fetch_photometric_series(ps_id)
 
         # make sure the data is not the same
         assert series_data != output_metadata
-        assert series_data["exp_time"] == output_metadata["exp_time"] + 10
+        assert series_data.exp_time == output_metadata.exp_time + 10
 
         # now change the data to have different inferred values
         input_data["dec"] = np.ones(len(input_data["mjd"])) * 123.45
         # don't add any metadata:
         byte_data = dump_dataframe_to_bytestream(pd.DataFrame(input_data), {})
 
-        status, data = api(
-            "PATCH",
-            f"photometric_series/{ps_id}",
-            data={"data": byte_data},
-            token=upload_data_token,
-        )
-        assert_api(status, data)
+        sp.update_photometric_series(ps_id, PhotometricSeriesPost(data=byte_data))
 
-        status, data = api(
-            "GET",
-            f"photometric_series/{ps_id}",
-            token=upload_data_token,
-        )
-        assert_api(status, data)
-        output_metadata = data["data"]
+        output_metadata = sp.fetch_photometric_series(ps_id)
 
         # make sure the data is not the same
         assert series_data != output_metadata
-        assert output_metadata["dec"] == 123.45
+        assert output_metadata.dec == 123.45
 
     finally:
         if ps_id is not None:
-            status, data = api(
-                "DELETE",
-                f"photometric_series/{ps_id}",
-                token=upload_data_token,
-            )
-            assert_api(status, data)
+            sp.delete_photometric_series(ps_id)
 
         if filename is not None and os.path.isfile(filename):
             os.remove(filename)
@@ -1128,6 +889,7 @@ def test_patch_series_data_file_and_metadata(
 def test_get_individual_series_by_id(
     upload_data_token, photometric_series, photometric_series2, photometric_series3
 ):
+    sp = client(upload_data_token)
     filenames = []
     ps_ids = []
     raw_datasets = []
@@ -1149,34 +911,25 @@ def test_get_individual_series_by_id(
 
     # check that we can GET each PS on its own
     for i in range(3):
-        status, data = api(
-            "GET",
-            f"photometric_series/{ps_ids[i]}",
-            token=upload_data_token,
-        )
-        assert_api(status, data)
-        assert data["data"]["filename"] == filenames[i]
-        assert data["data"]["ra"] == ras[i]
-        assert data["data"]["dec"] == decs[i]
-        assert data["data"]["filter"] == filters[i]
-        assert data["data"]["obj_id"] == object_ids[i]
-        assert data["data"]["instrument_id"] == inst_ids[i]
+        ps_data = sp.fetch_photometric_series(ps_ids[i])
+        assert ps_data.filename == filenames[i]
+        assert ps_data.ra == ras[i]
+        assert ps_data.dec == decs[i]
+        assert ps_data.filter == filters[i]
+        assert ps_data.obj_id == object_ids[i]
+        assert ps_data.instrument_id == inst_ids[i]
 
     # check that we can GET all PSs at once
-    status, data = api(
-        "GET",
-        "photometric_series",
-        token=upload_data_token,
-    )
-    assert_api(status, data)
-    assert data["data"]["totalMatches"] >= 3
-    assert len(data["data"]["series"]) >= 3
-    assert set(ps_ids).issubset({ps["id"] for ps in data["data"]["series"]})
+    page = sp.fetch_photometric_series_page()
+    assert page.total_matches >= 3
+    assert len(page.series) >= 3
+    assert set(ps_ids).issubset({ps.id for ps in page.series})
 
 
 def test_get_series_cone_search(
     upload_data_token, photometric_series, photometric_series2, photometric_series3
 ):
+    sp = client(upload_data_token)
     ps_ids = []
     ras = []
     decs = []
@@ -1188,33 +941,22 @@ def test_get_series_cone_search(
 
     # get each PS by its coordinates
     for i in range(3):
-        status, data = api(
-            "GET",
-            "photometric_series",
-            params={"ra": ras[i], "dec": decs[i], "radius": 2 / 3600},
-            token=upload_data_token,
-        )
-        assert_api(status, data)
-        assert data["data"]["totalMatches"] == 1
-        assert len(data["data"]["series"]) == 1
-        assert data["data"]["series"][0]["id"] == ps_ids[i]
+        page = sp.fetch_photometric_series_page(ra=ras[i], dec=decs[i], radius=2 / 3600)
+        assert page.total_matches == 1
+        assert len(page.series) == 1
+        assert page.series[0].id == ps_ids[i]
 
         # will not find them if we fudge the coordinates
         new_dec = decs[i] + 0.1 if decs[i] < 0 else decs[i] - 0.1
-        status, data = api(
-            "GET",
-            "photometric_series",
-            params={"ra": ras[i], "dec": new_dec, "radius": 2 / 3600},
-            token=upload_data_token,
-        )
-        assert_api(status, data)
-        assert data["data"]["totalMatches"] == 0
-        assert len(data["data"]["series"]) == 0
+        page = sp.fetch_photometric_series_page(ra=ras[i], dec=new_dec, radius=2 / 3600)
+        assert page.total_matches == 0
+        assert len(page.series) == 0
 
 
 def test_get_series_by_filename(
     upload_data_token, photometric_series, photometric_series2, photometric_series3
 ):
+    sp = client(upload_data_token)
     filenames = []
     ps_ids = []
 
@@ -1224,22 +966,17 @@ def test_get_series_by_filename(
 
     # filter by file name
     for i in range(3):
-        status, data = api(
-            "GET",
-            "photometric_series",
-            params={"filename": filenames[i]},
-            token=upload_data_token,
-        )
-        assert_api(status, data)
-        assert data["data"]["totalMatches"] == 1
-        assert len(data["data"]["series"]) == 1
-        assert data["data"]["series"][0]["id"] == ps_ids[i]
-        assert data["data"]["series"][0]["filename"] == filenames[i]
+        page = sp.fetch_photometric_series_page(filename=filenames[i])
+        assert page.total_matches == 1
+        assert len(page.series) == 1
+        assert page.series[0].id == ps_ids[i]
+        assert page.series[0].filename == filenames[i]
 
 
 def test_get_series_by_object(
     upload_data_token, photometric_series, photometric_series2, photometric_series3
 ):
+    sp = client(upload_data_token)
     ps_ids = []
     object_ids = []
 
@@ -1249,45 +986,27 @@ def test_get_series_by_object(
 
     # filter on full object IDs
     for i in range(3):
-        status, data = api(
-            "GET",
-            "photometric_series",
-            params={"objectID": object_ids[i]},
-            token=upload_data_token,
-        )
-        assert_api(status, data)
-        assert data["data"]["totalMatches"] == 1
-        assert len(data["data"]["series"]) == 1
-        assert data["data"]["series"][0]["id"] == ps_ids[i]
-        assert data["data"]["series"][0]["obj_id"] == object_ids[i]
+        page = sp.fetch_photometric_series_page(object_id=object_ids[i])
+        assert page.total_matches == 1
+        assert len(page.series) == 1
+        assert page.series[0].id == ps_ids[i]
+        assert page.series[0].obj_id == object_ids[i]
 
     # check this works even with partial names:
     for i in range(3):
-        status, data = api(
-            "GET",
-            "photometric_series",
-            params={"objectID": object_ids[i][0:10]},
-            token=upload_data_token,
-        )
-        assert_api(status, data)
-        assert data["data"]["totalMatches"] == 1
-        assert len(data["data"]["series"]) == 1
-        assert data["data"]["series"][0]["id"] == ps_ids[i]
-        assert data["data"]["series"][0]["obj_id"] == object_ids[i]
+        page = sp.fetch_photometric_series_page(object_id=object_ids[i][0:10])
+        assert page.total_matches == 1
+        assert len(page.series) == 1
+        assert page.series[0].id == ps_ids[i]
+        assert page.series[0].obj_id == object_ids[i]
 
     # now try to reject each object:
     for i in range(3):
-        status, data = api(
-            "GET",
-            "photometric_series",
-            params={"rejectedObjectID": object_ids[i]},
-            token=upload_data_token,
-        )
-        assert_api(status, data)
-        assert data["data"]["totalMatches"] >= 2
-        assert len(data["data"]["series"]) >= 2
-        assert data["data"]["series"][0]["id"] != ps_ids[i]
-        assert data["data"]["series"][0]["obj_id"] != object_ids[i]
+        page = sp.fetch_photometric_series_page(rejected_object_id=object_ids[i])
+        assert page.total_matches >= 2
+        assert len(page.series) >= 2
+        assert page.series[0].id != ps_ids[i]
+        assert page.series[0].obj_id != object_ids[i]
 
 
 def test_get_series_by_instrument_id(
@@ -1298,35 +1017,25 @@ def test_get_series_by_instrument_id(
     ztf_camera,
     sedm,
 ):
-    status, data = api(
-        "GET",
-        "photometric_series",
-        params={"instrumentID": ztf_camera.id},
-        token=upload_data_token,
-    )
-    assert_api(status, data)
-    assert data["data"]["totalMatches"] == 2
-    assert len(data["data"]["series"]) == 2
-    assert all(ps["instrument_id"] == ztf_camera.id for ps in data["data"]["series"])
-    assert photometric_series.id in [ps["id"] for ps in data["data"]["series"]]
-    assert photometric_series2.id in [ps["id"] for ps in data["data"]["series"]]
+    sp = client(upload_data_token)
+    page = sp.fetch_photometric_series_page(instrument_id=ztf_camera.id)
+    assert page.total_matches == 2
+    assert len(page.series) == 2
+    assert all(ps.instrument_id == ztf_camera.id for ps in page.series)
+    assert photometric_series.id in [ps.id for ps in page.series]
+    assert photometric_series2.id in [ps.id for ps in page.series]
 
-    status, data = api(
-        "GET",
-        "photometric_series",
-        params={"instrumentID": sedm.id},
-        token=upload_data_token,
-    )
-    assert_api(status, data)
-    assert data["data"]["totalMatches"] == 1
-    assert len(data["data"]["series"]) == 1
-    assert data["data"]["series"][0]["instrument_id"] == sedm.id
-    assert data["data"]["series"][0]["id"] == photometric_series3.id
+    page = sp.fetch_photometric_series_page(instrument_id=sedm.id)
+    assert page.total_matches == 1
+    assert len(page.series) == 1
+    assert page.series[0].instrument_id == sedm.id
+    assert page.series[0].id == photometric_series3.id
 
 
 def test_get_series_by_name_and_obj_id(
     upload_data_token, photometric_series, photometric_series2, photometric_series3
 ):
+    sp = client(upload_data_token)
     ps_ids = []
     series_names = []
     series_obj_ids = []
@@ -1338,35 +1047,24 @@ def test_get_series_by_name_and_obj_id(
 
     # filter series by series name
     for i in range(3):
-        status, data = api(
-            "GET",
-            "photometric_series",
-            params={"seriesName": series_names[i]},
-            token=upload_data_token,
-        )
-        assert_api(status, data)
-        assert data["data"]["totalMatches"] == 1
-        assert len(data["data"]["series"]) == 1
-        assert data["data"]["series"][0]["id"] == ps_ids[i]
-        assert data["data"]["series"][0]["series_name"] == series_names[i]
+        page = sp.fetch_photometric_series_page(series_name=series_names[i])
+        assert page.total_matches == 1
+        assert len(page.series) == 1
+        assert page.series[0].id == ps_ids[i]
+        assert page.series[0].series_name == series_names[i]
 
         # filter series by series obj id
-        status, data = api(
-            "GET",
-            "photometric_series",
-            params={"seriesObjID": series_obj_ids[i]},
-            token=upload_data_token,
-        )
-        assert_api(status, data)
-        assert data["data"]["totalMatches"] == 1
-        assert len(data["data"]["series"]) == 1
-        assert data["data"]["series"][0]["id"] == ps_ids[i]
-        assert data["data"]["series"][0]["series_obj_id"] == series_obj_ids[i]
+        page = sp.fetch_photometric_series_page(series_obj_id=series_obj_ids[i])
+        assert page.total_matches == 1
+        assert len(page.series) == 1
+        assert page.series[0].id == ps_ids[i]
+        assert page.series[0].series_obj_id == series_obj_ids[i]
 
 
 def test_get_series_by_filter_origin_channel(
     upload_data_token, photometric_series, photometric_series2, photometric_series3
 ):
+    sp = client(upload_data_token)
     ps_ids = []
     filters = []
     origins = []
@@ -1380,51 +1078,34 @@ def test_get_series_by_filter_origin_channel(
 
     # filter series by filter name
     for i in range(3):
-        status, data = api(
-            "GET",
-            "photometric_series",
-            params={"filter": filters[i]},
-            token=upload_data_token,
-        )
-        assert_api(status, data)
-        assert data["data"]["totalMatches"] == 1
-        assert len(data["data"]["series"]) == 1
-        assert data["data"]["series"][0]["id"] == ps_ids[i]
-        assert data["data"]["series"][0]["filter"] == filters[i]
+        page = sp.fetch_photometric_series_page(filter=filters[i])
+        assert page.total_matches == 1
+        assert len(page.series) == 1
+        assert page.series[0].id == ps_ids[i]
+        assert page.series[0].filter == filters[i]
 
     # filter series by origin
     for i in range(3):
-        status, data = api(
-            "GET",
-            "photometric_series",
-            params={"origin": origins[i]},
-            token=upload_data_token,
-        )
-        assert_api(status, data)
-        assert data["data"]["totalMatches"] == 1
-        assert len(data["data"]["series"]) == 1
-        assert data["data"]["series"][0]["id"] == ps_ids[i]
-        assert data["data"]["series"][0]["origin"] == origins[i]
+        page = sp.fetch_photometric_series_page(origin=origins[i])
+        assert page.total_matches == 1
+        assert len(page.series) == 1
+        assert page.series[0].id == ps_ids[i]
+        assert page.series[0].origin == origins[i]
 
     # filter series by channel (should get 1 or 2 each time)
     # because there are only channel A and B in the conftests!
     for i in range(3):
-        status, data = api(
-            "GET",
-            "photometric_series",
-            params={"channel": channels[i]},
-            token=upload_data_token,
-        )
-        assert_api(status, data)
-        assert data["data"]["totalMatches"] <= 2
-        assert len(data["data"]["series"]) <= 2
-        assert ps_ids[i] in [ps["id"] for ps in data["data"]["series"]]
-        assert all(channels[i] == ps["channel"] for ps in data["data"]["series"])
+        page = sp.fetch_photometric_series_page(channel=channels[i])
+        assert page.total_matches <= 2
+        assert len(page.series) <= 2
+        assert ps_ids[i] in [ps.id for ps in page.series]
+        assert all(channels[i] == ps.channel for ps in page.series)
 
 
 def test_get_series_start_mid_end_times(
     upload_data_token, photometric_series, photometric_series2, photometric_series3
 ):
+    sp = client(upload_data_token)
     ps_ids = []
     mjd_keys = ["first", "mid", "last"]
     time_keys = ["start", "mid", "end"]
@@ -1448,28 +1129,21 @@ def test_get_series_start_mid_end_times(
             if op == "After":
                 split_time = Time(split_mjd - 0.01, format="mjd").iso
 
-            status, data = api(
-                "GET",
-                "photometric_series",
-                params={f"{tk}{op}": split_time},
-                token=upload_data_token,
+            page = sp.fetch_photometric_series_page(
+                **{f"{tk}_{op.lower()}": split_time}
             )
-            assert_api(status, data)
-            assert data["data"]["totalMatches"] == 2
-            assert len(data["data"]["series"]) == 2
+            assert page.total_matches == 2
+            assert len(page.series) == 2
             if op == "Before":
-                assert all(
-                    ps[f"mjd_{mk}"] <= split_mjd for ps in data["data"]["series"]
-                )
+                assert all(getattr(ps, f"mjd_{mk}") <= split_mjd for ps in page.series)
             if op == "After":
-                assert all(
-                    ps[f"mjd_{mk}"] >= split_mjd for ps in data["data"]["series"]
-                )
+                assert all(getattr(ps, f"mjd_{mk}") >= split_mjd for ps in page.series)
 
 
 def test_get_series_by_exposure_time(
     upload_data_token, photometric_series, photometric_series2, photometric_series3
 ):
+    sp = client(upload_data_token)
     ps_ids = []
     exptimes = []
 
@@ -1482,38 +1156,27 @@ def test_get_series_by_exposure_time(
 
     # filter series by exposure time
     for i in range(3):
-        status, data = api(
-            "GET",
-            "photometric_series",
-            params={"expTime": exptimes[i]},
-            token=upload_data_token,
-        )
-        assert_api(status, data)
-        assert data["data"]["totalMatches"] == 1
-        assert len(data["data"]["series"]) == 1
-        assert data["data"]["series"][0]["id"] == ps_ids[i]
-        assert data["data"]["series"][0]["exp_time"] == exptimes[i]
+        page = sp.fetch_photometric_series_page(exp_time=exptimes[i])
+        assert page.total_matches == 1
+        assert len(page.series) == 1
+        assert page.series[0].id == ps_ids[i]
+        assert page.series[0].exp_time == exptimes[i]
 
     # filter series by exposure time range
     for op in ["min", "max"]:
-        status, data = api(
-            "GET",
-            "photometric_series",
-            params={f"{op}ExpTime": 30},
-            token=upload_data_token,
-        )
-        assert_api(status, data)
-        assert data["data"]["totalMatches"] == 2
-        assert len(data["data"]["series"]) == 2
+        page = sp.fetch_photometric_series_page(**{f"{op}_exp_time": 30})
+        assert page.total_matches == 2
+        assert len(page.series) == 2
         if op == "min":
-            assert all(ps["exp_time"] >= 30 for ps in data["data"]["series"])
+            assert all(ps.exp_time >= 30 for ps in page.series)
         if op == "max":
-            assert all(ps["exp_time"] <= 30 for ps in data["data"]["series"])
+            assert all(ps.exp_time <= 30 for ps in page.series)
 
 
 def test_get_series_by_frame_rate(
     upload_data_token, photometric_series, photometric_series2, photometric_series3
 ):
+    sp = client(upload_data_token)
     ps_ids = []
     rates = []
 
@@ -1527,24 +1190,19 @@ def test_get_series_by_frame_rate(
 
     # filter series by frame rate
     for op in ["min", "max"]:
-        status, data = api(
-            "GET",
-            "photometric_series",
-            params={f"{op}FrameRate": split_rate},
-            token=upload_data_token,
-        )
-        assert_api(status, data)
-        assert data["data"]["totalMatches"] == 2
-        assert len(data["data"]["series"]) == 2
+        page = sp.fetch_photometric_series_page(**{f"{op}_frame_rate": split_rate})
+        assert page.total_matches == 2
+        assert len(page.series) == 2
         if op == "min":
-            assert all(ps["frame_rate"] >= split_rate for ps in data["data"]["series"])
+            assert all(ps.frame_rate >= split_rate for ps in page.series)
         if op == "max":
-            assert all(ps["frame_rate"] <= split_rate for ps in data["data"]["series"])
+            assert all(ps.frame_rate <= split_rate for ps in page.series)
 
 
 def test_get_series_by_num_exp(
     upload_data_token, photometric_series, photometric_series2, photometric_series3
 ):
+    sp = client(upload_data_token)
     ps_ids = []
     numbers = []
 
@@ -1558,19 +1216,13 @@ def test_get_series_by_num_exp(
 
     # filter series by frame rate
     for op in ["min", "max"]:
-        status, data = api(
-            "GET",
-            "photometric_series",
-            params={f"{op}NumExposures": split_num},
-            token=upload_data_token,
-        )
-        assert_api(status, data)
-        assert data["data"]["totalMatches"] == 2
-        assert len(data["data"]["series"]) == 2
+        page = sp.fetch_photometric_series_page(**{f"{op}_num_exposures": split_num})
+        assert page.total_matches == 2
+        assert len(page.series) == 2
         if op == "min":
-            assert all(ps["num_exp"] >= split_num for ps in data["data"]["series"])
+            assert all(ps.num_exp >= split_num for ps in page.series)
         if op == "max":
-            assert all(ps["num_exp"] <= split_num for ps in data["data"]["series"])
+            assert all(ps.num_exp <= split_num for ps in page.series)
 
 
 def test_get_series_by_mean_and_rms(
@@ -1579,6 +1231,7 @@ def test_get_series_by_mean_and_rms(
     photometric_series_low_flux_with_outliers,
     photometric_series_high_flux,
 ):
+    sp = client(upload_data_token)
     ps_ids = []
     means = []
     rmses = []
@@ -1597,19 +1250,13 @@ def test_get_series_by_mean_and_rms(
 
     # filter series by mean mag
     for op in ["Fainter", "Brighter"]:
-        status, data = api(
-            "GET",
-            "photometric_series",
-            params={f"mag{op}Than": split_mag},
-            token=upload_data_token,
-        )
-        assert_api(status, data)
-        assert data["data"]["totalMatches"] == 2
-        assert len(data["data"]["series"]) == 2
+        page = sp.fetch_photometric_series_page(**{f"mag_{op.lower()}_than": split_mag})
+        assert page.total_matches == 2
+        assert len(page.series) == 2
         if op == "Fainter":
-            assert all(ps["mean_mag"] >= split_mag for ps in data["data"]["series"])
+            assert all(ps.mean_mag >= split_mag for ps in page.series)
         if op == "Brighter":
-            assert all(ps["mean_mag"] <= split_mag for ps in data["data"]["series"])
+            assert all(ps.mean_mag <= split_mag for ps in page.series)
 
     values = rmses.copy()
     values.sort()
@@ -1617,159 +1264,101 @@ def test_get_series_by_mean_and_rms(
 
     # filter series by rms
     for op in ["min", "max"]:
-        status, data = api(
-            "GET",
-            "photometric_series",
-            params={f"{op}RMS": split_rms},
-            token=upload_data_token,
-        )
-        assert_api(status, data)
-        assert data["data"]["totalMatches"] == 2
-        assert len(data["data"]["series"]) == 2
+        page = sp.fetch_photometric_series_page(**{f"{op}_rms": split_rms})
+        assert page.total_matches == 2
+        assert len(page.series) == 2
         if op == "min":
-            assert all(ps["rms_mag"] >= split_rms for ps in data["data"]["series"])
+            assert all(ps.rms_mag >= split_rms for ps in page.series)
         if op == "max":
-            assert all(ps["rms_mag"] <= split_rms for ps in data["data"]["series"])
+            assert all(ps.rms_mag <= split_rms for ps in page.series)
 
 
 def test_get_series_by_robust_mean_mag(
     upload_data_token, photometric_series_low_flux_with_outliers
 ):
+    sp = client(upload_data_token)
     ps = photometric_series_low_flux_with_outliers
 
     # make sure there is only one series with this name
-    status, data = api(
-        "GET",
-        "photometric_series",
-        params={"seriesName": "test_series_outliers"},
-        token=upload_data_token,
-    )
-    assert_api(status, data)
-    assert data["data"]["totalMatches"] == 1
-    assert len(data["data"]["series"]) == 1
-    assert data["data"]["series"][0]["id"] == ps.id
+    page = sp.fetch_photometric_series_page(series_name="test_series_outliers")
+    assert page.total_matches == 1
+    assert len(page.series) == 1
+    assert page.series[0].id == ps.id
 
     # the mean magnitude is brighter because of outliers
-    status, data = api(
-        "GET",
-        "photometric_series",
-        params={
-            "seriesName": "test_series_outliers",
-            "magBrighterThan": ps.robust_mag - 0.01,
-        },
-        token=upload_data_token,
+    page = sp.fetch_photometric_series_page(
+        series_name="test_series_outliers",
+        mag_brighter_than=ps.robust_mag - 0.01,
     )
-    assert_api(status, data)
-    assert data["data"]["totalMatches"] == 1
-    assert len(data["data"]["series"]) == 1
-    assert data["data"]["series"][0]["id"] == ps.id
+    assert page.total_matches == 1
+    assert len(page.series) == 1
+    assert page.series[0].id == ps.id
 
     # searching for mean magnitude fainter than the mean mag
-    status, data = api(
-        "GET",
-        "photometric_series",
-        params={
-            "seriesName": "test_series_outliers",
-            "magBrighterThan": ps.mean_mag - 0.01,
-        },
-        token=upload_data_token,
+    page = sp.fetch_photometric_series_page(
+        series_name="test_series_outliers",
+        mag_brighter_than=ps.mean_mag - 0.01,
     )
-    assert_api(status, data)
-    assert data["data"]["totalMatches"] == 0
-    assert len(data["data"]["series"]) == 0
+    assert page.total_matches == 0
+    assert len(page.series) == 0
 
     # if we choose to measure by robust mean, we also get no results
-    status, data = api(
-        "GET",
-        "photometric_series",
-        params={
-            "seriesName": "test_series_outliers",
-            "magBrighterThan": ps.robust_mag - 0.01,
-            "useRobustMagAndRMS": True,
-        },
-        token=upload_data_token,
+    page = sp.fetch_photometric_series_page(
+        series_name="test_series_outliers",
+        mag_brighter_than=ps.robust_mag - 0.01,
+        use_robust_mag_and_rms=True,
     )
-    assert_api(status, data)
-    assert data["data"]["totalMatches"] == 0
-    assert len(data["data"]["series"]) == 0
+    assert page.total_matches == 0
+    assert len(page.series) == 0
 
 
 def test_get_series_by_robust_rms(
     upload_data_token, photometric_series_low_flux_with_outliers
 ):
+    sp = client(upload_data_token)
     ps = photometric_series_low_flux_with_outliers
 
     # make sure there is only one series with this name
-    status, data = api(
-        "GET",
-        "photometric_series",
-        params={"seriesName": "test_series_outliers"},
-        token=upload_data_token,
-    )
-    assert_api(status, data)
-    assert data["data"]["totalMatches"] == 1
-    assert len(data["data"]["series"]) == 1
-    assert data["data"]["series"][0]["id"] == ps.id
+    page = sp.fetch_photometric_series_page(series_name="test_series_outliers")
+    assert page.total_matches == 1
+    assert len(page.series) == 1
+    assert page.series[0].id == ps.id
 
     # the magnitude RMS is bigger because of outliers
-    status, data = api(
-        "GET",
-        "photometric_series",
-        params={
-            "seriesName": "test_series_outliers",
-            "minRMS": 0.4,
-        },
-        token=upload_data_token,
+    page = sp.fetch_photometric_series_page(
+        series_name="test_series_outliers",
+        min_rms=0.4,
     )
-    assert_api(status, data)
-    assert data["data"]["totalMatches"] == 1
-    assert len(data["data"]["series"]) == 1
-    assert data["data"]["series"][0]["id"] == ps.id
+    assert page.total_matches == 1
+    assert len(page.series) == 1
+    assert page.series[0].id == ps.id
 
     # searching for smaller RMS fails
-    status, data = api(
-        "GET",
-        "photometric_series",
-        params={
-            "seriesName": "test_series_outliers",
-            "maxRMS": 0.4,
-        },
-        token=upload_data_token,
+    page = sp.fetch_photometric_series_page(
+        series_name="test_series_outliers",
+        max_rms=0.4,
     )
-    assert_api(status, data)
-    assert data["data"]["totalMatches"] == 0
-    assert len(data["data"]["series"]) == 0
+    assert page.total_matches == 0
+    assert len(page.series) == 0
 
     # if choose to measure by robust mean, the results are reversed
-    status, data = api(
-        "GET",
-        "photometric_series",
-        params={
-            "seriesName": "test_series_outliers",
-            "minRMS": 0.4,
-            "useRobustMagAndRMS": True,
-        },
-        token=upload_data_token,
+    page = sp.fetch_photometric_series_page(
+        series_name="test_series_outliers",
+        min_rms=0.4,
+        use_robust_mag_and_rms=True,
     )
-    assert_api(status, data)
-    assert data["data"]["totalMatches"] == 0
-    assert len(data["data"]["series"]) == 0
+    assert page.total_matches == 0
+    assert len(page.series) == 0
 
     # searching for smaller RMS now succeeds
-    status, data = api(
-        "GET",
-        "photometric_series",
-        params={
-            "seriesName": "test_series_outliers",
-            "maxRMS": 0.5,
-            "useRobustMagAndRMS": True,
-        },
-        token=upload_data_token,
+    page = sp.fetch_photometric_series_page(
+        series_name="test_series_outliers",
+        max_rms=0.5,
+        use_robust_mag_and_rms=True,
     )
-    assert_api(status, data)
-    assert data["data"]["totalMatches"] == 1
-    assert len(data["data"]["series"]) == 1
-    assert data["data"]["series"][0]["id"] == ps.id
+    assert page.total_matches == 1
+    assert len(page.series) == 1
+    assert page.series[0].id == ps.id
 
 
 def test_get_series_by_magref(
@@ -1779,74 +1368,51 @@ def test_get_series_by_magref(
     photometric_series3,
     photometric_series_low_flux,
 ):
+    sp = client(upload_data_token)
     assert photometric_series.magref == 18.1
     assert photometric_series2.magref == 19.2
     assert photometric_series3.magref == 20.3
     assert photometric_series_low_flux.magref is None
 
     # should retrieve first three series, not the low-flux one
-    status, data = api(
-        "GET",
-        "photometric_series",
-        params={"magrefFainterThan": 18.1},
-        token=upload_data_token,
-    )
-    assert_api(status, data)
+    page = sp.fetch_photometric_series_page(magref_fainter_than=18.1)
 
-    assert data["data"]["totalMatches"] >= 3
-    assert len(data["data"]["series"]) >= 3
-    ids = [s["id"] for s in data["data"]["series"]]
+    assert page.total_matches >= 3
+    assert len(page.series) >= 3
+    ids = [s.id for s in page.series]
     assert photometric_series.id in ids
     assert photometric_series2.id in ids
     assert photometric_series3.id in ids
     assert photometric_series_low_flux.id not in ids
 
     # the opposite:
-    status, data = api(
-        "GET",
-        "photometric_series",
-        params={"magrefBrighterThan": 18.1},
-        token=upload_data_token,
-    )
-    assert_api(status, data)
+    page = sp.fetch_photometric_series_page(magref_brighter_than=18.1)
 
-    assert data["data"]["totalMatches"] >= 1
-    assert len(data["data"]["series"]) >= 1
-    ids = [s["id"] for s in data["data"]["series"]]
+    assert page.total_matches >= 1
+    assert len(page.series) >= 1
+    ids = [s.id for s in page.series]
     assert photometric_series.id in ids
     assert photometric_series2.id not in ids
     assert photometric_series3.id not in ids
     assert photometric_series_low_flux.id not in ids
 
     # should retrieve last two series
-    status, data = api(
-        "GET",
-        "photometric_series",
-        params={"magrefFainterThan": 19.0},
-        token=upload_data_token,
-    )
-    assert_api(status, data)
+    page = sp.fetch_photometric_series_page(magref_fainter_than=19.0)
 
-    assert data["data"]["totalMatches"] >= 2
-    assert len(data["data"]["series"]) >= 2
-    ids = [s["id"] for s in data["data"]["series"]]
+    assert page.total_matches >= 2
+    assert len(page.series) >= 2
+    ids = [s.id for s in page.series]
     assert photometric_series.id not in ids
     assert photometric_series2.id in ids
     assert photometric_series3.id in ids
     assert photometric_series_low_flux.id not in ids
 
     # the opposite:
-    status, data = api(
-        "GET",
-        "photometric_series",
-        params={"magrefBrighterThan": 19.0},
-        token=upload_data_token,
-    )
-    assert_api(status, data)
+    page = sp.fetch_photometric_series_page(magref_brighter_than=19.0)
 
-    assert data["data"]["totalMatches"] >= 1
-    assert len(data["data"]["series"]) >= 1
-    ids = [s["id"] for s in data["data"]["series"]]
+    assert page.total_matches >= 1
+    assert len(page.series) >= 1
+    ids = [s.id for s in page.series]
     assert photometric_series.id in ids
     assert photometric_series2.id not in ids
     assert photometric_series3.id not in ids
@@ -1856,52 +1422,30 @@ def test_get_series_by_magref(
 def test_by_series_by_not_detected(
     upload_data_token, photometric_series_low_flux, photometric_series_undetected
 ):
+    sp = client(upload_data_token)
     assert not photometric_series_undetected.is_detected
 
-    status, data = api(
-        "GET",
-        "photometric_series",
-        params={"detected": True},
-        token=upload_data_token,
-    )
-    assert_api(status, data)
+    page = sp.fetch_photometric_series_page(detected=True)
 
-    assert data["data"]["totalMatches"] >= 1
-    assert len(data["data"]["series"]) >= 1
-    assert photometric_series_low_flux.id in [ps["id"] for ps in data["data"]["series"]]
-    assert photometric_series_undetected.id not in [
-        ps["id"] for ps in data["data"]["series"]
-    ]
+    assert page.total_matches >= 1
+    assert len(page.series) >= 1
+    assert photometric_series_low_flux.id in [ps.id for ps in page.series]
+    assert photometric_series_undetected.id not in [ps.id for ps in page.series]
 
-    status, data = api(
-        "GET",
-        "photometric_series",
-        params={"detected": False},
-        token=upload_data_token,
-    )
-    assert_api(status, data)
+    page = sp.fetch_photometric_series_page(detected=False)
 
-    assert data["data"]["totalMatches"] >= 1
-    assert len(data["data"]["series"]) >= 1
-    assert photometric_series_undetected.id in [
-        ps["id"] for ps in data["data"]["series"]
-    ]
-    assert photometric_series_low_flux.id not in [
-        ps["id"] for ps in data["data"]["series"]
-    ]
+    assert page.total_matches >= 1
+    assert len(page.series) >= 1
+    assert photometric_series_undetected.id in [ps.id for ps in page.series]
+    assert photometric_series_low_flux.id not in [ps.id for ps in page.series]
 
 
 def test_get_series_by_hash(upload_data_token, photometric_series):
-    status, data = api(
-        "GET",
-        "photometric_series",
-        params={"hash": photometric_series.hash},
-        token=upload_data_token,
-    )
-    assert_api(status, data)
-    assert data["data"]["totalMatches"] == 1
-    assert len(data["data"]["series"]) == 1
-    assert data["data"]["series"][0]["id"] == photometric_series.id
+    sp = client(upload_data_token)
+    page = sp.fetch_photometric_series_page(file_hash=photometric_series.hash)
+    assert page.total_matches == 1
+    assert len(page.series) == 1
+    assert page.series[0].id == photometric_series.id
 
 
 @pytest.mark.flaky(reruns=2)
@@ -1911,6 +1455,7 @@ def test_get_series_by_snr(
     photometric_series_low_flux_with_outliers,
     photometric_series_high_flux,
 ):
+    sp = client(upload_data_token)
     ps_l = photometric_series_low_flux
     ps_h = photometric_series_high_flux
     ps_o = photometric_series_low_flux_with_outliers
@@ -1937,30 +1482,18 @@ def test_get_series_by_snr(
     median_below_all = low_median / 2  # below every series' median SNR
 
     # >= median_below_all: all three series pass
-    status, data = api(
-        "GET",
-        "photometric_series",
-        params={"minMedianSNR": median_below_all},
-        token=upload_data_token,
-    )
+    page = sp.fetch_photometric_series_page(min_median_snr=median_below_all)
 
-    assert_api(status, data)
-    ids = [ps["id"] for ps in data["data"]["series"]]
-    assert data["data"]["totalMatches"] >= 3
+    ids = [ps.id for ps in page.series]
+    assert page.total_matches >= 3
     assert ps_l.id in ids
     assert ps_h.id in ids
     assert ps_o.id in ids
 
     # <= median_below_all: none pass
-    status, data = api(
-        "GET",
-        "photometric_series",
-        params={"maxMedianSNR": median_below_all},
-        token=upload_data_token,
-    )
+    page = sp.fetch_photometric_series_page(max_median_snr=median_below_all)
 
-    assert_api(status, data)
-    ids = [ps["id"] for ps in data["data"]["series"]]
+    ids = [ps.id for ps in page.series]
     assert ps_l.id not in ids
     assert ps_h.id not in ids
     assert ps_o.id not in ids
@@ -1975,29 +1508,17 @@ def test_get_series_by_snr(
     assert ps_o.worst_snr < worst_threshold < other_worst
 
     # only ps_o's worst SNR is below threshold
-    status, data = api(
-        "GET",
-        "photometric_series",
-        params={"maxWorstSNR": worst_threshold},
-        token=upload_data_token,
-    )
+    page = sp.fetch_photometric_series_page(max_worst_snr=worst_threshold)
 
-    assert_api(status, data)
-    ids = [ps["id"] for ps in data["data"]["series"]]
+    ids = [ps.id for ps in page.series]
     assert ps_l.id not in ids
     assert ps_h.id not in ids
     assert ps_o.id in ids
 
     # inverse: ps_l and ps_h have worst SNR above threshold
-    status, data = api(
-        "GET",
-        "photometric_series",
-        params={"minWorstSNR": worst_threshold},
-        token=upload_data_token,
-    )
+    page = sp.fetch_photometric_series_page(min_worst_snr=worst_threshold)
 
-    assert_api(status, data)
-    ids = [ps["id"] for ps in data["data"]["series"]]
+    ids = [ps.id for ps in page.series]
     assert ps_l.id in ids
     assert ps_h.id in ids
     assert ps_o.id not in ids
@@ -2011,28 +1532,16 @@ def test_get_series_by_snr(
     best_threshold = (ps_l.best_snr + high_best) / 2
     assert ps_l.best_snr < best_threshold < high_best
 
-    status, data = api(
-        "GET",
-        "photometric_series",
-        params={"minBestSNR": best_threshold},
-        token=upload_data_token,
-    )
+    page = sp.fetch_photometric_series_page(min_best_snr=best_threshold)
 
-    assert_api(status, data)
-    ids = [ps["id"] for ps in data["data"]["series"]]
+    ids = [ps.id for ps in page.series]
     assert ps_l.id not in ids
     assert ps_h.id in ids
     assert ps_o.id in ids
 
-    status, data = api(
-        "GET",
-        "photometric_series",
-        params={"maxBestSNR": best_threshold},
-        token=upload_data_token,
-    )
+    page = sp.fetch_photometric_series_page(max_best_snr=best_threshold)
 
-    assert_api(status, data)
-    ids = [ps["id"] for ps in data["data"]["series"]]
+    ids = [ps.id for ps in page.series]
     assert ps_l.id in ids
     assert ps_h.id not in ids
     assert ps_o.id not in ids
@@ -2041,6 +1550,7 @@ def test_get_series_by_snr(
 def test_get_series_sorting(
     upload_data_token, photometric_series, photometric_series2, photometric_series3
 ):
+    sp = client(upload_data_token)
     ids = [photometric_series.id, photometric_series2.id, photometric_series3.id]
 
     keys = [
@@ -2064,84 +1574,58 @@ def test_get_series_sorting(
     ]
 
     for key in keys:
-        status, data = api(
-            "GET",
-            "photometric_series",
-            params={"sortBy": key},
-            token=upload_data_token,
-        )
+        page = sp.fetch_photometric_series_page(sort_by=key)
 
-        assert_api(status, data)
-        assert data["data"]["totalMatches"] >= 3
-        series_list = data["data"]["series"]
+        assert page.total_matches >= 3
+        series_list = page.series
         assert len(series_list) >= 3
-        assert set(ids).issubset([ps["id"] for ps in series_list])
+        assert set(ids).issubset([ps.id for ps in series_list])
         for i in range(len(ids) - 1):
-            assert series_list[i][key] <= series_list[i + 1][key]
+            assert getattr(series_list[i], key) <= getattr(series_list[i + 1], key)
 
-        status, data = api(
-            "GET",
-            "photometric_series",
-            params={"sortBy": key, "sortOrder": "desc"},
-            token=upload_data_token,
-        )
+        page = sp.fetch_photometric_series_page(sort_by=key, sort_order="desc")
 
-        assert_api(status, data)
-        assert data["data"]["totalMatches"] >= 3
-        series_list = data["data"]["series"]
+        assert page.total_matches >= 3
+        series_list = page.series
         assert len(series_list) >= 3
-        assert set(ids).issubset([ps["id"] for ps in series_list])
+        assert set(ids).issubset([ps.id for ps in series_list])
         for i in range(len(ids) - 1):
-            assert series_list[i][key] >= series_list[i + 1][key]
+            assert getattr(series_list[i], key) >= getattr(series_list[i + 1], key)
 
 
 def test_get_series_paged(
     upload_data_token, photometric_series, photometric_series2, photometric_series3
 ):
+    sp = client(upload_data_token)
     ids = [photometric_series.id, photometric_series2.id, photometric_series3.id]
 
     # get all three series
-    status, data = api(
-        "GET",
-        "photometric_series",
-        token=upload_data_token,
-    )
+    page = sp.fetch_photometric_series_page()
 
-    assert_api(status, data)
-    assert data["data"]["totalMatches"] >= 3
-    assert len(data["data"]["series"]) >= 3
-    assert set(ids).issubset([ps["id"] for ps in data["data"]["series"]])
+    assert page.total_matches >= 3
+    assert len(page.series) >= 3
+    assert set(ids).issubset([ps.id for ps in page.series])
 
     # get the first two series
-    status, data = api(
-        "GET",
-        "photometric_series",
-        params={"numPerPage": 2},
-        token=upload_data_token,
-    )
+    page = sp.fetch_photometric_series_page(num_per_page=2)
 
-    assert_api(status, data)
-    assert data["data"]["totalMatches"] >= 3
-    assert len(data["data"]["series"]) == 2
-    page1_ids = [ps["id"] for ps in data["data"]["series"]]
+    assert page.total_matches >= 3
+    assert len(page.series) == 2
+    page1_ids = [ps.id for ps in page.series]
 
     # get the first two series
-    status, data = api(
-        "GET",
-        "photometric_series",
-        params={"numPerPage": 2, "pageNumber": 2},
-        token=upload_data_token,
-    )
+    page = sp.fetch_photometric_series_page(num_per_page=2, page_number=2)
 
-    assert_api(status, data)
-    assert data["data"]["totalMatches"] >= 3
-    assert 1 <= len(data["data"]["series"]) <= 2
-    page2_ids = [ps["id"] for ps in data["data"]["series"]]
+    assert page.total_matches >= 3
+    assert 1 <= len(page.series) <= 2
+    page2_ids = [ps.id for ps in page.series]
     assert set(page1_ids).isdisjoint(page2_ids)
 
 
 def test_download_formats_single_series(upload_data_token, photometric_series):
+    sp = client(upload_data_token)
     # regular download of a single series
+    # raw api: raw-JSON shape assertion the typed model would mask
     status, data = api(
         "GET",
         f"photometric_series/{photometric_series.id}",
@@ -2160,6 +1644,7 @@ def test_download_formats_single_series(upload_data_token, photometric_series):
         assert len(ps1["data"][key]) == ps1["num_exp"]
 
     # download of a single series using format='json'
+    # raw api: raw-JSON shape assertion the typed model would mask
     status, data = api(
         "GET",
         f"photometric_series/{photometric_series.id}",
@@ -2173,19 +1658,11 @@ def test_download_formats_single_series(upload_data_token, photometric_series):
     assert ps1 == ps2
 
     # download a single series using the HDF5 format
-    status, data = api(
-        "GET",
-        f"photometric_series/{photometric_series.id}",
-        params={"dataFormat": "hdf5"},
-        token=upload_data_token,
-    )
-    assert_api(status, data)
+    ps3 = sp.fetch_photometric_series(photometric_series.id, data_format="hdf5")
+    assert photometric_series.obj_id == ps3.obj_id
+    assert photometric_series.num_exp == ps3.num_exp
 
-    ps3 = data["data"]
-    assert photometric_series.obj_id == ps3["obj_id"]
-    assert photometric_series.num_exp == ps3["num_exp"]
-
-    df, metadata = load_dataframe_from_bytestream(ps3["data"])
+    df, metadata = load_dataframe_from_bytestream(ps3.data)
 
     assert isinstance(df, pd.DataFrame)
     assert isinstance(metadata, dict)
@@ -2210,35 +1687,27 @@ def test_download_formats_single_series(upload_data_token, photometric_series):
         assert metadata[key] == ps1[key]
 
         # download a single series using format='none'
-        status, data = api(
-            "GET",
-            f"photometric_series/{photometric_series.id}",
-            params={"dataFormat": "none"},
-            token=upload_data_token,
-        )
-        assert_api(status, data)
+        ps4 = sp.fetch_photometric_series(photometric_series.id, data_format="none")
 
-        ps4 = data["data"]
-        assert photometric_series.origin == ps4["origin"]
-        assert photometric_series.num_exp == ps4["num_exp"]
-        assert ps4["data"] is None
+        assert photometric_series.origin == ps4.origin
+        assert photometric_series.num_exp == ps4.num_exp
+        assert ps4.data is None
 
         # download a single series using wrong format='foobar'
-        status, data = api(
-            "GET",
-            f"photometric_series/{photometric_series.id}",
-            params={"dataFormat": "foobar"},
-            token=upload_data_token,
-        )
-        assert_api_fail(status, data, 400, 'Invalid dataFormat: "foobar"')
+        with pytest.raises(SkyPortalError, match='Invalid dataFormat: "foobar"') as err:
+            sp.fetch_photometric_series(photometric_series.id, data_format="foobar")
+        assert err.value.status_code == 400
 
 
 def test_download_formats_multiple_series(
     upload_data_token, photometric_series, photometric_series2
 ):
+    sp = client(upload_data_token)
     refs = [photometric_series, photometric_series2]
 
     # regular download of two series
+    # raw api: raw-JSON shape assertion the typed model would mask (the
+    # server-default dataFormat is under test; the typed client always sends it)
     status, data = api(
         "GET",
         "photometric_series",
@@ -2269,15 +1738,9 @@ def test_download_formats_multiple_series(
         assert ps["data"] is None
 
     # download multiple series and specifying format='none' explicitly
-    status, data = api(
-        "GET",
-        "photometric_series",
-        params={"dataFormat": "none"},
-        token=upload_data_token,
-    )
-    assert_api(status, data)
-    assert data["data"]["totalMatches"] >= 2
-    series = data["data"]["series"]
+    page = sp.fetch_photometric_series_page(data_format="none")
+    assert page.total_matches >= 2
+    series = page.series
     assert len(series) >= 2
 
     for ref_ps in refs:
@@ -2292,29 +1755,23 @@ def test_download_formats_multiple_series(
             "series_name",
             "best_snr",
         ]:
-            assert any(getattr(ref_ps, key) == ps[key] for ps in series)
+            assert any(getattr(ref_ps, key) == getattr(ps, key) for ps in series)
 
     # downloading multiple series with format='none' does not return any data
     for ps in series:
-        assert ps["data"] is None
+        assert ps.data is None
 
     # download multiple series using format='json'
-    status, data = api(
-        "GET",
-        "photometric_series",
-        params={"dataFormat": "json"},
-        token=upload_data_token,
-    )
-    assert_api(status, data)
-    assert data["data"]["totalMatches"] >= 2
-    series = data["data"]["series"]
+    page = sp.fetch_photometric_series_page(data_format="json")
+    assert page.total_matches >= 2
+    series = page.series
     assert len(series) >= 2
 
     # first match each returned series dict to the reference series
     pairs = []
     for ref_ps in refs:
         for ps in series:
-            if ref_ps.id == ps["id"]:
+            if ref_ps.id == ps.id:
                 pairs.append((ref_ps, ps))
 
     # check they are the same
@@ -2330,33 +1787,27 @@ def test_download_formats_multiple_series(
             "series_name",
             "best_snr",
         ]:
-            assert getattr(ref_ps, key) == ps[key]
+            assert getattr(ref_ps, key) == getattr(ps, key)
 
         # this time we should get the data as a dict of lists
-        assert isinstance(ps["data"], dict)
+        assert isinstance(ps.data, dict)
         for key in ["mag", "mjd"]:
-            assert key in ps["data"]
-            assert isinstance(ps["data"][key], list)
-            assert len(ps["data"][key]) == ps["num_exp"]
-            assert ps["data"][key] == ref_ps.data[key].to_list()
+            assert key in ps.data
+            assert isinstance(ps.data[key], list)
+            assert len(ps.data[key]) == ps.num_exp
+            assert ps.data[key] == ref_ps.data[key].to_list()
 
     # download multiple series using the HDF5 format
-    status, data = api(
-        "GET",
-        "photometric_series",
-        params={"dataFormat": "hdf5"},
-        token=upload_data_token,
-    )
-    assert_api(status, data)
-    assert data["data"]["totalMatches"] >= 2
-    series = data["data"]["series"]
+    page = sp.fetch_photometric_series_page(data_format="hdf5")
+    assert page.total_matches >= 2
+    series = page.series
     assert len(series) >= 2
 
     # first match each returned series dict to the reference series
     pairs = []
     for ref_ps in refs:
         for ps in series:
-            if ref_ps.id == ps["id"]:
+            if ref_ps.id == ps.id:
                 pairs.append((ref_ps, ps))
 
     for ref_ps, ps in pairs:
@@ -2371,10 +1822,10 @@ def test_download_formats_multiple_series(
             "series_name",
             "best_snr",
         ]:
-            assert getattr(ref_ps, key) == ps[key]
+            assert getattr(ref_ps, key) == getattr(ps, key)
 
         # this time the data should be a bytestream convertible to dataframe
-        df, metadata = load_dataframe_from_bytestream(ps["data"])
+        df, metadata = load_dataframe_from_bytestream(ps.data)
 
         assert isinstance(df, pd.DataFrame)
         assert isinstance(metadata, dict)
@@ -2397,10 +1848,6 @@ def test_download_formats_multiple_series(
             assert metadata[key] == getattr(ref_ps, key)
 
     # download multiple series using wrong format='foobar'
-    status, data = api(
-        "GET",
-        "photometric_series",
-        params={"dataFormat": "foobar"},
-        token=upload_data_token,
-    )
-    assert_api_fail(status, data, 400, 'Invalid dataFormat: "foobar"')
+    with pytest.raises(SkyPortalError, match='Invalid dataFormat: "foobar"') as err:
+        sp.fetch_photometric_series_page(data_format="foobar")
+    assert err.value.status_code == 400

--- a/skyportal/tests/api_tests/photometry_followup/test_photometry.py
+++ b/skyportal/tests/api_tests/photometry_followup/test_photometry.py
@@ -8,6 +8,11 @@ import pytest
 import sncosmo
 import sqlalchemy as sa
 from marshmallow.exceptions import ValidationError as MMValidationError
+from skyportal_py import SkyPortalError
+from skyportal_py.instruments import InstrumentPost
+from skyportal_py.photometry import PhotometryPost, PhotometryUpdate
+from skyportal_py.sources import SourcePost
+from skyportal_py.telescopes import TelescopePost
 
 from baselayer.app import models as baselayer_models
 from baselayer.app.env import load_env
@@ -17,7 +22,7 @@ from skyportal.handlers.api.photometry import (
 )
 from skyportal.models import DBSession, Token, User
 from skyportal.models.photometry import Photometry
-from skyportal.tests import api, assert_api
+from skyportal.tests import api, client
 
 from ....utils.naive_datetime import utcnow_naive
 
@@ -28,348 +33,286 @@ PHOT_DETECTION_THRESHOLD = cfg["misc.photometry_detection_threshold_nsigma"]
 def test_token_user_post_get_photometry_data(
     upload_data_token, public_source, public_group, ztf_camera
 ):
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 58000.0,
-            "instrument_id": ztf_camera.id,
-            "flux": 12.24,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "group_ids": [public_group.id],
-            "altdata": {"some_key": "some_value"},
-        },
-        token=upload_data_token,
-    )
-    assert_api(status, data)
+    sp = client(upload_data_token)
+    photometry_id = sp.post_photometry(
+        PhotometryPost(
+            obj_id=str(public_source.id),
+            mjd=58000.0,
+            instrument_id=ztf_camera.id,
+            flux=12.24,
+            fluxerr=0.031,
+            zp=25.0,
+            magsys="ab",
+            filter="ztfg",
+            group_ids=[public_group.id],
+            altdata={"some_key": "some_value"},
+        )
+    ).ids[0]
 
-    photometry_id = data["data"]["ids"][0]
-    status, data = api(
-        "GET", f"photometry/{photometry_id}?format=flux", token=upload_data_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    phot = sp.fetch_photometry_point(photometry_id, format="flux")
 
-    assert data["data"]["ra"] is None
-    assert data["data"]["dec"] is None
-    assert data["data"]["ra_unc"] is None
-    assert data["data"]["dec_unc"] is None
-    assert data["data"]["altdata"] == {"some_key": "some_value"}
+    assert phot.ra is None
+    assert phot.dec is None
+    assert phot.ra_unc is None
+    assert phot.dec_unc is None
+    assert phot.altdata == {"some_key": "some_value"}
 
-    np.testing.assert_allclose(
-        data["data"]["flux"], 12.24 * 10 ** (-0.4 * (25.0 - 23.9))
-    )
+    np.testing.assert_allclose(phot.flux, 12.24 * 10 ** (-0.4 * (25.0 - 23.9)))
 
 
 def test_ref_flux(upload_data_token, public_source, public_group, ztf_camera):
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 58003.0,
-            "instrument_id": ztf_camera.id,
-            "flux": 12.24,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "ref_flux": 8.01,
-            "ref_fluxerr": 0.01,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "group_ids": [public_group.id],
-            "altdata": {"some_key": "some_value"},
-        },
-        token=upload_data_token,
-    )
-    assert_api(status, data)
+    sp = client(upload_data_token)
+    photometry_id = sp.post_photometry(
+        PhotometryPost(
+            obj_id=str(public_source.id),
+            mjd=58003.0,
+            instrument_id=ztf_camera.id,
+            flux=12.24,
+            fluxerr=0.031,
+            zp=25.0,
+            ref_flux=8.01,
+            ref_fluxerr=0.01,
+            magsys="ab",
+            filter="ztfg",
+            group_ids=[public_group.id],
+            altdata={"some_key": "some_value"},
+        )
+    ).ids[0]
 
-    photometry_id = data["data"]["ids"][0]
-    status, data = api(
-        "GET", f"photometry/{photometry_id}?format=both", token=upload_data_token
-    )
-    assert_api(status, data)
+    phot = sp.fetch_photometry_point(photometry_id, format="both")
 
-    assert data["data"]["ra"] is None
-    assert data["data"]["dec"] is None
-    assert data["data"]["ra_unc"] is None
-    assert data["data"]["dec_unc"] is None
-    assert data["data"]["altdata"] == {"some_key": "some_value"}
+    assert phot.ra is None
+    assert phot.dec is None
+    assert phot.ra_unc is None
+    assert phot.dec_unc is None
+    assert phot.altdata == {"some_key": "some_value"}
 
     # correct for the difference in zeropoints
     corrected_flux = 12.24 / 10 ** (0.4 * (25.0 - 23.9))
     corrected_fluxerr = 0.031 / 10 ** (0.4 * (25.0 - 23.9))
-    assert np.isclose(data["data"]["flux"], corrected_flux)
-    assert data["data"]["fluxerr"] == corrected_fluxerr
-    assert data["data"]["ref_flux"] == 8.01
-    assert data["data"]["ref_fluxerr"] == 0.01
-    assert data["data"]["tot_flux"] == 8.01 + corrected_flux
-    assert data["data"]["tot_fluxerr"] == np.sqrt(corrected_fluxerr**2 + 0.01**2)
+    assert np.isclose(phot.flux, corrected_flux)
+    assert phot.fluxerr == corrected_fluxerr
+    assert phot.ref_flux == 8.01
+    assert phot.ref_fluxerr == 0.01
+    assert phot.tot_flux == 8.01 + corrected_flux
+    assert phot.tot_fluxerr == np.sqrt(corrected_fluxerr**2 + 0.01**2)
 
     # what about magnitudes?
-    assert np.isclose(data["data"]["mag"], -2.5 * np.log10(corrected_flux) + 23.9)
+    assert np.isclose(phot.mag, -2.5 * np.log10(corrected_flux) + 23.9)
     assert np.isclose(
-        data["data"]["magerr"], 2.5 / np.log(10) * corrected_fluxerr / corrected_flux
+        phot.magerr, 2.5 / np.log(10) * corrected_fluxerr / corrected_flux
     )
-    assert np.isclose(data["data"]["magref"], -2.5 * np.log10(8.01) + 23.9)
-    assert np.isclose(data["data"]["e_magref"], 2.5 / np.log(10) * 0.01 / 8.01)
-    assert np.isclose(
-        data["data"]["magtot"], -2.5 * np.log10(8.01 + corrected_flux) + 23.9
-    )
+    assert np.isclose(phot.magref, -2.5 * np.log10(8.01) + 23.9)
+    assert np.isclose(phot.e_magref, 2.5 / np.log(10) * 0.01 / 8.01)
+    assert np.isclose(phot.magtot, -2.5 * np.log10(8.01 + corrected_flux) + 23.9)
     total_mag_error_expected = (
         2.5
         / np.log(10)
         * np.sqrt(corrected_fluxerr**2 + 0.01**2)
         / (8.01 + corrected_flux)
     )
-    assert np.isclose(data["data"]["e_magtot"], total_mag_error_expected)
+    assert np.isclose(phot.e_magtot, total_mag_error_expected)
 
-    status, data = api(
-        "DELETE", f"photometry/{photometry_id}?format=both", token=upload_data_token
-    )
-    assert_api(status, data)
+    sp.delete_photometry(photometry_id)
 
     # give the reference flux a different zeropoint
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 58003.0,
-            "instrument_id": ztf_camera.id,
-            "flux": 12.24,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "ref_flux": 8.01,
-            "ref_fluxerr": 0.01,
-            "ref_zp": 26.0,  # different zeropoint
-            "magsys": "ab",
-            "filter": "ztfg",
-            "group_ids": [public_group.id],
-            "altdata": {"some_key": "some_value"},
-        },
-        token=upload_data_token,
-    )
-    assert_api(status, data)
+    photometry_id = sp.post_photometry(
+        PhotometryPost(
+            obj_id=str(public_source.id),
+            mjd=58003.0,
+            instrument_id=ztf_camera.id,
+            flux=12.24,
+            fluxerr=0.031,
+            zp=25.0,
+            ref_flux=8.01,
+            ref_fluxerr=0.01,
+            ref_zp=26.0,  # different zeropoint
+            magsys="ab",
+            filter="ztfg",
+            group_ids=[public_group.id],
+            altdata={"some_key": "some_value"},
+        )
+    ).ids[0]
 
-    photometry_id = data["data"]["ids"][0]
-    status, data = api(
-        "GET", f"photometry/{photometry_id}?format=both", token=upload_data_token
-    )
-    assert_api(status, data)
+    phot = sp.fetch_photometry_point(photometry_id, format="both")
 
     corrected_ref_flux = 8.01 / 10 ** (0.4 * (26.0 - 23.9))
     corrected_ref_fluxerr = 0.01 / 10 ** (0.4 * (26.0 - 23.9))
 
-    assert np.isclose(data["data"]["ref_flux"], corrected_ref_flux)
-    assert np.isclose(data["data"]["ref_fluxerr"], corrected_ref_fluxerr)
-    assert np.isclose(data["data"]["tot_flux"], corrected_ref_flux + corrected_flux)
+    assert np.isclose(phot.ref_flux, corrected_ref_flux)
+    assert np.isclose(phot.ref_fluxerr, corrected_ref_fluxerr)
+    assert np.isclose(phot.tot_flux, corrected_ref_flux + corrected_flux)
     assert np.isclose(
-        data["data"]["tot_fluxerr"],
+        phot.tot_fluxerr,
         np.sqrt(corrected_fluxerr**2 + corrected_ref_fluxerr**2),
     )
 
     # patch the reference flux
-    status, data = api(
-        "PATCH",
-        f"photometry/{photometry_id}",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 58003.0,
-            "instrument_id": ztf_camera.id,
-            "flux": 12.24,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "group_ids": [public_group.id],
-            "ref_flux": 9.02,
-            "ref_fluxerr": 0.03,
-            "ref_zp": 27.0,  # same zeropoint
-        },
-        token=upload_data_token,
+    sp.update_photometry(
+        photometry_id,
+        PhotometryUpdate(
+            obj_id=str(public_source.id),
+            mjd=58003.0,
+            instrument_id=ztf_camera.id,
+            flux=12.24,
+            fluxerr=0.031,
+            zp=25.0,
+            magsys="ab",
+            filter="ztfg",
+            group_ids=[public_group.id],
+            ref_flux=9.02,
+            ref_fluxerr=0.03,
+            ref_zp=27.0,  # same zeropoint
+        ),
     )
-    assert_api(status, data)
-    status, data = api(
-        "GET", f"photometry/{photometry_id}?format=both", token=upload_data_token
-    )
-    assert_api(status, data)
+    phot = sp.fetch_photometry_point(photometry_id, format="both")
     corrected_ref_flux = 9.02 / 10 ** (0.4 * (27.0 - 23.9))
     corrected_ref_fluxerr = 0.03 / 10 ** (0.4 * (27.0 - 23.9))
 
-    assert np.isclose(data["data"]["ref_flux"], corrected_ref_flux)
-    assert np.isclose(data["data"]["ref_fluxerr"], corrected_ref_fluxerr)
-    assert np.isclose(data["data"]["tot_flux"], corrected_ref_flux + corrected_flux)
+    assert np.isclose(phot.ref_flux, corrected_ref_flux)
+    assert np.isclose(phot.ref_fluxerr, corrected_ref_fluxerr)
+    assert np.isclose(phot.tot_flux, corrected_ref_flux + corrected_flux)
     assert np.isclose(
-        data["data"]["tot_fluxerr"],
+        phot.tot_fluxerr,
         np.sqrt(corrected_fluxerr**2 + corrected_ref_fluxerr**2),
     )
 
 
 def test_ref_mag(upload_data_token, public_source, public_group, ztf_camera):
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 58003.0,
-            "instrument_id": ztf_camera.id,
-            "mag": 19.24,
-            "limiting_mag": 20.5,
-            "magerr": 0.123,
-            "magref": 17.01,
-            "e_magref": 0.01,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "group_ids": [public_group.id],
-            "altdata": {"some_key": "some_value"},
-        },
-        token=upload_data_token,
-    )
-    assert_api(status, data)
+    sp = client(upload_data_token)
+    photometry_id = sp.post_photometry(
+        PhotometryPost(
+            obj_id=str(public_source.id),
+            mjd=58003.0,
+            instrument_id=ztf_camera.id,
+            mag=19.24,
+            limiting_mag=20.5,
+            magerr=0.123,
+            magref=17.01,
+            e_magref=0.01,
+            magsys="ab",
+            filter="ztfg",
+            group_ids=[public_group.id],
+            altdata={"some_key": "some_value"},
+        )
+    ).ids[0]
 
-    photometry_id = data["data"]["ids"][0]
-    status, data = api(
-        "GET", f"photometry/{photometry_id}?format=both", token=upload_data_token
-    )
-    assert_api(status, data)
+    phot = sp.fetch_photometry_point(photometry_id, format="both")
 
-    assert data["data"]["altdata"] == {"some_key": "some_value"}
+    assert phot.altdata == {"some_key": "some_value"}
 
     expected_flux = 10 ** (-0.4 * (19.24 - 23.9))
     expected_fluxerr = 0.123 * (np.log(10) / 2.5) * expected_flux
-    assert np.isclose(data["data"]["flux"], expected_flux)
-    assert np.isclose(data["data"]["fluxerr"], expected_fluxerr)
-    assert np.isclose(data["data"]["mag"], 19.24)
-    assert np.isclose(data["data"]["magerr"], 0.123)
-    assert np.isclose(data["data"]["magref"], 17.01)
-    assert np.isclose(data["data"]["e_magref"], 0.01)
+    assert np.isclose(phot.flux, expected_flux)
+    assert np.isclose(phot.fluxerr, expected_fluxerr)
+    assert np.isclose(phot.mag, 19.24)
+    assert np.isclose(phot.magerr, 0.123)
+    assert np.isclose(phot.magref, 17.01)
+    assert np.isclose(phot.e_magref, 0.01)
 
     expected_ref_flux = 10 ** (-0.4 * (17.01 - 23.9))
     expected_ref_fluxerr = 0.01 * (np.log(10) / 2.5) * expected_ref_flux
-    assert np.isclose(data["data"]["ref_flux"], expected_ref_flux)
-    assert np.isclose(data["data"]["ref_fluxerr"], expected_ref_fluxerr)
-    assert np.isclose(data["data"]["tot_flux"], expected_ref_flux + expected_flux)
+    assert np.isclose(phot.ref_flux, expected_ref_flux)
+    assert np.isclose(phot.ref_fluxerr, expected_ref_fluxerr)
+    assert np.isclose(phot.tot_flux, expected_ref_flux + expected_flux)
     assert np.isclose(
-        data["data"]["tot_fluxerr"],
+        phot.tot_fluxerr,
         np.sqrt(expected_fluxerr**2 + expected_ref_fluxerr**2),
     )
 
     assert np.isclose(
-        data["data"]["magtot"],
+        phot.magtot,
         -2.5 * np.log10(expected_ref_flux + expected_flux) + 23.9,
     )
 
-    expected_mag_error = (
-        2.5 / np.log(10) * data["data"]["tot_fluxerr"] / data["data"]["tot_flux"]
-    )
-    assert np.isclose(data["data"]["e_magtot"], expected_mag_error)
+    expected_mag_error = 2.5 / np.log(10) * phot.tot_fluxerr / phot.tot_flux
+    assert np.isclose(phot.e_magtot, expected_mag_error)
 
     # patch the reference mag
-    status, data = api(
-        "PATCH",
-        f"photometry/{photometry_id}",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 58003.0,
-            "instrument_id": ztf_camera.id,
-            "mag": 19.24,
-            "limiting_mag": 20.5,
-            "magerr": 0.123,
-            "magref": 18.01,
-            "e_magref": 0.02,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "group_ids": [public_group.id],
-            "altdata": {"some_key": "some_value"},
-        },
-        token=upload_data_token,
+    sp.update_photometry(
+        photometry_id,
+        PhotometryUpdate(
+            obj_id=str(public_source.id),
+            mjd=58003.0,
+            instrument_id=ztf_camera.id,
+            mag=19.24,
+            limiting_mag=20.5,
+            magerr=0.123,
+            magref=18.01,
+            e_magref=0.02,
+            magsys="ab",
+            filter="ztfg",
+            group_ids=[public_group.id],
+            altdata={"some_key": "some_value"},
+        ),
     )
-    assert_api(status, data)
-    status, data = api(
-        "GET", f"photometry/{photometry_id}?format=both", token=upload_data_token
-    )
-    assert_api(status, data)
+    phot = sp.fetch_photometry_point(photometry_id, format="both")
 
     expected_ref_flux = 10 ** (-0.4 * (18.01 - 23.9))
     expected_ref_fluxerr = 0.02 * (np.log(10) / 2.5) * expected_ref_flux
-    assert np.isclose(data["data"]["ref_flux"], expected_ref_flux)
-    assert np.isclose(data["data"]["ref_fluxerr"], expected_ref_fluxerr)
-    assert np.isclose(data["data"]["tot_flux"], expected_ref_flux + expected_flux)
+    assert np.isclose(phot.ref_flux, expected_ref_flux)
+    assert np.isclose(phot.ref_fluxerr, expected_ref_fluxerr)
+    assert np.isclose(phot.tot_flux, expected_ref_flux + expected_flux)
     assert np.isclose(
-        data["data"]["tot_fluxerr"],
+        phot.tot_fluxerr,
         np.sqrt(expected_fluxerr**2 + expected_ref_fluxerr**2),
     )
-    assert np.isclose(data["data"]["magref"], 18.01)
-    assert np.isclose(data["data"]["e_magref"], 0.02)
+    assert np.isclose(phot.magref, 18.01)
+    assert np.isclose(phot.e_magref, 0.02)
 
 
 def test_query_magnitudes(upload_data_token, public_source, public_group, ztf_camera):
     origin = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": public_source.id,
-            "instrument_id": ztf_camera.id,
-            "mjd": [59410, 59411, 59412],
-            "mag": [19.2, 19.3, np.random.uniform(19.3, 20)],
-            "magerr": [0.05, 0.06, np.random.uniform(0.01, 0.1)],
-            "magref": [18.1, 18.2, np.random.uniform(18.2, 19)],
-            "e_magref": [0.01, 0.02, np.random.uniform(0.01, 0.1)],
-            "limiting_mag": [20.0, 20.1, 20.2],
-            "magsys": ["ab", "ab", "ab"],
-            "filter": ["ztfr", "ztfg", "ztfr"],
-            "ra": [42.01, 42.01, 42.02],
-            "dec": [42.02, 42.01, 42.03],
-            "origin": origin,
-            "group_ids": [public_group.id],
-            "altdata": {"key1": "value1"},
-        },
-        token=upload_data_token,
-    )
-    assert_api(status, data)
-
-    ids = data["data"]["ids"]
+    sp = client(upload_data_token)
+    ids = sp.post_photometry(
+        PhotometryPost(
+            obj_id=public_source.id,
+            instrument_id=ztf_camera.id,
+            mjd=[59410, 59411, 59412],
+            mag=[19.2, 19.3, np.random.uniform(19.3, 20)],
+            magerr=[0.05, 0.06, np.random.uniform(0.01, 0.1)],
+            magref=[18.1, 18.2, np.random.uniform(18.2, 19)],
+            e_magref=[0.01, 0.02, np.random.uniform(0.01, 0.1)],
+            limiting_mag=[20.0, 20.1, 20.2],
+            magsys=["ab", "ab", "ab"],
+            filter=["ztfr", "ztfg", "ztfr"],
+            ra=[42.01, 42.01, 42.02],
+            dec=[42.02, 42.01, 42.03],
+            origin=origin,
+            group_ids=[public_group.id],
+            altdata={"key1": "value1"},
+        )
+    ).ids
     assert len(ids) == 3
 
     # check the first point is correct
-    status, data = api(
-        "GET", f"photometry/{ids[0]}?format=flux", token=upload_data_token
-    )
-    assert_api(status, data)
-    assert data["data"]["magref"] == 18.1
-    assert data["data"]["e_magref"] == 0.01
+    phot = sp.fetch_photometry_point(ids[0], format="flux")
+    assert phot.magref == 18.1
+    assert phot.e_magref == 0.01
     flux_trans1 = 10 ** (-0.4 * (19.2 - 23.9))
     fluxerr_trans1 = 0.05 / 2.5 * np.log(10) * flux_trans1
-    assert np.isclose(data["data"]["flux"], flux_trans1)
-    assert np.isclose(data["data"]["fluxerr"], fluxerr_trans1)
+    assert np.isclose(phot.flux, flux_trans1)
+    assert np.isclose(phot.fluxerr, fluxerr_trans1)
     flux_ref1 = 10 ** (-0.4 * (18.1 - 23.9))
     fluxerr_ref1 = 0.01 / 2.5 * np.log(10) * flux_ref1
-    assert np.isclose(data["data"]["ref_flux"], flux_ref1)
-    assert np.isclose(data["data"]["ref_fluxerr"], fluxerr_ref1)
+    assert np.isclose(phot.ref_flux, flux_ref1)
+    assert np.isclose(phot.ref_fluxerr, fluxerr_ref1)
 
-    assert np.isclose(data["data"]["tot_flux"], flux_trans1 + flux_ref1)
+    assert np.isclose(phot.tot_flux, flux_trans1 + flux_ref1)
     assert np.isclose(
-        data["data"]["tot_fluxerr"],
+        phot.tot_fluxerr,
         np.sqrt(fluxerr_trans1**2 + fluxerr_ref1**2),
     )
 
     # check the second point is correct
-    status, data = api(
-        "GET", f"photometry/{ids[1]}?format=flux", token=upload_data_token
-    )
-    assert_api(status, data)
-    assert data["data"]["magref"] == 18.2
-    assert data["data"]["e_magref"] == 0.02
+    phot = sp.fetch_photometry_point(ids[1], format="flux")
+    assert phot.magref == 18.2
+    assert phot.e_magref == 0.02
 
     flux_ref2 = 10 ** (-0.4 * (18.2 - 23.9))
     fluxerr_ref2 = 0.02 / 2.5 * np.log(10) * flux_ref2
-    assert np.isclose(data["data"]["ref_flux"], flux_ref2)
-    assert np.isclose(data["data"]["ref_fluxerr"], fluxerr_ref2)
+    assert np.isclose(phot.ref_flux, flux_ref2)
+    assert np.isclose(phot.ref_fluxerr, fluxerr_ref2)
 
     # see if we can filter points by ref flux
     mag_midpoint = (19.3 + 19.2) / 2
@@ -429,83 +372,71 @@ def test_query_magnitudes(upload_data_token, public_source, public_group, ztf_ca
 
 
 def test_ref_mag_vector(upload_data_token, public_source, public_group, ztf_camera):
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "instrument_id": ztf_camera.id,
-            "mjd": [59410, 59411, 59412],
-            "mag": [19.2, 19.3, np.random.uniform(19, 20)],
-            "magerr": [0.05, 0.06, np.random.uniform(0.01, 0.1)],
-            "limiting_mag": [20.0, 20.1, 20.2],
-            "magsys": ["ab", "ab", "ab"],
-            "filter": ["ztfr", "ztfg", "ztfr"],
-            "ra": [42.01, 42.01, 42.02],
-            "dec": [42.02, 42.01, 42.03],
-            "origin": [None, "lol", "lol"],
-            "group_ids": [public_group.id],
-            "altdata": {"key1": "value1"},
-        },
-        token=upload_data_token,
+    ids = (
+        client(upload_data_token)
+        .post_photometry(
+            PhotometryPost(
+                obj_id=str(public_source.id),
+                instrument_id=ztf_camera.id,
+                mjd=[59410, 59411, 59412],
+                mag=[19.2, 19.3, np.random.uniform(19, 20)],
+                magerr=[0.05, 0.06, np.random.uniform(0.01, 0.1)],
+                limiting_mag=[20.0, 20.1, 20.2],
+                magsys=["ab", "ab", "ab"],
+                filter=["ztfr", "ztfg", "ztfr"],
+                ra=[42.01, 42.01, 42.02],
+                dec=[42.02, 42.01, 42.03],
+                origin=[None, "lol", "lol"],
+                group_ids=[public_group.id],
+                altdata={"key1": "value1"},
+            )
+        )
+        .ids
     )
-    assert_api(status, data)
-
-    ids = data["data"]["ids"]
     assert len(ids) == 3
 
     for id in ids:
-        status, data = api(
-            "GET", f"photometry/{id}?format=flux", token=upload_data_token
-        )
-        assert status == 200
-        assert data["status"] == "success"
-        assert data["data"]["altdata"] == {"key1": "value1"}
+        phot = client(upload_data_token).fetch_photometry_point(id, format="flux")
+        assert phot.altdata == {"key1": "value1"}
 
 
 def test_post_multiple_photometry_vector_altdata(
     upload_data_token, public_source, public_group, ztf_camera
 ):
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "instrument_id": ztf_camera.id,
-            "mjd": [59408, 59409, 59410],
-            "mag": [19.2, 19.3, np.random.uniform(19, 20)],
-            "magerr": [0.05, 0.06, np.random.uniform(0.01, 0.1)],
-            "limiting_mag": [20.0, 20.1, 20.2],
-            "magsys": ["ab", "ab", "ab"],
-            "filter": ["ztfr", "ztfg", "ztfr"],
-            "ra": [42.01, 42.01, 42.02],
-            "dec": [42.02, 42.01, 42.03],
-            "origin": [None, "lol", "lol"],
-            "group_ids": [public_group.id],
-            "altdata": [{"key1": "value1"}, {"key2": "value2"}, {"key3": "value3"}],
-        },
-        token=upload_data_token,
+    ids = (
+        client(upload_data_token)
+        .post_photometry(
+            PhotometryPost(
+                obj_id=str(public_source.id),
+                instrument_id=ztf_camera.id,
+                mjd=[59408, 59409, 59410],
+                mag=[19.2, 19.3, np.random.uniform(19, 20)],
+                magerr=[0.05, 0.06, np.random.uniform(0.01, 0.1)],
+                limiting_mag=[20.0, 20.1, 20.2],
+                magsys=["ab", "ab", "ab"],
+                filter=["ztfr", "ztfg", "ztfr"],
+                ra=[42.01, 42.01, 42.02],
+                dec=[42.02, 42.01, 42.03],
+                origin=[None, "lol", "lol"],
+                group_ids=[public_group.id],
+                altdata=[{"key1": "value1"}, {"key2": "value2"}, {"key3": "value3"}],
+            )
+        )
+        .ids
     )
-    assert status == 200
-    assert data["status"] == "success"
-    ids = data["data"]["ids"]
     assert len(ids) == 3
 
     keys = []
     values = []
     for id in ids:
-        status, data = api(
-            "GET", f"photometry/{id}?format=flux", token=upload_data_token
-        )
-        assert status == 200
-        assert data["status"] == "success"
-        assert data["data"]["altdata"] in [
+        phot = client(upload_data_token).fetch_photometry_point(id, format="flux")
+        assert phot.altdata in [
             {"key1": "value1"},
             {"key2": "value2"},
             {"key3": "value3"},
         ]
-        keys.append(list(data["data"]["altdata"].keys())[0])
-        values.append(list(data["data"]["altdata"].values())[0])
+        keys.append(list(phot.altdata.keys())[0])
+        values.append(list(phot.altdata.values())[0])
     # Ensure each phot record was assigned associated distinct aldata value
     assert sorted(keys) == ["key1", "key2", "key3"]
     assert sorted(values) == ["value1", "value2", "value3"]
@@ -514,115 +445,95 @@ def test_post_multiple_photometry_vector_altdata(
 def test_post_multiple_photometry_scalar_altdata(
     upload_data_token, public_source, public_group, ztf_camera
 ):
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "instrument_id": ztf_camera.id,
-            "mjd": [59410, 59411, 59412],
-            "mag": [19.2, 19.3, np.random.uniform(19, 20)],
-            "magerr": [0.05, 0.06, np.random.uniform(0.01, 0.1)],
-            "limiting_mag": [20.0, 20.1, 20.2],
-            "magsys": ["ab", "ab", "ab"],
-            "filter": ["ztfr", "ztfg", "ztfr"],
-            "ra": [42.01, 42.01, 42.02],
-            "dec": [42.02, 42.01, 42.03],
-            "origin": [None, "lol", "lol"],
-            "group_ids": [public_group.id],
-            "altdata": {"key1": "value1"},
-        },
-        token=upload_data_token,
+    ids = (
+        client(upload_data_token)
+        .post_photometry(
+            PhotometryPost(
+                obj_id=str(public_source.id),
+                instrument_id=ztf_camera.id,
+                mjd=[59410, 59411, 59412],
+                mag=[19.2, 19.3, np.random.uniform(19, 20)],
+                magerr=[0.05, 0.06, np.random.uniform(0.01, 0.1)],
+                limiting_mag=[20.0, 20.1, 20.2],
+                magsys=["ab", "ab", "ab"],
+                filter=["ztfr", "ztfg", "ztfr"],
+                ra=[42.01, 42.01, 42.02],
+                dec=[42.02, 42.01, 42.03],
+                origin=[None, "lol", "lol"],
+                group_ids=[public_group.id],
+                altdata={"key1": "value1"},
+            )
+        )
+        .ids
     )
-    assert_api(status, data)
-
-    ids = data["data"]["ids"]
     assert len(ids) == 3
 
     for id in ids:
-        status, data = api(
-            "GET", f"photometry/{id}?format=flux", token=upload_data_token
-        )
-        assert status == 200
-        assert data["status"] == "success"
-        assert data["data"]["altdata"] == {"key1": "value1"}
+        phot = client(upload_data_token).fetch_photometry_point(id, format="flux")
+        assert phot.altdata == {"key1": "value1"}
 
 
 def test_token_user_post_put_photometry_data(
     super_admin_token, upload_data_token, public_source, public_group, ztf_camera
 ):
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "instrument_id": ztf_camera.id,
-            "mjd": [59400, 59401, 59402],
-            "mag": [19.2, 19.3, np.random.uniform(19, 20)],
-            "magerr": [0.05, 0.06, np.random.uniform(0.01, 0.1)],
-            "limiting_mag": [20.0, 20.1, 20.2],
-            "magsys": ["ab", "ab", "ab"],
-            "filter": ["ztfr", "ztfg", "ztfr"],
-            "ra": [42.01, 42.01, 42.02],
-            "dec": [42.02, 42.01, 42.03],
-            "origin": [None, "lol", "lol"],
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    ids = data["data"]["ids"]
+    sp = client(upload_data_token)
+    ids = sp.post_photometry(
+        PhotometryPost(
+            obj_id=str(public_source.id),
+            instrument_id=ztf_camera.id,
+            mjd=[59400, 59401, 59402],
+            mag=[19.2, 19.3, np.random.uniform(19, 20)],
+            magerr=[0.05, 0.06, np.random.uniform(0.01, 0.1)],
+            limiting_mag=[20.0, 20.1, 20.2],
+            magsys=["ab", "ab", "ab"],
+            filter=["ztfr", "ztfg", "ztfr"],
+            ra=[42.01, 42.01, 42.02],
+            dec=[42.02, 42.01, 42.03],
+            origin=[None, "lol", "lol"],
+            group_ids=[public_group.id],
+        )
+    ).ids
     assert len(ids) == 3
 
     # POSTing photometry that contains the same first two points should fail:
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "instrument_id": ztf_camera.id,
-            "mjd": [59400, 59401, 59402],
-            "mag": [19.2, 19.3, np.random.uniform(19, 20)],
-            "magerr": [0.05, 0.06, np.random.uniform(0.01, 0.1)],
-            "limiting_mag": [20.0, 20.1, 20.2],
-            "magsys": ["ab", "ab", "ab"],
-            "filter": ["ztfr", "ztfg", "ztfr"],
-            "ra": [42.01, 42.01, 42.02],
-            "dec": [42.02, 42.01, 42.03],
-            "origin": [None, "lol", "lol"],
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
-    )
-    assert status == 400
-    assert data["status"] == "error"
+    with pytest.raises(SkyPortalError) as err:
+        sp.post_photometry(
+            PhotometryPost(
+                obj_id=str(public_source.id),
+                instrument_id=ztf_camera.id,
+                mjd=[59400, 59401, 59402],
+                mag=[19.2, 19.3, np.random.uniform(19, 20)],
+                magerr=[0.05, 0.06, np.random.uniform(0.01, 0.1)],
+                limiting_mag=[20.0, 20.1, 20.2],
+                magsys=["ab", "ab", "ab"],
+                filter=["ztfr", "ztfg", "ztfr"],
+                ra=[42.01, 42.01, 42.02],
+                dec=[42.02, 42.01, 42.03],
+                origin=[None, "lol", "lol"],
+                group_ids=[public_group.id],
+            )
+        )
+    assert err.value.status_code == 400
 
     # PUTing photometry that contains
     # the same first point, the second point with a different origin, and a new third point should succeed
     # only the last two points will be ingested
-    status, data = api(
-        "PUT",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "instrument_id": ztf_camera.id,
-            "mjd": [59400, 59401, 59402],
-            "mag": [19.2, 19.3, np.random.uniform(19, 20)],
-            "magerr": [0.05, 0.06, np.random.uniform(0.01, 0.1)],
-            "limiting_mag": [20.0, 20.1, 20.2],
-            "magsys": ["ab", "ab", "ab"],
-            "filter": ["ztfr", "ztfg", "ztfr"],
-            "ra": [42.01, 42.01, 42.02],
-            "dec": [42.02, 42.01, 42.03],
-            "origin": [None, "omg", "lol"],
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    new_ids = data["data"]["ids"]
+    new_ids = sp.upsert_photometry(
+        PhotometryPost(
+            obj_id=str(public_source.id),
+            instrument_id=ztf_camera.id,
+            mjd=[59400, 59401, 59402],
+            mag=[19.2, 19.3, np.random.uniform(19, 20)],
+            magerr=[0.05, 0.06, np.random.uniform(0.01, 0.1)],
+            limiting_mag=[20.0, 20.1, 20.2],
+            magsys=["ab", "ab", "ab"],
+            filter=["ztfr", "ztfg", "ztfr"],
+            ra=[42.01, 42.01, 42.02],
+            dec=[42.02, 42.01, 42.03],
+            origin=[None, "omg", "lol"],
+            group_ids=[public_group.id],
+        )
+    ).ids
     assert len(new_ids) == 3
     assert len(set(new_ids).intersection(set(ids))) == 1
 
@@ -639,142 +550,117 @@ def test_token_user_post_put_photometry_data(
     # - same second point with different flux, should be updated because the existing poitn has an origin
     # - different third point, should be added as usual.
     ids = new_ids
-    input_data = {
-        "obj_id": str(public_source.id),
-        "instrument_id": ztf_camera.id,
-        "mjd": [59400, 59401, 59403],
-        "mag": [20.2, 20.3, np.random.uniform(18, 19)],
-        "magerr": [0.05, 0.1, np.random.uniform(0.01, 0.1)],
-        "limiting_mag": [21.0, 20.1, 20.2],
-        "magsys": ["ab", "ab", "ab"],
-        "filter": ["ztfr", "ztfg", "ztfr"],
-        "ra": [42.01, 42.01, 42.02],
-        "dec": [42.02, 42.01, 42.03],
-        "origin": [None, "omg", "lol"],
-        "group_ids": [public_group.id],
-    }
+    input_data = PhotometryPost(
+        obj_id=str(public_source.id),
+        instrument_id=ztf_camera.id,
+        mjd=[59400, 59401, 59403],
+        mag=[20.2, 20.3, np.random.uniform(18, 19)],
+        magerr=[0.05, 0.1, np.random.uniform(0.01, 0.1)],
+        limiting_mag=[21.0, 20.1, 20.2],
+        magsys=["ab", "ab", "ab"],
+        filter=["ztfr", "ztfg", "ztfr"],
+        ra=[42.01, 42.01, 42.02],
+        dec=[42.02, 42.01, 42.03],
+        origin=[None, "omg", "lol"],
+        group_ids=[public_group.id],
+    )
 
     # this feature is reserved to super admin, so this should fail
-    status, data = api(
-        "PUT",
-        "photometry?duplicate_ignore_flux=True&overwrite_flux=True",
-        data=input_data,
-        token=upload_data_token,
-    )
-    assert status == 400
-    assert (
-        "Ignoring flux/fluxerr when checking for duplicates is reserved to super admin users only"
-        in data["message"]
-    )
+    with pytest.raises(
+        SkyPortalError,
+        match="Ignoring flux/fluxerr when checking for duplicates is reserved to super admin users only",
+    ) as err:
+        sp.upsert_photometry(
+            input_data, duplicate_ignore_flux=True, overwrite_flux=True
+        )
+    assert err.value.status_code == 400
 
     # try with the super admin token now
-    status, data = api(
-        "PUT",
-        "photometry?duplicate_ignore_flux=True&overwrite_flux=True",
-        data=input_data,
-        token=super_admin_token,
+    new_ids = (
+        client(super_admin_token)
+        .upsert_photometry(input_data, duplicate_ignore_flux=True, overwrite_flux=True)
+        .ids
     )
-    assert status == 200
-    assert data["status"] == "success"
-    new_ids = data["data"]["ids"]
     assert len(new_ids) == 3
     # we should have 1 same + 1 updated - 1 new = 2 identical ids
     assert len(set(new_ids).intersection(set(ids))) == 2
 
     # GET the photometry
     # First point should be identical
-    status, data = api(
-        "GET", f"photometry/{ids[0]}?format=mag", token=upload_data_token
-    )
-    assert status == 200
-    assert "data" in data
-    data = data["data"]
-    assert data["mjd"] == 59400
-    assert data["mag"] == 19.2
-    assert data["magerr"] == 0.05
+    phot = client(upload_data_token).fetch_photometry_point(ids[0], format="mag")
+    assert phot.mjd == 59400
+    assert phot.mag == 19.2
+    assert phot.magerr == 0.05
 
     # second point should be updated
-    status, data = api(
-        "GET", f"photometry/{ids[1]}?format=mag", token=upload_data_token
-    )
-    assert status == 200
-    assert "data" in data
-    data = data["data"]
-    assert data["mjd"] == 59401
-    assert data["mag"] == 20.3
-    assert data["magerr"] == 0.1
+    phot = client(upload_data_token).fetch_photometry_point(ids[1], format="mag")
+    assert phot.mjd == 59401
+    assert phot.mag == 20.3
+    assert phot.magerr == 0.1
 
 
 def test_token_user_post_put_get_photometry_data(
     upload_data_token_two_groups, public_source, public_group, public_group2, ztf_camera
 ):
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "instrument_id": ztf_camera.id,
-            "mjd": [59400, 59401, 59402],
-            "mag": [19.2, 19.3, np.random.uniform(19, 20)],
-            "magerr": [0.05, 0.06, np.random.uniform(0.01, 0.1)],
-            "limiting_mag": [20.0, 20.1, 20.2],
-            "magsys": ["ab", "ab", "ab"],
-            "filter": ["ztfr", "ztfg", "ztfr"],
-            "ra": [42.01, 42.01, 42.02],
-            "dec": [42.02, 42.01, 42.03],
-            "origin": [None, "lol", "lol"],
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token_two_groups,
+    ids = (
+        client(upload_data_token_two_groups)
+        .post_photometry(
+            PhotometryPost(
+                obj_id=str(public_source.id),
+                instrument_id=ztf_camera.id,
+                mjd=[59400, 59401, 59402],
+                mag=[19.2, 19.3, np.random.uniform(19, 20)],
+                magerr=[0.05, 0.06, np.random.uniform(0.01, 0.1)],
+                limiting_mag=[20.0, 20.1, 20.2],
+                magsys=["ab", "ab", "ab"],
+                filter=["ztfr", "ztfg", "ztfr"],
+                ra=[42.01, 42.01, 42.02],
+                dec=[42.02, 42.01, 42.03],
+                origin=[None, "lol", "lol"],
+                group_ids=[public_group.id],
+            )
+        )
+        .ids
     )
-    assert status == 200
-    assert data["status"] == "success"
-    ids = data["data"]["ids"]
     assert len(ids) == 3
 
-    status, data = api(
-        "GET", f"photometry/{ids[0]}?format=flux", token=upload_data_token_two_groups
+    phot = client(upload_data_token_two_groups).fetch_photometry_point(
+        ids[0], format="flux"
     )
-    assert status == 200
-    assert data["status"] == "success"
-    group_ids = [g["id"] for g in data["data"]["groups"]]
+    group_ids = [g.id for g in phot.groups]
     assert len(group_ids) == 2
     assert public_group.id in group_ids
 
     # PUTing photometry that contains
     # the same first point, the second point with a different origin, and a new third point should succeed
     # only the last two points will be ingested
-    status, data = api(
-        "PUT",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "instrument_id": ztf_camera.id,
-            "mjd": [59400, 59401],
-            "mag": [19.2, 19.3],
-            "magerr": [0.05, 0.06],
-            "limiting_mag": [20.0, 20.1],
-            "magsys": ["ab", "ab"],
-            "filter": ["ztfr", "ztfg"],
-            "ra": [42.01, 42.01],
-            "dec": [42.02, 42.01],
-            "origin": [None, "lol"],
-            "group_ids": [public_group.id, public_group2.id],
-        },
-        token=upload_data_token_two_groups,
+    new_ids = (
+        client(upload_data_token_two_groups)
+        .upsert_photometry(
+            PhotometryPost(
+                obj_id=str(public_source.id),
+                instrument_id=ztf_camera.id,
+                mjd=[59400, 59401],
+                mag=[19.2, 19.3],
+                magerr=[0.05, 0.06],
+                limiting_mag=[20.0, 20.1],
+                magsys=["ab", "ab"],
+                filter=["ztfr", "ztfg"],
+                ra=[42.01, 42.01],
+                dec=[42.02, 42.01],
+                origin=[None, "lol"],
+                group_ids=[public_group.id, public_group2.id],
+            )
+        )
+        .ids
     )
-    assert status == 200
-    assert data["status"] == "success"
-    new_ids = data["data"]["ids"]
     assert len(new_ids) == 2
     assert len(set(new_ids).intersection(set(ids))) == 2
 
-    status, data = api(
-        "GET", f"photometry/{ids[0]}?format=flux", token=upload_data_token_two_groups
+    phot = client(upload_data_token_two_groups).fetch_photometry_point(
+        ids[0], format="flux"
     )
-    assert status == 200
-    assert data["status"] == "success"
-    group_ids = [g["id"] for g in data["data"]["groups"]]
+    group_ids = [g.id for g in phot.groups]
     assert len(group_ids) == 3
 
     token_object = (
@@ -802,42 +688,31 @@ def test_post_photometry_multiple_groups(
 ):
     upload_data_token = upload_data_token_two_groups
     public_source = public_source_two_groups
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 58000.0,
-            "instrument_id": ztf_camera.id,
-            "flux": 12.24,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "group_ids": [public_group.id, public_group2.id],
-        },
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp = client(upload_data_token)
+    photometry_id = sp.post_photometry(
+        PhotometryPost(
+            obj_id=str(public_source.id),
+            mjd=58000.0,
+            instrument_id=ztf_camera.id,
+            flux=12.24,
+            fluxerr=0.031,
+            zp=25.0,
+            magsys="ab",
+            filter="ztfg",
+            group_ids=[public_group.id, public_group2.id],
+        )
+    ).ids[0]
 
-    photometry_id = data["data"]["ids"][0]
-    status, data = api(
-        "GET", f"photometry/{photometry_id}?format=flux", token=upload_data_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    phot = sp.fetch_photometry_point(photometry_id, format="flux")
 
-    assert data["data"]["ra"] is None
-    assert data["data"]["dec"] is None
-    assert data["data"]["ra_unc"] is None
-    assert data["data"]["dec_unc"] is None
+    assert phot.ra is None
+    assert phot.dec is None
+    assert phot.ra_unc is None
+    assert phot.dec_unc is None
 
-    assert len(data["data"]["groups"]) == 3
+    assert len(phot.groups) == 3
 
-    np.testing.assert_allclose(
-        data["data"]["flux"], 12.24 * 10 ** (-0.4 * (25.0 - 23.9))
-    )
+    np.testing.assert_allclose(phot.flux, 12.24 * 10 ** (-0.4 * (25.0 - 23.9)))
 
 
 def test_post_photometry_all_groups(
@@ -851,48 +726,40 @@ def test_post_photometry_all_groups(
 ):
     upload_data_token = upload_data_token_two_groups
     public_source = public_source_two_groups
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 58000.0,
-            "instrument_id": ztf_camera.id,
-            "flux": 12.24,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "group_ids": "all",
-        },
-        token=upload_data_token,
+    photometry_id = (
+        client(upload_data_token)
+        .post_photometry(
+            PhotometryPost(
+                obj_id=str(public_source.id),
+                mjd=58000.0,
+                instrument_id=ztf_camera.id,
+                flux=12.24,
+                fluxerr=0.031,
+                zp=25.0,
+                magsys="ab",
+                filter="ztfg",
+                group_ids="all",
+            )
+        )
+        .ids[0]
     )
-    assert status == 200
-    assert data["status"] == "success"
 
-    photometry_id = data["data"]["ids"][0]
-    status, data = api(
-        "GET",
-        f"photometry/{photometry_id}?format=flux",
-        token=super_admin_token,
+    phot = client(super_admin_token).fetch_photometry_point(
+        photometry_id, format="flux"
     )
-    assert status == 200
-    assert data["status"] == "success"
 
-    assert data["data"]["ra"] is None
-    assert data["data"]["dec"] is None
-    assert data["data"]["ra_unc"] is None
-    assert data["data"]["dec_unc"] is None
+    assert phot.ra is None
+    assert phot.dec is None
+    assert phot.ra_unc is None
+    assert phot.dec_unc is None
 
     # Groups should be single user group and public group
-    assert len(data["data"]["groups"]) == 2
-    groups = [g["name"] for g in data["data"]["groups"]]
+    assert len(phot.groups) == 2
+    groups = [g.name for g in phot.groups]
     assert cfg["misc"]["public_group_name"] in groups
     assert user_two_groups.single_user_group.name in groups
 
-    np.testing.assert_allclose(
-        data["data"]["flux"], 12.24 * 10 ** (-0.4 * (25.0 - 23.9))
-    )
+    np.testing.assert_allclose(phot.flux, 12.24 * 10 ** (-0.4 * (25.0 - 23.9)))
 
 
 def test_retrieve_photometry_group_membership_posted_by_other(
@@ -905,40 +772,32 @@ def test_retrieve_photometry_group_membership_posted_by_other(
 ):
     upload_data_token = upload_data_token_two_groups
     public_source = public_source_two_groups
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 58000.0,
-            "instrument_id": ztf_camera.id,
-            "flux": 12.24,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "group_ids": [public_group.id, public_group2.id],
-        },
-        token=upload_data_token,
+    photometry_id = (
+        client(upload_data_token)
+        .post_photometry(
+            PhotometryPost(
+                obj_id=str(public_source.id),
+                mjd=58000.0,
+                instrument_id=ztf_camera.id,
+                flux=12.24,
+                fluxerr=0.031,
+                zp=25.0,
+                magsys="ab",
+                filter="ztfg",
+                group_ids=[public_group.id, public_group2.id],
+            )
+        )
+        .ids[0]
     )
-    assert status == 200
-    assert data["status"] == "success"
 
-    photometry_id = data["data"]["ids"][0]
-    status, data = api(
-        "GET", f"photometry/{photometry_id}?format=flux", token=view_only_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    phot = client(view_only_token).fetch_photometry_point(photometry_id, format="flux")
 
-    assert data["data"]["ra"] is None
-    assert data["data"]["dec"] is None
-    assert data["data"]["ra_unc"] is None
-    assert data["data"]["dec_unc"] is None
+    assert phot.ra is None
+    assert phot.dec is None
+    assert phot.ra_unc is None
+    assert phot.dec_unc is None
 
-    np.testing.assert_allclose(
-        data["data"]["flux"], 12.24 * 10 ** (-0.4 * (25.0 - 23.9))
-    )
+    np.testing.assert_allclose(phot.flux, 12.24 * 10 ** (-0.4 * (25.0 - 23.9)))
 
 
 def test_retrieve_photometry_error_group_membership_posted_by_other(
@@ -951,205 +810,149 @@ def test_retrieve_photometry_error_group_membership_posted_by_other(
 ):
     upload_data_token = upload_data_token_two_groups
     public_source = public_source_two_groups
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 58000.0,
-            "instrument_id": ztf_camera.id,
-            "flux": 12.24,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "group_ids": [public_group2.id],
-        },
-        token=upload_data_token,
+    photometry_id = (
+        client(upload_data_token)
+        .post_photometry(
+            PhotometryPost(
+                obj_id=str(public_source.id),
+                mjd=58000.0,
+                instrument_id=ztf_camera.id,
+                flux=12.24,
+                fluxerr=0.031,
+                zp=25.0,
+                magsys="ab",
+                filter="ztfg",
+                group_ids=[public_group2.id],
+            )
+        )
+        .ids[0]
     )
     # the upload_data_token user's single user group id is =
     # Token.query.get(upload_data_token).created_by.single_user_group.id
-
-    assert status == 200
-    assert data["status"] == "success"
-
-    photometry_id = data["data"]["ids"][0]
-    status, data = api(
-        "GET", f"photometry/{photometry_id}?format=flux", token=view_only_token
-    )
 
     # the view-only token group ids =
     # [g.id for g in Token.query.get(view_only_token).created_by.groups]
 
     # `view_only_token only` belongs to `public_group`, not `public_group2`
-    assert status == 400
-    assert data["status"] == "error"
-    assert "Cannot find photometry point with ID" in data["message"]
+    with pytest.raises(
+        SkyPortalError, match="Cannot find photometry point with ID"
+    ) as err:
+        client(view_only_token).fetch_photometry_point(photometry_id, format="flux")
+    assert err.value.status_code == 400
 
 
 def test_can_post_photometry_no_groups(
     upload_data_token, public_source, public_group, ztf_camera
 ):
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 58000.0,
-            "instrument_id": ztf_camera.id,
-            "flux": 12.24,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfg",
-        },
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp = client(upload_data_token)
+    photometry_id = sp.post_photometry(
+        PhotometryPost(
+            obj_id=str(public_source.id),
+            mjd=58000.0,
+            instrument_id=ztf_camera.id,
+            flux=12.24,
+            fluxerr=0.031,
+            zp=25.0,
+            magsys="ab",
+            filter="ztfg",
+        )
+    ).ids[0]
 
-    photometry_id = data["data"]["ids"][0]
-    status, data = api(
-        "GET", f"photometry/{photometry_id}?format=flux", token=upload_data_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]["groups"]) == 1
+    phot = sp.fetch_photometry_point(photometry_id, format="flux")
+    assert len(phot.groups) == 1
 
 
 def test_can_post_photometry_empty_groups_list(
     upload_data_token, public_source, public_group, ztf_camera
 ):
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 58000.0,
-            "instrument_id": ztf_camera.id,
-            "flux": 12.24,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "group_ids": [],
-        },
-        token=upload_data_token,
-    )
+    sp = client(upload_data_token)
+    photometry_id = sp.post_photometry(
+        PhotometryPost(
+            obj_id=str(public_source.id),
+            mjd=58000.0,
+            instrument_id=ztf_camera.id,
+            flux=12.24,
+            fluxerr=0.031,
+            zp=25.0,
+            magsys="ab",
+            filter="ztfg",
+            group_ids=[],
+        )
+    ).ids[0]
 
-    assert status == 200
-    assert data["status"] == "success"
-
-    photometry_id = data["data"]["ids"][0]
-    status, data = api(
-        "GET", f"photometry/{photometry_id}?format=flux", token=upload_data_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]["groups"]) == 1
+    phot = sp.fetch_photometry_point(photometry_id, format="flux")
+    assert len(phot.groups) == 1
 
 
 def test_token_user_post_mag_photometry_data_and_convert(
     upload_data_token, public_source, ztf_camera, public_group
 ):
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 58000.0,
-            "instrument_id": ztf_camera.id,
-            "mag": 21.0,
-            "magerr": 0.2,
-            "limiting_mag": 22.3,
-            "magsys": "vega",
-            "filter": "ztfg",
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp = client(upload_data_token)
+    photometry_id = sp.post_photometry(
+        PhotometryPost(
+            obj_id=str(public_source.id),
+            mjd=58000.0,
+            instrument_id=ztf_camera.id,
+            mag=21.0,
+            magerr=0.2,
+            limiting_mag=22.3,
+            magsys="vega",
+            filter="ztfg",
+            group_ids=[public_group.id],
+        )
+    ).ids[0]
 
-    photometry_id = data["data"]["ids"][0]
-    status, data = api(
-        "GET", f"photometry/{photometry_id}?format=flux", token=upload_data_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    phot = sp.fetch_photometry_point(photometry_id, format="flux")
 
     ab = sncosmo.get_magsystem("ab")
     vega = sncosmo.get_magsystem("vega")
     correction = 2.5 * np.log10(vega.zpbandflux("ztfg") / ab.zpbandflux("ztfg"))
 
-    np.testing.assert_allclose(
-        data["data"]["flux"], 10 ** (-0.4 * (21.0 - correction - 23.9))
-    )
+    np.testing.assert_allclose(phot.flux, 10 ** (-0.4 * (21.0 - correction - 23.9)))
 
-    np.testing.assert_allclose(
-        data["data"]["fluxerr"], 0.2 / (2.5 / np.log(10)) * data["data"]["flux"]
-    )
+    np.testing.assert_allclose(phot.fluxerr, 0.2 / (2.5 / np.log(10)) * phot.flux)
 
-    status, data = api("GET", f"photometry/{photometry_id}", token=upload_data_token)
-    assert status == 200
-    assert data["status"] == "success"
+    phot = sp.fetch_photometry_point(photometry_id)
 
-    np.testing.assert_allclose(data["data"]["mag"], 21.0 - correction)
+    np.testing.assert_allclose(phot.mag, 21.0 - correction)
 
-    np.testing.assert_allclose(data["data"]["magerr"], 0.2)
+    np.testing.assert_allclose(phot.magerr, 0.2)
 
 
 def test_token_user_post_and_get_different_systems_mag(
     upload_data_token, public_source, ztf_camera, public_group
 ):
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 58000.0,
-            "instrument_id": ztf_camera.id,
-            "mag": 21.0,
-            "magerr": 0.2,
-            "limiting_mag": 22.3,
-            "magsys": "vega",
-            "filter": "ztfg",
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp = client(upload_data_token)
+    photometry_id = sp.post_photometry(
+        PhotometryPost(
+            obj_id=str(public_source.id),
+            mjd=58000.0,
+            instrument_id=ztf_camera.id,
+            mag=21.0,
+            magerr=0.2,
+            limiting_mag=22.3,
+            magsys="vega",
+            filter="ztfg",
+            group_ids=[public_group.id],
+        )
+    ).ids[0]
 
-    photometry_id = data["data"]["ids"][0]
-    status, data = api(
-        "GET",
-        f"photometry/{photometry_id}?format=mag&magsys=vega",
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    assert data["data"]["magsys"] == "vega"
+    phot = sp.fetch_photometry_point(photometry_id, format="mag", magsys="vega")
+    assert phot.magsys == "vega"
 
     ab = sncosmo.get_magsystem("ab")
     vega = sncosmo.get_magsystem("vega")
     correction = 2.5 * np.log10(vega.zpbandflux("ztfg") / ab.zpbandflux("ztfg"))
 
-    np.testing.assert_allclose(data["data"]["mag"], 21.0)
-    np.testing.assert_allclose(data["data"]["magerr"], 0.2)
-    np.testing.assert_allclose(data["data"]["limiting_mag"], 22.3)
+    np.testing.assert_allclose(phot.mag, 21.0)
+    np.testing.assert_allclose(phot.magerr, 0.2)
+    np.testing.assert_allclose(phot.limiting_mag, 22.3)
 
-    status, data = api(
-        "GET",
-        f"photometry/{photometry_id}?format=mag&magsys=ab",
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    phot = sp.fetch_photometry_point(photometry_id, format="mag", magsys="ab")
 
-    np.testing.assert_allclose(data["data"]["mag"], 21.0 - correction)
-    np.testing.assert_allclose(data["data"]["magerr"], 0.2)
-    np.testing.assert_allclose(data["data"]["limiting_mag"], 22.3 - correction)
+    np.testing.assert_allclose(phot.mag, 21.0 - correction)
+    np.testing.assert_allclose(phot.magerr, 0.2)
+    np.testing.assert_allclose(phot.limiting_mag, 22.3 - correction)
 
 
 def test_token_user_post_extinction_corrected_photometry(
@@ -1164,173 +967,122 @@ def test_token_user_post_extinction_corrected_photometry(
 
     # Upload as MW-extinction corrected: SkyPortal stores observed photometry, so
     # it re-reddens for storage.
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": mjd,
-            "instrument_id": ztf_camera.id,
-            "mag": mag_in,
-            "magerr": 0.1,
-            "limiting_mag": 22.5,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "group_ids": [public_group.id],
-            "extinction_corrected": True,
-        },
-        token=upload_data_token,
-    )
-    assert status == 200, data
-    photometry_id = data["data"]["ids"][0]
+    sp = client(upload_data_token)
+    photometry_id = sp.post_photometry(
+        PhotometryPost(
+            obj_id=str(public_source.id),
+            mjd=mjd,
+            instrument_id=ztf_camera.id,
+            mag=mag_in,
+            magerr=0.1,
+            limiting_mag=22.5,
+            magsys="ab",
+            filter="ztfg",
+            group_ids=[public_group.id],
+            extinction_corrected=True,
+        )
+    ).ids[0]
 
     # Stored (observed) value is the uploaded mag re-reddened: mag_in + A_lambda.
-    status, data = api(
-        "GET",
-        f"photometry/{photometry_id}?format=mag&magsys=ab",
-        token=upload_data_token,
-    )
-    assert status == 200
-    np.testing.assert_allclose(data["data"]["mag"], mag_in + a_lambda, rtol=1e-4)
+    phot = sp.fetch_photometry_point(photometry_id, format="mag", magsys="ab")
+    np.testing.assert_allclose(phot.mag, mag_in + a_lambda, rtol=1e-4)
 
     # Displaying with extinction correction dereddens back to the uploaded value.
-    status, data = api(
-        "GET",
-        f"sources/{public_source.id}/photometry?format=mag&magsys=ab&includeExtinction=true",
-        token=upload_data_token,
+    points = sp.fetch_photometry(
+        public_source.id, format="mag", magsys="ab", include_extinction=True
     )
-    assert status == 200
-    point = next(p for p in data["data"] if p["mjd"] == mjd)
-    np.testing.assert_allclose(point["mag_corr"], mag_in, rtol=1e-4)
+    point = next(p for p in points if p.mjd == mjd)
+    np.testing.assert_allclose(point.mag_corr, mag_in, rtol=1e-4)
 
 
 def test_token_user_post_uncorrected_photometry_unchanged(
     upload_data_token, public_source, ztf_camera, public_group
 ):
     # Without the flag, magnitudes are stored as-is (observed) -- the control.
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 58124.0,
-            "instrument_id": ztf_camera.id,
-            "mag": 21.0,
-            "magerr": 0.1,
-            "limiting_mag": 22.5,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
-    )
-    assert status == 200, data
-    photometry_id = data["data"]["ids"][0]
-    status, data = api(
-        "GET",
-        f"photometry/{photometry_id}?format=mag&magsys=ab",
-        token=upload_data_token,
-    )
-    assert status == 200
-    np.testing.assert_allclose(data["data"]["mag"], 21.0)
+    sp = client(upload_data_token)
+    photometry_id = sp.post_photometry(
+        PhotometryPost(
+            obj_id=str(public_source.id),
+            mjd=58124.0,
+            instrument_id=ztf_camera.id,
+            mag=21.0,
+            magerr=0.1,
+            limiting_mag=22.5,
+            magsys="ab",
+            filter="ztfg",
+            group_ids=[public_group.id],
+        )
+    ).ids[0]
+    phot = sp.fetch_photometry_point(photometry_id, format="mag", magsys="ab")
+    np.testing.assert_allclose(phot.mag, 21.0)
 
 
 def test_token_user_post_and_get_different_systems_flux(
     upload_data_token, public_source, ztf_camera, public_group
 ):
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 58000.0,
-            "instrument_id": ztf_camera.id,
-            "mag": 21.0,
-            "magerr": 0.2,
-            "limiting_mag": 22.3,
-            "magsys": "vega",
-            "filter": "ztfg",
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp = client(upload_data_token)
+    photometry_id = sp.post_photometry(
+        PhotometryPost(
+            obj_id=str(public_source.id),
+            mjd=58000.0,
+            instrument_id=ztf_camera.id,
+            mag=21.0,
+            magerr=0.2,
+            limiting_mag=22.3,
+            magsys="vega",
+            filter="ztfg",
+            group_ids=[public_group.id],
+        )
+    ).ids[0]
 
-    photometry_id = data["data"]["ids"][0]
-    status, data = api(
-        "GET",
-        f"photometry/{photometry_id}?format=flux&magsys=vega",
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    phot = sp.fetch_photometry_point(photometry_id, format="flux", magsys="vega")
 
     ab = sncosmo.get_magsystem("ab")
     vega = sncosmo.get_magsystem("vega")
     correction = 2.5 * np.log10(vega.zpbandflux("ztfg") / ab.zpbandflux("ztfg"))
 
-    np.testing.assert_allclose(
-        data["data"]["flux"], 10 ** (-0.4 * (21 - correction - 23.9))
-    )
-    np.testing.assert_allclose(
-        data["data"]["fluxerr"], 0.2 / (2.5 / np.log(10)) * data["data"]["flux"]
-    )
-    np.testing.assert_allclose(data["data"]["zp"], 23.9 + correction)
+    np.testing.assert_allclose(phot.flux, 10 ** (-0.4 * (21 - correction - 23.9)))
+    np.testing.assert_allclose(phot.fluxerr, 0.2 / (2.5 / np.log(10)) * phot.flux)
+    np.testing.assert_allclose(phot.zp, 23.9 + correction)
 
-    status, data = api(
-        "GET",
-        f"photometry/{photometry_id}?format=flux&magsys=ab",
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    phot = sp.fetch_photometry_point(photometry_id, format="flux", magsys="ab")
 
-    np.testing.assert_allclose(
-        data["data"]["flux"], 10 ** (-0.4 * (21 - correction - 23.9))
-    )
-    np.testing.assert_allclose(
-        data["data"]["fluxerr"], 0.2 / (2.5 / np.log(10)) * data["data"]["flux"]
-    )
-    np.testing.assert_allclose(data["data"]["zp"], 23.9)
+    np.testing.assert_allclose(phot.flux, 10 ** (-0.4 * (21 - correction - 23.9)))
+    np.testing.assert_allclose(phot.fluxerr, 0.2 / (2.5 / np.log(10)) * phot.flux)
+    np.testing.assert_allclose(phot.zp, 23.9)
 
 
 def test_token_user_mixed_photometry_post(
     upload_data_token, public_source, ztf_camera, public_group
 ):
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 58000.0,
-            "instrument_id": ztf_camera.id,
-            "mag": 21.0,
-            "magerr": [0.2, 0.1],
-            "limiting_mag": 22.3,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    photometry_id = (
+        client(upload_data_token)
+        .post_photometry(
+            PhotometryPost(
+                obj_id=str(public_source.id),
+                mjd=58000.0,
+                instrument_id=ztf_camera.id,
+                mag=21.0,
+                magerr=[0.2, 0.1],
+                limiting_mag=22.3,
+                magsys="ab",
+                filter="ztfg",
+                group_ids=[public_group.id],
+            )
+        )
+        .ids[1]
     )
-    assert status == 200
-    assert data["status"] == "success"
 
-    photometry_id = data["data"]["ids"][1]
-    status, data = api(
-        "GET", f"photometry/{photometry_id}?format=flux", token=upload_data_token
+    phot = client(upload_data_token).fetch_photometry_point(
+        photometry_id, format="flux"
     )
-    assert status == 200
-    assert data["status"] == "success"
 
-    np.testing.assert_allclose(data["data"]["flux"], 10 ** (-0.4 * (21.0 - 23.9)))
+    np.testing.assert_allclose(phot.flux, 10 ** (-0.4 * (21.0 - 23.9)))
 
-    np.testing.assert_allclose(
-        data["data"]["fluxerr"], 0.1 / (2.5 / np.log(10)) * data["data"]["flux"]
-    )
+    np.testing.assert_allclose(phot.fluxerr, 0.1 / (2.5 / np.log(10)) * phot.flux)
 
     # should fail as len(mag) != len(magerr)
+    # raw api: intentionally malformed payload the typed client can't produce
     status, data = api(
         "POST",
         "photometry",
@@ -1354,6 +1106,7 @@ def test_token_user_mixed_photometry_post(
 def test_token_user_mixed_mag_none_photometry_post(
     upload_data_token, public_source, ztf_camera, public_group
 ):
+    # raw api: intentionally malformed payload the typed client can't produce
     status, data = api(
         "POST",
         "photometry",
@@ -1373,6 +1126,7 @@ def test_token_user_mixed_mag_none_photometry_post(
     assert status == 400
     assert data["status"] == "error"
 
+    # raw api: intentionally malformed payload the typed client can't produce
     status, data = api(
         "POST",
         "photometry",
@@ -1392,6 +1146,7 @@ def test_token_user_mixed_mag_none_photometry_post(
     assert status == 400
     assert data["status"] == "error"
 
+    # raw api: intentionally malformed payload the typed client can't produce
     status, data = api(
         "POST",
         "photometry",
@@ -1415,135 +1170,102 @@ def test_token_user_mixed_mag_none_photometry_post(
 def test_token_user_post_photometry_limits(
     upload_data_token, public_source, ztf_camera, public_group
 ):
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 58000.0,
-            "instrument_id": ztf_camera.id,
-            "mag": None,
-            "magerr": None,
-            "limiting_mag": 22.3,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
-    )
-    if status != 200:
-        print(data)
-    assert status == 200
-    assert data["status"] == "success"
+    sp = client(upload_data_token)
+    photometry_id = sp.post_photometry(
+        PhotometryPost(
+            obj_id=str(public_source.id),
+            mjd=58000.0,
+            instrument_id=ztf_camera.id,
+            limiting_mag=22.3,
+            magsys="ab",
+            filter="ztfg",
+            group_ids=[public_group.id],
+        )
+    ).ids[0]
 
-    photometry_id = data["data"]["ids"][0]
-    status, data = api(
-        "GET", f"photometry/{photometry_id}?format=flux", token=upload_data_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    phot = sp.fetch_photometry_point(photometry_id, format="flux")
 
-    assert data["data"]["flux"] is None
+    assert phot.flux is None
     np.testing.assert_allclose(
-        data["data"]["fluxerr"], 10 ** (-0.4 * (22.3 - 23.9)) / PHOT_DETECTION_THRESHOLD
+        phot.fluxerr, 10 ** (-0.4 * (22.3 - 23.9)) / PHOT_DETECTION_THRESHOLD
     )
 
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 58000.0,
-            "instrument_id": ztf_camera.id,
-            "flux": None,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    photometry_id = sp.post_photometry(
+        PhotometryPost(
+            obj_id=str(public_source.id),
+            mjd=58000.0,
+            instrument_id=ztf_camera.id,
+            fluxerr=0.031,
+            zp=25.0,
+            magsys="ab",
+            filter="ztfg",
+            group_ids=[public_group.id],
+        )
+    ).ids[0]
 
-    photometry_id = data["data"]["ids"][0]
-    status, data = api(
-        "GET", f"photometry/{photometry_id}?format=flux", token=upload_data_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    phot = sp.fetch_photometry_point(photometry_id, format="flux")
 
-    assert data["data"]["flux"] is None
-    np.testing.assert_allclose(
-        data["data"]["fluxerr"], 0.031 * 10 ** (-0.4 * (25.0 - 23.9))
-    )
+    assert phot.flux is None
+    np.testing.assert_allclose(phot.fluxerr, 0.031 * 10 ** (-0.4 * (25.0 - 23.9)))
 
 
 def test_token_user_post_invalid_filter(
     upload_data_token, public_source, ztf_camera, public_group
 ):
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 58000.0,
-            "instrument_id": ztf_camera.id,
-            "mag": None,
-            "magerr": None,
-            "limiting_mag": 22.3,
-            "magsys": "ab",
-            "filter": "bessellv",
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
-    )
-    assert status == 400
-    assert data["status"] == "error"
+    with pytest.raises(SkyPortalError) as err:
+        client(upload_data_token).post_photometry(
+            PhotometryPost(
+                obj_id=str(public_source.id),
+                mjd=58000.0,
+                instrument_id=ztf_camera.id,
+                limiting_mag=22.3,
+                magsys="ab",
+                filter="bessellv",
+                group_ids=[public_group.id],
+            )
+        )
+    assert err.value.status_code == 400
 
 
 def test_token_user_post_photometry_data_series(
     upload_data_token, public_source, ztf_camera, public_group
 ):
     # valid request
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": [58000.0, 58001.0, 58002.0],
-            "instrument_id": ztf_camera.id,
-            "flux": [12.24, 15.24, 12.24],
-            "fluxerr": [0.031, 0.029, 0.030],
-            "filter": ["ztfg", "ztfg", "ztfg"],
-            "zp": [25.0, 30.0, 21.2],
-            "magsys": ["ab", "ab", "ab"],
-            "ra": 264.1947917,
-            "dec": [50.5478333, 50.5478333 + 0.00001, 50.5478333],
-            "dec_unc": 0.2,
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    ids = (
+        client(upload_data_token)
+        .post_photometry(
+            PhotometryPost(
+                obj_id=str(public_source.id),
+                mjd=[58000.0, 58001.0, 58002.0],
+                instrument_id=ztf_camera.id,
+                flux=[12.24, 15.24, 12.24],
+                fluxerr=[0.031, 0.029, 0.030],
+                filter=["ztfg", "ztfg", "ztfg"],
+                zp=[25.0, 30.0, 21.2],
+                magsys=["ab", "ab", "ab"],
+                ra=264.1947917,
+                dec=[50.5478333, 50.5478333 + 0.00001, 50.5478333],
+                dec_unc=0.2,
+                group_ids=[public_group.id],
+            )
+        )
+        .ids
     )
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]["ids"]) == 3
+    assert len(ids) == 3
 
-    photometry_id = data["data"]["ids"][1]
-    status, data = api(
-        "GET", f"photometry/{photometry_id}?format=flux", token=upload_data_token
+    photometry_id = ids[1]
+    phot = client(upload_data_token).fetch_photometry_point(
+        photometry_id, format="flux"
     )
-    assert status == 200
-    assert data["status"] == "success"
-    assert np.allclose(data["data"]["flux"], 15.24 * 10 ** (-0.4 * (30 - 23.9)))
+    assert np.allclose(phot.flux, 15.24 * 10 ** (-0.4 * (30 - 23.9)))
 
-    assert np.allclose(data["data"]["dec"], 50.5478333 + 0.00001)
+    assert np.allclose(phot.dec, 50.5478333 + 0.00001)
 
-    assert np.allclose(data["data"]["dec_unc"], 0.2)
-    assert data["data"]["ra_unc"] is None
+    assert np.allclose(phot.dec_unc, 0.2)
+    assert phot.ra_unc is None
 
     # invalid request
+    # raw api: intentionally malformed payload the typed client can't produce
     status, data = api(
         "POST",
         "photometry",
@@ -1592,183 +1314,143 @@ def test_token_user_post_photometry_data_series(
 def test_post_photometry_no_access_token(
     view_only_token, public_source, ztf_camera, public_group
 ):
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 58000.0,
-            "instrument_id": ztf_camera.id,
-            "flux": 12.24,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "group_ids": [public_group.id],
-        },
-        token=view_only_token,
-    )
-    assert status == 401
-    assert data["status"] == "error"
+    with pytest.raises(SkyPortalError) as err:
+        client(view_only_token).post_photometry(
+            PhotometryPost(
+                obj_id=str(public_source.id),
+                mjd=58000.0,
+                instrument_id=ztf_camera.id,
+                flux=12.24,
+                fluxerr=0.031,
+                zp=25.0,
+                magsys="ab",
+                filter="ztfg",
+                group_ids=[public_group.id],
+            )
+        )
+    assert err.value.status_code == 401
 
 
 def test_token_user_update_photometry(
     upload_data_token, public_source, ztf_camera, public_group
 ):
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 58000.0,
-            "instrument_id": ztf_camera.id,
-            "flux": 12.24,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfi",
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp = client(upload_data_token)
+    photometry_id = sp.post_photometry(
+        PhotometryPost(
+            obj_id=str(public_source.id),
+            mjd=58000.0,
+            instrument_id=ztf_camera.id,
+            flux=12.24,
+            fluxerr=0.031,
+            zp=25.0,
+            magsys="ab",
+            filter="ztfi",
+            group_ids=[public_group.id],
+        )
+    ).ids[0]
 
-    photometry_id = data["data"]["ids"][0]
-    status, data = api(
-        "GET", f"photometry/{photometry_id}?format=flux", token=upload_data_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    np.testing.assert_allclose(data["data"]["flux"], 12.24 * 10 ** (-0.4 * (25 - 23.9)))
+    phot = sp.fetch_photometry_point(photometry_id, format="flux")
+    np.testing.assert_allclose(phot.flux, 12.24 * 10 ** (-0.4 * (25 - 23.9)))
 
-    status, data = api(
-        "PATCH",
-        f"photometry/{photometry_id}",
-        data={
-            "obj_id": str(public_source.id),
-            "flux": 11.0,
-            "mjd": 58000.0,
-            "instrument_id": ztf_camera.id,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfi",
-        },
-        token=upload_data_token,
+    sp.update_photometry(
+        photometry_id,
+        PhotometryUpdate(
+            obj_id=str(public_source.id),
+            flux=11.0,
+            mjd=58000.0,
+            instrument_id=ztf_camera.id,
+            fluxerr=0.031,
+            zp=25.0,
+            magsys="ab",
+            filter="ztfi",
+        ),
     )
-    assert status == 200
-    assert data["status"] == "success"
 
-    status, data = api(
-        "GET", f"photometry/{photometry_id}?format=flux", token=upload_data_token
-    )
-    np.testing.assert_allclose(data["data"]["flux"], 11.0 * 10 ** (-0.4 * (25 - 23.9)))
+    phot = sp.fetch_photometry_point(photometry_id, format="flux")
+    np.testing.assert_allclose(phot.flux, 11.0 * 10 ** (-0.4 * (25 - 23.9)))
 
 
 def test_token_user_update_photometry_mag_to_nondetection(
     upload_data_token, public_source, ztf_camera, public_group
 ):
     # Upload a magnitude-space detection.
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 58000.0,
-            "instrument_id": ztf_camera.id,
-            "mag": 18.5,
-            "magerr": 0.1,
-            "limiting_mag": 22.0,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    photometry_id = data["data"]["ids"][0]
+    sp = client(upload_data_token)
+    photometry_id = sp.post_photometry(
+        PhotometryPost(
+            obj_id=str(public_source.id),
+            mjd=58000.0,
+            instrument_id=ztf_camera.id,
+            mag=18.5,
+            magerr=0.1,
+            limiting_mag=22.0,
+            magsys="ab",
+            filter="ztfg",
+            group_ids=[public_group.id],
+        )
+    ).ids[0]
 
     # The photometry-edit form sends mag/magerr cleared (null) with a limiting_mag
     # and, for a point not tied to an observing-run assignment, omits the optional
     # assignment_id / ra_unc / dec_unc keys entirely. This used to 500 with a
     # KeyError because parse_mag/parse_flux read those keys directly under a
     # partial load.
-    status, data = api(
-        "PATCH",
-        f"photometry/{photometry_id}",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 58000.0,
-            "instrument_id": ztf_camera.id,
-            "mag": None,
-            "magerr": None,
-            "limiting_mag": 22.0,
-            "magsys": "ab",
-            "filter": "ztfg",
-        },
-        token=upload_data_token,
+    sp.update_photometry(
+        photometry_id,
+        PhotometryUpdate(
+            obj_id=str(public_source.id),
+            mjd=58000.0,
+            instrument_id=ztf_camera.id,
+            mag=None,
+            magerr=None,
+            limiting_mag=22.0,
+            magsys="ab",
+            filter="ztfg",
+        ),
     )
-    assert status == 200
-    assert data["status"] == "success"
 
-    status, data = api(
-        "GET", f"photometry/{photometry_id}?format=mag", token=upload_data_token
-    )
-    assert status == 200
+    phot = sp.fetch_photometry_point(photometry_id, format="mag")
     # mag+magerr removed -> it is now a non-detection with the limiting magnitude.
-    assert data["data"]["mag"] is None
-    assert data["data"]["magerr"] is None
-    np.testing.assert_allclose(data["data"]["limiting_mag"], 22.0)
+    assert phot.mag is None
+    assert phot.magerr is None
+    np.testing.assert_allclose(phot.limiting_mag, 22.0)
 
 
 def test_token_user_cannot_update_unowned_photometry(
     upload_data_token, manage_sources_token, public_source, ztf_camera, public_group
 ):
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 58000.0,
-            "instrument_id": ztf_camera.id,
-            "flux": 12.24,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfi",
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp = client(upload_data_token)
+    photometry_id = sp.post_photometry(
+        PhotometryPost(
+            obj_id=str(public_source.id),
+            mjd=58000.0,
+            instrument_id=ztf_camera.id,
+            flux=12.24,
+            fluxerr=0.031,
+            zp=25.0,
+            magsys="ab",
+            filter="ztfi",
+            group_ids=[public_group.id],
+        )
+    ).ids[0]
 
-    photometry_id = data["data"]["ids"][0]
-    status, data = api(
-        "GET", f"photometry/{photometry_id}?format=flux", token=upload_data_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    np.testing.assert_allclose(data["data"]["flux"], 12.24 * 10 ** (-0.4 * (25 - 23.9)))
+    phot = sp.fetch_photometry_point(photometry_id, format="flux")
+    np.testing.assert_allclose(phot.flux, 12.24 * 10 ** (-0.4 * (25 - 23.9)))
 
-    status, data = api(
-        "PATCH",
-        f"photometry/{photometry_id}",
-        data={
-            "obj_id": str(public_source.id),
-            "flux": 11.0,
-            "mjd": 58000.0,
-            "instrument_id": ztf_camera.id,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfi",
-        },
-        token=manage_sources_token,
-    )
-    assert status == 401
+    with pytest.raises(SkyPortalError) as err:
+        client(manage_sources_token).update_photometry(
+            photometry_id,
+            PhotometryUpdate(
+                obj_id=str(public_source.id),
+                flux=11.0,
+                mjd=58000.0,
+                instrument_id=ztf_camera.id,
+                fluxerr=0.031,
+                zp=25.0,
+                magsys="ab",
+                filter="ztfi",
+            ),
+        )
+    assert err.value.status_code == 401
 
 
 def test_token_user_update_photometry_groups(
@@ -1783,231 +1465,163 @@ def test_token_user_update_photometry_groups(
     upload_data_token = upload_data_token_two_groups
     public_source = public_source_two_groups
 
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 58000.0,
-            "instrument_id": ztf_camera.id,
-            "flux": 12.24,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfi",
-            "group_ids": [public_group.id, public_group2.id],
-        },
-        token=upload_data_token,
+    photometry_id = (
+        client(upload_data_token)
+        .post_photometry(
+            PhotometryPost(
+                obj_id=str(public_source.id),
+                mjd=58000.0,
+                instrument_id=ztf_camera.id,
+                flux=12.24,
+                fluxerr=0.031,
+                zp=25.0,
+                magsys="ab",
+                filter="ztfi",
+                group_ids=[public_group.id, public_group2.id],
+            )
+        )
+        .ids[0]
     )
-    assert status == 200
-    assert data["status"] == "success"
 
-    photometry_id = data["data"]["ids"][0]
-    status, data = api(
-        "GET", f"photometry/{photometry_id}?format=flux", token=view_only_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    client(view_only_token).fetch_photometry_point(photometry_id, format="flux")
 
-    status, data = api(
-        "PATCH",
-        f"photometry/{photometry_id}",
-        data={
-            "obj_id": str(public_source.id),
-            "flux": 11.0,
-            "mjd": 58000.0,
-            "instrument_id": ztf_camera.id,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfi",
-            "group_ids": [public_group2.id],
-        },
-        token=upload_data_token,
+    client(upload_data_token).update_photometry(
+        photometry_id,
+        PhotometryUpdate(
+            obj_id=str(public_source.id),
+            flux=11.0,
+            mjd=58000.0,
+            instrument_id=ztf_camera.id,
+            fluxerr=0.031,
+            zp=25.0,
+            magsys="ab",
+            filter="ztfi",
+            group_ids=[public_group2.id],
+        ),
     )
-    assert status == 200
-    assert data["status"] == "success"
 
-    status, data = api(
-        "GET", f"photometry/{photometry_id}?format=flux", token=view_only_token
-    )
-    assert status == 400
-    assert data["status"] == "error"
-    assert "Cannot find photometry point with ID" in data["message"]
+    with pytest.raises(
+        SkyPortalError, match="Cannot find photometry point with ID"
+    ) as err:
+        client(view_only_token).fetch_photometry_point(photometry_id, format="flux")
+    assert err.value.status_code == 400
 
 
 def test_user_can_delete_owned_photometry_data(
     upload_data_token, public_source, ztf_camera, public_group
 ):
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 58000.0,
-            "instrument_id": ztf_camera.id,
-            "flux": 12.24,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfi",
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp = client(upload_data_token)
+    photometry_id = sp.post_photometry(
+        PhotometryPost(
+            obj_id=str(public_source.id),
+            mjd=58000.0,
+            instrument_id=ztf_camera.id,
+            flux=12.24,
+            fluxerr=0.031,
+            zp=25.0,
+            magsys="ab",
+            filter="ztfi",
+            group_ids=[public_group.id],
+        )
+    ).ids[0]
 
-    photometry_id = data["data"]["ids"][0]
-    status, data = api(
-        "GET", f"photometry/{photometry_id}?format=flux", token=upload_data_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    np.testing.assert_allclose(data["data"]["flux"], 12.24 * 10 ** (-0.4 * (25 - 23.9)))
+    phot = sp.fetch_photometry_point(photometry_id, format="flux")
+    np.testing.assert_allclose(phot.flux, 12.24 * 10 ** (-0.4 * (25 - 23.9)))
 
-    status, data = api("DELETE", f"photometry/{photometry_id}", token=upload_data_token)
-    assert status == 200
+    sp.delete_photometry(photometry_id)
 
-    status, data = api(
-        "GET", f"photometry/{photometry_id}?format=flux", token=upload_data_token
-    )
-    assert status == 400
+    with pytest.raises(SkyPortalError) as err:
+        sp.fetch_photometry_point(photometry_id, format="flux")
+    assert err.value.status_code == 400
 
 
 def test_user_cannot_delete_unowned_photometry_data(
     upload_data_token, manage_sources_token, public_source, ztf_camera, public_group
 ):
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 58000.0,
-            "instrument_id": ztf_camera.id,
-            "flux": 12.24,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfi",
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp = client(upload_data_token)
+    photometry_id = sp.post_photometry(
+        PhotometryPost(
+            obj_id=str(public_source.id),
+            mjd=58000.0,
+            instrument_id=ztf_camera.id,
+            flux=12.24,
+            fluxerr=0.031,
+            zp=25.0,
+            magsys="ab",
+            filter="ztfi",
+            group_ids=[public_group.id],
+        )
+    ).ids[0]
 
-    photometry_id = data["data"]["ids"][0]
-    status, data = api(
-        "GET", f"photometry/{photometry_id}?format=flux", token=upload_data_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    np.testing.assert_allclose(data["data"]["flux"], 12.24 * 10 ** (-0.4 * (25 - 23.9)))
+    phot = sp.fetch_photometry_point(photometry_id, format="flux")
+    np.testing.assert_allclose(phot.flux, 12.24 * 10 ** (-0.4 * (25 - 23.9)))
 
-    status, data = api(
-        "DELETE", f"photometry/{photometry_id}", token=manage_sources_token
-    )
-
-    assert status == 401
+    with pytest.raises(SkyPortalError) as err:
+        client(manage_sources_token).delete_photometry(photometry_id)
+    assert err.value.status_code == 401
 
 
 def test_admin_can_delete_unowned_photometry_data(
     upload_data_token, super_admin_token, public_source, ztf_camera, public_group
 ):
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 58000.0,
-            "instrument_id": ztf_camera.id,
-            "flux": 12.24,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfi",
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp = client(upload_data_token)
+    photometry_id = sp.post_photometry(
+        PhotometryPost(
+            obj_id=str(public_source.id),
+            mjd=58000.0,
+            instrument_id=ztf_camera.id,
+            flux=12.24,
+            fluxerr=0.031,
+            zp=25.0,
+            magsys="ab",
+            filter="ztfi",
+            group_ids=[public_group.id],
+        )
+    ).ids[0]
 
-    photometry_id = data["data"]["ids"][0]
-    status, data = api(
-        "GET", f"photometry/{photometry_id}?format=flux", token=upload_data_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    np.testing.assert_allclose(data["data"]["flux"], 12.24 * 10 ** (-0.4 * (25 - 23.9)))
+    phot = sp.fetch_photometry_point(photometry_id, format="flux")
+    np.testing.assert_allclose(phot.flux, 12.24 * 10 ** (-0.4 * (25 - 23.9)))
 
-    status, data = api("DELETE", f"photometry/{photometry_id}", token=super_admin_token)
-    assert status == 200
+    client(super_admin_token).delete_photometry(photometry_id)
 
-    status, data = api(
-        "GET", f"photometry/{photometry_id}?format=flux", token=upload_data_token
-    )
-    assert status == 400
+    with pytest.raises(SkyPortalError) as err:
+        sp.fetch_photometry_point(photometry_id, format="flux")
+    assert err.value.status_code == 400
 
 
 def test_token_user_retrieving_source_photometry_and_convert(
     view_only_token, public_source
 ):
-    status, data = api(
-        "GET",
-        f"sources/{public_source.id}/photometry?format=flux&magsys=ab",
-        token=view_only_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    assert isinstance(data["data"], list)
-    assert "mjd" in data["data"][0]
-    assert "ra_unc" in data["data"][0]
+    sp = client(view_only_token)
+    points = sp.fetch_photometry(public_source.id, format="flux", magsys="ab")
+    assert isinstance(points, list)
+    assert "mjd" in points[0].model_fields_set
+    assert "ra_unc" in points[0].model_fields_set
 
-    data["data"] = sorted(data["data"], key=lambda d: d["mjd"])
-    mag1_ab = -2.5 * np.log10(data["data"][0]["flux"]) + data["data"][0]["zp"]
-    magerr1_ab = 2.5 / np.log(10) * data["data"][0]["fluxerr"] / data["data"][0]["flux"]
+    points = sorted(points, key=lambda p: p.mjd)
+    mag1_ab = -2.5 * np.log10(points[0].flux) + points[0].zp
+    magerr1_ab = 2.5 / np.log(10) * points[0].fluxerr / points[0].flux
 
-    maglast_ab = -2.5 * np.log10(data["data"][-1]["flux"]) + data["data"][-1]["zp"]
-    magerrlast_ab = (
-        2.5 / np.log(10) * data["data"][-1]["fluxerr"] / data["data"][-1]["flux"]
-    )
+    maglast_ab = -2.5 * np.log10(points[-1].flux) + points[-1].zp
+    magerrlast_ab = 2.5 / np.log(10) * points[-1].fluxerr / points[-1].flux
 
-    status, data = api(
-        "GET",
-        f"sources/{public_source.id}/photometry?format=mag&magsys=ab",
-        token=view_only_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    points = sp.fetch_photometry(public_source.id, format="mag", magsys="ab")
 
-    data["data"] = sorted(data["data"], key=lambda d: d["mjd"])
-    assert np.allclose(mag1_ab, data["data"][0]["mag"])
-    assert np.allclose(magerr1_ab, data["data"][0]["magerr"])
+    points = sorted(points, key=lambda p: p.mjd)
+    assert np.allclose(mag1_ab, points[0].mag)
+    assert np.allclose(magerr1_ab, points[0].magerr)
 
-    assert np.allclose(maglast_ab, data["data"][-1]["mag"])
-    assert np.allclose(magerrlast_ab, data["data"][-1]["magerr"])
+    assert np.allclose(maglast_ab, points[-1].mag)
+    assert np.allclose(magerrlast_ab, points[-1].magerr)
 
-    status, data = api(
-        "GET",
-        f"sources/{public_source.id}/photometry?format=flux&magsys=vega",
-        token=view_only_token,
-    )
+    points = sp.fetch_photometry(public_source.id, format="flux", magsys="vega")
 
-    data["data"] = sorted(data["data"], key=lambda d: d["mjd"])
-    mag1_vega = -2.5 * np.log10(data["data"][0]["flux"]) + data["data"][0]["zp"]
-    magerr1_vega = (
-        2.5 / np.log(10) * data["data"][0]["fluxerr"] / data["data"][0]["flux"]
-    )
+    points = sorted(points, key=lambda p: p.mjd)
+    mag1_vega = -2.5 * np.log10(points[0].flux) + points[0].zp
+    magerr1_vega = 2.5 / np.log(10) * points[0].fluxerr / points[0].flux
 
-    maglast_vega = -2.5 * np.log10(data["data"][-1]["flux"]) + data["data"][-1]["zp"]
-    magerrlast_vega = (
-        2.5 / np.log(10) * data["data"][-1]["fluxerr"] / data["data"][-1]["flux"]
-    )
-
-    assert status == 200
-    assert data["status"] == "success"
+    maglast_vega = -2.5 * np.log10(points[-1].flux) + points[-1].zp
+    magerrlast_vega = 2.5 / np.log(10) * points[-1].fluxerr / points[-1].flux
 
     ab = sncosmo.get_magsystem("ab")
     vega = sncosmo.get_magsystem("vega")
@@ -2016,18 +1630,17 @@ def test_token_user_retrieving_source_photometry_and_convert(
         for filter in ["ztfg", "ztfr", "ztfi"]
     }
 
-    assert np.allclose(mag1_ab, mag1_vega + vega_to_ab[data["data"][0]["filter"]])
+    assert np.allclose(mag1_ab, mag1_vega + vega_to_ab[points[0].filter])
     assert np.allclose(magerr1_ab, magerr1_vega)
 
-    assert np.allclose(
-        maglast_ab, maglast_vega + vega_to_ab[data["data"][-1]["filter"]]
-    )
+    assert np.allclose(maglast_ab, maglast_vega + vega_to_ab[points[-1].filter])
     assert np.allclose(magerrlast_ab, magerrlast_vega)
 
 
 def test_source_photometry_format_plot_is_slim(view_only_token, public_source):
     """``format=plot`` must return only the lightcurve-plotter fields and
     match the magnitudes that ``format=mag`` produces."""
+    # skyportal-py gap: typed models cannot expose raw JSON keys (format=plot key-set check)
     status, plot_resp = api(
         "GET",
         f"sources/{public_source.id}/photometry?format=plot&magsys=ab",
@@ -2054,140 +1667,104 @@ def test_source_photometry_format_plot_is_slim(view_only_token, public_source):
             f"missing: {allowed_keys - set(point.keys())}"
         )
 
-    status, mag_resp = api(
-        "GET",
-        f"sources/{public_source.id}/photometry?format=mag&magsys=ab",
-        token=view_only_token,
+    mag_points = client(view_only_token).fetch_photometry(
+        public_source.id, format="mag", magsys="ab"
     )
-    assert status == 200
-    assert mag_resp["status"] == "success"
 
-    mag_by_id = {p["id"]: p for p in mag_resp["data"]}
+    mag_by_id = {p.id: p for p in mag_points}
     assert {p["id"] for p in plot_resp["data"]} == set(mag_by_id), (
         "format=plot and format=mag returned different photometry IDs"
     )
     for plot_point in plot_resp["data"]:
         mag_point = mag_by_id[plot_point["id"]]
         for field in ("mag", "magerr", "limiting_mag"):
-            if mag_point[field] is None:
+            if getattr(mag_point, field) is None:
                 assert plot_point[field] is None
             else:
-                assert np.allclose(plot_point[field], mag_point[field])
+                assert np.allclose(plot_point[field], getattr(mag_point, field))
 
 
 def test_token_user_retrieve_null_photometry(
     upload_data_token, public_source, ztf_camera, public_group
 ):
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 58000.0,
-            "instrument_id": ztf_camera.id,
-            "mag": None,
-            "magerr": None,
-            "limiting_mag": 22.3,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp = client(upload_data_token)
+    photometry_id = sp.post_photometry(
+        PhotometryPost(
+            obj_id=str(public_source.id),
+            mjd=58000.0,
+            instrument_id=ztf_camera.id,
+            limiting_mag=22.3,
+            magsys="ab",
+            filter="ztfg",
+            group_ids=[public_group.id],
+        )
+    ).ids[0]
 
-    photometry_id = data["data"]["ids"][0]
-    status, data = api(
-        "GET", f"photometry/{photometry_id}?format=flux", token=upload_data_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    assert data["data"]["flux"] is None
+    phot = sp.fetch_photometry_point(photometry_id, format="flux")
+    assert phot.flux is None
 
     np.testing.assert_allclose(
-        data["data"]["fluxerr"], 10 ** (-0.4 * (22.3 - 23.9)) / PHOT_DETECTION_THRESHOLD
+        phot.fluxerr, 10 ** (-0.4 * (22.3 - 23.9)) / PHOT_DETECTION_THRESHOLD
     )
 
-    status, data = api(
-        "GET", f"photometry/{photometry_id}?format=mag", token=upload_data_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    assert data["data"]["mag"] is None
-    assert data["data"]["magerr"] is None
+    phot = sp.fetch_photometry_point(photometry_id, format="mag")
+    assert phot.mag is None
+    assert phot.magerr is None
 
 
 def test_token_user_get_range_photometry(
     upload_data_token, public_source, public_group, ztf_camera
 ):
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": [58000.0, 58500.0, 59000.0],
-            "instrument_id": ztf_camera.id,
-            "flux": 12.24,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    sp = client(upload_data_token)
+    sp.post_photometry(
+        PhotometryPost(
+            obj_id=str(public_source.id),
+            mjd=[58000.0, 58500.0, 59000.0],
+            instrument_id=ztf_camera.id,
+            flux=12.24,
+            fluxerr=0.031,
+            zp=25.0,
+            magsys="ab",
+            filter="ztfg",
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
-    assert data["status"] == "success"
 
-    status, data = api(
-        "GET",
-        "photometry/range",
-        token=upload_data_token,
-        data={"instrument_ids": [ztf_camera.id], "max_date": "2018-05-15T00:00:00"},
+    points = sp.fetch_photometry_range(
+        instrument_ids=[ztf_camera.id], max_date="2018-05-15T00:00:00"
     )
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]) == 1
+    assert len(points) == 1
 
-    status, data = api(
-        "GET",
-        "photometry/range?format=flux&magsys=vega",
-        token=upload_data_token,
-        data={"instrument_ids": [ztf_camera.id], "max_date": "2019-02-01T00:00:00"},
+    points = sp.fetch_photometry_range(
+        instrument_ids=[ztf_camera.id],
+        max_date="2019-02-01T00:00:00",
+        format="flux",
+        magsys="vega",
     )
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]) == 2
+    assert len(points) == 2
 
 
 def test_token_user_post_to_foreign_group_and_retrieve(
     upload_data_token, public_source_two_groups, public_group2, ztf_camera
 ):
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source_two_groups.id),
-            "mjd": [58000.0, 58500.0, 59000.0],
-            "instrument_id": ztf_camera.id,
-            "flux": 12.24,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "group_ids": [public_group2.id],
-        },
-        token=upload_data_token,
+    photometry_id = (
+        client(upload_data_token)
+        .post_photometry(
+            PhotometryPost(
+                obj_id=str(public_source_two_groups.id),
+                mjd=[58000.0, 58500.0, 59000.0],
+                instrument_id=ztf_camera.id,
+                flux=12.24,
+                fluxerr=0.031,
+                zp=25.0,
+                magsys="ab",
+                filter="ztfg",
+                group_ids=[public_group2.id],
+            )
+        )
+        .ids[0]
     )
-    assert status == 200
-    assert data["status"] == "success"
-
-    photometry_id = data["data"]["ids"][0]
-    status, data = api(
-        "GET", f"photometry/{photometry_id}?format=flux", token=upload_data_token
-    )
-    assert status == 200
+    client(upload_data_token).fetch_photometry_point(photometry_id, format="flux")
 
 
 @pytest.mark.flaky(reruns=2, reruns_delay=5)
@@ -2374,14 +1951,7 @@ def test_problematic_photometry_1263(
         ],
     }
 
-    status, data = api(
-        "POST",
-        "photometry",
-        data=payload,
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    client(upload_data_token).post_photometry(PhotometryPost(**payload))
 
     payload = {
         "obj_id": public_source.id,
@@ -2565,33 +2135,15 @@ def test_problematic_photometry_1263(
         ],
     }
 
-    status, data = api(
-        "POST",
-        "photometry",
-        data=payload,
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    client(upload_data_token).post_photometry(PhotometryPost(**payload))
 
     payload["group_ids"] = "all"
 
-    status, data = api(
-        "PUT",
-        "photometry",
-        data=payload,
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    ids = client(upload_data_token).upsert_photometry(PhotometryPost(**payload)).ids
 
-    for id in data["data"]["ids"]:
-        status, data = api(
-            "GET", f"photometry/{id}?format=flux", token=upload_data_token
-        )
-        assert status == 200
-        assert data["status"] == "success"
-        assert len(data["data"]["groups"]) == 2
+    for id in ids:
+        phot = client(upload_data_token).fetch_photometry_point(id, format="flux")
+        assert len(phot.groups) == 2
 
 
 def test_problematic_photometry_1276(
@@ -2821,60 +2373,47 @@ def test_problematic_photometry_1276(
         ],
     }
 
-    status, data = api(
-        "PUT",
-        "photometry",
-        data=payload,
-        token=super_admin_token,
-    )
-    assert status in [400, 500]
-    assert data["status"] == "error"
+    with pytest.raises(SkyPortalError) as err:
+        client(super_admin_token).upsert_photometry(PhotometryPost(**payload))
+    assert err.value.status_code in [400, 500]
 
 
 def test_cannot_post_negative_fluxerr(
     upload_data_token, public_source, public_group, ztf_camera
 ):
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 58000.0,
-            "instrument_id": ztf_camera.id,
-            "flux": 12.24,
-            "fluxerr": -0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "group_ids": [public_group.id],
-            "altdata": {"some_key": "some_value"},
-        },
-        token=upload_data_token,
-    )
-    assert status == 400
-    assert data["status"] == "error"
-    assert "Invalid value" in data["message"]
+    with pytest.raises(SkyPortalError, match="Invalid value") as err:
+        client(upload_data_token).post_photometry(
+            PhotometryPost(
+                obj_id=str(public_source.id),
+                mjd=58000.0,
+                instrument_id=ztf_camera.id,
+                flux=12.24,
+                fluxerr=-0.031,
+                zp=25.0,
+                magsys="ab",
+                filter="ztfg",
+                group_ids=[public_group.id],
+                altdata={"some_key": "some_value"},
+            )
+        )
+    assert err.value.status_code == 400
 
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": [58000.0, 58000.4],
-            "instrument_id": ztf_camera.id,
-            "flux": [12.24, 12.43],
-            "fluxerr": [0.35, -0.031],
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "group_ids": [public_group.id],
-            "altdata": {"some_key": "some_value"},
-        },
-        token=upload_data_token,
-    )
-    assert status == 400
-    assert data["status"] == "error"
-    assert "Invalid value" in data["message"]
+    with pytest.raises(SkyPortalError, match="Invalid value") as err:
+        client(upload_data_token).post_photometry(
+            PhotometryPost(
+                obj_id=str(public_source.id),
+                mjd=[58000.0, 58000.4],
+                instrument_id=ztf_camera.id,
+                flux=[12.24, 12.43],
+                fluxerr=[0.35, -0.031],
+                zp=25.0,
+                magsys="ab",
+                filter="ztfg",
+                group_ids=[public_group.id],
+                altdata={"some_key": "some_value"},
+            )
+        )
+    assert err.value.status_code == 400
 
 
 def test_photometry_stream_read_access(
@@ -2885,40 +2424,34 @@ def test_photometry_stream_read_access(
     public_stream,
     ztf_camera,
 ):
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 58000.0,
-            "instrument_id": ztf_camera.id,
-            "flux": 12.24,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "stream_ids": [public_stream.id],
-            "altdata": {"some_key": "some_value"},
-        },
-        token=upload_data_token,
+    photometry_id = (
+        client(upload_data_token)
+        .post_photometry(
+            PhotometryPost(
+                obj_id=str(public_source.id),
+                mjd=58000.0,
+                instrument_id=ztf_camera.id,
+                flux=12.24,
+                fluxerr=0.031,
+                zp=25.0,
+                magsys="ab",
+                filter="ztfg",
+                stream_ids=[public_stream.id],
+                altdata={"some_key": "some_value"},
+            )
+        )
+        .ids[0]
     )
-    assert status == 200
-    assert data["status"] == "success"
-    photometry_id = data["data"]["ids"][0]
 
     # this token has sufficient stream access
-    status, data = api(
-        "GET", f"photometry/{photometry_id}", token=view_only_token_no_groups
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    client(view_only_token_no_groups).fetch_photometry_point(photometry_id)
 
     # this token does not have sufficient stream access
-    status, data = api(
-        "GET", f"photometry/{photometry_id}", token=view_only_token_no_groups_no_streams
-    )
-    assert status == 400
-    assert data["status"] == "error"
+    with pytest.raises(SkyPortalError) as err:
+        client(view_only_token_no_groups_no_streams).fetch_photometry_point(
+            photometry_id
+        )
+    assert err.value.status_code == 400
 
 
 def test_photometry_stream_post_access(
@@ -2929,46 +2462,38 @@ def test_photometry_stream_post_access(
     ztf_camera,
 ):
     # this token has sufficient stream access to create a StreamPhotometry row
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 58000.0,
-            "instrument_id": ztf_camera.id,
-            "flux": 12.24,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "stream_ids": [public_stream.id],
-            "altdata": {"some_key": "some_value"},
-        },
-        token=upload_data_token_no_groups,
+    client(upload_data_token_no_groups).post_photometry(
+        PhotometryPost(
+            obj_id=str(public_source.id),
+            mjd=58000.0,
+            instrument_id=ztf_camera.id,
+            flux=12.24,
+            fluxerr=0.031,
+            zp=25.0,
+            magsys="ab",
+            filter="ztfg",
+            stream_ids=[public_stream.id],
+            altdata={"some_key": "some_value"},
+        )
     )
-    assert status == 200
-    assert data["status"] == "success"
 
     # this token doesn't have sufficient stream access to create a StreamPhotometry row
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 58001.0,
-            "instrument_id": ztf_camera.id,
-            "flux": 13.24,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "stream_ids": [public_stream.id],
-            "altdata": {"some_key": "some_value"},
-        },
-        token=upload_data_token_no_groups_no_streams,
-    )
-    assert status == 400
-    assert data["status"] == "error"
+    with pytest.raises(SkyPortalError) as err:
+        client(upload_data_token_no_groups_no_streams).post_photometry(
+            PhotometryPost(
+                obj_id=str(public_source.id),
+                mjd=58001.0,
+                instrument_id=ztf_camera.id,
+                flux=13.24,
+                fluxerr=0.031,
+                zp=25.0,
+                magsys="ab",
+                filter="ztfg",
+                stream_ids=[public_stream.id],
+                altdata={"some_key": "some_value"},
+            )
+        )
+    assert err.value.status_code == 400
 
 
 def test_photometry_stream_put_access(
@@ -2981,88 +2506,72 @@ def test_photometry_stream_put_access(
     ztf_camera,
 ):
     # this token has sufficient stream access to create a StreamPhotometry row
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 58000.0,
-            "instrument_id": ztf_camera.id,
-            "flux": 12.24,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "stream_ids": [public_stream.id],
-            "altdata": {"some_key": "some_value"},
-        },
-        token=upload_data_token_no_groups,
+    client(upload_data_token_no_groups).post_photometry(
+        PhotometryPost(
+            obj_id=str(public_source.id),
+            mjd=58000.0,
+            instrument_id=ztf_camera.id,
+            flux=12.24,
+            fluxerr=0.031,
+            zp=25.0,
+            magsys="ab",
+            filter="ztfg",
+            stream_ids=[public_stream.id],
+            altdata={"some_key": "some_value"},
+        )
     )
-    assert status == 200
-    assert data["status"] == "success"
 
     # this token doesn't have sufficient stream access to add to stream2
-    status, data = api(
-        "PUT",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 58001.0,
-            "instrument_id": ztf_camera.id,
-            "flux": 13.24,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "stream_ids": [public_stream2.id],
-            "altdata": {"some_key": "some_value"},
-        },
-        token=upload_data_token_no_groups_no_streams,
-    )
-    assert status == 400
-    assert data["status"] == "error"
+    with pytest.raises(SkyPortalError) as err:
+        client(upload_data_token_no_groups_no_streams).upsert_photometry(
+            PhotometryPost(
+                obj_id=str(public_source.id),
+                mjd=58001.0,
+                instrument_id=ztf_camera.id,
+                flux=13.24,
+                fluxerr=0.031,
+                zp=25.0,
+                magsys="ab",
+                filter="ztfg",
+                stream_ids=[public_stream2.id],
+                altdata={"some_key": "some_value"},
+            )
+        )
+    assert err.value.status_code == 400
 
     # this token doesn't have sufficient stream access to create a StreamPhotometry row
-    status, data = api(
-        "PUT",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 58001.0,
-            "instrument_id": ztf_camera.id,
-            "flux": 13.24,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "stream_ids": [public_stream2.id],
-            "altdata": {"some_key": "some_value"},
-        },
-        token=upload_data_token_no_groups,
-    )
-    assert status == 400
-    assert data["status"] == "error"
+    with pytest.raises(SkyPortalError) as err:
+        client(upload_data_token_no_groups).upsert_photometry(
+            PhotometryPost(
+                obj_id=str(public_source.id),
+                mjd=58001.0,
+                instrument_id=ztf_camera.id,
+                flux=13.24,
+                fluxerr=0.031,
+                zp=25.0,
+                magsys="ab",
+                filter="ztfg",
+                stream_ids=[public_stream2.id],
+                altdata={"some_key": "some_value"},
+            )
+        )
+    assert err.value.status_code == 400
 
     # this token does have sufficient stream access to add to stream2
-    status, data = api(
-        "PUT",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 58001.0,
-            "instrument_id": ztf_camera.id,
-            "flux": 13.24,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "stream_ids": [public_stream2.id],
-            "altdata": {"some_key": "some_value"},
-        },
-        token=upload_data_token_stream2,
+    client(upload_data_token_stream2).upsert_photometry(
+        PhotometryPost(
+            obj_id=str(public_source.id),
+            mjd=58001.0,
+            instrument_id=ztf_camera.id,
+            flux=13.24,
+            fluxerr=0.031,
+            zp=25.0,
+            magsys="ab",
+            filter="ztfg",
+            stream_ids=[public_stream2.id],
+            altdata={"some_key": "some_value"},
+        )
     )
-    assert status == 200
-    assert data["status"] == "success"
 
 
 def test_photometry_stream_patch_access(
@@ -3075,333 +2584,241 @@ def test_photometry_stream_patch_access(
     ztf_camera,
 ):
     # this token has sufficient stream access to create a StreamPhotometry row
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 58000.0,
-            "instrument_id": ztf_camera.id,
-            "flux": 12.24,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "stream_ids": [public_stream.id],
-            "altdata": {"some_key": "some_value"},
-        },
-        token=upload_data_token_no_groups_two_streams,
+    phot_id = (
+        client(upload_data_token_no_groups_two_streams)
+        .post_photometry(
+            PhotometryPost(
+                obj_id=str(public_source.id),
+                mjd=58000.0,
+                instrument_id=ztf_camera.id,
+                flux=12.24,
+                fluxerr=0.031,
+                zp=25.0,
+                magsys="ab",
+                filter="ztfg",
+                stream_ids=[public_stream.id],
+                altdata={"some_key": "some_value"},
+            )
+        )
+        .ids[0]
     )
-    assert status == 200
-    assert data["status"] == "success"
-    phot_id = data["data"]["ids"][0]
 
     # this token doesn't have sufficient stream access to add to stream2
-    status, data = api(
-        "PATCH",
-        f"photometry/{phot_id}",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 58001.0,
-            "instrument_id": ztf_camera.id,
-            "flux": 13.24,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "stream_ids": [public_stream2.id],
-            "altdata": {"some_key": "some_value"},
-        },
-        token=upload_data_token_no_groups_no_streams,
-    )
-    assert status == 400
-    assert data["status"] == "error"
+    with pytest.raises(SkyPortalError) as err:
+        client(upload_data_token_no_groups_no_streams).update_photometry(
+            phot_id,
+            PhotometryUpdate(
+                obj_id=str(public_source.id),
+                mjd=58001.0,
+                instrument_id=ztf_camera.id,
+                flux=13.24,
+                fluxerr=0.031,
+                zp=25.0,
+                magsys="ab",
+                filter="ztfg",
+                stream_ids=[public_stream2.id],
+                altdata={"some_key": "some_value"},
+            ),
+        )
+    assert err.value.status_code == 400
 
     # this token doesn't have sufficient stream access to create a StreamPhotometry row
-    status, data = api(
-        "PATCH",
-        f"photometry/{phot_id}",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 58001.0,
-            "instrument_id": ztf_camera.id,
-            "flux": 13.24,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "stream_ids": [public_stream2.id],
-            "altdata": {"some_key": "some_value"},
-        },
-        token=upload_data_token_no_groups,
-    )
-    assert status == 400
-    assert data["status"] == "error"
+    with pytest.raises(SkyPortalError) as err:
+        client(upload_data_token_no_groups).update_photometry(
+            phot_id,
+            PhotometryUpdate(
+                obj_id=str(public_source.id),
+                mjd=58001.0,
+                instrument_id=ztf_camera.id,
+                flux=13.24,
+                fluxerr=0.031,
+                zp=25.0,
+                magsys="ab",
+                filter="ztfg",
+                stream_ids=[public_stream2.id],
+                altdata={"some_key": "some_value"},
+            ),
+        )
+    assert err.value.status_code == 400
 
     # this token does have sufficient stream access to add to stream2
-    status, data = api(
-        "PATCH",
-        f"photometry/{phot_id}",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 58001.0,
-            "instrument_id": ztf_camera.id,
-            "flux": 13.24,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "stream_ids": [public_stream2.id],
-            "altdata": {"some_key": "some_value"},
-        },
-        token=upload_data_token_no_groups_two_streams,
+    client(upload_data_token_no_groups_two_streams).update_photometry(
+        phot_id,
+        PhotometryUpdate(
+            obj_id=str(public_source.id),
+            mjd=58001.0,
+            instrument_id=ztf_camera.id,
+            flux=13.24,
+            fluxerr=0.031,
+            zp=25.0,
+            magsys="ab",
+            filter="ztfg",
+            stream_ids=[public_stream2.id],
+            altdata={"some_key": "some_value"},
+        ),
     )
-    assert status == 200
-    assert data["status"] == "success"
 
 
 def test_token_user_delete_object_photometry(
     super_admin_token, upload_data_token, view_only_token, ztf_camera, public_group
 ):
     obj_id = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id,
-            "ra": 234.22,
-            "dec": -22.33,
-            "redshift": 3,
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    client(upload_data_token).post_source(
+        SourcePost(
+            id=obj_id,
+            ra=234.22,
+            dec=-22.33,
+            redshift=3,
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
 
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": obj_id,
-            "mjd": 58000.0,
-            "instrument_id": ztf_camera.id,
-            "mag": None,
-            "magerr": None,
-            "limiting_mag": 22.3,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    client(upload_data_token).post_photometry(
+        PhotometryPost(
+            obj_id=obj_id,
+            mjd=58000.0,
+            instrument_id=ztf_camera.id,
+            limiting_mag=22.3,
+            magsys="ab",
+            filter="ztfg",
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
-    assert data["status"] == "success"
 
-    status, data = api(
-        "GET",
-        f"sources/{obj_id}/photometry",
-        token=view_only_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]) > 0
+    points = client(view_only_token).fetch_photometry(obj_id)
+    assert len(points) > 0
 
-    status, data = api(
-        "DELETE",
-        f"sources/{obj_id}/photometry",
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    client(super_admin_token).delete_source_photometry(obj_id)
 
-    status, data = api(
-        "GET",
-        f"sources/{obj_id}/photometry",
-        token=view_only_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]) == 0
+    points = client(view_only_token).fetch_photometry(obj_id)
+    assert len(points) == 0
 
 
 def test_photometry_validation(
     super_admin_token, upload_data_token, view_only_token, ztf_camera, public_group
 ):
     obj_id = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id,
-            "ra": 234.22,
-            "dec": -22.33,
-            "redshift": 3,
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    client(upload_data_token).post_source(
+        SourcePost(
+            id=obj_id,
+            ra=234.22,
+            dec=-22.33,
+            redshift=3,
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
 
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": obj_id,
-            "mjd": 58000.0,
-            "instrument_id": ztf_camera.id,
-            "mag": None,
-            "magerr": None,
-            "limiting_mag": 22.3,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    photometry_id = (
+        client(upload_data_token)
+        .post_photometry(
+            PhotometryPost(
+                obj_id=obj_id,
+                mjd=58000.0,
+                instrument_id=ztf_camera.id,
+                limiting_mag=22.3,
+                magsys="ab",
+                filter="ztfg",
+                group_ids=[public_group.id],
+            )
+        )
+        .ids[0]
     )
-    assert status == 200
-    assert data["status"] == "success"
-    photometry_id = data["data"]["ids"][0]
 
     # insufficient access, should fail
-    status, data = api(
-        "POST",
-        f"photometry/{photometry_id}/validation",
-        data={
-            "validated": True,
-            "explanation": "GOOD SUBTRACTION",
-            "notes": "beautiful image",
-        },
-        token=view_only_token,
-    )
-    assert status == 401
-    assert data["status"] == "error"
+    with pytest.raises(SkyPortalError) as err:
+        client(view_only_token).post_photometry_validation(
+            photometry_id,
+            validated=True,
+            explanation="GOOD SUBTRACTION",
+            notes="beautiful image",
+        )
+    assert err.value.status_code == 401
 
-    status, data = api(
-        "POST",
-        f"photometry/{photometry_id}/validation",
-        data={
-            "validated": True,
-            "explanation": "GOOD SUBTRACTION",
-            "notes": "beautiful image",
-        },
-        token=super_admin_token,
+    client(super_admin_token).post_photometry_validation(
+        photometry_id,
+        validated=True,
+        explanation="GOOD SUBTRACTION",
+        notes="beautiful image",
     )
-    assert status == 200
-    assert data["status"] == "success"
 
-    status, data = api(
-        "GET",
-        f"sources/{obj_id}/photometry",
-        token=view_only_token,
-        params={"includeValidationInfo": True},
+    points = client(view_only_token).fetch_photometry(
+        obj_id, include_validation_info=True
     )
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]) > 0
-    assert len(data["data"][0]["validations"]) > 0
-    assert data["data"][0]["validations"][0]["explanation"] == "GOOD SUBTRACTION"
-    assert data["data"][0]["validations"][0]["notes"] == "beautiful image"
-    assert data["data"][0]["validations"][0]["validated"] is True
+    assert len(points) > 0
+    assert len(points[0].validations) > 0
+    assert points[0].validations[0].explanation == "GOOD SUBTRACTION"
+    assert points[0].validations[0].notes == "beautiful image"
+    assert points[0].validations[0].validated is True
 
-    status, data = api(
-        "PATCH",
-        f"photometry/{photometry_id}/validation",
-        data={
-            "validated": False,
-            "explanation": "BAD SUBTRACTION",
-            "notes": "ugly image",
-        },
-        token=super_admin_token,
+    client(super_admin_token).update_photometry_validation(
+        photometry_id,
+        validated=False,
+        explanation="BAD SUBTRACTION",
+        notes="ugly image",
     )
-    assert status == 200
-    assert data["status"] == "success"
 
-    status, data = api(
-        "GET",
-        f"sources/{obj_id}/photometry",
-        token=view_only_token,
-        params={"includeValidationInfo": True},
+    points = client(view_only_token).fetch_photometry(
+        obj_id, include_validation_info=True
     )
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]) > 0
-    assert len(data["data"][0]["validations"]) > 0
-    assert data["data"][0]["validations"][0]["explanation"] == "BAD SUBTRACTION"
-    assert data["data"][0]["validations"][0]["notes"] == "ugly image"
-    assert data["data"][0]["validations"][0]["validated"] is False
+    assert len(points) > 0
+    assert len(points[0].validations) > 0
+    assert points[0].validations[0].explanation == "BAD SUBTRACTION"
+    assert points[0].validations[0].notes == "ugly image"
+    assert points[0].validations[0].validated is False
 
-    status, data = api(
-        "DELETE",
-        f"photometry/{photometry_id}/validation",
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    client(super_admin_token).delete_photometry_validation(photometry_id)
 
-    status, data = api(
-        "GET",
-        f"sources/{obj_id}/photometry",
-        token=view_only_token,
-        params={"includeValidationInfo": True},
+    points = client(view_only_token).fetch_photometry(
+        obj_id, include_validation_info=True
     )
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]) > 0
-    assert len(data["data"][0]["validations"]) == 0
+    assert len(points) > 0
+    assert len(points[0].validations) == 0
 
 
 def test_post_external_photometry(
     upload_data_token, super_admin_token, super_admin_user, public_group
 ):
     obj_id = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id,
-            "ra": 234.22,
-            "dec": -22.33,
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    source = client(upload_data_token).post_source(
+        SourcePost(
+            id=obj_id,
+            ra=234.22,
+            dec=-22.33,
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
-    assert data["data"]["id"] == obj_id
+    assert source.id == obj_id
 
     name = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "telescope",
-        data={
-            "name": name,
-            "nickname": name,
-            "lat": 0.0,
-            "lon": 0.0,
-            "elevation": 0.0,
-            "diameter": 10.0,
-        },
-        token=super_admin_token,
+    telescope_id = (
+        client(super_admin_token)
+        .post_telescope(
+            TelescopePost(
+                name=name,
+                nickname=name,
+                lat=0.0,
+                lon=0.0,
+                elevation=0.0,
+                diameter=10.0,
+            )
+        )
+        .id
     )
-    assert status == 200
-    assert data["status"] == "success"
-    telescope_id = data["data"]["id"]
 
     instrument_name = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "instrument",
-        data={
-            "name": instrument_name,
-            "type": "imager",
-            "band": "NIR",
-            "filters": ["atlaso", "atlasc"],
-            "telescope_id": telescope_id,
-        },
-        token=super_admin_token,
+    instrument_id = (
+        client(super_admin_token)
+        .post_instrument(
+            InstrumentPost(
+                name=instrument_name,
+                type="imager",
+                band="NIR",
+                filters=["atlaso", "atlasc"],
+                telescope_id=telescope_id,
+            )
+        )
+        .id
     )
-    assert status == 200
-    assert data["status"] == "success"
-    instrument_id = data["data"]["id"]
 
     datafile = f"{os.path.dirname(__file__)}/../../data/ZTFrlh6cyjh_ATLAS.csv"
     df = pd.read_csv(datafile)
@@ -3422,42 +2839,33 @@ def test_post_external_photometry(
     asyncio.run(_call())
 
     # Check the photometry sent back with the source
-    status, data = api(
-        "GET",
-        f"sources/{obj_id}",
-        params={"includePhotometry": "true"},
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert len(data["data"]["photometry"]) == 384
+    fetched = client(super_admin_token).fetch_source(obj_id, include_photometry=True)
+    assert len(fetched.photometry) == 384
 
-    assert all(p["obj_id"] == obj_id for p in data["data"]["photometry"])
-    assert all(p["instrument_id"] == instrument_id for p in data["data"]["photometry"])
+    assert all(p.obj_id == obj_id for p in fetched.photometry)
+    assert all(p.instrument_id == instrument_id for p in fetched.photometry)
 
 
 def test_token_user_big_post(
     upload_data_token, public_source, ztf_camera, public_group
 ):
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": [58000 + i for i in range(30000)],
-            "instrument_id": ztf_camera.id,
-            "mag": np.random.uniform(low=18, high=22, size=30000).tolist(),
-            "magerr": np.random.uniform(low=0.1, high=0.3, size=30000).tolist(),
-            "limiting_mag": 22.3,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
-    )
-    assert status == 400
-    assert data["status"] == "error"
+    with pytest.raises(SkyPortalError) as err:
+        client(upload_data_token).post_photometry(
+            PhotometryPost(
+                obj_id=str(public_source.id),
+                mjd=[58000 + i for i in range(30000)],
+                instrument_id=ztf_camera.id,
+                mag=np.random.uniform(low=18, high=22, size=30000).tolist(),
+                magerr=np.random.uniform(low=0.1, high=0.3, size=30000).tolist(),
+                limiting_mag=22.3,
+                magsys="ab",
+                filter="ztfg",
+                group_ids=[public_group.id],
+            )
+        )
+    assert err.value.status_code == 400
     assert (
-        data["message"]
+        str(err.value)
         == "Maximum number of photometry rows to post exceeded: 30000 > 10000. Please break up the data into smaller sets and try again"
     )
 
@@ -3585,6 +2993,6 @@ def test_bulk_upsert_photometry_update_mode(public_source, ztf_camera, user):
 def test_get_photometry_without_id_returns_error(upload_data_token):
     # A bare GET /api/photometry (id is optional in the route, shared with POST)
     # must return a clean error, not crash with a TypeError.
+    # raw api: intentionally malformed request the typed client can't produce
     status, data = api("GET", "photometry", token=upload_data_token)
     assert status == 400
-    assert "photometry_id" in data["message"]

--- a/skyportal/tests/api_tests/photometry_followup/test_photometry.py
+++ b/skyportal/tests/api_tests/photometry_followup/test_photometry.py
@@ -1640,7 +1640,7 @@ def test_token_user_retrieving_source_photometry_and_convert(
 def test_source_photometry_format_plot_is_slim(view_only_token, public_source):
     """``format=plot`` must return only the lightcurve-plotter fields and
     match the magnitudes that ``format=mag`` produces."""
-    # skyportal-py gap: typed models cannot expose raw JSON keys (format=plot key-set check)
+    # raw api: raw-JSON key-set assertion (format=plot) the typed model would mask
     status, plot_resp = api(
         "GET",
         f"sources/{public_source.id}/photometry?format=plot&magsys=ab",

--- a/skyportal/tests/api_tests/photometry_followup/test_photometry_concurrency.py
+++ b/skyportal/tests/api_tests/photometry_followup/test_photometry_concurrency.py
@@ -12,7 +12,7 @@ deliberately have N HTTP clients race on the *same* dedup tuple
 ON-CONFLICT DO NOTHING / DO UPDATE paths actually fire under contention.
 
 Concurrency is provided by `concurrent.futures.ThreadPoolExecutor`
-calling the test client's `api(...)` helper. The test server is the
+calling the typed skyportal-py client. The test server is the
 same single-process tornado supervisor the rest of the suite uses, so
 "concurrent" here means multiple HTTP requests in flight against the
 same backend at the same time.
@@ -21,19 +21,29 @@ same backend at the same time.
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 
-from skyportal.tests import api
+from skyportal_py import SkyPortalError
+from skyportal_py.photometry import PhotometryPost
+from skyportal_py.sources import SourcePost
+
+from skyportal.tests import client
 
 N_WORKERS = 8
 
 
 def _post_photometry(token, payload):
-    """Single POST call returning (status, response_json)."""
-    return api("POST", "photometry", data=payload, token=token)
+    """Single POST call returning (status, response-or-error)."""
+    try:
+        return 200, client(token).post_photometry(payload)
+    except SkyPortalError as err:
+        return err.status_code, err
 
 
 def _put_photometry(token, payload):
-    """Single PUT call returning (status, response_json)."""
-    return api("PUT", "photometry", data=payload, token=token)
+    """Single PUT call returning (status, response-or-error)."""
+    try:
+        return 200, client(token).upsert_photometry(payload)
+    except SkyPortalError as err:
+        return err.status_code, err
 
 
 def test_concurrent_post_identical_dedup_key(
@@ -51,20 +61,20 @@ def test_concurrent_post_identical_dedup_key(
       mode is the default).
     - No worker sees a 500 (no IntegrityError leaks through).
     """
-    payload = {
-        "obj_id": str(public_source.id),
-        "instrument_id": ztf_camera.id,
-        "mjd": [59500.0],
-        "mag": [19.5],
-        "magerr": [0.05],
-        "limiting_mag": [21.0],
-        "magsys": ["ab"],
-        "filter": ["ztfr"],
-        "ra": [42.0],
-        "dec": [-22.0],
-        "origin": [f"concurrency-test-{uuid.uuid4()}"],
-        "group_ids": [public_group.id],
-    }
+    payload = PhotometryPost(
+        obj_id=str(public_source.id),
+        instrument_id=ztf_camera.id,
+        mjd=[59500.0],
+        mag=[19.5],
+        magerr=[0.05],
+        limiting_mag=[21.0],
+        magsys=["ab"],
+        filter=["ztfr"],
+        ra=[42.0],
+        dec=[-22.0],
+        origin=[f"concurrency-test-{uuid.uuid4()}"],
+        group_ids=[public_group.id],
+    )
 
     with ThreadPoolExecutor(max_workers=N_WORKERS) as pool:
         futures = [
@@ -98,18 +108,10 @@ def test_concurrent_post_identical_dedup_key(
         ), f"unexpected 400 body: {err}"
 
     # End state: exactly one photometry row for this origin tag exists.
-    status, get_data = api(
-        "GET",
-        f"sources/{public_source.id}",
-        params={"includePhotometry": "true"},
-        token=upload_data_token,
+    source = client(upload_data_token).fetch_source(
+        str(public_source.id), include_photometry=True
     )
-    assert status == 200
-    matching = [
-        p
-        for p in get_data["data"]["photometry"]
-        if p.get("origin") == payload["origin"][0]
-    ]
+    matching = [p for p in source.photometry if p.origin == payload.origin[0]]
     assert len(matching) == 1, (
         f"expected exactly 1 row for this origin, found {len(matching)}"
     )
@@ -150,34 +152,35 @@ def test_concurrent_put_ignore_flux_overwrite_flux(
     mjd = 59600.0
 
     # Seed: create the row that the concurrent PUTs will then update.
-    seed_payload = {
-        "obj_id": str(public_source.id),
-        "instrument_id": ztf_camera.id,
-        "mjd": [mjd],
-        "mag": [19.0],
-        "magerr": [0.05],
-        "limiting_mag": [21.0],
-        "magsys": ["ab"],
-        "filter": ["ztfr"],
-        "ra": [42.0],
-        "dec": [-22.0],
-        "origin": [origin],
-        "group_ids": [public_group.id],
-    }
-    status, data = api("POST", "photometry", data=seed_payload, token=upload_data_token)
-    assert status == 200, f"seed POST failed: {data}"
+    seed_payload = PhotometryPost(
+        obj_id=str(public_source.id),
+        instrument_id=ztf_camera.id,
+        mjd=[mjd],
+        mag=[19.0],
+        magerr=[0.05],
+        limiting_mag=[21.0],
+        magsys=["ab"],
+        filter=["ztfr"],
+        ra=[42.0],
+        dec=[-22.0],
+        origin=[origin],
+        group_ids=[public_group.id],
+    )
+    client(upload_data_token).post_photometry(seed_payload)
 
     # Each worker submits a distinct mag at the same (mjd, filter, origin).
     mags_in = [20.0 + 0.1 * i for i in range(N_WORKERS)]
 
+    sp_admin = client(super_admin_token)
+
     def _put_with_mag(mag):
-        payload = {**seed_payload, "mag": [mag]}
-        return api(
-            "PUT",
-            "photometry?duplicate_ignore_flux=True&overwrite_flux=True",
-            data=payload,
-            token=super_admin_token,
-        )
+        payload = seed_payload.model_copy(update={"mag": [mag]})
+        try:
+            return 200, sp_admin.upsert_photometry(
+                payload, duplicate_ignore_flux=True, overwrite_flux=True
+            )
+        except SkyPortalError as err:
+            return err.status_code, err
 
     with ThreadPoolExecutor(max_workers=N_WORKERS) as pool:
         results = list(pool.map(_put_with_mag, mags_in))
@@ -189,20 +192,16 @@ def test_concurrent_put_ignore_flux_overwrite_flux(
         f"sample error body: {errors[0] if errors else None}"
     )
 
-    status, get_data = api(
-        "GET",
-        f"sources/{public_source.id}",
-        params={"includePhotometry": "true"},
-        token=upload_data_token,
+    source = client(upload_data_token).fetch_source(
+        str(public_source.id), include_photometry=True
     )
-    assert status == 200
-    matching = [p for p in get_data["data"]["photometry"] if p.get("origin") == origin]
+    matching = [p for p in source.photometry if p.origin == origin]
     assert len(matching) == 1, (
         f"expected exactly 1 row for this origin after concurrent "
         f"ignore_flux+overwrite_flux PUTs, found {len(matching)} "
         "(dedup pre-check race?)"
     )
-    final_mag = matching[0]["mag"]
+    final_mag = matching[0].mag
     # The final mag must be one of the submitted values (a real winner
     # of the race), not the seed mag (which would mean ALL updates were
     # lost) and not something corrupt.
@@ -228,21 +227,21 @@ def test_concurrent_post_disjoint_keys(
     base_mjd = 59700.0
 
     def _post_at_offset(i):
-        payload = {
-            "obj_id": str(public_source.id),
-            "instrument_id": ztf_camera.id,
-            "mjd": [base_mjd + i],
-            "mag": [19.5],
-            "magerr": [0.05],
-            "limiting_mag": [21.0],
-            "magsys": ["ab"],
-            "filter": ["ztfr"],
-            "ra": [42.0],
-            "dec": [-22.0],
-            "origin": [f"disjoint-{uuid.uuid4()}"],
-            "group_ids": [public_group.id],
-        }
-        return api("POST", "photometry", data=payload, token=upload_data_token)
+        payload = PhotometryPost(
+            obj_id=str(public_source.id),
+            instrument_id=ztf_camera.id,
+            mjd=[base_mjd + i],
+            mag=[19.5],
+            magerr=[0.05],
+            limiting_mag=[21.0],
+            magsys=["ab"],
+            filter=["ztfr"],
+            ra=[42.0],
+            dec=[-22.0],
+            origin=[f"disjoint-{uuid.uuid4()}"],
+            group_ids=[public_group.id],
+        )
+        return _post_photometry(upload_data_token, payload)
 
     with ThreadPoolExecutor(max_workers=N_WORKERS) as pool:
         results = list(pool.map(_post_at_offset, range(N_WORKERS)))
@@ -252,7 +251,7 @@ def test_concurrent_post_disjoint_keys(
         f"disjoint POSTs should all succeed, got: {statuses}"
     )
 
-    inserted_ids = {data["data"]["ids"][0] for _, data in results}
+    inserted_ids = {data.ids[0] for _, data in results}
     assert len(inserted_ids) == N_WORKERS, (
         f"expected {N_WORKERS} distinct row IDs, got {len(inserted_ids)} "
         "(some inserts may have collided)"
@@ -272,18 +271,14 @@ def test_concurrent_posts_phot_stat_no_double_count(
     object's very first PhotStat row.
     """
     source_id = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": source_id,
-            "ra": 12.3,
-            "dec": -4.5,
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    client(upload_data_token).post_source(
+        SourcePost(
+            id=source_id,
+            ra=12.3,
+            dec=-4.5,
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200, data
 
     base_mjds = [59700.0 + i for i in range(10)]  # shared across workers -> collisions
     n_unique = 5
@@ -292,18 +287,18 @@ def test_concurrent_posts_phot_stat_no_double_count(
         unique = [59800.0 + worker * 100 + i for i in range(n_unique)]
         mjds = base_mjds + unique
         n = len(mjds)
-        payload = {
-            "obj_id": source_id,
-            "instrument_id": ztf_camera.id,
-            "mjd": mjds,
-            "mag": [19.0] * n,
-            "magerr": [0.05] * n,
-            "limiting_mag": [21.0] * n,
-            "magsys": ["ab"] * n,
-            "filter": ["ztfr"] * n,
-            "origin": ["concurrency-photstat"] * n,
-            "group_ids": [public_group.id],
-        }
+        payload = PhotometryPost(
+            obj_id=source_id,
+            instrument_id=ztf_camera.id,
+            mjd=mjds,
+            mag=[19.0] * n,
+            magerr=[0.05] * n,
+            limiting_mag=[21.0] * n,
+            magsys=["ab"] * n,
+            filter=["ztfr"] * n,
+            origin=["concurrency-photstat"] * n,
+            group_ids=[public_group.id],
+        )
         return _put_photometry(upload_data_token, payload)
 
     with ThreadPoolExecutor(max_workers=N_WORKERS) as executor:
@@ -313,17 +308,13 @@ def test_concurrent_posts_phot_stat_no_double_count(
 
     expected = len(base_mjds) + N_WORKERS * n_unique
 
-    status, data = api(
-        "GET", f"sources/{source_id}/photometry", token=upload_data_token
-    )
-    assert status == 200
-    assert len(data["data"]) == expected, (
-        f"expected {expected} distinct photometry rows, got {len(data['data'])}"
+    points = client(upload_data_token).fetch_photometry(source_id)
+    assert len(points) == expected, (
+        f"expected {expected} distinct photometry rows, got {len(points)}"
     )
 
-    status, data = api("GET", f"sources/{source_id}/phot_stat", token=upload_data_token)
-    assert status == 200
-    assert data["data"]["num_obs_global"] == expected, (
-        f"PhotStat num_obs_global={data['data']['num_obs_global']} != distinct "
+    phot_stat = client(upload_data_token).fetch_source_phot_stat(source_id)
+    assert phot_stat.num_obs_global == expected, (
+        f"PhotStat num_obs_global={phot_stat.num_obs_global} != distinct "
         f"photometry count {expected} (double-count or loss under concurrency)"
     )

--- a/skyportal/tests/api_tests/photometry_followup/test_public_release.py
+++ b/skyportal/tests/api_tests/photometry_followup/test_public_release.py
@@ -1,21 +1,29 @@
 import time
 import uuid
 
-from skyportal.tests import api, assert_api, assert_api_fail
+import pytest
+from skyportal_py import SkyPortalError
+from skyportal_py.public_pages import PublicReleasePost, PublicReleaseUpdate
+from skyportal_py.source_groups import SourceGroupsPost
+from skyportal_py.sources import SourcePost
+
+from skyportal.tests import api, assert_api, assert_api_fail, client
 
 
 def test_create_release(
     view_only_token, manage_sources_token, public_source, public_group
 ):
+    sp = client(manage_sources_token)
     link_name = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "public_pages/release",
-        data={},
-        token=view_only_token,
-    )
-    assert_api_fail(status, data, 401, "HTTP 401: Unauthorized")
+    with pytest.raises(SkyPortalError, match="HTTP 401: Unauthorized") as err:
+        client(view_only_token).post_public_release(
+            PublicReleasePost(
+                name="Name", link_name=link_name, group_ids=[public_group.id]
+            )
+        )
+    assert err.value.status_code == 401
 
+    # raw api: intentionally malformed payload the typed client can't produce
     status, data = api(
         "POST",
         "public_pages/release",
@@ -24,6 +32,7 @@ def test_create_release(
     )
     assert_api_fail(status, data, 400, "No data provided")
 
+    # raw api: intentionally malformed payload the typed client can't produce
     status, data = api(
         "POST",
         "public_pages/release",
@@ -32,6 +41,7 @@ def test_create_release(
     )
     assert_api_fail(status, data, 400, "Name is required")
 
+    # raw api: intentionally malformed payload the typed client can't produce
     status, data = api(
         "POST",
         "public_pages/release",
@@ -40,6 +50,7 @@ def test_create_release(
     )
     assert_api_fail(status, data, 400, "Link name is required")
 
+    # raw api: intentionally malformed payload the typed client can't produce
     status, data = api(
         "POST",
         "public_pages/release",
@@ -48,102 +59,81 @@ def test_create_release(
     )
     assert_api_fail(status, data, 400, "Specify at least one group")
 
-    status, data = api(
-        "POST",
-        "public_pages/release",
-        data={"name": "Name", "link_name": "Link name", "group_ids": []},
-        token=manage_sources_token,
-    )
-    assert_api_fail(status, data, 400, "Specify at least one group")
+    with pytest.raises(SkyPortalError, match="Specify at least one group") as err:
+        sp.post_public_release(
+            PublicReleasePost(name="Name", link_name="Link name", group_ids=[])
+        )
+    assert err.value.status_code == 400
 
     error_validation_link_name = (
         "Link name must contain only alphanumeric characters, dashes, underscores, periods, "
         "or plus signs"
     )
-    status, data = api(
-        "POST",
-        "public_pages/release",
-        data={"name": "Name", "link_name": "Link name", "group_ids": [0]},
-        token=manage_sources_token,
-    )
-    assert_api_fail(status, data, 400, error_validation_link_name)
+    with pytest.raises(SkyPortalError, match=error_validation_link_name) as err:
+        sp.post_public_release(
+            PublicReleasePost(name="Name", link_name="Link name", group_ids=[0])
+        )
+    assert err.value.status_code == 400
 
-    status, data = api(
-        "POST",
-        "public_pages/release",
-        data={"name": "Name", "link_name": "Link_name_é", "group_ids": [0]},
-        token=manage_sources_token,
-    )
-    assert_api_fail(status, data, 400, error_validation_link_name)
+    with pytest.raises(SkyPortalError, match=error_validation_link_name) as err:
+        sp.post_public_release(
+            PublicReleasePost(name="Name", link_name="Link_name_é", group_ids=[0])
+        )
+    assert err.value.status_code == 400
 
-    status, data = api(
-        "POST",
-        "public_pages/release",
-        data={"name": "Name", "link_name": "Aa0_Zz9-.+", "group_ids": [0]},
-        token=manage_sources_token,
-    )
-    assert_api_fail(status, data, 400)
-    assert data["message"] != error_validation_link_name
-    assert data["message"] == "Invalid groups"
+    with pytest.raises(SkyPortalError) as err:
+        sp.post_public_release(
+            PublicReleasePost(name="Name", link_name="Aa0_Zz9-.+", group_ids=[0])
+        )
+    assert err.value.status_code == 400
+    assert str(err.value) != error_validation_link_name
+    assert str(err.value) == "Invalid groups"
 
-    status, data = api(
-        "POST",
-        "public_pages/release",
-        data={
-            "name": "Name",
-            "link_name": link_name,
-            "group_ids": [public_group.id],
-        },
-        token=manage_sources_token,
-    )
-    assert_api(status, data)
-    release_id = data["data"]["id"]
+    release_id = sp.post_public_release(
+        PublicReleasePost(
+            name="Name",
+            link_name=link_name,
+            group_ids=[public_group.id],
+        )
+    ).id
 
-    status, data = api("GET", "public_pages/release", token=manage_sources_token)
-    assert_api(status, data)
-    release = next(r for r in data["data"] if r["id"] == release_id)
-    assert release["is_visible"] is True
-    assert release["auto_publish_enabled"] is False
-    assert release["group_ids"] == [public_group.id]
+    releases = sp.fetch_public_releases()
+    release = next(r for r in releases if r.id == release_id)
+    assert release.is_visible is True
+    assert release.auto_publish_enabled is False
+    assert release.group_ids == [public_group.id]
 
-    status, data = api(
-        "POST",
-        "public_pages/release",
-        data={
-            "name": "Name",
-            "link_name": link_name,
-            "group_ids": [public_group.id],
-        },
-        token=manage_sources_token,
-    )
-    assert_api_fail(status, data, 400, "This link name is already in use")
+    with pytest.raises(SkyPortalError, match="This link name is already in use") as err:
+        sp.post_public_release(
+            PublicReleasePost(
+                name="Name",
+                link_name=link_name,
+                group_ids=[public_group.id],
+            )
+        )
+    assert err.value.status_code == 400
 
 
 def test_update_release(
     view_only_token, manage_sources_token, public_source, public_group
 ):
+    sp = client(manage_sources_token)
     link_name = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "public_pages/release",
-        data={
-            "name": "Name",
-            "link_name": link_name,
-            "group_ids": [public_group.id],
-        },
-        token=manage_sources_token,
-    )
-    assert_api(status, data)
-    release_id = data["data"]["id"]
+    release_id = sp.post_public_release(
+        PublicReleasePost(
+            name="Name",
+            link_name=link_name,
+            group_ids=[public_group.id],
+        )
+    ).id
 
-    status, data = api(
-        "PATCH",
-        f"public_pages/release/{release_id}",
-        data={},
-        token=view_only_token,
-    )
-    assert_api_fail(status, data, 401, "HTTP 401: Unauthorized")
+    with pytest.raises(SkyPortalError, match="HTTP 401: Unauthorized") as err:
+        client(view_only_token).update_public_release(
+            release_id, PublicReleaseUpdate(name="Name", group_ids=[public_group.id])
+        )
+    assert err.value.status_code == 401
 
+    # raw api: intentionally malformed payload the typed client can't produce
     status, data = api(
         "PATCH",
         f"public_pages/release/{release_id}",
@@ -152,6 +142,7 @@ def test_update_release(
     )
     assert_api_fail(status, data, 400, "No data provided")
 
+    # raw api: intentionally malformed payload the typed client can't produce
     status, data = api(
         "PATCH",
         f"public_pages/release/{release_id}",
@@ -160,6 +151,7 @@ def test_update_release(
     )
     assert_api_fail(status, data, 400, "Name is required")
 
+    # raw api: intentionally malformed payload the typed client can't produce
     status, data = api(
         "PATCH",
         f"public_pages/release/{release_id}",
@@ -168,48 +160,40 @@ def test_update_release(
     )
     assert_api_fail(status, data, 400, "Specify at least one group")
 
-    status, data = api(
-        "PATCH",
-        f"public_pages/release/{release_id}",
-        data={"name": "Name", "group_ids": []},
-        token=manage_sources_token,
+    with pytest.raises(SkyPortalError, match="Specify at least one group") as err:
+        sp.update_public_release(
+            release_id, PublicReleaseUpdate(name="Name", group_ids=[])
+        )
+    assert err.value.status_code == 400
+
+    with pytest.raises(SkyPortalError, match="Invalid groups") as err:
+        sp.update_public_release(
+            release_id, PublicReleaseUpdate(name="Name", group_ids=[0])
+        )
+    assert err.value.status_code == 400
+
+    releases = sp.fetch_public_releases()
+    release = next(r for r in releases if r.id == release_id)
+    assert release.is_visible is True
+    assert release.auto_publish_enabled is False
+
+    sp.update_public_release(
+        release_id,
+        PublicReleaseUpdate(
+            name="Name",
+            group_ids=[public_group.id],
+            is_visible=False,
+            auto_publish_enabled=True,
+        ),
     )
-    assert_api_fail(status, data, 400, "Specify at least one group")
 
-    status, data = api(
-        "PATCH",
-        f"public_pages/release/{release_id}",
-        data={"name": "Name", "group_ids": [0]},
-        token=manage_sources_token,
-    )
-    assert_api_fail(status, data, 400, "Invalid groups")
+    releases = sp.fetch_public_releases()
+    release = next(r for r in releases if r.id == release_id)
+    assert release.is_visible is False
+    assert release.auto_publish_enabled is True
+    assert release.link_name == link_name
 
-    status, data = api("GET", "public_pages/release", token=manage_sources_token)
-    assert_api(status, data)
-    release = next(r for r in data["data"] if r["id"] == release_id)
-    assert release["is_visible"] is True
-    assert release["auto_publish_enabled"] is False
-
-    status, data = api(
-        "PATCH",
-        f"public_pages/release/{release_id}",
-        data={
-            "name": "Name",
-            "group_ids": [public_group.id],
-            "is_visible": False,
-            "auto_publish_enabled": True,
-        },
-        token=manage_sources_token,
-    )
-    assert_api(status, data)
-
-    status, data = api("GET", "public_pages/release", token=manage_sources_token)
-    assert_api(status, data)
-    release = next(r for r in data["data"] if r["id"] == release_id)
-    assert release["is_visible"] is False
-    assert release["auto_publish_enabled"] is True
-    assert release["link_name"] == link_name
-
+    # raw api: PublicReleaseUpdate omits link_name by design (it is immutable server-side)
     status, data = api(
         "PATCH",
         f"public_pages/release/{release_id}",
@@ -222,11 +206,10 @@ def test_update_release(
     )
     assert_api(status, data)
 
-    status, data = api("GET", "public_pages/release", token=manage_sources_token)
-    assert_api(status, data)
-    release = next(r for r in data["data"] if r["id"] == release_id)
-    assert release["link_name"] != "new_link_name"
-    assert release["link_name"] == link_name
+    releases = sp.fetch_public_releases()
+    release = next(r for r in releases if r.id == release_id)
+    assert release.link_name != "new_link_name"
+    assert release.link_name == link_name
 
 
 def test_auto_publish_enabled_and_delete_sources_in_same_group_when_create_or_update_source(
@@ -239,154 +222,104 @@ def test_auto_publish_enabled_and_delete_sources_in_same_group_when_create_or_up
 ):
     link_name = str(uuid.uuid4())
     # create a release with auto_publish_enabled to false
-    status, data = api(
-        "POST",
-        "public_pages/release",
-        data={
-            "name": "Name",
-            "link_name": link_name,
-            "group_ids": [public_group.id],
-            "auto_publish_enabled": False,
-        },
-        token=manage_sources_token,
+    release_id = (
+        client(manage_sources_token)
+        .post_public_release(
+            PublicReleasePost(
+                name="Name",
+                link_name=link_name,
+                group_ids=[public_group.id],
+                auto_publish_enabled=False,
+            )
+        )
+        .id
     )
-    assert_api(status, data)
-    release_id = data["data"]["id"]
 
     # create a source in the same group
     source_id = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": source_id,
-            "ra": 26.5,
-            "dec": 28.3,
-            "redshift": 0.5,
-            "group_ids": [public_group.id],
-        },
-        token=super_admin_token,
+    client(super_admin_token).post_source(
+        SourcePost(
+            id=source_id,
+            ra=26.5,
+            dec=28.3,
+            redshift=0.5,
+            group_ids=[public_group.id],
+        )
     )
-    assert_api(status, data)
 
     # check that the source have not been published
-    status, data = api(
-        "GET",
-        f"public_pages/source/{source_id}",
-        token=view_only_token,
-    )
-    assert_api(status, data)
-    assert len(data["data"]) == 0
+    pages = client(view_only_token).fetch_public_source_pages(source_id)
+    assert len(pages) == 0
 
     # update the release to auto_publish_enabled to true
-    status, data = api(
-        "PATCH",
-        f"public_pages/release/{release_id}",
-        data={
-            "name": "Name",
-            "group_ids": [public_group.id],
-            "auto_publish_enabled": True,
-        },
-        token=manage_sources_token,
+    client(manage_sources_token).update_public_release(
+        release_id,
+        PublicReleaseUpdate(
+            name="Name",
+            group_ids=[public_group.id],
+            auto_publish_enabled=True,
+        ),
     )
-    assert_api(status, data)
 
     # create a new source in the same group
     new_source_id = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": new_source_id,
-            "ra": 26.5,
-            "dec": 28.3,
-            "redshift": 0.5,
-            "group_ids": [public_group.id],
-        },
-        token=super_admin_token,
+    client(super_admin_token).post_source(
+        SourcePost(
+            id=new_source_id,
+            ra=26.5,
+            dec=28.3,
+            redshift=0.5,
+            group_ids=[public_group.id],
+        )
     )
-    assert_api(status, data)
 
     # check that the new source have been published
     for n_times in range(3):
-        status, data = api(
-            "GET",
-            f"public_pages/source/{new_source_id}",
-            token=view_only_token,
-        )
-        assert_api(status, data)
-        if len(data["data"]) == 1:
-            assert data["data"][0]["release_link_name"] == link_name
+        pages = client(view_only_token).fetch_public_source_pages(new_source_id)
+        if len(pages) == 1:
+            assert pages[0].release_link_name == link_name
             break
         time.sleep(2)
     assert n_times < 2
 
     # Update the source by first unregister it to the release group.
-    status, data = api(
-        "POST",
-        "source_groups",
-        data={
-            "objId": new_source_id,
-            "unsaveGroupIds": [public_group.id],
-        },
-        token=upload_data_token,
+    client(upload_data_token).post_source_groups(
+        SourceGroupsPost(
+            obj_id=new_source_id,
+            unsave_group_ids=[public_group.id],
+        )
     )
-    assert_api(status, data)
 
     # check that the automatically published source have been deleted
     for n_times in range(3):
-        status, data = api(
-            "GET",
-            f"public_pages/source/{new_source_id}",
-            token=view_only_token,
-        )
-        assert_api(status, data)
-        if len(data["data"]) == 0:
+        pages = client(view_only_token).fetch_public_source_pages(new_source_id)
+        if len(pages) == 0:
             break
         time.sleep(2)
     assert n_times < 2
 
     # Update the source by register it back to the release group.
-    status, data = api(
-        "POST",
-        "source_groups",
-        data={
-            "objId": new_source_id,
-            "inviteGroupIds": [public_group.id],
-        },
-        token=upload_data_token,
+    client(upload_data_token).post_source_groups(
+        SourceGroupsPost(
+            obj_id=new_source_id,
+            invite_group_ids=[public_group.id],
+        )
     )
-    assert_api(status, data)
 
     for n_time in range(3):
         # check that the new source have been published
-        status, data = api(
-            "GET",
-            f"public_pages/source/{new_source_id}",
-            token=view_only_token,
-        )
-        assert_api(status, data)
+        pages = client(view_only_token).fetch_public_source_pages(new_source_id)
 
-        if len(data["data"]) == 1:
-            assert data["data"][0]["release_link_name"] == link_name
+        if len(pages) == 1:
+            assert pages[0].release_link_name == link_name
             break
         else:
             time.sleep(2)
     assert n_time < 2
 
-    status, data = api(
-        "DELETE",
-        f"objs/{source_id}",
-        token=view_only_token,
-    )
-    assert_api(status, data)
+    client(view_only_token).delete_obj(source_id)
 
-    status, data = api(
-        "DELETE",
-        f"objs/{new_source_id}",
-        token=view_only_token,
-    )
-    assert_api(status, data)
+    client(view_only_token).delete_obj(new_source_id)
 
 
 def test_auto_publish_enabled_and_delete_sources_in_same_group_when_update_source_with_photometry(
@@ -399,62 +332,40 @@ def test_auto_publish_enabled_and_delete_sources_in_same_group_when_update_sourc
 ):
     link_name = str(uuid.uuid4())
     # create a release with auto_publish_enabled to true
-    status, data = api(
-        "POST",
-        "public_pages/release",
-        data={
-            "name": "Name",
-            "link_name": link_name,
-            "group_ids": [public_group.id],
-            "auto_publish_enabled": True,
-        },
-        token=manage_sources_token,
+    client(manage_sources_token).post_public_release(
+        PublicReleasePost(
+            name="Name",
+            link_name=link_name,
+            group_ids=[public_group.id],
+            auto_publish_enabled=True,
+        )
     )
-    assert_api(status, data)
 
     # Update the source by first unregister it to the release group.
-    status, data = api(
-        "POST",
-        "source_groups",
-        data={
-            "objId": public_source.id,
-            "unsaveGroupIds": [public_group.id],
-        },
-        token=upload_data_token,
+    client(upload_data_token).post_source_groups(
+        SourceGroupsPost(
+            obj_id=public_source.id,
+            unsave_group_ids=[public_group.id],
+        )
     )
-    assert_api(status, data)
 
     # check that no source have been already published in the release
-    status, data = api(
-        "GET",
-        f"public_pages/source/{public_source.id}",
-        token=view_only_token,
-    )
-    assert_api(status, data)
-    assert all(x["release_link_name"] != link_name for x in data["data"])
+    pages = client(view_only_token).fetch_public_source_pages(public_source.id)
+    assert all(x.release_link_name != link_name for x in pages)
 
     # Update the source by register it back to the release group.
-    status, data = api(
-        "POST",
-        "source_groups",
-        data={
-            "objId": public_source.id,
-            "inviteGroupIds": [public_group.id],
-        },
-        token=upload_data_token,
+    client(upload_data_token).post_source_groups(
+        SourceGroupsPost(
+            obj_id=public_source.id,
+            invite_group_ids=[public_group.id],
+        )
     )
-    assert_api(status, data)
 
     for n_time in range(3):
         # check that the source have been published
-        status, data = api(
-            "GET",
-            f"public_pages/source/{public_source.id}",
-            token=view_only_token,
-        )
-        assert_api(status, data)
+        pages = client(view_only_token).fetch_public_source_pages(public_source.id)
 
-        if any(x["release_link_name"] == link_name for x in data["data"]):
+        if any(x.release_link_name == link_name for x in pages):
             break
         else:
             time.sleep(2)
@@ -465,33 +376,28 @@ def test_delete_release(
     view_only_token, manage_sources_token, public_source, public_group
 ):
     link_name = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "public_pages/release",
-        data={
-            "name": "Name",
-            "link_name": link_name,
-            "group_ids": [public_group.id],
-        },
-        token=manage_sources_token,
+    release_id = (
+        client(manage_sources_token)
+        .post_public_release(
+            PublicReleasePost(
+                name="Name",
+                link_name=link_name,
+                group_ids=[public_group.id],
+            )
+        )
+        .id
     )
-    assert_api(status, data)
-    release_id = data["data"]["id"]
 
+    # raw api: intentionally malformed request (no release ID) the typed client can't produce
     status, data = api("DELETE", "public_pages/release/", token=view_only_token)
     assert_api_fail(status, data, 405, "HTTP 405: Method Not Allowed")
 
-    status, data = api(
-        "DELETE", f"public_pages/release/{release_id}", token=view_only_token
-    )
-    assert_api_fail(status, data, 401, "HTTP 401: Unauthorized")
+    with pytest.raises(SkyPortalError, match="HTTP 401: Unauthorized") as err:
+        client(view_only_token).delete_public_release(release_id)
+    assert err.value.status_code == 401
 
-    status, data = api(
-        "DELETE", f"public_pages/release/{release_id}", token=manage_sources_token
-    )
-    assert_api(status, data)
+    client(manage_sources_token).delete_public_release(release_id)
 
-    status, data = api(
-        "DELETE", f"public_pages/release/{release_id}", token=manage_sources_token
-    )
-    assert_api_fail(status, data, 404, "Release not found")
+    with pytest.raises(SkyPortalError, match="Release not found") as err:
+        client(manage_sources_token).delete_public_release(release_id)
+    assert err.value.status_code == 404

--- a/skyportal/tests/api_tests/photometry_followup/test_public_source_pages.py
+++ b/skyportal/tests/api_tests/photometry_followup/test_public_source_pages.py
@@ -71,7 +71,9 @@ def test_create_page_groups_and_streams(
     assert len(sp.fetch_spectra(public_source.id)) > 0
 
     # Add summary to source
-    sp.update_source(public_source.id, summary="This is a summary")
+    client(super_admin_token).update_source(
+        public_source.id, summary="This is a summary"
+    )
     assert len(sp.fetch_source(public_source.id).summary) > 0
 
     # No classifications

--- a/skyportal/tests/api_tests/photometry_followup/test_public_source_pages.py
+++ b/skyportal/tests/api_tests/photometry_followup/test_public_source_pages.py
@@ -1,15 +1,16 @@
-from skyportal.tests import api, assert_api, assert_api_fail
+import pytest
+from skyportal_py import SkyPortalError
+
+from skyportal.tests import api, assert_api_fail, client
 
 
 def test_create_page(view_only_token, manage_sources_token, public_source):
-    status, data = api(
-        "POST",
-        f"public_pages/source/{public_source.id}",
-        data={},
-        token=view_only_token,
-    )
-    assert_api_fail(status, data, 401, "HTTP 401: Unauthorized")
+    sp = client(manage_sources_token)
+    with pytest.raises(SkyPortalError, match="HTTP 401: Unauthorized") as err:
+        client(view_only_token).post_public_source_page(public_source.id, {})
+    assert err.value.status_code == 401
 
+    # raw api: intentionally malformed payload the typed client can't produce
     status, data = api(
         "POST",
         f"public_pages/source/{public_source.id}",
@@ -17,6 +18,7 @@ def test_create_page(view_only_token, manage_sources_token, public_source):
     )
     assert_api_fail(status, data, 400, "No data provided")
 
+    # raw api: intentionally malformed payload the typed client can't produce
     status, data = api(
         "POST",
         f"public_pages/source/{public_source.id}",
@@ -25,6 +27,7 @@ def test_create_page(view_only_token, manage_sources_token, public_source):
     )
     assert_api_fail(status, data, 400, "No data provided")
 
+    # raw api: intentionally malformed payload the typed client can't produce
     status, data = api(
         "POST",
         f"public_pages/source/{public_source.id}",
@@ -33,14 +36,11 @@ def test_create_page(view_only_token, manage_sources_token, public_source):
     )
     assert_api_fail(status, data, 400, "Options are required")
 
-    status, data = api(
-        "POST",
-        f"public_pages/source/{public_source.id[:1]}",
-        data={"options": {}},
-        token=manage_sources_token,
-    )
-    assert_api_fail(status, data, 404, "Source not found")
+    with pytest.raises(SkyPortalError, match="Source not found") as err:
+        sp.post_public_source_page(public_source.id[:1], {})
+    assert err.value.status_code == 404
 
+    # raw api: intentionally malformed payload the typed client can't produce
     status, data = api(
         "POST",
         f"public_pages/source/{public_source.id}",
@@ -52,199 +52,107 @@ def test_create_page(view_only_token, manage_sources_token, public_source):
     )
     assert_api_fail(status, data, 400, "Invalid release ID")
 
-    status, data = api(
-        "POST",
-        f"public_pages/source/{public_source.id}",
-        data={
-            "options": {},
-            "release_id": 0,
-        },
-        token=manage_sources_token,
-    )
-    assert_api_fail(status, data, 404, "Release not found")
+    with pytest.raises(SkyPortalError, match="Release not found") as err:
+        sp.post_public_source_page(public_source.id, {}, release_id=0)
+    assert err.value.status_code == 404
 
-    status, data = api(
-        "POST",
-        f"public_pages/source/{public_source.id}",
-        data={"options": {}},
-        token=manage_sources_token,
-    )
-    assert_api(status, data)
-    public_source_page_id = data["data"]["id"]
+    public_source_page_id = sp.post_public_source_page(public_source.id, {}).id
 
-    status, data = api(
-        "GET", f"public_pages/source/{public_source.id}", token=manage_sources_token
-    )
-    assert_api(status, data)
-    assert any(item["id"] == public_source_page_id for item in data["data"])
+    pages = sp.fetch_public_source_pages(public_source.id)
+    assert any(item.id == public_source_page_id for item in pages)
 
 
 def test_create_page_groups_and_streams(
     super_admin_token, manage_sources_token, public_source
 ):
-    status, data = api(
-        "GET",
-        f"sources/{public_source.id}/photometry",
-        token=manage_sources_token,
-    )
-    assert_api(status, data)
-    assert len(data["data"]) > 0
+    sp = client(manage_sources_token)
+    assert len(sp.fetch_photometry(public_source.id)) > 0
 
-    status, data = api(
-        "GET",
-        f"sources/{public_source.id}/spectra",
-        token=manage_sources_token,
-    )
-    assert_api(status, data)
-    assert len(data["data"]) > 0
+    assert len(sp.fetch_spectra(public_source.id)) > 0
 
     # Add summary to source
-    status, data = api(
-        "PATCH",
-        f"sources/{public_source.id}",
-        data={"summary": "This is a summary"},
-        token=super_admin_token,
-    )
-    assert_api(status, data)
-    status, data = api(
-        "GET",
-        f"sources/{public_source.id}",
-        token=manage_sources_token,
-    )
-    assert_api(status, data)
-    assert len(data["data"]["summary"]) > 0
+    sp.update_source(public_source.id, summary="This is a summary")
+    assert len(sp.fetch_source(public_source.id).summary) > 0
 
     # No classifications
-    status, data = api(
-        "GET",
-        f"sources/{public_source.id}/classifications",
-        token=manage_sources_token,
-    )
-    assert_api(status, data)
-    assert len(data["data"]) == 0
+    assert len(sp.fetch_classifications(public_source.id)) == 0
 
     # No groups and streams select and all includes to true
-    status, data = api(
-        "POST",
-        f"public_pages/source/{public_source.id}",
-        data={
-            "options": {
-                "include_summary": True,
-                "include_photometry": True,
-                "include_spectroscopy": True,
-                "include_classifications": True,
-                "groups": [],
-                "streams": [],
-            },
+    public_source_page_id = sp.post_public_source_page(
+        public_source.id,
+        {
+            "include_summary": True,
+            "include_photometry": True,
+            "include_spectroscopy": True,
+            "include_classifications": True,
+            "groups": [],
+            "streams": [],
         },
-        token=manage_sources_token,
-    )
-    public_source_page_id = data["data"]["id"]
-    assert_api(status, data)
-    status, data = api(
-        "GET",
-        f"public_pages/source/{public_source.id}",
-        token=manage_sources_token,
-    )
-    assert_api(status, data)
+    ).id
+    pages = sp.fetch_public_source_pages(public_source.id)
     public_source_page = next(
-        item for item in data["data"] if item["id"] == public_source_page_id
+        item for item in pages if item.id == public_source_page_id
     )
-    assert public_source_page["options"]["summary"] == "public"
-    assert public_source_page["options"]["photometry"] == "public"
-    assert public_source_page["options"]["spectroscopy"] == "public"
-    assert public_source_page["options"]["classifications"] == "no data"
+    assert public_source_page.options.summary == "public"
+    assert public_source_page.options.photometry == "public"
+    assert public_source_page.options.spectroscopy == "public"
+    assert public_source_page.options.classifications == "no data"
 
     # No groups and streams select and all includes to false
-    status, data = api(
-        "POST",
-        f"public_pages/source/{public_source.id}",
-        data={
-            "options": {
-                "include_summary": False,
-                "include_photometry": False,
-                "include_spectroscopy": False,
-                "include_classifications": False,
-                "groups": [],
-                "streams": [],
-            },
+    public_source_page_id = sp.post_public_source_page(
+        public_source.id,
+        {
+            "include_summary": False,
+            "include_photometry": False,
+            "include_spectroscopy": False,
+            "include_classifications": False,
+            "groups": [],
+            "streams": [],
         },
-        token=manage_sources_token,
-    )
-    assert_api(status, data)
-    public_source_page_id = data["data"]["id"]
-    status, data = api(
-        "GET",
-        f"public_pages/source/{public_source.id}",
-        token=manage_sources_token,
-    )
+    ).id
+    pages = sp.fetch_public_source_pages(public_source.id)
     public_source_page = next(
-        item for item in data["data"] if item["id"] == public_source_page_id
+        item for item in pages if item.id == public_source_page_id
     )
-    assert public_source_page["options"]["summary"] == "private"
-    assert public_source_page["options"]["photometry"] == "private"
-    assert public_source_page["options"]["spectroscopy"] == "private"
-    assert public_source_page["options"]["classifications"] == "private"
+    assert public_source_page.options.summary == "private"
+    assert public_source_page.options.photometry == "private"
+    assert public_source_page.options.spectroscopy == "private"
+    assert public_source_page.options.classifications == "private"
 
     # Bad groups and streams select
-    status, data = api(
-        "POST",
-        f"public_pages/source/{public_source.id}",
-        data={
-            "options": {
-                "include_summary": True,
-                "include_photometry": True,
-                "include_spectroscopy": True,
-                "include_classifications": True,
-                "groups": [0],
-                "streams": [0],
-            },
+    public_source_page_id = sp.post_public_source_page(
+        public_source.id,
+        {
+            "include_summary": True,
+            "include_photometry": True,
+            "include_spectroscopy": True,
+            "include_classifications": True,
+            "groups": [0],
+            "streams": [0],
         },
-        token=manage_sources_token,
-    )
-    assert_api(status, data)
-    public_source_page_id = data["data"]["id"]
-    status, data = api(
-        "GET",
-        f"public_pages/source/{public_source.id}",
-        token=manage_sources_token,
-    )
+    ).id
+    pages = sp.fetch_public_source_pages(public_source.id)
     public_source_page = next(
-        item for item in data["data"] if item["id"] == public_source_page_id
+        item for item in pages if item.id == public_source_page_id
     )
     # No data found for this group and stream because they don't exist
-    assert public_source_page["options"]["photometry"] == "no data"
-    assert public_source_page["options"]["spectroscopy"] == "no data"
-    assert public_source_page["options"]["classifications"] == "no data"
+    assert public_source_page.options.photometry == "no data"
+    assert public_source_page.options.spectroscopy == "no data"
+    assert public_source_page.options.classifications == "no data"
     # Summary is still public because it is not link to group or stream
-    assert public_source_page["options"]["summary"] == "public"
+    assert public_source_page.options.summary == "public"
 
 
 def test_delete_page(view_only_token, manage_sources_token, public_source):
-    status, data = api(
-        "POST",
-        f"public_pages/source/{public_source.id}",
-        data={"options": {}},
-        token=manage_sources_token,
-    )
-    assert_api(status, data)
-    public_source_page_id = data["data"]["id"]
+    sp = client(manage_sources_token)
+    public_source_page_id = sp.post_public_source_page(public_source.id, {}).id
 
-    status, data = api(
-        "DELETE", f"public_pages/source/{public_source_page_id}", token=view_only_token
-    )
-    assert_api_fail(status, data, 401, "HTTP 401: Unauthorized")
+    with pytest.raises(SkyPortalError, match="HTTP 401: Unauthorized") as err:
+        client(view_only_token).delete_public_source_page(public_source_page_id)
+    assert err.value.status_code == 401
 
-    status, data = api(
-        "DELETE",
-        f"public_pages/source/{public_source_page_id}",
-        token=manage_sources_token,
-    )
-    assert_api(status, data)
+    sp.delete_public_source_page(public_source_page_id)
 
-    status, data = api(
-        "DELETE",
-        f"public_pages/source/{public_source_page_id}",
-        token=manage_sources_token,
-    )
-    assert_api_fail(status, data, 404, "Public source page not found")
+    with pytest.raises(SkyPortalError, match="Public source page not found") as err:
+        sp.delete_public_source_page(public_source_page_id)
+    assert err.value.status_code == 404

--- a/skyportal/tests/api_tests/photometry_followup/test_sharing_services.py
+++ b/skyportal/tests/api_tests/photometry_followup/test_sharing_services.py
@@ -1,6 +1,16 @@
 import uuid
 
-from skyportal.tests import api
+import pytest
+from skyportal_py import SkyPortalError
+from skyportal_py.groups import GroupPost
+from skyportal_py.instruments import InstrumentPost
+from skyportal_py.profile import ProfilePatch
+from skyportal_py.sharing_services import (
+    SharingServicePost,
+    SharingServiceSubmissionPost,
+)
+
+from skyportal.tests import client
 
 
 def test_post_and_delete_sharing_service(
@@ -12,338 +22,213 @@ def test_post_and_delete_sharing_service(
     public_source,
     ztf_camera,
 ):
+    sp = client(super_admin_token)
+
     # get all external sharing services
-    status, data = api("GET", "sharing_service", token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-    initial_count = len(data["data"])
+    initial_count = len(sp.fetch_sharing_services())
 
     # first, add a private group
-    status, data = api(
-        "POST", "groups", data={"name": str(uuid.uuid4())}, token=super_admin_token
-    )
-    assert status == 200
-    private_group_id = data["data"]["id"]
+    private_group_id = sp.post_group(GroupPost(name=str(uuid.uuid4()))).id
 
-    request_data = {
-        "name": str(uuid.uuid4()),
-        "owner_group_ids": [private_group_id],
-        "tns_bot_name": str(uuid.uuid4()),
-        "tns_bot_id": 10,
-        "tns_source_group_id": 200,
-        "_tns_altdata": '{"api_key": "test_key"}',
-    }
+    request_data = SharingServicePost(
+        name=str(uuid.uuid4()),
+        owner_group_ids=[private_group_id],
+        tns_bot_name=str(uuid.uuid4()),
+        tns_bot_id=10,
+        tns_source_group_id=200,
+        tns_altdata={"api_key": "test_key"},
+    )
 
     # add an external sharing service without specifying any instruments (should fail)
-    status, data = api(
-        "PUT", "sharing_service", data=request_data, token=super_admin_token
-    )
-    assert status == 400
-    assert "At least one instrument must be specified for sharing" in data["message"]
+    with pytest.raises(
+        SkyPortalError, match="At least one instrument must be specified for sharing"
+    ) as err:
+        sp.post_sharing_service(request_data)
+    assert err.value.status_code == 400
 
     # add an external sharing service with instruments that are not valid (should fail)
-    request_data["instrument_ids"] = [ztf_camera.id]
-    status, data = api(
-        "PUT", "sharing_service", data=request_data, token=super_admin_token
-    )
-    assert status == 400
-    assert f"Instrument {ztf_camera.name} not supported for sharing" in data["message"]
+    request_data.instrument_ids = [ztf_camera.id]
+    with pytest.raises(SkyPortalError) as err:
+        sp.post_sharing_service(request_data)
+    assert err.value.status_code == 400
+    assert f"Instrument {ztf_camera.name} not supported for sharing" in str(err.value)
 
     # post an instrument which name is supported for sharing, like ZTF
-    status, data = api(
-        "POST",
-        "instrument",
-        data={"name": "ZTF", "telescope_id": ztf_camera.telescope_id, "type": "imager"},
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert "data" in data
-    assert "id" in data["data"]
-    ztf_instrument_id = data["data"]["id"]
+    ztf_instrument_id = sp.post_instrument(
+        InstrumentPost(name="ZTF", telescope_id=ztf_camera.telescope_id, type="imager")
+    ).id
 
     # add an external sharing service with instruments
-    request_data["instrument_ids"] = [ztf_instrument_id]
-    status, data = api(
-        "PUT", "sharing_service", data=request_data, token=super_admin_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    id = data["data"]["id"]
+    request_data.instrument_ids = [ztf_instrument_id]
+    id = sp.post_sharing_service(request_data).id
 
     # get all external sharing services
-    status, data = api("GET", "sharing_service", token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]) == initial_count + 1
+    assert len(sp.fetch_sharing_services()) == initial_count + 1
 
     # get the external sharing service
-    status, data = api("GET", f"sharing_service/{id}", token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]["groups"]) == 1
+    service = sp.fetch_sharing_service(id)
+    assert len(service.groups) == 1
 
-    for key in request_data:
-        if key == "_tns_altdata":
-            continue
-        if key == "instrument_ids":
-            for instrument_id in request_data[key]:
-                assert any(
-                    i["id"] == instrument_id for i in data["data"]["instruments"]
-                )
-            continue
-        assert data["data"][key] == request_data[key]
+    assert service.name == request_data.name
+    assert service.owner_group_ids == request_data.owner_group_ids
+    assert service.tns_bot_name == request_data.tns_bot_name
+    assert service.tns_bot_id == request_data.tns_bot_id
+    assert service.tns_source_group_id == request_data.tns_source_group_id
+    for instrument_id in request_data.instrument_ids:
+        assert any(i.id == instrument_id for i in service.instruments)
 
     # get all sharing services with view only token (should not see it)
-    status, data = api("GET", "sharing_service", token=view_only_token)
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]) == 0
+    assert len(client(view_only_token).fetch_sharing_services()) == 0
 
     # get the sharing service with view only token (should not see it)
-    status, data = api("GET", f"sharing_service/{id}", token=view_only_token)
-    assert status == 400
-    assert "No sharing service with" in data["message"]
+    with pytest.raises(SkyPortalError, match="No sharing service with") as err:
+        client(view_only_token).fetch_sharing_service(id)
+    assert err.value.status_code == 400
 
     # add a group to the sharing service
-    status, data = api(
-        "PUT",
-        f"sharing_service/{id}/group",
-        data={"group_id": public_group.id},
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp.update_sharing_service_group(id, public_group.id)
 
     # get the sharing service again, should have the new group
-    status, data = api("GET", f"sharing_service/{id}", token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]["groups"]) == 2
+    assert len(sp.fetch_sharing_service(id).groups) == 2
 
     # edit the sharing service, to give it ownership and to set auto_share_to_tns to True
-    status, data = api(
-        "PUT",
-        f"sharing_service/{id}/group/{public_group.id}",
-        data={"owner": True, "auto_share_to_tns": True},
-        token=super_admin_token,
+    sp.update_sharing_service_group(
+        id, public_group.id, owner=True, auto_share_to_tns=True
     )
-    assert status == 200
-    assert data["status"] == "success"
 
     # get the sharing service again, should have the new group edited
-    status, data = api("GET", f"sharing_service/{id}", token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-    group = [g for g in data["data"]["groups"] if g["group_id"] == public_group.id]
+    service = sp.fetch_sharing_service(id)
+    group = [g for g in service.groups if g.group_id == public_group.id]
     assert len(group) == 1
-    assert group[0]["owner"] is True
-    assert group[0]["auto_share_to_tns"] is True
-    assert group[0]["auto_share_to_hermes"] is False
+    assert group[0].owner is True
+    assert group[0].auto_share_to_tns is True
+    assert group[0].auto_share_to_hermes is False
 
     # try adding a coauthor with no affiliations to the sharing service
-    status, data = api(
-        "POST",
-        f"sharing_service/{id}/coauthor/{super_admin_user.id}",
-        token=super_admin_token,
-    )
-    assert status == 400
-    assert "has no affiliation(s), required to be a coauthor" in data["message"]
+    with pytest.raises(SkyPortalError) as err:
+        sp.post_sharing_service_coauthor(id, super_admin_user.id)
+    assert err.value.status_code == 400
+    assert "has no affiliation(s), required to be a coauthor" in str(err.value)
 
     # add an affiliation to the user
-    status, data = api(
-        "PATCH",
-        f"internal/profile/{super_admin_user.id}",
-        data={"affiliations": ["CIT"]},
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp.update_profile(ProfilePatch(affiliations=["CIT"]))
 
     # now add the coauthor
-    status, data = api(
-        "POST",
-        f"sharing_service/{id}/coauthor/{super_admin_user.id}",
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp.post_sharing_service_coauthor(id, super_admin_user.id)
 
     # get the sharing service again, should have the new coauthor
-    status, data = api("GET", f"sharing_service/{id}", token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]["coauthors"]) == 1
-    assert data["data"]["coauthors"][0]["user_id"] == super_admin_user.id
+    service = sp.fetch_sharing_service(id)
+    assert len(service.coauthors) == 1
+    assert service.coauthors[0].user_id == super_admin_user.id
 
     # try adding the viewonly user as an auto_publisher of the sharing service public group, will fail (no affiliation)
-    status, data = api(
-        "POST",
-        f"sharing_service/{id}/group/{public_group.id}/auto_publisher",
-        data={"user_ids": [view_only_user.id]},
-        token=super_admin_token,
-    )
-    assert status == 400
-    assert (
-        "has no affiliation(s), required to be an auto_publisher of" in data["message"]
+    with pytest.raises(SkyPortalError) as err:
+        sp.post_sharing_service_auto_publishers(
+            id, public_group.id, [view_only_user.id]
+        )
+    assert err.value.status_code == 400
+    assert "has no affiliation(s), required to be an auto_publisher of" in str(
+        err.value
     )
 
     # add an affiliation to the user
-    status, data = api(
-        "PATCH",
-        f"internal/profile/{view_only_user.id}",
-        data={"affiliations": ["CIT"]},
-        token=super_admin_token,
+    client(super_admin_token).update_profile(
+        ProfilePatch(affiliations=["CIT"]), user_id=view_only_user.id
     )
-    assert status == 200
-    assert data["status"] == "success"
 
     # now add the auto_publisher
-    status, data = api(
-        "POST",
-        f"sharing_service/{id}/group/{public_group.id}/auto_publisher",
-        data={"user_ids": [view_only_user.id]},
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp.post_sharing_service_auto_publishers(id, public_group.id, [view_only_user.id])
 
     # get the sharing service again, should have the new auto_publisher
-    status, data = api("GET", f"sharing_service/{id}", token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]["groups"]) == 2
-    group = [g for g in data["data"]["groups"] if g["group_id"] == public_group.id]
+    service = sp.fetch_sharing_service(id)
+    assert len(service.groups) == 2
+    group = [g for g in service.groups if g.group_id == public_group.id]
     assert len(group) == 1
-    assert len(group[0]["auto_publishers"]) == 1
-    assert group[0]["auto_publishers"][0]["user_id"] == view_only_user.id
+    assert len(group[0].auto_publishers) == 1
+    assert group[0].auto_publishers[0].user_id == view_only_user.id
 
     # publish the public source but don't specify the service to publish to (hermes or tns), should fail
-    request_data = {
-        "obj_id": public_source.id,
-        "sharing_service_id": id,
-        "publishers": "test publisher string",
-        "remarks": "test remark string",
-        "archival": False,
-    }
-    status, data = api(
-        "POST",
-        f"sharing_service/submission",
-        data=request_data,
-        token=super_admin_token,
-    )
-    assert status == 400
-    assert (
-        "Either publish to TNS or publish to Hermes must be set to True"
-        in data["message"]
-    )
+    with pytest.raises(
+        SkyPortalError,
+        match="Either publish to TNS or publish to Hermes must be set to True",
+    ) as err:
+        sp.post_sharing_service_submission(
+            SharingServiceSubmissionPost(
+                obj_id=public_source.id,
+                sharing_service_id=id,
+                publishers="test publisher string",
+                remarks="test remark string",
+                archival=False,
+            )
+        )
+    assert err.value.status_code == 400
 
     # publish the public source to Hermes and TNS, should fail because hermes token is not set in config
-    request_data = {
-        "sharing_service_id": id,
-        "obj_id": public_source.id,
-        "publish_to_hermes": True,
-        "publish_to_tns": True,
-        "publishers": "test publisher string",
-        "remarks": "test remark string",
-        "archival": False,
-    }
-    status, data = api(
-        "POST",
-        f"sharing_service/submission",
-        data=request_data,
-        token=super_admin_token,
-    )
-    assert status == 400
-    assert "This instance is not configured to use Hermes" in data["message"]
+    with pytest.raises(
+        SkyPortalError, match="This instance is not configured to use Hermes"
+    ) as err:
+        sp.post_sharing_service_submission(
+            SharingServiceSubmissionPost(
+                sharing_service_id=id,
+                obj_id=public_source.id,
+                publish_to_hermes=True,
+                publish_to_tns=True,
+                publishers="test publisher string",
+                remarks="test remark string",
+                archival=False,
+            )
+        )
+    assert err.value.status_code == 400
 
     # publish the public source to TNS
-    request_data = {
-        "sharing_service_id": id,
-        "obj_id": public_source.id,
-        "publish_to_tns": True,
-        "publishers": "test publisher string",
-        "remarks": "test remark string",
-        "archival": False,
-    }
-    status, data = api(
-        "POST",
-        f"sharing_service/submission",
-        data=request_data,
-        token=super_admin_token,
+    sp.post_sharing_service_submission(
+        SharingServiceSubmissionPost(
+            sharing_service_id=id,
+            obj_id=public_source.id,
+            publish_to_tns=True,
+            publishers="test publisher string",
+            remarks="test remark string",
+            archival=False,
+        )
     )
-    assert status == 200
-    assert data["status"] == "success"
 
     # get the submission from the sharing service
-    status, data = api(
-        "GET",
-        f"sharing_service/submission",
-        params={"sharing_service_id": id},
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    assert data["data"]["sharing_service_id"] == id
-    submissions = data["data"]["submissions"]
+    page = sp.fetch_sharing_service_submissions(sharing_service_id=id)
+    assert page.sharing_service_id == id
+    submissions = page.submissions
     assert len(submissions) >= 1
-    assert submissions[0]["obj_id"] == public_source.id
-    assert submissions[0]["custom_publishing_string"] == "test publisher string"
-    assert submissions[0]["custom_remarks_string"] == "test remark string"
-    assert submissions[0]["archival"] is False
+    assert submissions[0].obj_id == public_source.id
+    assert submissions[0].custom_publishing_string == "test publisher string"
+    assert submissions[0].custom_remarks_string == "test remark string"
+    assert submissions[0].archival is False
     # TNS status should be pending
-    assert "pending" in submissions[0]["tns_status"]
+    assert "pending" in submissions[0].tns_status
     # Hermes status should be None
-    assert submissions[0]["hermes_status"] is None
+    assert submissions[0].hermes_status is None
 
     # remove the coauthor
-    status, data = api(
-        "DELETE",
-        f"sharing_service/{id}/coauthor/{super_admin_user.id}",
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp.delete_sharing_service_coauthor(id, super_admin_user.id)
 
     # remove the auto_publisher
-    status, data = api(
-        "DELETE",
-        f"sharing_service/{id}/group/{public_group.id}/auto_publisher/{view_only_user.id}",
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp.delete_sharing_service_auto_publishers(id, public_group.id, [view_only_user.id])
 
     # get the sharing service again, should have no auto publishers and no coauthors
-    status, data = api("GET", f"sharing_service/{id}", token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]["groups"]) == 2
-    group = [g for g in data["data"]["groups"] if g["group_id"] == public_group.id]
+    service = sp.fetch_sharing_service(id)
+    assert len(service.groups) == 2
+    group = [g for g in service.groups if g.group_id == public_group.id]
     assert len(group) == 1
-    assert len(group[0]["auto_publishers"]) == 0
-    assert len(data["data"]["coauthors"]) == 0
+    assert len(group[0].auto_publishers) == 0
+    assert len(service.coauthors) == 0
 
     # delete the public group
-    status, data = api(
-        "DELETE",
-        f"sharing_service/{id}/group/{public_group.id}",
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp.delete_sharing_service_group(id, public_group.id)
 
     # try deleting the sharing service group (should fail as we always need at least one owner group)
-    status, data = api(
-        "DELETE",
-        f"sharing_service/{id}/group/{private_group_id}",
-        token=super_admin_token,
-    )
-    assert status == 400
-    assert (
-        "Cannot delete the only group owning this sharing service, add another group as an owner first."
-        in data["message"]
-    )
+    with pytest.raises(
+        SkyPortalError,
+        match="Cannot delete the only group owning this sharing service, add another group as an owner first.",
+    ) as err:
+        sp.delete_sharing_service_group(id, private_group_id)
+    assert err.value.status_code == 400
 
-    status, data = api("DELETE", f"sharing_service/{id}", token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
+    sp.delete_sharing_service(id)

--- a/skyportal/tests/api_tests/sources_candidates/test_annotations.py
+++ b/skyportal/tests/api_tests/sources_candidates/test_annotations.py
@@ -1,10 +1,14 @@
 import uuid
 
-from skyportal.tests import api
+import pytest
+from skyportal_py import SkyPortalError
+
+from skyportal.tests import api, client
 
 
 def test_post_without_origin_fails(annotation_token, public_source, public_group):
     # this should not work, since no "origin" is given
+    # raw api: intentionally malformed payload the typed client can't produce
     status, data = api(
         "POST",
         f"sources/{public_source.id}/annotations",
@@ -19,78 +23,56 @@ def test_post_without_origin_fails(annotation_token, public_source, public_group
     assert "origin: Field required" in data["message"]
 
     # this should not work, since "origin" is empty
-    status, data = api(
-        "POST",
-        f"sources/{public_source.id}/annotations",
-        data={
-            "origin": "",
-            "data": {"offset_from_host_galaxy": 1.5},
-            "group_ids": [public_group.id],
-        },
-        token=annotation_token,
-    )
-
-    assert status == 400
-    assert "origin: String should match pattern" in data["message"]
+    with pytest.raises(
+        SkyPortalError, match="origin: String should match pattern"
+    ) as err:
+        client(annotation_token).post_annotation(
+            public_source.id,
+            "",
+            {"offset_from_host_galaxy": 1.5},
+            group_ids=[public_group.id],
+        )
+    assert err.value.status_code == 400
 
 
 def test_post_same_origin_fails(annotation_token, public_source, public_group):
+    sp = client(annotation_token)
     # first time adding an annotation to this object from Kowalski
-    status, data = api(
-        "POST",
-        f"sources/{public_source.id}/annotations",
-        data={
-            "origin": "kowalski",
-            "data": {"offset_from_host_galaxy": 1.5},
-            "group_ids": [public_group.id],
-        },
-        token=annotation_token,
+    sp.post_annotation(
+        public_source.id,
+        "kowalski",
+        {"offset_from_host_galaxy": 1.5},
+        group_ids=[public_group.id],
     )
-
-    assert status == 200
 
     # this should not work, since "origin" Kowalski was already posted to this object
     # instead, try updating the existing annotation if you have new information!
-    status, data = api(
-        "POST",
-        f"sources/{public_source.id}/annotations",
-        data={
-            "origin": "kowalski",
-            "data": {"offset_from_host_galaxy": 1.5},
-            "group_ids": [public_group.id],
-        },
-        token=annotation_token,
-    )
-
-    assert status in [500, 400]
-    assert "duplicate key value violates unique constraint" in data["message"]
+    with pytest.raises(
+        SkyPortalError, match="duplicate key value violates unique constraint"
+    ) as err:
+        sp.post_annotation(
+            public_source.id,
+            "kowalski",
+            {"offset_from_host_galaxy": 1.5},
+            group_ids=[public_group.id],
+        )
+    assert err.value.status_code in [500, 400]
 
 
 def test_add_and_retrieve_annotation_group_id(
     annotation_token, public_source, public_group
 ):
-    status, data = api(
-        "POST",
-        f"sources/{public_source.id}/annotations",
-        data={
-            "origin": "kowalski",
-            "data": {"offset_from_host_galaxy": 1.5},
-            "group_ids": [public_group.id],
-        },
-        token=annotation_token,
-    )
-    assert status == 200
-    annotation_id = data["data"]["annotation_id"]
+    sp = client(annotation_token)
+    annotation_id = sp.post_annotation(
+        public_source.id,
+        "kowalski",
+        {"offset_from_host_galaxy": 1.5},
+        group_ids=[public_group.id],
+    ).annotation_id
 
-    status, data = api(
-        "GET",
-        f"sources/{public_source.id}/annotations/{annotation_id}",
-        token=annotation_token,
-    )
-
-    assert status == 200
-    assert data["data"]["data"] == {"offset_from_host_galaxy": 1.5}
-    assert data["data"]["origin"] == "kowalski"
+    annotation = sp.fetch_annotation(public_source.id, annotation_id)
+    assert annotation.data == {"offset_from_host_galaxy": 1.5}
+    assert annotation.origin == "kowalski"
 
 
 def test_post_annotation_ignores_handler_derived_body_fields(
@@ -98,6 +80,7 @@ def test_post_annotation_ignores_handler_derived_body_fields(
 ):
     # Clients send obj_id (derived by the handler from the URL) in the body; it
     # must be ignored, not rejected.
+    # raw api: intentionally malformed payload the typed client can't produce
     status, data = api(
         "POST",
         f"sources/{public_source.id}/annotations",
@@ -111,6 +94,7 @@ def test_post_annotation_ignores_handler_derived_body_fields(
     assert status == 200
     annotation_id = data["data"]["annotation_id"]
 
+    # raw api: intentionally malformed payload the typed client can't produce
     status, data = api(
         "PUT",
         f"sources/{public_source.id}/annotations/{annotation_id}",
@@ -125,27 +109,14 @@ def test_post_annotation_ignores_handler_derived_body_fields(
 
 
 def test_add_and_retrieve_annotation_no_group_id(annotation_token, public_source):
-    status, data = api(
-        "POST",
-        f"sources/{public_source.id}/annotations",
-        data={
-            "origin": "kowalski",
-            "data": {"offset_from_host_galaxy": 1.5},
-        },
-        token=annotation_token,
-    )
-    assert status == 200
-    annotation_id = data["data"]["annotation_id"]
+    sp = client(annotation_token)
+    annotation_id = sp.post_annotation(
+        public_source.id, "kowalski", {"offset_from_host_galaxy": 1.5}
+    ).annotation_id
 
-    status, data = api(
-        "GET",
-        f"sources/{public_source.id}/annotations/{annotation_id}",
-        token=annotation_token,
-    )
-
-    assert status == 200
-    assert data["data"]["data"] == {"offset_from_host_galaxy": 1.5}
-    assert data["data"]["origin"] == "kowalski"
+    annotation = sp.fetch_annotation(public_source.id, annotation_id)
+    assert annotation.data == {"offset_from_host_galaxy": 1.5}
+    assert annotation.origin == "kowalski"
 
 
 def test_add_and_retrieve_annotation_group_access(
@@ -155,69 +126,43 @@ def test_add_and_retrieve_annotation_group_access(
     public_group,
     annotation_token,
 ):
-    status, data = api(
-        "POST",
-        f"sources/{public_source_two_groups.id}/annotations",
-        data={
-            "origin": "kowalski",
-            "data": {"offset_from_host_galaxy": 1.5},
-            "group_ids": [public_group2.id],
-        },
-        token=annotation_token_two_groups,
-    )
-
-    assert status == 200
-    annotation_id = data["data"]["annotation_id"]
+    sp_two_groups = client(annotation_token_two_groups)
+    sp = client(annotation_token)
+    annotation_id = sp_two_groups.post_annotation(
+        public_source_two_groups.id,
+        "kowalski",
+        {"offset_from_host_galaxy": 1.5},
+        group_ids=[public_group2.id],
+    ).annotation_id
 
     # This token belongs to public_group2
-    status, data = api(
-        "GET",
-        f"sources/{public_source_two_groups.id}/annotations/{annotation_id}",
-        token=annotation_token_two_groups,
+    annotation = sp_two_groups.fetch_annotation(
+        public_source_two_groups.id, annotation_id
     )
-    assert status == 200
-    assert data["data"]["data"] == {"offset_from_host_galaxy": 1.5}
-    assert data["data"]["origin"] == "kowalski"
+    assert annotation.data == {"offset_from_host_galaxy": 1.5}
+    assert annotation.origin == "kowalski"
 
     # This token does not belong to public_group2
-    status, data = api(
-        "GET",
-        f"sources/{public_source_two_groups.id}/annotations/{annotation_id}",
-        token=annotation_token,
-    )
-    assert status == 403
+    with pytest.raises(SkyPortalError) as err:
+        sp.fetch_annotation(public_source_two_groups.id, annotation_id)
+    assert err.value.status_code == 403
 
     # Both tokens should be able to view this annotation
-    status, data = api(
-        "POST",
-        f"sources/{public_source_two_groups.id}/annotations",
-        data={
-            "origin": "GAIA",
-            "data": {"offset_from_host_galaxy": 1.5},
-            "group_ids": [public_group.id, public_group2.id],
-        },
-        token=annotation_token_two_groups,
-    )
+    annotation_id = sp_two_groups.post_annotation(
+        public_source_two_groups.id,
+        "GAIA",
+        {"offset_from_host_galaxy": 1.5},
+        group_ids=[public_group.id, public_group2.id],
+    ).annotation_id
 
-    assert status == 200
-    annotation_id = data["data"]["annotation_id"]
-
-    status, data = api(
-        "GET",
-        f"sources/{public_source_two_groups.id}/annotations/{annotation_id}",
-        token=annotation_token_two_groups,
+    annotation = sp_two_groups.fetch_annotation(
+        public_source_two_groups.id, annotation_id
     )
-    assert status == 200
-    assert data["data"]["data"] == {"offset_from_host_galaxy": 1.5}
-    assert data["data"]["origin"] == "GAIA"
+    assert annotation.data == {"offset_from_host_galaxy": 1.5}
+    assert annotation.origin == "GAIA"
 
-    status, data = api(
-        "GET",
-        f"sources/{public_source_two_groups.id}/annotations/{annotation_id}",
-        token=annotation_token,
-    )
-    assert status == 200
-    assert data["data"]["data"] == {"offset_from_host_galaxy": 1.5}
+    annotation = sp.fetch_annotation(public_source_two_groups.id, annotation_id)
+    assert annotation.data == {"offset_from_host_galaxy": 1.5}
 
 
 def test_update_annotation_group_list(
@@ -227,141 +172,87 @@ def test_update_annotation_group_list(
     public_group,
     annotation_token,
 ):
-    status, data = api(
-        "POST",
-        f"sources/{public_source_two_groups.id}/annotations",
-        data={
-            "origin": "kowalski",
-            "data": {"offset_from_host_galaxy": 1.5},
-            "group_ids": [public_group2.id],
-        },
-        token=annotation_token_two_groups,
-    )
-    assert status == 200
-    annotation_id = data["data"]["annotation_id"]
+    sp_two_groups = client(annotation_token_two_groups)
+    sp = client(annotation_token)
+    annotation_id = sp_two_groups.post_annotation(
+        public_source_two_groups.id,
+        "kowalski",
+        {"offset_from_host_galaxy": 1.5},
+        group_ids=[public_group2.id],
+    ).annotation_id
 
     # This token belongs to public_group2
-    status, data = api(
-        "GET",
-        f"sources/{public_source_two_groups.id}/annotations/{annotation_id}",
-        token=annotation_token_two_groups,
+    annotation = sp_two_groups.fetch_annotation(
+        public_source_two_groups.id, annotation_id
     )
-    assert status == 200
-    assert data["data"]["origin"] == "kowalski"
-    assert data["data"]["data"] == {"offset_from_host_galaxy": 1.5}
+    assert annotation.origin == "kowalski"
+    assert annotation.data == {"offset_from_host_galaxy": 1.5}
 
     # This token does not belong to public_group2
-    status, data = api(
-        "GET",
-        f"sources/{public_source_two_groups.id}/annotations/{annotation_id}",
-        token=annotation_token,
-    )
-    assert status == 403
+    with pytest.raises(SkyPortalError) as err:
+        sp.fetch_annotation(public_source_two_groups.id, annotation_id)
+    assert err.value.status_code == 403
 
     # Both tokens should be able to view annotation after updating group list
-    status, data = api(
-        "PUT",
-        f"sources/{public_source_two_groups.id}/annotations/{annotation_id}",
-        data={
-            "data": {"offset_from_host_galaxy": 1.7},
-            "group_ids": [public_group.id, public_group2.id],
-        },
-        token=annotation_token_two_groups,
+    sp_two_groups.update_annotation(
+        public_source_two_groups.id,
+        annotation_id,
+        {"offset_from_host_galaxy": 1.7},
+        group_ids=[public_group.id, public_group2.id],
     )
-    assert status == 200
 
-    status, data = api(
-        "GET",
-        f"sources/{public_source_two_groups.id}/annotations/{annotation_id}",
-        token=annotation_token_two_groups,
+    annotation = sp_two_groups.fetch_annotation(
+        public_source_two_groups.id, annotation_id
     )
-    assert status == 200
-    assert data["data"]["data"] == {"offset_from_host_galaxy": 1.7}
+    assert annotation.data == {"offset_from_host_galaxy": 1.7}
 
-    status, data = api(
-        "GET",
-        f"sources/{public_source_two_groups.id}/annotations/{annotation_id}",
-        token=annotation_token,
-    )
-    assert status == 200
-    assert data["data"]["data"] == {"offset_from_host_galaxy": 1.7}
+    annotation = sp.fetch_annotation(public_source_two_groups.id, annotation_id)
+    assert annotation.data == {"offset_from_host_galaxy": 1.7}
 
 
 def test_cannot_add_annotation_without_permission(view_only_token, public_source):
-    status, data = api(
-        "POST",
-        f"sources/{public_source.id}/annotations",
-        data={
-            "origin": "kowalski",
-            "data": {"offset_from_host_galaxy": 1.5},
-        },
-        token=view_only_token,
-    )
-    assert status == 401
-    assert data["status"] == "error"
+    with pytest.raises(SkyPortalError) as err:
+        client(view_only_token).post_annotation(
+            public_source.id, "kowalski", {"offset_from_host_galaxy": 1.5}
+        )
+    assert err.value.status_code == 401
 
 
 def test_obj_annotations(annotation_token, public_source):
+    sp = client(annotation_token)
     origin = str(uuid.uuid4())
 
-    status, data = api(
-        "POST",
-        f"sources/{public_source.id}/annotations",
-        data={
-            "origin": origin,
-            "data": {"offset_from_host_galaxy": 1.5},
-        },
-        token=annotation_token,
-    )
-    assert status == 200
-    annotation_id = data["data"]["annotation_id"]
+    annotation_id = sp.post_annotation(
+        public_source.id, origin, {"offset_from_host_galaxy": 1.5}
+    ).annotation_id
 
-    status, data = api(
-        "GET",
-        f"sources/{public_source.id}/annotations/{annotation_id}",
-        token=annotation_token,
-    )
-    assert status == 200
-    assert data["data"]["data"] == {"offset_from_host_galaxy": 1.5}
-    assert data["data"]["origin"] == origin
+    annotation = sp.fetch_annotation(public_source.id, annotation_id)
+    assert annotation.data == {"offset_from_host_galaxy": 1.5}
+    assert annotation.origin == origin
 
-    status, data = api(
-        "GET", f"sources/{public_source.id}/annotations", token=annotation_token
-    )
-    assert status == 200
-    assert data["data"][0]["id"] == annotation_id
-    assert len(data["data"]) == 1
+    annotations = sp.fetch_annotations(public_source.id)
+    assert annotations[0].id == annotation_id
+    assert len(annotations) == 1
 
     # delete should fail if using the wrong object ID
-    status, data = api(
-        "DELETE",
-        f"sources/{public_source.id}zzz/annotations/{annotation_id}",
-        token=annotation_token,
-    )
-    assert status == 400
-    assert (
-        "Annotation resource ID does not match resource ID given in path"
-        in data["message"]
-    )
+    with pytest.raises(
+        SkyPortalError,
+        match="Annotation resource ID does not match resource ID given in path",
+    ) as err:
+        sp.delete_annotation(f"{public_source.id}zzz", annotation_id)
+    assert err.value.status_code == 400
 
-    status, data = api(
-        "DELETE",
-        f"sources/{public_source.id}/annotations/{annotation_id}",
-        token=annotation_token,
-    )
-    assert status == 200
+    sp.delete_annotation(public_source.id, annotation_id)
 
-    status, data = api(
-        "GET",
-        f"sources/{public_source.id}/annotations/{annotation_id}",
-        token=annotation_token,
-    )
-    assert status == 403
+    with pytest.raises(SkyPortalError) as err:
+        sp.fetch_annotation(public_source.id, annotation_id)
+    assert err.value.status_code == 403
 
 
 def test_cannot_add_annotation_without_data(
     annotation_token, public_source, public_group
 ):
+    # raw api: intentionally malformed payload the typed client can't produce
     status, data = api(
         "POST",
         f"sources/{public_source.id}/annotations",
@@ -377,6 +268,7 @@ def test_cannot_add_annotation_without_data(
 
 def test_post_invalid_data(annotation_token, public_source, public_group):
     origin = str(uuid.uuid4())
+    # raw api: intentionally malformed payload the typed client can't produce
     status, data = api(
         "POST",
         f"sources/{public_source.id}/annotations",

--- a/skyportal/tests/api_tests/sources_candidates/test_annotations_altdata_info.py
+++ b/skyportal/tests/api_tests/sources_candidates/test_annotations_altdata_info.py
@@ -1,37 +1,33 @@
 import uuid
 
+from skyportal_py.sources import SourcePost
+
 from skyportal.handlers.api.internal.altdata_info import cache as altdata_info_cache
 from skyportal.handlers.api.internal.annotations_info import (
     cache as annotations_info_cache,
 )
-from skyportal.tests import api
+from skyportal.tests import client
 
 
 def test_altdata_info(upload_data_token, view_only_token, public_group):
     obj_id = str(uuid.uuid4())
     key = f"key_{uuid.uuid4().hex}"
 
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id,
-            "ra": 210.0,
-            "dec": -22.33,
-            "group_ids": [public_group.id],
-            "altdata": {key: 1.5},
-        },
-        token=upload_data_token,
+    client(upload_data_token).post_source(
+        SourcePost(
+            id=obj_id,
+            ra=210.0,
+            dec=-22.33,
+            group_ids=[public_group.id],
+            altdata={key: 1.5},
+        )
     )
-    assert status == 200
 
     # Clear the (global) cache so the freshly-posted key is reflected.
     del altdata_info_cache["altdata_info"]
 
-    status, data = api("GET", "internal/altdata_info", token=view_only_token)
-    assert status == 200
-    assert data["status"] == "success"
-    keys = data["data"]["keys"]
+    info = client(view_only_token).fetch_altdata_info()
+    keys = info["keys"]
     entry = next((e for e in keys if key in e), None)
     assert entry is not None
     assert entry[key] == "number"
@@ -39,36 +35,23 @@ def test_altdata_info(upload_data_token, view_only_token, public_group):
 
 def test_annotations_info(upload_data_token, annotation_token, public_group):
     obj_id = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id,
-            "ra": 211.0,
-            "dec": -22.33,
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    client(upload_data_token).post_source(
+        SourcePost(
+            id=obj_id,
+            ra=211.0,
+            dec=-22.33,
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
 
     origin = f"origin_{uuid.uuid4().hex}"
     key = f"key_{uuid.uuid4().hex}"
-    status, data = api(
-        "POST",
-        f"sources/{obj_id}/annotations",
-        data={"origin": origin, "data": {key: 2.0}},
-        token=annotation_token,
-    )
-    assert status == 200
+    client(annotation_token).post_annotation(obj_id, origin, {key: 2.0})
 
     # Clear this user's cache so the new annotation is reflected.
-    status, profile = api("GET", "internal/profile", token=annotation_token)
-    assert status == 200
-    del annotations_info_cache[f"annotations_info_{profile['data']['id']}"]
+    profile = client(annotation_token).fetch_profile()
+    del annotations_info_cache[f"annotations_info_{profile.id}"]
 
-    status, data = api("GET", "internal/annotations_info", token=annotation_token)
-    assert status == 200
-    assert data["status"] == "success"
-    assert origin in data["data"]
-    assert any(key in entry for entry in data["data"][origin])
+    info = client(annotation_token).fetch_annotations_info()
+    assert origin in info
+    assert any(key in entry for entry in info[origin])

--- a/skyportal/tests/api_tests/sources_candidates/test_candidates.py
+++ b/skyportal/tests/api_tests/sources_candidates/test_candidates.py
@@ -93,6 +93,8 @@ def test_token_user_post_candidate_numeric_id(
     # string column: without coercion Postgres rejects the varchar = bigint
     # comparison and the post 500s.
     obj_id = 170591539488620622
+    # raw api: intentionally malformed payload the typed client can't produce
+    # (CandidatePost.id is a str; the point is that the server coerces a JSON number)
     status, data = api(
         "POST",
         "candidates",
@@ -118,36 +120,25 @@ def test_candidate_autosave_group_ids(
     """autosaveGroupIds is a comma-separated list; it used to be handed to
     post_source_async as a raw string, whose per-element int() then ran on
     single characters."""
+    sp = client(upload_data_token_two_groups)
     obj_id = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "candidates",
-        data={
-            "id": obj_id,
-            "ra": 234.22,
-            "dec": -22.33,
-            "filter_ids": [public_filter.id],
-            "passed_at": str(utcnow_naive()),
-        },
-        token=upload_data_token_two_groups,
+    sp.post_candidate(
+        CandidatePost(
+            id=obj_id,
+            ra=234.22,
+            dec=-22.33,
+            filter_ids=[public_filter.id],
+            passed_at=str(utcnow_naive()),
+        )
     )
-    assert status == 200
 
-    status, data = api(
-        "GET",
-        "candidates",
-        params={
-            "groupIDs": f"{public_group.id}",
-            "autosave": "true",
-            "autosaveGroupIds": f"{public_group.id},{public_group2.id}",
-        },
-        token=upload_data_token_two_groups,
+    sp.fetch_candidates(
+        group_ids=[public_group.id],
+        autosave=True,
+        autosave_group_ids=[public_group.id, public_group2.id],
     )
-    assert status == 200
 
-    status, data = api("GET", f"sources/{obj_id}", token=upload_data_token_two_groups)
-    assert status == 200
-    saved_group_ids = {g["id"] for g in data["data"]["groups"]}
+    saved_group_ids = {g.id for g in sp.fetch_source(obj_id).groups}
     assert {public_group.id, public_group2.id}.issubset(saved_group_ids)
 
 

--- a/skyportal/tests/api_tests/sources_candidates/test_candidates.py
+++ b/skyportal/tests/api_tests/sources_candidates/test_candidates.py
@@ -3,30 +3,33 @@ import time
 import uuid
 
 import numpy.testing as npt
+import pytest
+from skyportal_py import SkyPortalError
+from skyportal_py.candidates import CandidatePost
+from skyportal_py.classifications import ClassificationPost
+from skyportal_py.photometry import PhotometryPost
+from skyportal_py.sources import SourcePost
+from skyportal_py.taxonomies import TaxonomyPost
 from tdtax import __version__, taxonomy
 
-from skyportal.tests import api, assert_api
+from skyportal.tests import api, client
 
 from ....utils.naive_datetime import utcnow_naive
 
 
 def test_candidate_list(view_only_token, public_candidate):
-    status, data = api("GET", "candidates", token=view_only_token)
-    assert status == 200
-    assert data["status"] == "success"
+    client(view_only_token).fetch_candidates()
 
 
 def test_candidate_existence(view_only_token, public_candidate):
-    status, _ = api("HEAD", f"candidates/{public_candidate.id}", token=view_only_token)
-    assert status == 200
+    sp = client(view_only_token)
+    assert sp.candidate_exists(public_candidate.id)
 
-    status, _ = api(
-        "HEAD", f"candidates/{public_candidate.id[:-1]}", token=view_only_token
-    )
-    assert status == 404
+    assert not sp.candidate_exists(public_candidate.id[:-1])
 
 
 def test_token_user_retrieving_candidate(view_only_token, public_candidate):
+    # raw api: raw-JSON shape assertion the typed model would mask
     status, data = api(
         "GET", f"candidates/{public_candidate.id}", token=view_only_token
     )
@@ -37,25 +40,19 @@ def test_token_user_retrieving_candidate(view_only_token, public_candidate):
 
 
 def test_token_user_retrieving_candidate_with_phot(view_only_token, public_candidate):
-    status, data = api(
-        "GET",
-        f"candidates/{public_candidate.id}?includePhotometry=true",
-        token=view_only_token,
+    candidate = client(view_only_token).fetch_candidate(
+        public_candidate.id, include_photometry=True
     )
-    assert status == 200
-    assert data["status"] == "success"
-    assert all(k in data["data"] for k in ["ra", "dec", "redshift", "dm", "photometry"])
+    # ra/dec/redshift/dm presence is guaranteed by the typed model
+    assert candidate.photometry is not None
 
 
 def test_token_user_retrieving_candidate_with_spec(view_only_token, public_candidate):
-    status, data = api(
-        "GET",
-        f"candidates/{public_candidate.id}?includeSpectra=true",
-        token=view_only_token,
+    candidate = client(view_only_token).fetch_candidate(
+        public_candidate.id, include_spectra=True
     )
-    assert status == 200
-    assert data["status"] == "success"
-    assert all(k in data["data"] for k in ["ra", "dec", "redshift", "dm", "spectra"])
+    # ra/dec/redshift/dm presence is guaranteed by the typed model
+    assert candidate.spectra is not None
 
 
 def test_token_user_post_delete_new_candidate(
@@ -64,37 +61,27 @@ def test_token_user_post_delete_new_candidate(
     public_filter,
 ):
     obj_id = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "candidates",
-        data={
-            "id": obj_id,
-            "ra": 234.22,
-            "dec": -22.33,
-            "redshift": 3,
-            "transient": False,
-            "ra_dis": 2.3,
-            "filter_ids": [public_filter.id],
-            "passed_at": str(utcnow_naive()),
-        },
-        token=upload_data_token,
+    client(upload_data_token).post_candidate(
+        CandidatePost(
+            id=obj_id,
+            ra=234.22,
+            dec=-22.33,
+            redshift=3,
+            transient=False,
+            ra_dis=2.3,
+            filter_ids=[public_filter.id],
+            passed_at=str(utcnow_naive()),
+        )
     )
-    assert status == 200
 
-    status, data = api("GET", f"candidates/{obj_id}", token=view_only_token)
-    assert status == 200
-    assert data["data"]["id"] == obj_id
-    npt.assert_almost_equal(data["data"]["ra"], 234.22)
-    redshift_history = data["data"]["redshift_history"]
+    candidate = client(view_only_token).fetch_candidate(obj_id)
+    assert candidate.id == obj_id
+    npt.assert_almost_equal(candidate.ra, 234.22)
+    redshift_history = candidate.redshift_history
     assert redshift_history is not None
     assert redshift_history[-1]["value"] == 3
 
-    status, data = api(
-        "DELETE",
-        f"candidates/{obj_id}/{public_filter.id}",
-        token=upload_data_token,
-    )
-    assert status == 200
+    client(upload_data_token).delete_candidate(obj_id, public_filter.id)
 
 
 def test_token_user_post_candidate_numeric_id(
@@ -170,45 +157,36 @@ def test_candidate_name_only_search(
     public_filter,
 ):
     obj_id = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "candidates",
-        data={
-            "id": obj_id,
-            "ra": 234.22,
-            "dec": -22.33,
-            "redshift": 3,
-            "transient": False,
-            "ra_dis": 2.3,
-            "filter_ids": [public_filter.id],
-            "passed_at": str(utcnow_naive()),
-        },
-        token=upload_data_token,
+    client(upload_data_token).post_candidate(
+        CandidatePost(
+            id=obj_id,
+            ra=234.22,
+            dec=-22.33,
+            redshift=3,
+            transient=False,
+            ra_dis=2.3,
+            filter_ids=[public_filter.id],
+            passed_at=str(utcnow_naive()),
+        )
     )
-    assert status == 200
 
     # nameOnly autocomplete (toolbar quick-search): a prefix of the obj_id
     # returns the candidate's obj_id.
-    status, data = api(
-        "GET",
-        f"candidates?objID={obj_id[:8]}&nameOnly=true&numPerPage=25",
-        token=view_only_token,
+    page = client(view_only_token).fetch_candidates(
+        obj_id=obj_id[:8], name_only=True, num_per_page=25
     )
-    assert status == 200
-    assert obj_id in [c["id"] for c in data["data"]["candidates"]]
+    assert obj_id in [c.id for c in page.candidates]
 
     # a non-matching prefix does not return it
-    status, data = api(
-        "GET",
-        "candidates?objID=zzz-no-such-candidate&nameOnly=true",
-        token=view_only_token,
+    page = client(view_only_token).fetch_candidates(
+        obj_id="zzz-no-such-candidate", name_only=True
     )
-    assert status == 200
-    assert obj_id not in [c["id"] for c in data["data"]["candidates"]]
+    assert obj_id not in [c.id for c in page.candidates]
 
 
 def test_cannot_add_candidate_without_filter_id(upload_data_token):
     obj_id = str(uuid.uuid4())
+    # raw api: intentionally malformed payload the typed client can't produce
     status, data = api(
         "POST",
         "candidates",
@@ -228,6 +206,7 @@ def test_cannot_add_candidate_without_filter_id(upload_data_token):
 
 def test_cannot_add_candidate_without_passed_at(upload_data_token, public_filter):
     obj_id = str(uuid.uuid4())
+    # raw api: intentionally malformed payload the typed client can't produce
     status, data = api(
         "POST",
         "candidates",
@@ -249,44 +228,36 @@ def test_token_user_post_two_candidates_same_obj_filter(
     upload_data_token, view_only_token, public_filter
 ):
     obj_id = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "candidates",
-        data={
-            "id": obj_id,
-            "ra": 234.22,
-            "dec": -22.33,
-            "redshift": 3,
-            "transient": False,
-            "ra_dis": 2.3,
-            "filter_ids": [public_filter.id],
-            "passed_at": str(utcnow_naive()),
-        },
-        token=upload_data_token,
+    sp = client(upload_data_token)
+    sp.post_candidate(
+        CandidatePost(
+            id=obj_id,
+            ra=234.22,
+            dec=-22.33,
+            redshift=3,
+            transient=False,
+            ra_dis=2.3,
+            filter_ids=[public_filter.id],
+            passed_at=str(utcnow_naive()),
+        )
     )
-    assert status == 200
 
-    status, data = api("GET", f"candidates/{obj_id}", token=view_only_token)
-    assert status == 200
-    assert data["data"]["id"] == obj_id
-    npt.assert_almost_equal(data["data"]["ra"], 234.22)
+    candidate = client(view_only_token).fetch_candidate(obj_id)
+    assert candidate.id == obj_id
+    npt.assert_almost_equal(candidate.ra, 234.22)
 
-    status, data = api(
-        "POST",
-        "candidates",
-        data={
-            "id": obj_id,
-            "ra": 234.22,
-            "dec": -22.33,
-            "redshift": 3,
-            "transient": False,
-            "ra_dis": 2.3,
-            "filter_ids": [public_filter.id],
-            "passed_at": str(utcnow_naive()),
-        },
-        token=upload_data_token,
+    sp.post_candidate(
+        CandidatePost(
+            id=obj_id,
+            ra=234.22,
+            dec=-22.33,
+            redshift=3,
+            transient=False,
+            ra_dis=2.3,
+            filter_ids=[public_filter.id],
+            passed_at=str(utcnow_naive()),
+        )
     )
-    assert status == 200
 
 
 def test_token_user_repost_same_obj_filter_passed_at_is_idempotent(
@@ -294,48 +265,41 @@ def test_token_user_repost_same_obj_filter_passed_at_is_idempotent(
 ):
     obj_id = str(uuid.uuid4())
     passed_at = str(utcnow_naive())
-    status, data = api(
-        "POST",
-        "candidates",
-        data={
-            "id": obj_id,
-            "ra": 234.22,
-            "dec": -22.33,
-            "redshift": 3,
-            "transient": False,
-            "ra_dis": 2.3,
-            "filter_ids": [public_filter.id],
-            "passed_at": passed_at,
-        },
-        token=upload_data_token,
-    )
-    assert status == 200
-    first_ids = data["data"]["ids"]
+    sp = client(upload_data_token)
+    first_ids = sp.post_candidate(
+        CandidatePost(
+            id=obj_id,
+            ra=234.22,
+            dec=-22.33,
+            redshift=3,
+            transient=False,
+            ra_dis=2.3,
+            filter_ids=[public_filter.id],
+            passed_at=passed_at,
+        )
+    ).ids
 
-    status, data = api("GET", f"candidates/{obj_id}", token=view_only_token)
-    assert status == 200
-    assert data["data"]["id"] == obj_id
-    npt.assert_almost_equal(data["data"]["ra"], 234.22)
+    candidate = client(view_only_token).fetch_candidate(obj_id)
+    assert candidate.id == obj_id
+    npt.assert_almost_equal(candidate.ra, 234.22)
 
     # Re-posting the same obj/filter/passed_at reuses the existing row instead of
     # 400-ing on the unique index; it returns the same candidate id.
-    status, data = api(
-        "POST",
-        "candidates",
-        data={
-            "id": obj_id,
-            "ra": 234.22,
-            "dec": -22.33,
-            "redshift": 3,
-            "transient": False,
-            "ra_dis": 2.3,
-            "filter_ids": [public_filter.id],
-            "passed_at": passed_at,
-        },
-        token=upload_data_token,
+    assert (
+        sp.post_candidate(
+            CandidatePost(
+                id=obj_id,
+                ra=234.22,
+                dec=-22.33,
+                redshift=3,
+                transient=False,
+                ra_dis=2.3,
+                filter_ids=[public_filter.id],
+                passed_at=passed_at,
+            )
+        ).ids
+        == first_ids
     )
-    assert status == 200
-    assert data["data"]["ids"] == first_ids
 
 
 def test_repost_candidate_reuses_duplicate_and_adds_new_filter(
@@ -343,38 +307,29 @@ def test_repost_candidate_reuses_duplicate_and_adds_new_filter(
 ):
     obj_id = str(uuid.uuid4())
     passed_at = str(utcnow_naive())
-    status, data = api(
-        "POST",
-        "candidates",
-        data={
-            "id": obj_id,
-            "ra": 234.22,
-            "dec": -22.33,
-            "filter_ids": [public_filter.id],
-            "passed_at": passed_at,
-        },
-        token=upload_data_token_two_groups,
-    )
-    assert status == 200
-    first_ids = data["data"]["ids"]
+    sp = client(upload_data_token_two_groups)
+    first_ids = sp.post_candidate(
+        CandidatePost(
+            id=obj_id,
+            ra=234.22,
+            dec=-22.33,
+            filter_ids=[public_filter.id],
+            passed_at=passed_at,
+        )
+    ).ids
     assert len(first_ids) == 1
 
     # public_filter is a duplicate (reused), public_filter2 is genuinely new: a
     # duplicate on one filter must not drop the new candidate for the other.
-    status, data = api(
-        "POST",
-        "candidates",
-        data={
-            "id": obj_id,
-            "ra": 234.22,
-            "dec": -22.33,
-            "filter_ids": [public_filter.id, public_filter2.id],
-            "passed_at": passed_at,
-        },
-        token=upload_data_token_two_groups,
-    )
-    assert status == 200
-    ids = data["data"]["ids"]
+    ids = sp.post_candidate(
+        CandidatePost(
+            id=obj_id,
+            ra=234.22,
+            dec=-22.33,
+            filter_ids=[public_filter.id, public_filter2.id],
+            passed_at=passed_at,
+        )
+    ).ids
     assert len(ids) == 2
     assert first_ids[0] in ids
 
@@ -383,42 +338,19 @@ def test_candidate_list_sorting_basic(
     annotation_token, view_only_token, public_candidate, public_candidate2
 ):
     origin = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        f"sources/{public_candidate.id}/annotations",
-        data={
-            "origin": origin,
-            "data": {"numeric_field": 1},
-        },
-        token=annotation_token,
-    )
-    assert status == 200
+    sp = client(annotation_token)
+    sp.post_annotation(public_candidate.id, origin, {"numeric_field": 1})
 
-    status, data = api(
-        "POST",
-        f"sources/{public_candidate2.id}/annotations",
-        data={
-            "origin": origin,
-            "data": {"numeric_field": 2},
-        },
-        token=annotation_token,
-    )
-    assert status == 200
+    sp.post_annotation(public_candidate2.id, origin, {"numeric_field": 2})
 
     # Sort by the numeric field so that public_candidate is returned first,
     # instead of by last_detected_at (which would put public_candidate2 first)
-    status, data = api(
-        "GET",
-        "candidates",
-        params={
-            "sortByAnnotationOrigin": f"{origin}",
-            "sortByAnnotationKey": "numeric_field",
-        },
-        token=view_only_token,
+    page = client(view_only_token).fetch_candidates(
+        sort_by_annotation_origin=f"{origin}",
+        sort_by_annotation_key="numeric_field",
     )
-    assert status == 200
-    assert data["data"]["candidates"][0]["id"] == public_candidate.id
-    assert data["data"]["candidates"][1]["id"] == public_candidate2.id
+    assert page.candidates[0].id == public_candidate.id
+    assert page.candidates[1].id == public_candidate2.id
 
 
 def test_candidate_list_sorting_different_origins(
@@ -426,45 +358,20 @@ def test_candidate_list_sorting_different_origins(
 ):
     origin = str(uuid.uuid4())
     origin2 = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        f"sources/{public_candidate.id}/annotations",
-        data={
-            "origin": origin,
-            "data": {"numeric_field": 1},
-        },
-        token=annotation_token,
-    )
-    assert_api(status, data)
+    sp = client(annotation_token)
+    sp.post_annotation(public_candidate.id, origin, {"numeric_field": 1})
 
-    status, data = api(
-        "POST",
-        f"sources/{public_candidate2.id}/annotations",
-        data={
-            "origin": origin2,
-            "data": {"numeric_field": 2},
-        },
-        token=annotation_token,
-    )
-    assert_api(status, data)
-    assert status == 200
+    sp.post_annotation(public_candidate2.id, origin2, {"numeric_field": 2})
 
     # If just sorting on numeric_field, public_candidate should be returned first
     # but since we specify origin2 (which is not the origin for the
     # public_candidate annotation) public_candidate2 is returned first
-    status, data = api(
-        "GET",
-        "candidates",
-        params={
-            "sortByAnnotationOrigin": f"{origin2}",
-            "sortByAnnotationKey": "numeric_field",
-        },
-        token=view_only_token,
+    page = client(view_only_token).fetch_candidates(
+        sort_by_annotation_origin=f"{origin2}",
+        sort_by_annotation_key="numeric_field",
     )
-    assert_api(status, data)
-    assert status == 200
-    assert data["data"]["candidates"][0]["id"] == public_candidate2.id
-    assert data["data"]["candidates"][1]["id"] == public_candidate.id
+    assert page.candidates[0].id == public_candidate2.id
+    assert page.candidates[1].id == public_candidate.id
 
 
 def test_candidate_list_sorting_hidden_group(
@@ -474,214 +381,105 @@ def test_candidate_list_sorting_hidden_group(
     public_candidate2,
     public_group2,
 ):
+    sp = client(annotation_token_two_groups)
     # Post an annotation that belongs only to public_group2 (not allowed for view_only_token)
-    status, data = api(
-        "POST",
-        f"sources/{public_candidate_two_groups.id}/annotations",
-        data={
-            "origin": f"{public_group2.id}",
-            "data": {"numeric_field": 1},
-            "group_ids": [public_group2.id],
-        },
-        token=annotation_token_two_groups,
+    sp.post_annotation(
+        public_candidate_two_groups.id,
+        f"{public_group2.id}",
+        {"numeric_field": 1},
+        group_ids=[public_group2.id],
     )
-    assert status == 200
 
     # This one belongs to both public groups and is thus visible
-    status, data = api(
-        "POST",
-        f"sources/{public_candidate2.id}/annotations",
-        data={
-            "origin": f"{public_group2.id}",
-            "data": {"numeric_field": 2},
-        },
-        token=annotation_token_two_groups,
+    sp.post_annotation(
+        public_candidate2.id, f"{public_group2.id}", {"numeric_field": 2}
     )
-    assert status == 200
 
     # Sort by the numeric field ascending, but since view_only_token does not
     # have access to public_group2, the first annotation above should not be
     # seen in the response
-    status, data = api(
-        "GET",
-        "candidates",
-        params={
-            "sortByAnnotationOrigin": f"{public_group2.id}",
-            "sortByAnnotationKey": "numeric_field",
-        },
-        token=view_only_token,
+    page = client(view_only_token).fetch_candidates(
+        sort_by_annotation_origin=f"{public_group2.id}",
+        sort_by_annotation_key="numeric_field",
     )
-    assert status == 200
-    assert data["data"]["candidates"][0]["id"] == public_candidate_two_groups.id
-    assert data["data"]["candidates"][0]["annotations"] == []
-    assert data["data"]["candidates"][1]["id"] == public_candidate2.id
+    assert page.candidates[0].id == public_candidate_two_groups.id
+    assert page.candidates[0].annotations == []
+    assert page.candidates[1].id == public_candidate2.id
 
 
 def test_candidate_list_sorting_null_value(
     annotation_token, view_only_token, public_candidate, public_candidate2
 ):
     origin = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        f"sources/{public_candidate.id}/annotations",
-        data={
-            "origin": origin,
-            "data": {"numeric_field": 1},
-        },
-        token=annotation_token,
-    )
-    assert status == 200
+    sp = client(annotation_token)
+    sp.post_annotation(public_candidate.id, origin, {"numeric_field": 1})
 
-    status, data = api(
-        "POST",
-        f"sources/{public_candidate2.id}/annotations",
-        data={
-            "origin": origin,
-            "data": {"some_other_field": 2},
-        },
-        token=annotation_token,
-    )
-    assert status == 200
+    sp.post_annotation(public_candidate2.id, origin, {"some_other_field": 2})
 
     # The second candidate does not have "numeric_field" in the annotations, and
     # should thus show up after the first candidate, even though it was posted
     # latest
-    status, data = api(
-        "GET",
-        "candidates",
-        params={
-            "sortByAnnotationOrigin": f"{origin}",
-            "sortByAnnotationKey": "numeric_field",
-        },
-        token=view_only_token,
+    page = client(view_only_token).fetch_candidates(
+        sort_by_annotation_origin=f"{origin}",
+        sort_by_annotation_key="numeric_field",
     )
 
-    assert status == 200
-    assert data["data"]["candidates"][0]["id"] == public_candidate.id
-    assert data["data"]["candidates"][1]["id"] == public_candidate2.id
+    assert page.candidates[0].id == public_candidate.id
+    assert page.candidates[1].id == public_candidate2.id
 
 
 def test_candidate_list_filtering_numeric(
     annotation_token, view_only_token, public_candidate, public_candidate2
 ):
     origin = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        f"sources/{public_candidate.id}/annotations",
-        data={
-            "origin": origin,
-            "data": {"numeric_field": 1},
-        },
-        token=annotation_token,
-    )
-    assert status == 200
+    sp = client(annotation_token)
+    sp.post_annotation(public_candidate.id, origin, {"numeric_field": 1})
 
-    status, data = api(
-        "POST",
-        f"sources/{public_candidate2.id}/annotations",
-        data={
-            "origin": origin,
-            "data": {"numeric_field": 2},
-        },
-        token=annotation_token,
-    )
-    assert status == 200
+    sp.post_annotation(public_candidate2.id, origin, {"numeric_field": 2})
 
     # Filter by the numeric field with max value 1.5 so that only public_candidate
     # is returned
-    status, data = api(
-        "GET",
-        "candidates",
-        params={
-            "annotationFilterList": f'{{"origin":"{origin}","key":"numeric_field","min":0,"max":1.5}}',
-        },
-        token=view_only_token,
+    page = client(view_only_token).fetch_candidates(
+        annotation_filter_list=f'{{"origin":"{origin}","key":"numeric_field","min":0,"max":1.5}}',
     )
-    assert status == 200
-    assert len(data["data"]["candidates"]) == 1
-    assert data["data"]["candidates"][0]["id"] == public_candidate.id
+    assert len(page.candidates) == 1
+    assert page.candidates[0].id == public_candidate.id
 
 
 def test_candidate_list_filtering_boolean(
     annotation_token, view_only_token, public_candidate, public_candidate2
 ):
     origin = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        f"sources/{public_candidate.id}/annotations",
-        data={
-            "origin": origin,
-            "data": {"bool_field": True},
-        },
-        token=annotation_token,
-    )
-    assert status == 200
+    sp = client(annotation_token)
+    sp.post_annotation(public_candidate.id, origin, {"bool_field": True})
 
-    status, data = api(
-        "POST",
-        f"sources/{public_candidate2.id}/annotations",
-        data={
-            "origin": origin,
-            "data": {"bool_field": False},
-        },
-        token=annotation_token,
-    )
-    assert status == 200
+    sp.post_annotation(public_candidate2.id, origin, {"bool_field": False})
 
     # Filter by the numeric field with value == true so that only public_candidate
     # is returned
-    status, data = api(
-        "GET",
-        "candidates",
-        params={
-            "annotationFilterList": f'{{"origin": "{origin}", "key": "bool_field", "value": "true"}}',
-        },
-        token=view_only_token,
+    page = client(view_only_token).fetch_candidates(
+        annotation_filter_list=f'{{"origin": "{origin}", "key": "bool_field", "value": "true"}}',
     )
-    assert status == 200
-    assert len(data["data"]["candidates"]) == 1
-    assert data["data"]["candidates"][0]["id"] == public_candidate.id
+    assert len(page.candidates) == 1
+    assert page.candidates[0].id == public_candidate.id
 
 
 def test_candidate_list_filtering_string(
     annotation_token, view_only_token, public_candidate, public_candidate2
 ):
     origin = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        f"sources/{public_candidate.id}/annotations",
-        data={
-            "origin": origin,
-            "data": {"string_field": "a"},
-        },
-        token=annotation_token,
-    )
-    assert status == 200
+    sp = client(annotation_token)
+    sp.post_annotation(public_candidate.id, origin, {"string_field": "a"})
 
-    status, data = api(
-        "POST",
-        f"sources/{public_candidate2.id}/annotations",
-        data={
-            "origin": origin,
-            "data": {"string_field": "b"},
-        },
-        token=annotation_token,
-    )
-    assert status == 200
+    sp.post_annotation(public_candidate2.id, origin, {"string_field": "b"})
 
     # Filter by the numeric field with value == "a" so that only public_candidate
     # is returned
-    status, data = api(
-        "GET",
-        "candidates",
-        params={
-            "annotationFilterList": f'{{"origin": "{origin}", "key": "string_field", "value": "a"}}',
-        },
-        token=view_only_token,
+    page = client(view_only_token).fetch_candidates(
+        annotation_filter_list=f'{{"origin": "{origin}", "key": "string_field", "value": "a"}}',
     )
-    assert status == 200
-    assert len(data["data"]["candidates"]) == 1
-    assert data["data"]["candidates"][0]["id"] == public_candidate.id
+    assert len(page.candidates) == 1
+    assert page.candidates[0].id == public_candidate.id
 
 
 def test_candidate_list_classifications(
@@ -695,86 +493,64 @@ def test_candidate_list_classifications(
     # Post a candidate with a classification, and one without
     obj_id1 = str(uuid.uuid4())
     obj_id2 = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "candidates",
-        data={
-            "id": obj_id1,
-            "ra": 234.22,
-            "dec": -22.33,
-            "redshift": 3,
-            "transient": False,
-            "ra_dis": 2.3,
-            "filter_ids": [public_filter.id],
-            "passed_at": str(utcnow_naive()),
-        },
-        token=upload_data_token,
+    sp = client(upload_data_token)
+    sp.post_candidate(
+        CandidatePost(
+            id=obj_id1,
+            ra=234.22,
+            dec=-22.33,
+            redshift=3,
+            transient=False,
+            ra_dis=2.3,
+            filter_ids=[public_filter.id],
+            passed_at=str(utcnow_naive()),
+        )
     )
-    assert status == 200
-    status, data = api(
-        "POST",
-        "candidates",
-        data={
-            "id": obj_id2,
-            "ra": 234.22,
-            "dec": -22.33,
-            "redshift": 3,
-            "transient": False,
-            "ra_dis": 2.3,
-            "filter_ids": [public_filter.id],
-            "passed_at": str(utcnow_naive()),
-        },
-        token=upload_data_token,
+    sp.post_candidate(
+        CandidatePost(
+            id=obj_id2,
+            ra=234.22,
+            dec=-22.33,
+            redshift=3,
+            transient=False,
+            ra_dis=2.3,
+            filter_ids=[public_filter.id],
+            passed_at=str(utcnow_naive()),
+        )
     )
-    assert status == 200
 
-    status, data = api(
-        "POST",
-        "sources",
-        data={"id": obj_id1},
-        token=upload_data_token,
+    sp.post_source(SourcePost(id=obj_id1))
+    taxonomy_id = (
+        client(taxonomy_token)
+        .post_taxonomy(
+            TaxonomyPost(
+                name="test taxonomy" + str(uuid.uuid4()),
+                hierarchy=taxonomy,
+                group_ids=[public_group.id],
+                provenance=f"tdtax_{__version__}",
+                version=__version__,
+                is_latest=True,
+            )
+        )
+        .taxonomy_id
     )
-    assert status == 200
-    status, data = api(
-        "POST",
-        "taxonomy",
-        data={
-            "name": "test taxonomy" + str(uuid.uuid4()),
-            "hierarchy": taxonomy,
-            "group_ids": [public_group.id],
-            "provenance": f"tdtax_{__version__}",
-            "version": __version__,
-            "isLatest": True,
-        },
-        token=taxonomy_token,
-    )
-    assert status == 200
-    taxonomy_id = data["data"]["taxonomy_id"]
 
-    status, data = api(
-        "POST",
-        "classification",
-        data={
-            "obj_id": obj_id1,
-            "classification": "Algol",
-            "taxonomy_id": taxonomy_id,
-            "probability": 1.0,
-            "group_ids": [public_group.id],
-        },
-        token=classification_token,
+    client(classification_token).post_classification(
+        ClassificationPost(
+            obj_id=obj_id1,
+            classification="Algol",
+            taxonomy_id=taxonomy_id,
+            probability=1.0,
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
 
     # Filter for candidates with classification 'Algol' - should only get obj_id1 back
-    status, data = api(
-        "GET",
-        "candidates",
-        params={"classifications": "Algol", "groupIDs": f"{public_group.id}"},
-        token=view_only_token,
+    page = client(view_only_token).fetch_candidates(
+        classifications=["Algol"], group_ids=[public_group.id]
     )
-    assert status == 200
-    assert len(data["data"]["candidates"]) == 1
-    assert data["data"]["candidates"][0]["id"] == obj_id1
+    assert len(page.candidates) == 1
+    assert page.candidates[0].id == obj_id1
 
 
 def test_candidate_list_redshift_range(
@@ -783,67 +559,48 @@ def test_candidate_list_redshift_range(
     # Post candidates with different redshifts
     obj_id1 = str(uuid.uuid4())
     obj_id2 = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "candidates",
-        data={
-            "id": obj_id1,
-            "ra": 234.22,
-            "dec": -22.33,
-            "redshift": 0,
-            "transient": False,
-            "ra_dis": 2.3,
-            "filter_ids": [public_filter.id],
-            "passed_at": str(utcnow_naive()),
-        },
-        token=upload_data_token,
+    sp = client(upload_data_token)
+    sp.post_candidate(
+        CandidatePost(
+            id=obj_id1,
+            ra=234.22,
+            dec=-22.33,
+            redshift=0,
+            transient=False,
+            ra_dis=2.3,
+            filter_ids=[public_filter.id],
+            passed_at=str(utcnow_naive()),
+        )
     )
-    assert status == 200
-    status, data = api(
-        "POST",
-        "candidates",
-        data={
-            "id": obj_id2,
-            "ra": 234.22,
-            "dec": -22.33,
-            "redshift": 1,
-            "transient": False,
-            "ra_dis": 2.3,
-            "filter_ids": [public_filter.id],
-            "passed_at": str(utcnow_naive()),
-        },
-        token=upload_data_token,
+    sp.post_candidate(
+        CandidatePost(
+            id=obj_id2,
+            ra=234.22,
+            dec=-22.33,
+            redshift=1,
+            transient=False,
+            ra_dis=2.3,
+            filter_ids=[public_filter.id],
+            passed_at=str(utcnow_naive()),
+        )
     )
-    assert status == 200
 
     # Filter for candidates redshift between 0 and 0.5 - should only get obj_id1 back
-    status, data = api(
-        "GET",
-        "candidates",
-        params={
-            "minRedshift": "0",
-            "maxRedshift": "0.5",
-            "groupIDs": f"{public_group.id}",
-        },
-        token=view_only_token,
+    page = client(view_only_token).fetch_candidates(
+        min_redshift=0,
+        max_redshift=0.5,
+        group_ids=[public_group.id],
     )
-    assert status == 200
-    assert len(data["data"]["candidates"]) == 1
-    assert data["data"]["candidates"][0]["id"] == obj_id1
+    assert len(page.candidates) == 1
+    assert page.candidates[0].id == obj_id1
 
 
 def test_exclude_by_outdated_annotations(
     annotation_token, view_only_token, public_group, public_candidate, public_candidate2
 ):
-    status, data = api(
-        "GET",
-        "candidates",
-        params={"groupIDs": f"{public_group.id}"},
-        token=view_only_token,
-    )
+    page = client(view_only_token).fetch_candidates(group_ids=[public_group.id])
 
-    assert status == 200
-    num_candidates = len(data["data"]["candidates"])
+    num_candidates = len(page.candidates)
 
     origin = str(uuid.uuid4())
     t0 = utcnow_naive()  # recall when it was created
@@ -856,13 +613,7 @@ def test_exclude_by_outdated_annotations(
     t0 += datetime.timedelta(seconds=60)  # give some extra time
 
     # add an annotation from this origin
-    status, data = api(
-        "POST",
-        f"sources/{public_candidate.id}/annotations",
-        data={"origin": origin, "data": {"value1": 1}},
-        token=annotation_token,
-    )
-    assert status == 200
+    client(annotation_token).post_annotation(public_candidate.id, origin, {"value1": 1})
 
 
 def test_candidate_list_saved_to_all_selected_groups(
@@ -876,90 +627,63 @@ def test_candidate_list_saved_to_all_selected_groups(
     obj_id1 = str(uuid.uuid4())
     obj_id2 = str(uuid.uuid4())
     obj_id3 = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "candidates",
-        data={
-            "id": obj_id1,
-            "ra": 234.22,
-            "dec": -22.33,
-            "redshift": 3,
-            "transient": False,
-            "ra_dis": 2.3,
-            "filter_ids": [public_filter.id],
-            "passed_at": str(utcnow_naive()),
-        },
-        token=upload_data_token_two_groups,
+    sp = client(upload_data_token_two_groups)
+    sp.post_candidate(
+        CandidatePost(
+            id=obj_id1,
+            ra=234.22,
+            dec=-22.33,
+            redshift=3,
+            transient=False,
+            ra_dis=2.3,
+            filter_ids=[public_filter.id],
+            passed_at=str(utcnow_naive()),
+        )
     )
-    assert status == 200
-    status, data = api(
-        "POST",
-        "candidates",
-        data={
-            "id": obj_id2,
-            "ra": 234.22,
-            "dec": -22.33,
-            "redshift": 3,
-            "transient": False,
-            "ra_dis": 2.3,
-            "filter_ids": [public_filter.id],
-            "passed_at": str(utcnow_naive()),
-        },
-        token=upload_data_token_two_groups,
+    sp.post_candidate(
+        CandidatePost(
+            id=obj_id2,
+            ra=234.22,
+            dec=-22.33,
+            redshift=3,
+            transient=False,
+            ra_dis=2.3,
+            filter_ids=[public_filter.id],
+            passed_at=str(utcnow_naive()),
+        )
     )
-    assert status == 200
-    status, data = api(
-        "POST",
-        "candidates",
-        data={
-            "id": obj_id3,
-            "ra": 234.22,
-            "dec": -22.33,
-            "redshift": 3,
-            "transient": False,
-            "ra_dis": 2.3,
-            "filter_ids": [public_filter.id],
-            "passed_at": str(utcnow_naive()),
-        },
-        token=upload_data_token_two_groups,
+    sp.post_candidate(
+        CandidatePost(
+            id=obj_id3,
+            ra=234.22,
+            dec=-22.33,
+            redshift=3,
+            transient=False,
+            ra_dis=2.3,
+            filter_ids=[public_filter.id],
+            passed_at=str(utcnow_naive()),
+        )
     )
-    assert status == 200
 
     # Save the two candidates as sources
     # obj_id1 is saved to both public groups
-    status, data = api(
-        "POST",
-        "sources",
-        data={"id": obj_id1, "group_ids": [public_group.id, public_group2.id]},
-        token=upload_data_token_two_groups,
+    saved = sp.post_source(
+        SourcePost(id=obj_id1, group_ids=[public_group.id, public_group2.id])
     )
-    assert status == 200
-    assert data["data"]["id"] == obj_id1
+    assert saved.id == obj_id1
     # obj_id2 is saved to only public_group
-    status, data = api(
-        "POST",
-        "sources",
-        data={"id": obj_id2, "group_ids": [public_group.id]},
-        token=upload_data_token_two_groups,
-    )
-    assert status == 200
-    assert data["data"]["id"] == obj_id2
+    saved = sp.post_source(SourcePost(id=obj_id2, group_ids=[public_group.id]))
+    assert saved.id == obj_id2
 
     # Now get candidates saved to both public_group and public_group2
     # Should not get obj_id3 back since it was not saved
-    status, data = api(
-        "GET",
-        "candidates",
-        params={
-            "groupIDs": f"{public_group.id},{public_group2.id}",
-            "savedStatus": "savedToAllSelected",
-        },
-        token=view_only_token_two_groups,
+    page = client(view_only_token_two_groups).fetch_candidates(
+        group_ids=[public_group.id, public_group2.id],
+        saved_status="savedToAllSelected",
     )
-    assert status == 200
     # Should only get obj_id1 back
-    assert len(data["data"]["candidates"]) == 1
-    assert data["data"]["candidates"][0]["id"] == obj_id1
+    assert len(page.candidates) == 1
+    assert page.candidates[0].id == obj_id1
 
 
 def test_candidate_list_saved_to_any_selected_groups(
@@ -973,93 +697,61 @@ def test_candidate_list_saved_to_any_selected_groups(
     obj_id1 = str(uuid.uuid4())
     obj_id2 = str(uuid.uuid4())
     obj_id3 = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "candidates",
-        data={
-            "id": obj_id1,
-            "ra": 234.22,
-            "dec": -22.33,
-            "redshift": 3,
-            "transient": False,
-            "ra_dis": 2.3,
-            "filter_ids": [public_filter.id],
-            "passed_at": str(utcnow_naive()),
-        },
-        token=upload_data_token_two_groups,
+    sp = client(upload_data_token_two_groups)
+    sp.post_candidate(
+        CandidatePost(
+            id=obj_id1,
+            ra=234.22,
+            dec=-22.33,
+            redshift=3,
+            transient=False,
+            ra_dis=2.3,
+            filter_ids=[public_filter.id],
+            passed_at=str(utcnow_naive()),
+        )
     )
-    assert status == 200
-    status, data = api(
-        "POST",
-        "candidates",
-        data={
-            "id": obj_id2,
-            "ra": 234.22,
-            "dec": -22.33,
-            "redshift": 3,
-            "transient": False,
-            "ra_dis": 2.3,
-            "filter_ids": [public_filter.id],
-            "passed_at": str(utcnow_naive()),
-        },
-        token=upload_data_token_two_groups,
+    sp.post_candidate(
+        CandidatePost(
+            id=obj_id2,
+            ra=234.22,
+            dec=-22.33,
+            redshift=3,
+            transient=False,
+            ra_dis=2.3,
+            filter_ids=[public_filter.id],
+            passed_at=str(utcnow_naive()),
+        )
     )
-    assert status == 200
-    status, data = api(
-        "POST",
-        "candidates",
-        data={
-            "id": obj_id3,
-            "ra": 234.22,
-            "dec": -22.33,
-            "redshift": 3,
-            "transient": False,
-            "ra_dis": 2.3,
-            "filter_ids": [public_filter.id],
-            "passed_at": str(utcnow_naive()),
-        },
-        token=upload_data_token_two_groups,
+    sp.post_candidate(
+        CandidatePost(
+            id=obj_id3,
+            ra=234.22,
+            dec=-22.33,
+            redshift=3,
+            transient=False,
+            ra_dis=2.3,
+            filter_ids=[public_filter.id],
+            passed_at=str(utcnow_naive()),
+        )
     )
-    assert status == 200
 
     # Save the two candidates as sources
     # obj_id1 is saved to only public_group2
-    status, data = api(
-        "POST",
-        "sources",
-        data={"id": obj_id1, "group_ids": [public_group2.id]},
-        token=upload_data_token_two_groups,
-    )
-    assert status == 200
-    assert data["data"]["id"] == obj_id1
+    saved = sp.post_source(SourcePost(id=obj_id1, group_ids=[public_group2.id]))
+    assert saved.id == obj_id1
     # obj_id2 is saved to only public_group
-    status, data = api(
-        "POST",
-        "sources",
-        data={"id": obj_id2, "group_ids": [public_group.id]},
-        token=upload_data_token_two_groups,
-    )
-    assert status == 200
-    assert data["data"]["id"] == obj_id2
+    saved = sp.post_source(SourcePost(id=obj_id2, group_ids=[public_group.id]))
+    assert saved.id == obj_id2
 
     # Now get candidates saved to any of public_group and public_group2
     # Should not get obj_id3 back since it was not saved
-    status, data = api(
-        "GET",
-        "candidates",
-        params={
-            "groupIDs": f"{public_group.id},{public_group2.id}",
-            "savedStatus": "savedToAnySelected",
-        },
-        token=view_only_token_two_groups,
+    page = client(view_only_token_two_groups).fetch_candidates(
+        group_ids=[public_group.id, public_group2.id],
+        saved_status="savedToAnySelected",
     )
-    assert status == 200
     # Should get obj_id1 and obj_id2 back
-    assert len(data["data"]["candidates"]) == 2
-    assert (
-        len({obj_id1, obj_id2}.difference(x["id"] for x in data["data"]["candidates"]))
-        == 0
-    )
+    assert len(page.candidates) == 2
+    assert len({obj_id1, obj_id2}.difference(x.id for x in page.candidates)) == 0
 
 
 def test_candidate_list_saved_to_any_accessible_groups(
@@ -1072,65 +764,46 @@ def test_candidate_list_saved_to_any_accessible_groups(
     # Post two candidates for filter belonging to public_group
     obj_id = str(uuid.uuid4())
     obj_id2 = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "candidates",
-        data={
-            "id": obj_id,
-            "ra": 234.22,
-            "dec": -22.33,
-            "redshift": 3,
-            "transient": False,
-            "ra_dis": 2.3,
-            "filter_ids": [public_filter.id],
-            "passed_at": str(utcnow_naive()),
-        },
-        token=upload_data_token_two_groups,
+    sp = client(upload_data_token_two_groups)
+    sp.post_candidate(
+        CandidatePost(
+            id=obj_id,
+            ra=234.22,
+            dec=-22.33,
+            redshift=3,
+            transient=False,
+            ra_dis=2.3,
+            filter_ids=[public_filter.id],
+            passed_at=str(utcnow_naive()),
+        )
     )
-    assert status == 200
-    status, data = api(
-        "POST",
-        "candidates",
-        data={
-            "id": obj_id2,
-            "ra": 234.22,
-            "dec": -22.33,
-            "redshift": 3,
-            "transient": False,
-            "ra_dis": 2.3,
-            "filter_ids": [public_filter.id],
-            "passed_at": str(utcnow_naive()),
-        },
-        token=upload_data_token_two_groups,
+    sp.post_candidate(
+        CandidatePost(
+            id=obj_id2,
+            ra=234.22,
+            dec=-22.33,
+            redshift=3,
+            transient=False,
+            ra_dis=2.3,
+            filter_ids=[public_filter.id],
+            passed_at=str(utcnow_naive()),
+        )
     )
-    assert status == 200
 
     # obj_id is saved to only public_group2
-    status, data = api(
-        "POST",
-        "sources",
-        data={"id": obj_id, "group_ids": [public_group2.id]},
-        token=upload_data_token_two_groups,
-    )
-    assert status == 200
-    assert data["data"]["id"] == obj_id
+    saved = sp.post_source(SourcePost(id=obj_id, group_ids=[public_group2.id]))
+    assert saved.id == obj_id
 
     # Select for candidates passing public_filter, which belongs to public_group
     # Since we set "savedToAnyAccessible", should still get back obj_id even if
     # is saved to only public_group2
     # Should not get obj_id2 back since it was not saved
-    status, data = api(
-        "GET",
-        "candidates",
-        params={
-            "groupIDs": f"{public_group.id}",
-            "savedStatus": "savedToAnyAccessible",
-        },
-        token=view_only_token_two_groups,
+    page = client(view_only_token_two_groups).fetch_candidates(
+        group_ids=[public_group.id],
+        saved_status="savedToAnyAccessible",
     )
-    assert status == 200
-    assert len(data["data"]["candidates"]) == 1
-    assert data["data"]["candidates"][0]["id"] == obj_id
+    assert len(page.candidates) == 1
+    assert page.candidates[0].id == obj_id
 
 
 def test_candidate_list_not_saved_to_any_accessible_groups(
@@ -1144,96 +817,64 @@ def test_candidate_list_not_saved_to_any_accessible_groups(
     obj_id1 = str(uuid.uuid4())
     obj_id2 = str(uuid.uuid4())
     obj_id3 = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "candidates",
-        data={
-            "id": obj_id1,
-            "ra": 234.22,
-            "dec": -22.33,
-            "redshift": 3,
-            "transient": False,
-            "ra_dis": 2.3,
-            "filter_ids": [public_filter.id],
-            "passed_at": str(utcnow_naive()),
-        },
-        token=upload_data_token_two_groups,
+    sp = client(upload_data_token_two_groups)
+    sp.post_candidate(
+        CandidatePost(
+            id=obj_id1,
+            ra=234.22,
+            dec=-22.33,
+            redshift=3,
+            transient=False,
+            ra_dis=2.3,
+            filter_ids=[public_filter.id],
+            passed_at=str(utcnow_naive()),
+        )
     )
-    assert status == 200
-    status, data = api(
-        "POST",
-        "candidates",
-        data={
-            "id": obj_id2,
-            "ra": 234.22,
-            "dec": -22.33,
-            "redshift": 3,
-            "transient": False,
-            "ra_dis": 2.3,
-            "filter_ids": [public_filter.id],
-            "passed_at": str(utcnow_naive()),
-        },
-        token=upload_data_token_two_groups,
+    sp.post_candidate(
+        CandidatePost(
+            id=obj_id2,
+            ra=234.22,
+            dec=-22.33,
+            redshift=3,
+            transient=False,
+            ra_dis=2.3,
+            filter_ids=[public_filter.id],
+            passed_at=str(utcnow_naive()),
+        )
     )
-    assert status == 200
-    status, data = api(
-        "POST",
-        "candidates",
-        data={
-            "id": obj_id3,
-            "ra": 234.22,
-            "dec": -22.33,
-            "redshift": 3,
-            "transient": False,
-            "ra_dis": 2.3,
-            "filter_ids": [public_filter.id],
-            "passed_at": str(utcnow_naive()),
-        },
-        token=upload_data_token_two_groups,
+    sp.post_candidate(
+        CandidatePost(
+            id=obj_id3,
+            ra=234.22,
+            dec=-22.33,
+            redshift=3,
+            transient=False,
+            ra_dis=2.3,
+            filter_ids=[public_filter.id],
+            passed_at=str(utcnow_naive()),
+        )
     )
-    assert status == 200
 
     # Obj_id1 is saved to public_group2
-    status, data = api(
-        "POST",
-        "sources",
-        data={"id": obj_id1, "group_ids": [public_group2.id]},
-        token=upload_data_token_two_groups,
-    )
-    assert status == 200
-    assert data["data"]["id"] == obj_id1
+    saved = sp.post_source(SourcePost(id=obj_id1, group_ids=[public_group2.id]))
+    assert saved.id == obj_id1
 
     # Obj_id3 is saved to public_group
-    status, data = api(
-        "POST",
-        "sources",
-        data={"id": obj_id3, "group_ids": [public_group.id]},
-        token=upload_data_token_two_groups,
-    )
-    assert status == 200
-    assert data["data"]["id"] == obj_id3
+    saved = sp.post_source(SourcePost(id=obj_id3, group_ids=[public_group.id]))
+    assert saved.id == obj_id3
 
     # Select for candidates passing public_filter, which belongs to public_group
     # Since we set "notSavedToAnyAccessible", should get back obj_id even though
     # it is saved, since view_only_user doesn"t have public_group2 access
     # Should also get back obj_id2 since it is not saved at all
     # Should not get back obj_id3 since it is saved to public_group
-    status, data = api(
-        "GET",
-        "candidates",
-        params={
-            "groupIDs": f"{public_group.id}",
-            "savedStatus": "notSavedToAnyAccessible",
-        },
-        token=view_only_token,
+    page = client(view_only_token).fetch_candidates(
+        group_ids=[public_group.id],
+        saved_status="notSavedToAnyAccessible",
     )
-    assert status == 200
     # Should get obj_id1 and obj_id2 back
-    assert len(data["data"]["candidates"]) == 2
-    assert (
-        len({obj_id1, obj_id2}.difference(x["id"] for x in data["data"]["candidates"]))
-        == 0
-    )
+    assert len(page.candidates) == 2
+    assert len({obj_id1, obj_id2}.difference(x.id for x in page.candidates)) == 0
 
 
 def test_candidate_list_not_saved_to_any_selected_groups(
@@ -1247,92 +888,63 @@ def test_candidate_list_not_saved_to_any_selected_groups(
     obj_id1 = str(uuid.uuid4())
     obj_id2 = str(uuid.uuid4())
     obj_id3 = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "candidates",
-        data={
-            "id": obj_id1,
-            "ra": 234.22,
-            "dec": -22.33,
-            "redshift": 3,
-            "transient": False,
-            "ra_dis": 2.3,
-            "filter_ids": [public_filter.id],
-            "passed_at": str(utcnow_naive()),
-        },
-        token=upload_data_token_two_groups,
+    sp = client(upload_data_token_two_groups)
+    sp.post_candidate(
+        CandidatePost(
+            id=obj_id1,
+            ra=234.22,
+            dec=-22.33,
+            redshift=3,
+            transient=False,
+            ra_dis=2.3,
+            filter_ids=[public_filter.id],
+            passed_at=str(utcnow_naive()),
+        )
     )
-    assert status == 200
-    status, data = api(
-        "POST",
-        "candidates",
-        data={
-            "id": obj_id2,
-            "ra": 234.22,
-            "dec": -22.33,
-            "redshift": 3,
-            "transient": False,
-            "ra_dis": 2.3,
-            "filter_ids": [public_filter.id],
-            "passed_at": str(utcnow_naive()),
-        },
-        token=upload_data_token_two_groups,
+    sp.post_candidate(
+        CandidatePost(
+            id=obj_id2,
+            ra=234.22,
+            dec=-22.33,
+            redshift=3,
+            transient=False,
+            ra_dis=2.3,
+            filter_ids=[public_filter.id],
+            passed_at=str(utcnow_naive()),
+        )
     )
-    assert status == 200
-    status, data = api(
-        "POST",
-        "candidates",
-        data={
-            "id": obj_id3,
-            "ra": 234.22,
-            "dec": -22.33,
-            "redshift": 3,
-            "transient": False,
-            "ra_dis": 2.3,
-            "filter_ids": [public_filter.id],
-            "passed_at": str(utcnow_naive()),
-        },
-        token=upload_data_token_two_groups,
+    sp.post_candidate(
+        CandidatePost(
+            id=obj_id3,
+            ra=234.22,
+            dec=-22.33,
+            redshift=3,
+            transient=False,
+            ra_dis=2.3,
+            filter_ids=[public_filter.id],
+            passed_at=str(utcnow_naive()),
+        )
     )
-    assert status == 200
 
     # Obj_id1 is saved to public_group2
-    status, data = api(
-        "POST",
-        "sources",
-        data={"id": obj_id1, "group_ids": [public_group2.id]},
-        token=upload_data_token_two_groups,
-    )
-    assert status == 200
-    assert data["data"]["id"] == obj_id1
+    saved = sp.post_source(SourcePost(id=obj_id1, group_ids=[public_group2.id]))
+    assert saved.id == obj_id1
 
     # Obj_id3 is saved to public_group
-    status, data = api(
-        "POST",
-        "sources",
-        data={"id": obj_id3, "group_ids": [public_group.id]},
-        token=upload_data_token_two_groups,
-    )
-    assert status == 200
-    assert data["data"]["id"] == obj_id3
+    saved = sp.post_source(SourcePost(id=obj_id3, group_ids=[public_group.id]))
+    assert saved.id == obj_id3
 
     # Select for candidates using public_group and public_group2
     # Should not get back obj_id1 since it is saved to public_group2
     # Should get back obj_id2 since it is not saved at all
     # Should not get back obj_id3 since it is saved to public_group
-    status, data = api(
-        "GET",
-        "candidates",
-        params={
-            "groupIDs": f"{public_group.id},{public_group2.id}",
-            "savedStatus": "notSavedToAnySelected",
-        },
-        token=view_only_token_two_groups,
+    page = client(view_only_token_two_groups).fetch_candidates(
+        group_ids=[public_group.id, public_group2.id],
+        saved_status="notSavedToAnySelected",
     )
-    assert status == 200
     # Should get obj_id1 back
-    assert len(data["data"]["candidates"]) == 1
-    assert data["data"]["candidates"][0]["id"] == obj_id2
+    assert len(page.candidates) == 1
+    assert page.candidates[0].id == obj_id2
 
 
 def test_candidate_list_not_saved_to_all_selected_groups(
@@ -1346,97 +958,65 @@ def test_candidate_list_not_saved_to_all_selected_groups(
     obj_id1 = str(uuid.uuid4())
     obj_id2 = str(uuid.uuid4())
     obj_id3 = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "candidates",
-        data={
-            "id": obj_id1,
-            "ra": 234.22,
-            "dec": -22.33,
-            "redshift": 3,
-            "transient": False,
-            "ra_dis": 2.3,
-            "filter_ids": [public_filter.id],
-            "passed_at": str(utcnow_naive()),
-        },
-        token=upload_data_token_two_groups,
+    sp = client(upload_data_token_two_groups)
+    sp.post_candidate(
+        CandidatePost(
+            id=obj_id1,
+            ra=234.22,
+            dec=-22.33,
+            redshift=3,
+            transient=False,
+            ra_dis=2.3,
+            filter_ids=[public_filter.id],
+            passed_at=str(utcnow_naive()),
+        )
     )
-    assert status == 200
-    status, data = api(
-        "POST",
-        "candidates",
-        data={
-            "id": obj_id2,
-            "ra": 234.22,
-            "dec": -22.33,
-            "redshift": 3,
-            "transient": False,
-            "ra_dis": 2.3,
-            "filter_ids": [public_filter.id],
-            "passed_at": str(utcnow_naive()),
-        },
-        token=upload_data_token_two_groups,
+    sp.post_candidate(
+        CandidatePost(
+            id=obj_id2,
+            ra=234.22,
+            dec=-22.33,
+            redshift=3,
+            transient=False,
+            ra_dis=2.3,
+            filter_ids=[public_filter.id],
+            passed_at=str(utcnow_naive()),
+        )
     )
-    assert status == 200
-    status, data = api(
-        "POST",
-        "candidates",
-        data={
-            "id": obj_id3,
-            "ra": 234.22,
-            "dec": -22.33,
-            "redshift": 3,
-            "transient": False,
-            "ra_dis": 2.3,
-            "filter_ids": [public_filter.id],
-            "passed_at": str(utcnow_naive()),
-        },
-        token=upload_data_token_two_groups,
+    sp.post_candidate(
+        CandidatePost(
+            id=obj_id3,
+            ra=234.22,
+            dec=-22.33,
+            redshift=3,
+            transient=False,
+            ra_dis=2.3,
+            filter_ids=[public_filter.id],
+            passed_at=str(utcnow_naive()),
+        )
     )
-    assert status == 200
 
     # Obj_id1 is saved to both groups
-    status, data = api(
-        "POST",
-        "sources",
-        data={"id": obj_id1, "group_ids": [public_group.id, public_group2.id]},
-        token=upload_data_token_two_groups,
+    saved = sp.post_source(
+        SourcePost(id=obj_id1, group_ids=[public_group.id, public_group2.id])
     )
-    assert status == 200
-    assert data["data"]["id"] == obj_id1
+    assert saved.id == obj_id1
 
     # Obj_id3 is saved to public_group
-    status, data = api(
-        "POST",
-        "sources",
-        data={"id": obj_id3, "group_ids": [public_group.id]},
-        token=upload_data_token_two_groups,
-    )
-    assert status == 200
-    assert data["data"]["id"] == obj_id3
+    saved = sp.post_source(SourcePost(id=obj_id3, group_ids=[public_group.id]))
+    assert saved.id == obj_id3
 
     # Select for candidates using public_group and public_group2
     # Should not get back obj_id since it is saved to both selected groups
     # Should get back obj_id2 since it is not saved at all
     # Should get back obj_id3 since it is saved to only public_group
-    status, data = api(
-        "GET",
-        "candidates",
-        params={
-            "groupIDs": f"{public_group.id},{public_group2.id}",
-            "savedStatus": "notSavedToAllSelected",
-        },
-        token=view_only_token_two_groups,
+    page = client(view_only_token_two_groups).fetch_candidates(
+        group_ids=[public_group.id, public_group2.id],
+        saved_status="notSavedToAllSelected",
     )
-    if status != 200:
-        print(data["message"])
-    assert status == 200
     # Should get obj_id2 and obj_id3 back
-    assert len(data["data"]["candidates"]) == 2
-    assert (
-        len({obj_id2, obj_id3}.difference(x["id"] for x in data["data"]["candidates"]))
-        == 0
-    )
+    assert len(page.candidates) == 2
+    assert len({obj_id2, obj_id3}.difference(x.id for x in page.candidates)) == 0
 
 
 def test_correct_spectra_and_photometry_returned_by_candidate(
@@ -1444,24 +1024,19 @@ def test_correct_spectra_and_photometry_returned_by_candidate(
     public_candidate2,  # adds phot and spec that should not be returned
     view_only_token_two_groups,
 ):
-    status, data = api(
-        "GET",
-        f"candidates/{public_candidate.id}?includePhotometry=t&includeSpectra=t",
-        token=view_only_token_two_groups,
+    candidate = client(view_only_token_two_groups).fetch_candidate(
+        public_candidate.id, include_photometry=True, include_spectra=True
     )
 
-    assert status == 200
-    assert data["status"] == "success"
-
-    assert len(public_candidate.photometry) == len(data["data"]["photometry"])
-    assert len(public_candidate.spectra) == len(data["data"]["spectra"])
+    assert len(public_candidate.photometry) == len(candidate.photometry)
+    assert len(public_candidate.spectra) == len(candidate.spectra)
 
     phot_ids_db = sorted(p.id for p in public_candidate.photometry)
-    phot_ids_api = sorted(p["id"] for p in data["data"]["photometry"])
+    phot_ids_api = sorted(p["id"] for p in candidate.photometry)
     assert phot_ids_db == phot_ids_api
 
     spec_ids_db = sorted(p.id for p in public_candidate.spectra)
-    spec_ids_api = sorted(p["id"] for p in data["data"]["spectra"])
+    spec_ids_api = sorted(p["id"] for p in candidate.spectra)
     assert spec_ids_db == spec_ids_api
 
 
@@ -1475,55 +1050,39 @@ def test_candidates_hidden_photometry_not_leaked(
 ):
     obj_id = str(public_candidate.id)
     # Post photometry to the object belonging to a different group
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": obj_id,
-            "mjd": 58000.0,
-            "instrument_id": ztf_camera.id,
-            "flux": 12.24,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "group_ids": [public_group2.id],
-            "altdata": {"some_key": "some_value"},
-        },
-        token=upload_data_token_two_groups,
+    photometry_id = (
+        client(upload_data_token_two_groups)
+        .post_photometry(
+            PhotometryPost(
+                obj_id=obj_id,
+                mjd=58000.0,
+                instrument_id=ztf_camera.id,
+                flux=12.24,
+                fluxerr=0.031,
+                zp=25.0,
+                magsys="ab",
+                filter="ztfg",
+                group_ids=[public_group2.id],
+                altdata={"some_key": "some_value"},
+            )
+        )
+        .ids[0]
     )
-    assert status == 200
-    assert data["status"] == "success"
-    photometry_id = data["data"]["ids"][0]
 
     # Check the photometry sent back with the candidate
-    status, data = api(
-        "GET",
-        "candidates",
-        params={"groupIDs": f"{public_group.id}", "includePhotometry": "true"},
-        token=view_only_token,
+    page = client(view_only_token).fetch_candidates(
+        group_ids=[public_group.id], include_photometry=True
     )
-    assert status == 200
-    assert len(data["data"]["candidates"]) == 1
-    assert data["data"]["candidates"][0]["id"] == obj_id
-    assert len(public_candidate.photometry) - 1 == len(
-        data["data"]["candidates"][0]["photometry"]
-    )
-    assert photometry_id not in (
-        x["id"] for x in data["data"]["candidates"][0]["photometry"]
-    )
+    assert len(page.candidates) == 1
+    assert page.candidates[0].id == obj_id
+    assert len(public_candidate.photometry) - 1 == len(page.candidates[0].photometry)
+    assert photometry_id not in (x["id"] for x in page.candidates[0].photometry)
 
     # Check for single GET call as well
-    status, data = api(
-        "GET",
-        f"candidates/{obj_id}",
-        params={"includePhotometry": "true"},
-        token=view_only_token,
-    )
-    assert status == 200
-    assert data["data"]["id"] == obj_id
-    assert len(public_candidate.photometry) - 1 == len(data["data"]["photometry"])
-    assert photometry_id not in (x["id"] for x in data["data"]["photometry"])
+    candidate = client(view_only_token).fetch_candidate(obj_id, include_photometry=True)
+    assert candidate.id == obj_id
+    assert len(public_candidate.photometry) - 1 == len(candidate.photometry)
+    assert photometry_id not in (x["id"] for x in candidate.photometry)
 
 
 def test_candidate_list_pagination(
@@ -1535,91 +1094,58 @@ def test_candidate_list_pagination(
     # Upload two candidates with know passed_at order
     obj_id1 = str(uuid.uuid4())
     obj_id2 = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "candidates",
-        data={
-            "id": obj_id1,
-            "ra": 234.22,
-            "dec": -22.33,
-            "redshift": 3,
-            "transient": False,
-            "ra_dis": 2.3,
-            "filter_ids": [public_filter.id],
-            "passed_at": str(utcnow_naive()),
-        },
-        token=upload_data_token,
+    sp = client(upload_data_token)
+    sp.post_candidate(
+        CandidatePost(
+            id=obj_id1,
+            ra=234.22,
+            dec=-22.33,
+            redshift=3,
+            transient=False,
+            ra_dis=2.3,
+            filter_ids=[public_filter.id],
+            passed_at=str(utcnow_naive()),
+        )
     )
-    assert status == 200
-    status, data = api(
-        "POST",
-        "candidates",
-        data={
-            "id": obj_id2,
-            "ra": 234.22,
-            "dec": -22.33,
-            "redshift": 3,
-            "transient": False,
-            "ra_dis": 2.3,
-            "filter_ids": [public_filter.id],
-            "passed_at": str(utcnow_naive() + datetime.timedelta(days=1)),
-        },
-        token=upload_data_token,
+    sp.post_candidate(
+        CandidatePost(
+            id=obj_id2,
+            ra=234.22,
+            dec=-22.33,
+            redshift=3,
+            transient=False,
+            ra_dis=2.3,
+            filter_ids=[public_filter.id],
+            passed_at=str(utcnow_naive() + datetime.timedelta(days=1)),
+        )
     )
-    assert status == 200
 
     # Default order is descending passed_at
-    status, data = api(
-        "GET",
-        "candidates",
-        params={"numPerPage": 1, "pageNumber": 2, "groupIDs": f"{public_group.id}"},
-        token=view_only_token,
+    page = client(view_only_token).fetch_candidates(
+        num_per_page=1, page_number=2, group_ids=[public_group.id]
     )
-    assert status == 200
-    assert data["data"]["candidates"][0]["id"] == obj_id1
-    assert "queryID" in data["data"]
-    query_id = data["data"]["queryID"]
+    assert page.candidates[0].id == obj_id1
+    assert page.query_id is not None
+    query_id = page.query_id
 
-    status, data = api(
-        "GET",
-        "candidates",
-        params={"pageNumber": 1, "queryID": query_id},
-        token=view_only_token,
-    )
-    assert status == 200
-    assert data["data"]["queryID"] == query_id
+    page = client(view_only_token).fetch_candidates(page_number=1, query_id=query_id)
+    assert page.query_id == query_id
 
     # Wait until cache is expired
     time.sleep(3)
 
     # Submit new request, which will create new (unrelated) cache, triggering
     # cleanup of expired cache files
-    status, data = api(
-        "GET",
-        "candidates",
-        token=view_only_token,
-    )
-    assert status == 200
+    client(view_only_token).fetch_candidates()
 
     # Cache should now be removed, so we expect a new query ID
-    status, data = api(
-        "GET",
-        "candidates",
-        params={"pageNumber": 1, "queryID": query_id},
-        token=view_only_token,
-    )
-    assert status == 200
-    assert data["data"]["queryID"] != query_id
+    page = client(view_only_token).fetch_candidates(page_number=1, query_id=query_id)
+    assert page.query_id != query_id
 
     # Invalid page
-    status, data = api(
-        "GET",
-        "candidates",
-        params={"numPerPage": 1, "pageNumber": 4},
-        token=view_only_token,
-    )
-    assert status == 400
-    assert "Page number out of range" in data["message"]
+    with pytest.raises(SkyPortalError, match="Page number out of range") as err:
+        client(view_only_token).fetch_candidates(num_per_page=1, page_number=4)
+    assert err.value.status_code == 400
 
 
 def test_candidates_annotation_filtering(
@@ -1632,121 +1158,80 @@ def test_candidates_annotation_filtering(
 ):
     obj_id = str(public_candidate.id)
     # Post photometry to the object belonging to a different group
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": obj_id,
-            "mjd": 58000.0,
-            "instrument_id": ztf_camera.id,
-            "flux": 12.24,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "group_ids": [public_group.id],
-            "altdata": {"some_key": "some_value"},
-        },
-        token=upload_data_token_two_groups,
+    photometry_id = (
+        client(upload_data_token_two_groups)
+        .post_photometry(
+            PhotometryPost(
+                obj_id=obj_id,
+                mjd=58000.0,
+                instrument_id=ztf_camera.id,
+                flux=12.24,
+                fluxerr=0.031,
+                zp=25.0,
+                magsys="ab",
+                filter="ztfg",
+                group_ids=[public_group.id],
+                altdata={"some_key": "some_value"},
+            )
+        )
+        .ids[0]
     )
-    assert status == 200
-    assert data["status"] == "success"
-    photometry_id = data["data"]["ids"][0]
 
-    status, data = api(
-        "POST",
-        f"photometry/{photometry_id}/annotations",
-        data={
-            "origin": "kowalski",
-            "data": {"gaia_G": 15.7},
-            "group_ids": [public_group.id],
-        },
-        token=annotation_token,
+    client(annotation_token).post_annotation(
+        photometry_id,
+        "kowalski",
+        {"gaia_G": 15.7},
+        resource_type="photometry",
+        group_ids=[public_group.id],
     )
-    assert status == 200
 
     # Check the photometry sent back with the candidate
-    status, data = api(
-        "GET",
-        "candidates",
-        params={
-            "groupIDs": f"{public_group.id}",
-            "photometryAnnotationsFilterOrigin": "kowalski",
-        },
-        token=view_only_token,
+    sp = client(view_only_token)
+    page = sp.fetch_candidates(
+        group_ids=[public_group.id],
+        photometry_annotations_filter_origin="kowalski",
     )
-    assert status == 200
-    assert len(data["data"]["candidates"]) == 1
-    assert data["data"]["candidates"][0]["id"] == obj_id
+    assert len(page.candidates) == 1
+    assert page.candidates[0].id == obj_id
 
-    status, data = api(
-        "GET",
-        "candidates",
-        params={
-            "groupIDs": f"{public_group.id}",
-            "photometryAnnotationsFilter": "gaia_G",
-        },
-        token=view_only_token,
+    page = sp.fetch_candidates(
+        group_ids=[public_group.id],
+        photometry_annotations_filter="gaia_G",
     )
-    assert status == 200
-    assert len(data["data"]["candidates"]) == 1
-    assert data["data"]["candidates"][0]["id"] == obj_id
+    assert len(page.candidates) == 1
+    assert page.candidates[0].id == obj_id
 
-    status, data = api(
-        "GET",
-        "candidates",
-        params={
-            "groupIDs": f"{public_group.id}",
-            "photometryAnnotationsFilter": "gaia_G : 15.0 : ge",
-        },
-        token=view_only_token,
+    page = sp.fetch_candidates(
+        group_ids=[public_group.id],
+        photometry_annotations_filter="gaia_G : 15.0 : ge",
     )
-    assert status == 200
-    assert len(data["data"]["candidates"]) == 1
-    assert data["data"]["candidates"][0]["id"] == obj_id
+    assert len(page.candidates) == 1
+    assert page.candidates[0].id == obj_id
 
-    status, data = api(
-        "GET",
-        "candidates",
-        params={
-            "groupIDs": f"{public_group.id}",
-            "photometryAnnotationsFilter": "gaia_G : 15.0 : le",
-        },
-        token=view_only_token,
+    page = sp.fetch_candidates(
+        group_ids=[public_group.id],
+        photometry_annotations_filter="gaia_G : 15.0 : le",
     )
-    assert status == 200
-    assert len(data["data"]["candidates"]) == 0
+    assert len(page.candidates) == 0
 
     # Date-bounded filters on the photometry annotation's created_at. These
     # exercise the AnnotationOnPhotometry.created_at (timestamp) comparison: the
     # date string must be coerced to a datetime or psycopg3 raises "operator
     # does not exist: timestamp without time zone = character varying".
-    status, data = api(
-        "GET",
-        "candidates",
-        params={
-            "groupIDs": f"{public_group.id}",
-            "photometryAnnotationsFilterOrigin": "kowalski",
-            "photometryAnnotationsFilterAfter": "2000-01-01T00:00:00",
-        },
-        token=view_only_token,
+    page = sp.fetch_candidates(
+        group_ids=[public_group.id],
+        photometry_annotations_filter_origin="kowalski",
+        photometry_annotations_filter_after="2000-01-01T00:00:00",
     )
-    assert status == 200
-    assert len(data["data"]["candidates"]) == 1
-    assert data["data"]["candidates"][0]["id"] == obj_id
+    assert len(page.candidates) == 1
+    assert page.candidates[0].id == obj_id
 
-    status, data = api(
-        "GET",
-        "candidates",
-        params={
-            "groupIDs": f"{public_group.id}",
-            "photometryAnnotationsFilterOrigin": "kowalski",
-            "photometryAnnotationsFilterBefore": "2000-01-01T00:00:00",
-        },
-        token=view_only_token,
+    page = sp.fetch_candidates(
+        group_ids=[public_group.id],
+        photometry_annotations_filter_origin="kowalski",
+        photometry_annotations_filter_before="2000-01-01T00:00:00",
     )
-    assert status == 200
-    assert len(data["data"]["candidates"]) == 0
+    assert len(page.candidates) == 0
 
 
 def test_candidate_savers(
@@ -1760,87 +1245,65 @@ def test_candidate_savers(
     obj_id1 = str(uuid.uuid4())
     obj_id2 = str(uuid.uuid4())
     obj_id3 = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "candidates",
-        data={
-            "id": obj_id1,
-            "ra": 234.22,
-            "dec": -22.33,
-            "redshift": 3,
-            "transient": False,
-            "ra_dis": 2.3,
-            "filter_ids": [public_filter.id],
-            "passed_at": str(utcnow_naive()),
-        },
-        token=upload_data_token_two_groups,
+    sp_two_groups = client(upload_data_token_two_groups)
+    sp_two_groups.post_candidate(
+        CandidatePost(
+            id=obj_id1,
+            ra=234.22,
+            dec=-22.33,
+            redshift=3,
+            transient=False,
+            ra_dis=2.3,
+            filter_ids=[public_filter.id],
+            passed_at=str(utcnow_naive()),
+        )
     )
-    assert status == 200
-    status, data = api(
-        "POST",
-        "candidates",
-        data={
-            "id": obj_id2,
-            "ra": 234.22,
-            "dec": -22.33,
-            "redshift": 3,
-            "transient": False,
-            "ra_dis": 2.3,
-            "filter_ids": [public_filter.id],
-            "passed_at": str(utcnow_naive()),
-        },
-        token=upload_data_token_two_groups,
+    sp_two_groups.post_candidate(
+        CandidatePost(
+            id=obj_id2,
+            ra=234.22,
+            dec=-22.33,
+            redshift=3,
+            transient=False,
+            ra_dis=2.3,
+            filter_ids=[public_filter.id],
+            passed_at=str(utcnow_naive()),
+        )
     )
-    assert status == 200
-    status, data = api(
-        "POST",
-        "candidates",
-        data={
-            "id": obj_id3,
-            "ra": 234.22,
-            "dec": -22.33,
-            "redshift": 3,
-            "transient": False,
-            "ra_dis": 2.3,
-            "filter_ids": [public_filter.id],
-            "passed_at": str(utcnow_naive()),
-        },
-        token=upload_data_token_two_groups,
+    sp_two_groups.post_candidate(
+        CandidatePost(
+            id=obj_id3,
+            ra=234.22,
+            dec=-22.33,
+            redshift=3,
+            transient=False,
+            ra_dis=2.3,
+            filter_ids=[public_filter.id],
+            passed_at=str(utcnow_naive()),
+        )
     )
-    assert status == 200
 
     # Save the three candidates as sources
     # obj_id1 is saved by the upload_data_token token
-    status, data = api(
-        "POST",
-        "sources",
-        data={"id": obj_id1, "group_ids": [public_group.id]},
-        token=upload_data_token,
+    saved = client(upload_data_token).post_source(
+        SourcePost(id=obj_id1, group_ids=[public_group.id])
     )
-    assert status == 200
-    assert data["data"]["id"] == obj_id1
+    assert saved.id == obj_id1
 
     # obj_id2 is also saved by the upload_data_token token
-    status, data = api(
-        "POST",
-        "sources",
-        data={"id": obj_id2, "group_ids": [public_group.id]},
-        token=upload_data_token,
+    saved = client(upload_data_token).post_source(
+        SourcePost(id=obj_id2, group_ids=[public_group.id])
     )
-    assert status == 200
-    assert data["data"]["id"] == obj_id2
+    assert saved.id == obj_id2
 
     # obj_id3 is saved by the upload_data_token_two_groups token
-    status, data = api(
-        "POST",
-        "sources",
-        data={"id": obj_id3, "group_ids": [public_group.id]},
-        token=upload_data_token_two_groups,
+    saved = sp_two_groups.post_source(
+        SourcePost(id=obj_id3, group_ids=[public_group.id])
     )
-    assert status == 200
-    assert data["data"]["id"] == obj_id3
+    assert saved.id == obj_id3
 
     # Check scanning statistics
+    # raw api: internal dashboard-widget endpoint, outside skyportal-py's scope
     status, data = api(
         "GET",
         "internal/source_savers",
@@ -1855,6 +1318,7 @@ def test_candidate_savers(
 
 
 def test_candidate_filter_list(view_only_token, public_candidate):
+    # raw api: raw-JSON shape assertion the typed model would mask
     status, data = api("GET", "candidates_filter", token=view_only_token)
     assert status == 200
     assert data["status"] == "success"
@@ -1875,68 +1339,47 @@ def test_bulk_delete_old_unsaved_candidates(
     old_saved = str(uuid.uuid4())  # old but actively saved -> should be kept
     recent_unsaved = str(uuid.uuid4())  # unsaved but recent -> should be kept
 
+    sp = client(upload_data_token)
     for obj_id, passed_at in [
         (old_unsaved, old),
         (old_saved, old),
         (recent_unsaved, recent),
     ]:
-        status, data = api(
-            "POST",
-            "candidates",
-            data={
-                "id": obj_id,
-                "ra": 10.0,
-                "dec": 10.0,
-                "filter_ids": [public_filter.id],
-                "passed_at": passed_at,
-            },
-            token=upload_data_token,
+        sp.post_candidate(
+            CandidatePost(
+                id=obj_id,
+                ra=10.0,
+                dec=10.0,
+                filter_ids=[public_filter.id],
+                passed_at=passed_at,
+            )
         )
-        assert status == 200, data
 
     # save old_saved as an active source so it is protected
-    status, data = api(
-        "POST",
-        "sources",
-        data={"id": old_saved, "group_ids": [public_group.id]},
-        token=upload_data_token,
-    )
-    assert status == 200, data
+    sp.post_source(SourcePost(id=old_saved, group_ids=[public_group.id]))
 
     # non-admins cannot call the purge
-    status, data = api("POST", "candidates/bulk_delete", data={}, token=view_only_token)
-    assert status == 401
+    sp_view = client(view_only_token)
+    with pytest.raises(SkyPortalError) as err:
+        sp_view.bulk_delete_candidates()
+    assert err.value.status_code == 401
 
     # dry run deletes nothing but reports the old, unsaved candidate
-    status, data = api(
-        "POST",
-        "candidates/bulk_delete",
-        data={"maxAgeMonths": 6, "dryRun": True},
-        token=super_admin_token,
+    result = client(super_admin_token).bulk_delete_candidates(
+        max_age_months=6, dry_run=True
     )
-    assert status == 200, data
-    assert data["data"]["deleted"] == 0
-    assert data["data"]["remaining"] >= 1
+    assert result.deleted == 0
+    assert result.remaining >= 1
     # dry run did not actually delete
-    status, _ = api("HEAD", f"candidates/{old_unsaved}", token=view_only_token)
-    assert status == 200
+    assert sp_view.candidate_exists(old_unsaved)
 
     # real purge
-    status, data = api(
-        "POST",
-        "candidates/bulk_delete",
-        data={"maxAgeMonths": 6},
-        token=super_admin_token,
-    )
-    assert status == 200, data
-    assert data["data"]["deleted"] >= 1
+    result = client(super_admin_token).bulk_delete_candidates(max_age_months=6)
+    assert result.deleted >= 1
 
     # old + unsaved was deleted
-    status, _ = api("HEAD", f"candidates/{old_unsaved}", token=view_only_token)
-    assert status == 404
+    assert not sp_view.candidate_exists(old_unsaved)
     # old + saved was kept (has an active source)
-    status, _ = api("HEAD", f"candidates/{old_saved}", token=view_only_token)
-    assert status == 200
+    assert sp_view.candidate_exists(old_saved)
     # recent + unsaved was kept (too new)
-    status, _ = api("HEAD", f"candidates/{recent_unsaved}", token=view_only_token)
-    assert status == 200
+    assert sp_view.candidate_exists(recent_unsaved)

--- a/skyportal/tests/api_tests/sources_candidates/test_classifications.py
+++ b/skyportal/tests/api_tests/sources_candidates/test_classifications.py
@@ -1,503 +1,393 @@
 import uuid
 
+import pytest
+from skyportal_py import SkyPortalError
+from skyportal_py.classifications import ClassificationPost, ClassificationUpdate
+from skyportal_py.taxonomies import TaxonomyPost
 from tdtax import __version__, taxonomy
 
-from skyportal.tests import api
+from skyportal.tests import client
 
 
 def test_add_bad_classification(
     taxonomy_token, classification_token, public_source, public_group
 ):
-    status, data = api(
-        "POST",
-        "taxonomy",
-        data={
-            "name": "test taxonomy" + str(uuid.uuid4()),
-            "hierarchy": taxonomy,
-            "group_ids": [public_group.id],
-            "provenance": f"tdtax_{__version__}",
-            "version": __version__,
-            "isLatest": True,
-        },
-        token=taxonomy_token,
+    taxonomy_id = (
+        client(taxonomy_token)
+        .post_taxonomy(
+            TaxonomyPost(
+                name="test taxonomy" + str(uuid.uuid4()),
+                hierarchy=taxonomy,
+                group_ids=[public_group.id],
+                provenance=f"tdtax_{__version__}",
+                version=__version__,
+                is_latest=True,
+            )
+        )
+        .taxonomy_id
     )
-    assert status == 200
-    taxonomy_id = data["data"]["taxonomy_id"]
 
-    status, data = api(
-        "POST",
-        "classification",
-        data={
-            "obj_id": public_source.id,
-            "classification": "Fried Green Tomato",
-            "origin": "SCoPe",
-            "taxonomy_id": taxonomy_id,
-            "probability": 1.0,
-            "group_ids": [public_group.id],
-        },
-        token=classification_token,
-    )
-    assert "is not in the allowed classes" in data["message"]
-    assert status == 400
+    with pytest.raises(SkyPortalError, match="is not in the allowed classes") as err:
+        client(classification_token).post_classification(
+            ClassificationPost(
+                obj_id=public_source.id,
+                classification="Fried Green Tomato",
+                origin="SCoPe",
+                taxonomy_id=taxonomy_id,
+                probability=1.0,
+                group_ids=[public_group.id],
+            )
+        )
+    assert err.value.status_code == 400
 
-    status, data = api(
-        "POST",
-        "classification",
-        data={
-            "obj_id": public_source.id,
-            "classification": "RRab",
-            "origin": "SCoPe",
-            "taxonomy_id": taxonomy_id,
-            "probability": 10.0,
-            "group_ids": [public_group.id],
-        },
-        token=classification_token,
-    )
-    assert "outside the allowable range" in data["message"]
-    assert status == 400
+    with pytest.raises(SkyPortalError, match="outside the allowable range") as err:
+        client(classification_token).post_classification(
+            ClassificationPost(
+                obj_id=public_source.id,
+                classification="RRab",
+                origin="SCoPe",
+                taxonomy_id=taxonomy_id,
+                probability=10.0,
+                group_ids=[public_group.id],
+            )
+        )
+    assert err.value.status_code == 400
 
 
 def test_add_and_retrieve_classification_group_id(
     taxonomy_token, classification_token, public_source, public_group
 ):
-    status, data = api(
-        "POST",
-        "taxonomy",
-        data={
-            "name": "test taxonomy" + str(uuid.uuid4()),
-            "hierarchy": taxonomy,
-            "group_ids": [public_group.id],
-            "provenance": f"tdtax_{__version__}",
-            "version": __version__,
-            "isLatest": True,
-        },
-        token=taxonomy_token,
-    )
-    assert status == 200
-    taxonomy_id = data["data"]["taxonomy_id"]
-
-    status, data = api(
-        "POST",
-        "classification",
-        data={
-            "obj_id": public_source.id,
-            "classification": "Algol",
-            "origin": "SCoPe",
-            "taxonomy_id": taxonomy_id,
-            "probability": 1.0,
-            "group_ids": [public_group.id],
-        },
-        token=classification_token,
-    )
-    assert status == 200
-    classification_id = data["data"]["classification_id"]
-
-    status, data = api(
-        "GET", f"classification/{classification_id}", token=classification_token
+    taxonomy_id = (
+        client(taxonomy_token)
+        .post_taxonomy(
+            TaxonomyPost(
+                name="test taxonomy" + str(uuid.uuid4()),
+                hierarchy=taxonomy,
+                group_ids=[public_group.id],
+                provenance=f"tdtax_{__version__}",
+                version=__version__,
+                is_latest=True,
+            )
+        )
+        .taxonomy_id
     )
 
-    assert status == 200
-    assert data["data"]["classification"] == "Algol"
-    assert data["data"]["probability"] == 1.0
-    assert data["data"]["origin"] == "SCoPe"
+    sp = client(classification_token)
+    classification_id = sp.post_classification(
+        ClassificationPost(
+            obj_id=public_source.id,
+            classification="Algol",
+            origin="SCoPe",
+            taxonomy_id=taxonomy_id,
+            probability=1.0,
+            group_ids=[public_group.id],
+        )
+    ).classification_id
 
-    params = {"numPerPage": 100}
+    fetched = sp.fetch_classification(classification_id)
+    assert fetched.classification == "Algol"
+    assert fetched.probability == 1.0
+    assert fetched.origin == "SCoPe"
 
-    status, data = api(
-        "GET", "classification", token=classification_token, params=params
-    )
-
-    assert status == 200
-    data = data["data"]["classifications"]
-    assert [d["classification"] == "Algol" for d in data]
-    assert [d["origin"] == "SCoPe" for d in data]
-    assert [d["probability"] == 1.0 for d in data]
-    assert [d["obj_id"] == public_source.id for d in data]
+    data = sp.fetch_classifications_query(num_per_page=100).classifications
+    assert [d.classification == "Algol" for d in data]
+    assert [d.origin == "SCoPe" for d in data]
+    assert [d.probability == 1.0 for d in data]
+    assert [d.obj_id == public_source.id for d in data]
 
 
 def test_add_and_retrieve_classification_no_group_id(
     taxonomy_token, classification_token, public_source, public_group
 ):
-    status, data = api(
-        "POST",
-        "taxonomy",
-        data={
-            "name": "test taxonomy" + str(uuid.uuid4()),
-            "hierarchy": taxonomy,
-            "group_ids": [public_group.id],
-            "provenance": f"tdtax_{__version__}",
-            "version": __version__,
-            "isLatest": True,
-        },
-        token=taxonomy_token,
-    )
-    assert status == 200
-    taxonomy_id = data["data"]["taxonomy_id"]
-
-    status, data = api(
-        "POST",
-        "classification",
-        data={
-            "obj_id": public_source.id,
-            "classification": "Algol",
-            "origin": "SCoPe",
-            "taxonomy_id": taxonomy_id,
-        },
-        token=classification_token,
-    )
-    assert status == 200
-    classification_id = data["data"]["classification_id"]
-
-    status, data = api(
-        "GET", f"classification/{classification_id}", token=classification_token
+    taxonomy_id = (
+        client(taxonomy_token)
+        .post_taxonomy(
+            TaxonomyPost(
+                name="test taxonomy" + str(uuid.uuid4()),
+                hierarchy=taxonomy,
+                group_ids=[public_group.id],
+                provenance=f"tdtax_{__version__}",
+                version=__version__,
+                is_latest=True,
+            )
+        )
+        .taxonomy_id
     )
 
-    assert status == 200
-    assert data["data"]["classification"] == "Algol"
+    sp = client(classification_token)
+    classification_id = sp.post_classification(
+        ClassificationPost(
+            obj_id=public_source.id,
+            classification="Algol",
+            origin="SCoPe",
+            taxonomy_id=taxonomy_id,
+        )
+    ).classification_id
+
+    assert sp.fetch_classification(classification_id).classification == "Algol"
 
 
 def test_cannot_add_classification_without_permission(
     taxonomy_token, view_only_token, public_source, public_group
 ):
-    status, data = api(
-        "POST",
-        "taxonomy",
-        data={
-            "name": "test taxonomy" + str(uuid.uuid4()),
-            "hierarchy": taxonomy,
-            "group_ids": [public_group.id],
-            "provenance": f"tdtax_{__version__}",
-            "version": __version__,
-            "isLatest": True,
-        },
-        token=taxonomy_token,
+    taxonomy_id = (
+        client(taxonomy_token)
+        .post_taxonomy(
+            TaxonomyPost(
+                name="test taxonomy" + str(uuid.uuid4()),
+                hierarchy=taxonomy,
+                group_ids=[public_group.id],
+                provenance=f"tdtax_{__version__}",
+                version=__version__,
+                is_latest=True,
+            )
+        )
+        .taxonomy_id
     )
-    assert status == 200
-    taxonomy_id = data["data"]["taxonomy_id"]
 
-    status, data = api(
-        "POST",
-        "classification",
-        data={
-            "obj_id": public_source.id,
-            "classification": "Algol",
-            "origin": "SCoPe",
-            "taxonomy_id": taxonomy_id,
-        },
-        token=view_only_token,
-    )
-    assert status == 401
-    assert data["status"] == "error"
+    with pytest.raises(SkyPortalError) as err:
+        client(view_only_token).post_classification(
+            ClassificationPost(
+                obj_id=public_source.id,
+                classification="Algol",
+                origin="SCoPe",
+                taxonomy_id=taxonomy_id,
+            )
+        )
+    assert err.value.status_code == 401
 
 
 def test_update_classification_probability_records_edit(
     taxonomy_token, classification_token, public_source, public_group
 ):
-    status, data = api(
-        "POST",
-        "taxonomy",
-        data={
-            "name": "test taxonomy" + str(uuid.uuid4()),
-            "hierarchy": taxonomy,
-            "group_ids": [public_group.id],
-            "provenance": f"tdtax_{__version__}",
-            "version": __version__,
-            "isLatest": True,
-        },
-        token=taxonomy_token,
+    taxonomy_id = (
+        client(taxonomy_token)
+        .post_taxonomy(
+            TaxonomyPost(
+                name="test taxonomy" + str(uuid.uuid4()),
+                hierarchy=taxonomy,
+                group_ids=[public_group.id],
+                provenance=f"tdtax_{__version__}",
+                version=__version__,
+                is_latest=True,
+            )
+        )
+        .taxonomy_id
     )
-    assert status == 200
-    taxonomy_id = data["data"]["taxonomy_id"]
 
-    status, data = api(
-        "POST",
-        "classification",
-        data={
-            "obj_id": public_source.id,
-            "classification": "Algol",
-            "taxonomy_id": taxonomy_id,
-            "probability": 1.0,
-            "group_ids": [public_group.id],
-        },
-        token=classification_token,
-    )
-    assert status == 200
-    classification_id = data["data"]["classification_id"]
+    sp = client(classification_token)
+    classification_id = sp.post_classification(
+        ClassificationPost(
+            obj_id=public_source.id,
+            classification="Algol",
+            taxonomy_id=taxonomy_id,
+            probability=1.0,
+            group_ids=[public_group.id],
+        )
+    ).classification_id
 
     # Zeroing the probability updates the existing classification in place
     # rather than posting a new one
-    status, data = api(
-        "PUT",
-        f"classification/{classification_id}",
-        data={
-            "obj_id": public_source.id,
-            "classification": "Algol",
-            "taxonomy_id": taxonomy_id,
-            "probability": 0,
-        },
-        token=classification_token,
+    sp.update_classification(
+        classification_id,
+        ClassificationUpdate(
+            classification="Algol",
+            taxonomy_id=taxonomy_id,
+            probability=0,
+        ),
     )
-    assert status == 200
 
-    status, data = api(
-        "GET", f"sources/{public_source.id}/classifications", token=classification_token
-    )
-    assert status == 200
-    assert len(data["data"]) == 1
-    assert data["data"][0]["id"] == classification_id
-    assert data["data"][0]["probability"] == 0
+    classifications = sp.fetch_classifications(public_source.id)
+    assert len(classifications) == 1
+    assert classifications[0].id == classification_id
+    assert classifications[0].probability == 0
 
-    edits = data["data"][0]["edits"]
+    edits = classifications[0].edits
     assert len(edits) == 1
-    assert edits[0]["old_probability"] == 1.0
-    assert edits[0]["new_probability"] == 0
+    assert edits[0].old_probability == 1.0
+    assert edits[0].new_probability == 0
 
     # An update that doesn't change the probability adds no edit
-    status, data = api(
-        "PUT",
-        f"classification/{classification_id}",
-        data={
-            "obj_id": public_source.id,
-            "classification": "Algol",
-            "taxonomy_id": taxonomy_id,
-            "probability": 0,
-        },
-        token=classification_token,
+    sp.update_classification(
+        classification_id,
+        ClassificationUpdate(
+            classification="Algol",
+            taxonomy_id=taxonomy_id,
+            probability=0,
+        ),
     )
-    assert status == 200
 
-    status, data = api(
-        "GET", f"sources/{public_source.id}/classifications", token=classification_token
-    )
-    assert status == 200
-    assert len(data["data"][0]["edits"]) == 1
+    classifications = sp.fetch_classifications(public_source.id)
+    assert len(classifications[0].edits) == 1
 
 
 def test_delete_classification(
     taxonomy_token, classification_token, public_source, public_group
 ):
-    status, data = api(
-        "POST",
-        "taxonomy",
-        data={
-            "name": "test taxonomy" + str(uuid.uuid4()),
-            "hierarchy": taxonomy,
-            "group_ids": [public_group.id],
-            "provenance": f"tdtax_{__version__}",
-            "version": __version__,
-            "isLatest": True,
-        },
-        token=taxonomy_token,
+    taxonomy_id = (
+        client(taxonomy_token)
+        .post_taxonomy(
+            TaxonomyPost(
+                name="test taxonomy" + str(uuid.uuid4()),
+                hierarchy=taxonomy,
+                group_ids=[public_group.id],
+                provenance=f"tdtax_{__version__}",
+                version=__version__,
+                is_latest=True,
+            )
+        )
+        .taxonomy_id
     )
-    assert status == 200
-    taxonomy_id = data["data"]["taxonomy_id"]
 
-    status, data = api(
-        "POST",
-        "classification",
-        data={
-            "obj_id": public_source.id,
-            "classification": "Algol",
-            "origin": "SCoPe",
-            "taxonomy_id": taxonomy_id,
-        },
-        token=classification_token,
-    )
-    assert status == 200
-    classification_id = data["data"]["classification_id"]
+    sp = client(classification_token)
+    classification_id = sp.post_classification(
+        ClassificationPost(
+            obj_id=public_source.id,
+            classification="Algol",
+            origin="SCoPe",
+            taxonomy_id=taxonomy_id,
+        )
+    ).classification_id
 
-    status, data = api(
-        "GET", f"classification/{classification_id}", token=classification_token
-    )
-    assert status == 200
-    assert data["data"]["classification"] == "Algol"
-    assert data["data"]["origin"] == "SCoPe"
+    fetched = sp.fetch_classification(classification_id)
+    assert fetched.classification == "Algol"
+    assert fetched.origin == "SCoPe"
 
-    status, data = api(
-        "DELETE", f"classification/{classification_id}", token=classification_token
-    )
-    assert status == 200
+    sp.delete_classification(classification_id)
 
-    status, data = api(
-        "GET", f"classification/{classification_id}", token=classification_token
-    )
-    assert status == 400
+    with pytest.raises(SkyPortalError) as err:
+        sp.fetch_classification(classification_id)
+    assert err.value.status_code == 400
 
 
 def test_obj_classifications(
     taxonomy_token, classification_token, public_source, public_group
 ):
-    status, data = api(
-        "POST",
-        "taxonomy",
-        data={
-            "name": "test taxonomy" + str(uuid.uuid4()),
-            "hierarchy": taxonomy,
-            "group_ids": [public_group.id],
-            "provenance": f"tdtax_{__version__}",
-            "version": __version__,
-            "isLatest": True,
-        },
-        token=taxonomy_token,
+    taxonomy_id = (
+        client(taxonomy_token)
+        .post_taxonomy(
+            TaxonomyPost(
+                name="test taxonomy" + str(uuid.uuid4()),
+                hierarchy=taxonomy,
+                group_ids=[public_group.id],
+                provenance=f"tdtax_{__version__}",
+                version=__version__,
+                is_latest=True,
+            )
+        )
+        .taxonomy_id
     )
-    assert status == 200
-    taxonomy_id = data["data"]["taxonomy_id"]
 
-    status, data = api(
-        "POST",
-        "classification",
-        data={
-            "obj_id": public_source.id,
-            "classification": "Algol",
-            "origin": "SCoPe",
-            "taxonomy_id": taxonomy_id,
-        },
-        token=classification_token,
-    )
-    assert status == 200
-    classification_id = data["data"]["classification_id"]
+    sp = client(classification_token)
+    classification_id = sp.post_classification(
+        ClassificationPost(
+            obj_id=public_source.id,
+            classification="Algol",
+            origin="SCoPe",
+            taxonomy_id=taxonomy_id,
+        )
+    ).classification_id
 
-    status, data = api(
-        "GET", f"sources/{public_source.id}/classifications", token=classification_token
-    )
-    assert status == 200
-    assert data["data"][0]["classification"] == "Algol"
-    assert data["data"][0]["origin"] == "SCoPe"
-    assert data["data"][0]["id"] == classification_id
-    assert len(data["data"]) == 1
+    classifications = sp.fetch_classifications(public_source.id)
+    assert classifications[0].classification == "Algol"
+    assert classifications[0].origin == "SCoPe"
+    assert classifications[0].id == classification_id
+    assert len(classifications) == 1
 
-    status, data = api("GET", "classification/sources", token=classification_token)
-    assert status == 200
-    assert public_source.id in data["data"]
+    assert public_source.id in sp.fetch_sources_by_classification()
 
 
 def test_add_and_retrieve_multiple_classifications(
     taxonomy_token, classification_token, public_source, public_group
 ):
-    status, data = api(
-        "POST",
-        "taxonomy",
-        data={
-            "name": "test taxonomy" + str(uuid.uuid4()),
-            "hierarchy": taxonomy,
-            "group_ids": [public_group.id],
-            "provenance": f"tdtax_{__version__}",
-            "version": __version__,
-            "isLatest": True,
-        },
-        token=taxonomy_token,
+    taxonomy_id = (
+        client(taxonomy_token)
+        .post_taxonomy(
+            TaxonomyPost(
+                name="test taxonomy" + str(uuid.uuid4()),
+                hierarchy=taxonomy,
+                group_ids=[public_group.id],
+                provenance=f"tdtax_{__version__}",
+                version=__version__,
+                is_latest=True,
+            )
+        )
+        .taxonomy_id
     )
-    assert status == 200
-    taxonomy_id = data["data"]["taxonomy_id"]
 
-    data = {
-        "classifications": [
-            {
-                "obj_id": public_source.id,
-                "classification": "Algol",
-                "origin": "SCoPe",
-                "taxonomy_id": taxonomy_id,
-                "probability": 1.0,
-                "group_ids": [public_group.id],
-            },
-            {
-                "obj_id": public_source.id,
-                "classification": "Time-domain Source",
-                "origin": "SCoPe",
-                "taxonomy_id": taxonomy_id,
-                "probability": 1.0,
-                "group_ids": [public_group.id],
-            },
+    client(classification_token).post_classifications(
+        [
+            ClassificationPost(
+                obj_id=public_source.id,
+                classification="Algol",
+                origin="SCoPe",
+                taxonomy_id=taxonomy_id,
+                probability=1.0,
+                group_ids=[public_group.id],
+            ),
+            ClassificationPost(
+                obj_id=public_source.id,
+                classification="Time-domain Source",
+                origin="SCoPe",
+                taxonomy_id=taxonomy_id,
+                probability=1.0,
+                group_ids=[public_group.id],
+            ),
         ]
-    }
-
-    status, data = api(
-        "POST",
-        "classification",
-        data=data,
-        token=classification_token,
-    )
-    assert status == 200
-
-    params = {"numPerPage": 100}
-
-    status, data = api(
-        "GET", "classification", token=classification_token, params=params
     )
 
-    assert status == 200
-    data = data["data"]["classifications"]
-    assert any(d["classification"] == "Algol" for d in data)
-    assert any(d["classification"] == "Time-domain Source" for d in data)
+    data = (
+        client(classification_token)
+        .fetch_classifications_query(num_per_page=100)
+        .classifications
+    )
+    assert any(d.classification == "Algol" for d in data)
+    assert any(d.classification == "Time-domain Source" for d in data)
 
 
 def test_obj_classifications_vote(
     taxonomy_token, classification_token, public_source, public_group
 ):
-    status, data = api(
-        "POST",
-        "taxonomy",
-        data={
-            "name": "test taxonomy" + str(uuid.uuid4()),
-            "hierarchy": taxonomy,
-            "group_ids": [public_group.id],
-            "provenance": f"tdtax_{__version__}",
-            "version": __version__,
-            "isLatest": True,
-        },
-        token=taxonomy_token,
+    taxonomy_id = (
+        client(taxonomy_token)
+        .post_taxonomy(
+            TaxonomyPost(
+                name="test taxonomy" + str(uuid.uuid4()),
+                hierarchy=taxonomy,
+                group_ids=[public_group.id],
+                provenance=f"tdtax_{__version__}",
+                version=__version__,
+                is_latest=True,
+            )
+        )
+        .taxonomy_id
     )
-    assert status == 200
-    taxonomy_id = data["data"]["taxonomy_id"]
 
-    status, data = api(
-        "POST",
-        "classification",
-        data={
-            "obj_id": public_source.id,
-            "classification": "Algol",
-            "origin": "SCoPe",
-            "taxonomy_id": taxonomy_id,
-        },
-        token=classification_token,
-    )
-    assert status == 200
-    classification_id = data["data"]["classification_id"]
+    sp = client(classification_token)
+    classification_id = sp.post_classification(
+        ClassificationPost(
+            obj_id=public_source.id,
+            classification="Algol",
+            origin="SCoPe",
+            taxonomy_id=taxonomy_id,
+        )
+    ).classification_id
 
-    status, data = api(
-        "POST",
-        f"classification/votes/{classification_id}",
-        data={
-            "vote": 1,
-        },
-        token=classification_token,
-    )
-    assert status == 200
+    sp.post_classification_vote(classification_id, 1)
 
-    status, data = api(
-        "GET", f"sources/{public_source.id}/classifications", token=classification_token
-    )
-    assert status == 200
-    assert data["data"][0]["classification"] == "Algol"
-    assert data["data"][0]["origin"] == "SCoPe"
-    assert data["data"][0]["id"] == classification_id
-    assert len(data["data"]) == 1
-    assert len(data["data"][0]["votes"]) == 1
-    assert data["data"][0]["votes"][0]["vote"] == 1
+    classifications = sp.fetch_classifications(public_source.id)
+    assert classifications[0].classification == "Algol"
+    assert classifications[0].origin == "SCoPe"
+    assert classifications[0].id == classification_id
+    assert len(classifications) == 1
+    assert len(classifications[0].votes) == 1
+    assert classifications[0].votes[0].vote == 1
 
-    status, data = api(
-        "DELETE",
-        f"classification/votes/{classification_id}",
-        token=classification_token,
-    )
-    assert status == 200
+    sp.delete_classification_vote(classification_id)
 
-    status, data = api(
-        "GET", f"sources/{public_source.id}/classifications", token=classification_token
-    )
-    assert status == 200
-    assert data["data"][0]["classification"] == "Algol"
-    assert data["data"][0]["origin"] == "SCoPe"
-    assert data["data"][0]["id"] == classification_id
-    assert len(data["data"]) == 1
-    assert len(data["data"][0]["votes"]) == 0
+    classifications = sp.fetch_classifications(public_source.id)
+    assert classifications[0].classification == "Algol"
+    assert classifications[0].origin == "SCoPe"
+    assert classifications[0].id == classification_id
+    assert len(classifications) == 1
+    assert len(classifications[0].votes) == 0

--- a/skyportal/tests/api_tests/sources_candidates/test_ep_ingestion.py
+++ b/skyportal/tests/api_tests/sources_candidates/test_ep_ingestion.py
@@ -13,8 +13,11 @@ import uuid
 from datetime import timedelta
 
 import numpy as np
+import pytest
+from skyportal_py import SkyPortalError
+from skyportal_py.gcn_events import GcnEventPost
 
-from skyportal.tests import api
+from skyportal.tests import client
 from skyportal.utils.naive_datetime import utcnow_naive
 
 RADIUS_MULTIPLIER = 1.0
@@ -34,13 +37,13 @@ def _ep_payload(
         dec = float(np.random.uniform(-30, 30))
 
     error = pos_err * RADIUS_MULTIPLIER
-    payload = {
-        "dateobs": dateobs.isoformat(),
-        "trigger_id": name,
-        "aliases": [f"EP#{name}"],
-        "skymap": {"ra": ra, "dec": dec, "error": error},
-        "tags": ["EP", "X-ray"] + ([tag] if tag else []),
-        "properties": {
+    payload = GcnEventPost(
+        dateobs=dateobs.isoformat(),
+        trigger_id=name,
+        aliases=[f"EP#{name}"],
+        skymap={"ra": ra, "dec": dec, "error": error},
+        tags=["EP", "X-ray"] + ([tag] if tag else []),
+        properties={
             "ep_name": name,
             "ep_version": "1",
             "flux": 1.2e-10,
@@ -51,8 +54,8 @@ def _ep_payload(
             "net_rate": 0.35,
             "exp_time": 1200.0,
         },
-        "group_ids": list(group_ids),
-    }
+        group_ids=list(group_ids),
+    )
     localization_name = f"{ra:.5f}_{dec:.5f}_{error:.5f}"
     return payload, dateobs, localization_name
 
@@ -64,27 +67,21 @@ def test_ep_candidate_creates_restricted_event(
     name = f"EP{uuid.uuid4().hex[:10]}"
     payload, dateobs, localization_name = _ep_payload(name, [public_group2.id])
 
-    status, data = api("POST", "gcn_event", data=payload, token=super_admin_token)
-    assert status == 200, data
+    client(super_admin_token).post_gcn_event(payload)
 
     dateobs_str = dateobs.strftime("%Y-%m-%d %H:%M:%S")
 
-    status, data = api("GET", f"gcn_event/{dateobs_str}", token=view_only_token_group2)
-    assert status == 200, data
-    assert data["data"]["trigger_id"] == name
-    assert "EP" in data["data"]["tags"]
+    event = client(view_only_token_group2).fetch_gcn_event(dateobs_str)
+    assert event.trigger_id == name
+    assert "EP" in event.tags
 
     # the proprietary feed must not be visible outside the EP group
-    status, data = api("GET", f"gcn_event/{dateobs_str}", token=view_only_token)
-    assert status in (400, 403, 404), data
+    with pytest.raises(SkyPortalError) as err:
+        client(view_only_token).fetch_gcn_event(dateobs_str)
+    assert err.value.status_code in (400, 403, 404)
 
     # the cone localization was built from ra/dec/pos_err
-    status, data = api(
-        "GET",
-        f"localization/{dateobs_str}/name/{localization_name}",
-        token=view_only_token_group2,
-    )
-    assert status == 200, data
+    client(view_only_token_group2).fetch_localization(dateobs_str, localization_name)
 
 
 def test_ep_new_version_reuses_event_via_trigger_id(
@@ -103,8 +100,7 @@ def test_ep_new_version_reuses_event_via_trigger_id(
     payload_v1, dateobs_v1, loc_v1 = _ep_payload(
         name, [public_group2.id], tag=tag, ra=10.0, dec=20.0, pos_err=0.05
     )
-    status, data = api("POST", "gcn_event", data=payload_v1, token=super_admin_token)
-    assert status == 200, data
+    client(super_admin_token).post_gcn_event(payload_v1)
 
     # version 2: refined position AND a shifted observation start
     payload_v2, _, loc_v2 = _ep_payload(
@@ -116,28 +112,20 @@ def test_ep_new_version_reuses_event_via_trigger_id(
         pos_err=0.02,
         tag=tag,
     )
-    payload_v2["properties"]["ep_version"] = "2"
-    status, data = api("POST", "gcn_event", data=payload_v2, token=super_admin_token)
-    assert status == 200, data
+    payload_v2.properties["ep_version"] = "2"
+    client(super_admin_token).post_gcn_event(payload_v2)
 
     # exactly one event carries this candidate's tag -- v2 did not fork a new one
-    status, data = api(
-        "GET", "gcn_event", params={"gcnTagKeep": tag}, token=view_only_token_group2
-    )
-    assert status == 200, data
-    events = data["data"]["events"]
+    events = client(view_only_token_group2).fetch_gcn_events(gcn_tag_keep=[tag]).events
     assert len(events) == 1, events
-    assert events[0]["trigger_id"] == name
+    assert events[0].trigger_id == name
 
     # and the event keeps its original dateobs, with both localizations attached
     dateobs_str = dateobs_v1.strftime("%Y-%m-%d %H:%M:%S")
     for localization_name in (loc_v1, loc_v2):
-        status, data = api(
-            "GET",
-            f"localization/{dateobs_str}/name/{localization_name}",
-            token=view_only_token_group2,
+        client(view_only_token_group2).fetch_localization(
+            dateobs_str, localization_name
         )
-        assert status == 200, data
 
 
 def test_ep_properties_recorded(
@@ -147,16 +135,14 @@ def test_ep_properties_recorded(
     name = f"EP{uuid.uuid4().hex[:10]}"
     payload, dateobs, _ = _ep_payload(name, [public_group2.id])
 
-    status, data = api("POST", "gcn_event", data=payload, token=super_admin_token)
-    assert status == 200, data
+    client(super_admin_token).post_gcn_event(payload)
 
     dateobs_str = dateobs.strftime("%Y-%m-%d %H:%M:%S")
-    status, data = api("GET", f"gcn_event/{dateobs_str}", token=view_only_token_group2)
-    assert status == 200, data
+    event = client(view_only_token_group2).fetch_gcn_event(dateobs_str)
 
-    properties = data["data"].get("properties") or []
-    assert properties, data["data"]
-    recorded = properties[0]["data"]
+    properties = event.properties or []
+    assert properties, event
+    recorded = properties[0].data
     assert recorded["ep_name"] == name
     assert recorded["ep_version"] == "1"
     assert recorded["net_counts"] == 42.0
@@ -179,17 +165,19 @@ def test_restricted_ep_event_does_not_leak_position_as_source(
     # mid-range of the real EP pos_err distribution (0.031-0.053 deg)
     payload, dateobs, _ = _ep_payload(name, [public_group2.id], pos_err=0.04)
 
-    status, data = api("POST", "gcn_event", data=payload, token=super_admin_token)
-    assert status == 200, data
+    client(super_admin_token).post_gcn_event(payload)
 
     dateobs_str = dateobs.strftime("%Y-%m-%d %H:%M:%S")
-    status, _ = api("GET", f"gcn_event/{dateobs_str}", token=view_only_token)
-    assert status in (400, 403, 404), "the event itself should be hidden"
+    with pytest.raises(SkyPortalError) as err:
+        client(view_only_token).fetch_gcn_event(dateobs_str)
+    assert err.value.status_code in (400, 403, 404), "the event itself should be hidden"
 
     stamp = dateobs.strftime("%y%m%d_%H%M%S")
     leaked = []
     for obj_id in (f"EP-{stamp}", f"GCN-{stamp}", f"GRB-{stamp}", stamp):
-        status, data = api("GET", f"sources/{obj_id}", token=view_only_token)
-        if status == 200:
-            leaked.append((obj_id, data["data"].get("ra"), data["data"].get("dec")))
+        try:
+            source = client(view_only_token).fetch_source(obj_id)
+        except SkyPortalError:
+            continue
+        leaked.append((obj_id, source.ra, source.dec))
     assert not leaked, f"restricted EP position exposed via object(s): {leaked}"

--- a/skyportal/tests/api_tests/sources_candidates/test_filters.py
+++ b/skyportal/tests/api_tests/sources_candidates/test_filters.py
@@ -1,100 +1,77 @@
 import uuid
 
-from skyportal.tests import api
+import pytest
+from skyportal_py import SkyPortalError
+from skyportal_py.brokers import BrokerPost
+from skyportal_py.filters import FilterPatch, FilterPost
+
+from skyportal.tests import client
 
 
 def test_filter_list(view_only_token, public_filter):
-    status, data = api("GET", "filters", token=view_only_token)
-    assert status == 200
-    assert data["status"] == "success"
-    assert all(k in data["data"][0] for k in ["name", "group_id", "stream_id"])
+    filters = client(view_only_token).fetch_filters()
+    assert filters[0].name is not None
+    assert filters[0].group_id is not None
+    assert filters[0].stream_id is not None
 
 
 def test_token_user_retrieving_filter(view_only_token, public_filter):
-    status, data = api("GET", f"filters/{public_filter.id}", token=view_only_token)
-    assert status == 200
-    assert data["status"] == "success"
-    assert all(k in data["data"] for k in ["name", "group_id", "stream_id"])
+    fetched = client(view_only_token).fetch_filter(public_filter.id)
+    assert fetched.name is not None
+    assert fetched.group_id is not None
+    assert fetched.stream_id is not None
 
 
 def test_token_user_update_filter(manage_groups_token, public_filter):
-    status, data = api(
-        "PATCH",
-        f"filters/{public_filter.id}",
-        data={"name": "new_name"},
-        token=manage_groups_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp = client(manage_groups_token)
+    sp.update_filter(public_filter.id, FilterPatch(name="new_name"))
 
-    status, data = api("GET", f"filters/{public_filter.id}", token=manage_groups_token)
-    assert status == 200
-    assert data["status"] == "success"
-    assert data["data"]["name"] == "new_name"
+    assert sp.fetch_filter(public_filter.id).name == "new_name"
 
 
 def test_cannot_update_filter_group_stream(view_only_token, public_filter):
-    status, data = api(
-        "PATCH",
-        f"filters/{public_filter.id}",
-        data={"group_id": 0},
-        token=view_only_token,
-    )
-    assert status == 401
-    assert data["status"] == "error"
+    sp = client(view_only_token)
+    with pytest.raises(SkyPortalError) as err:
+        sp.update_filter(public_filter.id, FilterPatch(group_id=0))
+    assert err.value.status_code == 401
 
-    status, data = api(
-        "PATCH",
-        f"filters/{public_filter.id}",
-        data={"stream_id": 0},
-        token=view_only_token,
-    )
-    assert status == 401
-    assert data["status"] == "error"
+    with pytest.raises(SkyPortalError) as err:
+        sp.update_filter(public_filter.id, FilterPatch(stream_id=0))
+    assert err.value.status_code == 401
 
 
 def test_token_user_post_delete_filter(
     manage_groups_token, group_with_stream, public_stream
 ):
-    status, data = api(
-        "POST",
-        "filters",
-        data={
-            "name": str(uuid.uuid4()),
-            "stream_id": public_stream.id,
-            "group_id": group_with_stream.id,
-        },
-        token=manage_groups_token,
-    )
-    assert status == 200
-    filter_id = data["data"]["id"]
+    sp = client(manage_groups_token)
+    filter_id = sp.post_filter(
+        FilterPost(
+            name=str(uuid.uuid4()),
+            stream_id=public_stream.id,
+            group_id=group_with_stream.id,
+        )
+    ).id
 
-    status, data = api("GET", f"filters/{filter_id}", token=manage_groups_token)
-    assert status == 200
-    assert data["data"]["id"] == filter_id
+    assert sp.fetch_filter(filter_id).id == filter_id
 
-    status, data = api("DELETE", f"filters/{filter_id}", token=manage_groups_token)
-    assert status == 200
+    sp.delete_filter(filter_id)
 
-    status, data = api("GET", f"filters/{filter_id}", token=manage_groups_token)
-    assert status == 400
-    assert "Cannot find a filter with ID" in data["message"]
+    with pytest.raises(SkyPortalError, match="Cannot find a filter with ID"):
+        sp.fetch_filter(filter_id)
 
 
 def test_post_filter_with_unauthorized_stream(
     manage_groups_token, group_with_stream, public_stream
 ):
-    status, data = api(
-        "POST",
-        "filters",
-        data={
-            "name": str(uuid.uuid4()),
-            "stream_id": public_stream.id - 1,
-            "group_id": group_with_stream.id,
-        },
-        token=manage_groups_token,
-    )
-    assert status in [401, 500]
+    with pytest.raises(SkyPortalError) as err:
+        client(manage_groups_token).post_filter(
+            FilterPost(
+                name=str(uuid.uuid4()),
+                stream_id=public_stream.id - 1,
+                group_id=group_with_stream.id,
+            )
+        )
+    assert err.value.status_code in [401, 500]
 
 
 def _force_active(broker_id):
@@ -125,14 +102,11 @@ def _mark_broker_managed(filter_id, broker_id):
 
 def test_rename_requires_group_admin(upload_data_token, public_filter):
     """A rename is an admin action even for a user who may otherwise post data."""
-    status, data = api(
-        "PATCH",
-        f"filters/{public_filter.id}",
-        data={"name": f"nope_{uuid.uuid4().hex[:8]}"},
-        token=upload_data_token,
-    )
-    assert status == 403, data
-    assert "group admin" in data["message"]
+    with pytest.raises(SkyPortalError, match="group admin") as err:
+        client(upload_data_token).update_filter(
+            public_filter.id, FilterPatch(name=f"nope_{uuid.uuid4().hex[:8]}")
+        )
+    assert err.value.status_code == 403
 
 
 def test_rename_is_blocked_when_the_broker_rename_fails(
@@ -143,96 +117,58 @@ def test_rename_is_blocked_when_the_broker_rename_fails(
     The broker here is unreachable, so the propagation attempt fails -- and that
     has to abort the whole rename rather than leaving the two names disagreeing.
     """
-    status, data = api(
-        "POST",
-        "brokers",
-        data={
-            "name": str(uuid.uuid4()),
-            "broker_classname": "BOOMBROKER",
-            "altdata": {"host": "boom.invalid", "username": "x", "password": "y"},
-        },
-        token=super_admin_token,
-    )
-    assert status == 200, data
-    broker_id = data["data"]["id"]
+    sp = client(super_admin_token)
+    broker_id = sp.post_broker(
+        BrokerPost(
+            name=str(uuid.uuid4()),
+            broker_classname="BOOMBROKER",
+            altdata={"host": "boom.invalid", "username": "x", "password": "y"},
+        )
+    ).id
     _force_active(broker_id)
 
-    status, data = api("GET", f"filters/{public_filter.id}", token=super_admin_token)
-    original_name = data["data"]["name"]
+    original_name = sp.fetch_filter(public_filter.id).name
 
     _mark_broker_managed(public_filter.id, broker_id)
 
     new_name = f"renamed_{uuid.uuid4().hex[:8]}"
-    status, data = api(
-        "PATCH",
-        f"filters/{public_filter.id}",
-        data={"name": new_name},
-        token=super_admin_token,
-    )
-    assert status == 400, data
-    assert "rename" in data["message"].lower()
+    with pytest.raises(SkyPortalError, match="(?i)rename") as err:
+        sp.update_filter(public_filter.id, FilterPatch(name=new_name))
+    assert err.value.status_code == 400
 
-    status, data = api("GET", f"filters/{public_filter.id}", token=super_admin_token)
-    assert data["data"]["name"] == original_name, "local rename outlived the failure"
+    assert sp.fetch_filter(public_filter.id).name == original_name, (
+        "local rename outlived the failure"
+    )
 
 
 def test_group_admin_can_rename_filter(group_admin_token, public_filter):
     """The admin gate must not be so tight that it blocks the group's own admin."""
+    sp = client(group_admin_token)
     new_name = f"renamed_by_group_admin_{uuid.uuid4().hex[:8]}"
-    status, data = api(
-        "PATCH",
-        f"filters/{public_filter.id}",
-        data={"name": new_name},
-        token=group_admin_token,
-    )
-    assert status == 200, data
+    sp.update_filter(public_filter.id, FilterPatch(name=new_name))
 
-    status, data = api("GET", f"filters/{public_filter.id}", token=group_admin_token)
-    assert data["data"]["name"] == new_name
+    assert sp.fetch_filter(public_filter.id).name == new_name
 
 
 def test_super_admin_can_rename_filter(super_admin_token, public_filter):
     """A system admin needs no group membership to rename."""
+    sp = client(super_admin_token)
     new_name = f"renamed_by_super_admin_{uuid.uuid4().hex[:8]}"
-    status, data = api(
-        "PATCH",
-        f"filters/{public_filter.id}",
-        data={"name": new_name},
-        token=super_admin_token,
-    )
-    assert status == 200, data
+    sp.update_filter(public_filter.id, FilterPatch(name=new_name))
 
-    status, data = api("GET", f"filters/{public_filter.id}", token=super_admin_token)
-    assert data["data"]["name"] == new_name
+    assert sp.fetch_filter(public_filter.id).name == new_name
 
 
 def test_update_filter_autosave(manage_groups_token, public_filter):
     """Ingestion honours the autosave column, so the API must be able to set it."""
-    status, data = api("GET", f"filters/{public_filter.id}", token=manage_groups_token)
-    assert status == 200
-    assert data["data"]["autosave"] is False
+    sp = client(manage_groups_token)
+    assert sp.fetch_filter(public_filter.id).autosave is False
 
-    status, _ = api(
-        "PATCH",
-        f"filters/{public_filter.id}",
-        data={"autosave": True},
-        token=manage_groups_token,
-    )
-    assert status == 200
+    sp.update_filter(public_filter.id, FilterPatch(autosave=True))
+    assert sp.fetch_filter(public_filter.id).autosave is True
 
-    status, data = api("GET", f"filters/{public_filter.id}", token=manage_groups_token)
-    assert status == 200
-    assert data["data"]["autosave"] is True
-
-    status, _ = api(
-        "PATCH",
-        f"filters/{public_filter.id}",
-        data={"autosave": False},
-        token=manage_groups_token,
-    )
-    assert status == 200
-    status, data = api("GET", f"filters/{public_filter.id}", token=manage_groups_token)
-    assert data["data"]["autosave"] is False
+    sp.update_filter(public_filter.id, FilterPatch(autosave=False))
+    assert sp.fetch_filter(public_filter.id).autosave is False
 
 
 def test_set_autosave_keeps_broker_ui_mirror_in_step():

--- a/skyportal/tests/api_tests/sources_candidates/test_gcn.py
+++ b/skyportal/tests/api_tests/sources_candidates/test_gcn.py
@@ -1,6 +1,8 @@
+import json
 import os
 import time
 import uuid
+from contextlib import suppress
 from datetime import timedelta
 
 import numpy as np
@@ -9,10 +11,19 @@ import requests
 import sqlalchemy as sa
 from astropy.table import Table
 from astropy.time import Time
+from skyportal_py import SkyPortalError
+from skyportal_py.allocations import AllocationPost
+from skyportal_py.galaxies import GalaxyCatalogPost
+from skyportal_py.gcn_events import GcnEventObjPost, GcnEventPost, GcnSummaryPost
+from skyportal_py.instruments import InstrumentPost
+from skyportal_py.mmadetectors import MMADetectorPost
+from skyportal_py.photometry import PhotometryPost
+from skyportal_py.sources import SourcePost
+from skyportal_py.telescopes import TelescopePost
 
 from skyportal.handlers.api.gcn import add_default_gcn_tags
 from skyportal.models import DBSession, DefaultGcnTag, User
-from skyportal.tests import api, retry_until
+from skyportal.tests import client, retry_until
 from skyportal.tests.external.test_moving_objects import (
     add_telescope_and_instrument,
     remove_telescope_and_instrument,
@@ -34,26 +45,23 @@ else:
 
 @pytest.mark.flaky(reruns=2)
 def test_gcn_GW(super_admin_token, view_only_token):
+    sp = client(super_admin_token)
     datafile = f"{os.path.dirname(__file__)}/../../data/GW190425_initial.xml"
     with open(datafile, "rb") as fid:
         payload = fid.read()
-    event_data = {"xml": payload}
+    event_data = GcnEventPost(xml=payload)
 
     dateobs = "2019-04-25 08:18:05"
-    status, data = api("GET", f"gcn_event/{dateobs}", token=super_admin_token)
-    if status == 404:
-        status, data = api(
-            "POST", "gcn_event", data=event_data, token=super_admin_token
-        )
-        assert status == 200
-        assert data["status"] == "success"
+    try:
+        sp.fetch_gcn_event(dateobs)
+    except SkyPortalError as err:
+        if err.status_code == 404:
+            sp.post_gcn_event(event_data)
 
     dateobs = "2019-04-25 08:18:05"
-    status, data = api("GET", f"gcn_event/{dateobs}", token=super_admin_token)
-    assert status == 200
-    data = data["data"]
-    assert data["dateobs"] == "2019-04-25T08:18:05"
-    assert "GW" in data["tags"]
+    event = sp.fetch_gcn_event(dateobs)
+    assert event.dateobs.isoformat() == "2019-04-25T08:18:05"
+    assert "GW" in event.tags
     property_dict = {
         "BBH": 0.0,
         "BNS": 0.999402567114,
@@ -65,137 +73,90 @@ def test_gcn_GW(super_admin_token, view_only_token):
         "Terrestrial": 0.00059743288626,
         "num_instruments": 2,
     }
-    assert data["properties"][0]["data"] == property_dict
+    assert event.properties[0].data == property_dict
 
-    params = {
-        "startDate": "2019-04-25T00:00:00",
-        "endDate": "2019-04-26T00:00:00",
-        "gcnTagKeep": "GW",
-    }
+    page = sp.fetch_gcn_events(
+        start_date="2019-04-25T00:00:00",
+        end_date="2019-04-26T00:00:00",
+        gcn_tag_keep=["GW"],
+    )
+    assert len(page.events) > 0
+    event = page.events[0]
+    assert event.dateobs.isoformat() == "2019-04-25T08:18:05"
+    assert "GW" in event.tags
 
-    status, data = api("GET", "gcn_event", token=super_admin_token, params=params)
-    assert status == 200
-    data = data["data"]
-    assert len(data["events"]) > 0
-    data = data["events"][0]
-    assert data["dateobs"] == "2019-04-25T08:18:05"
-    assert "GW" in data["tags"]
+    page = sp.fetch_gcn_events(
+        start_date="2019-04-25T00:00:00",
+        end_date="2019-04-26T00:00:00",
+        gcn_tag_keep=["Fermi"],
+    )
+    assert len(page.events) == 0
 
-    params = {
-        "startDate": "2019-04-25T00:00:00",
-        "endDate": "2019-04-26T00:00:00",
-        "gcnTagKeep": "Fermi",
-    }
-
-    status, data = api("GET", "gcn_event", token=super_admin_token, params=params)
-    assert status == 200
-    data = data["data"]
-    assert len(data["events"]) == 0
-
-    params = {"include2DMap": True}
     skymap = "bayestar.fits.gz"
-    status, data = api(
-        "GET",
-        f"localization/{dateobs}/name/{skymap}",
-        token=super_admin_token,
-        params=params,
-    )
+    localization = sp.fetch_localization(dateobs, skymap, include_2d_map=True)
 
-    data = data["data"]
-    assert data["dateobs"] == "2019-04-25T08:18:05"
-    assert data["localization_name"] == "bayestar.fits.gz"
-    assert np.isclose(np.sum(data["flat_2d"]), 1)
+    assert localization.dateobs.isoformat() == "2019-04-25T08:18:05"
+    assert localization.localization_name == "bayestar.fits.gz"
+    assert np.isclose(np.sum(localization.flat_2d), 1)
 
-    status, data = api(
-        "DELETE",
-        f"localization/{dateobs}/name/{skymap}",
-        token=view_only_token,
-    )
-    assert status == 404
+    with pytest.raises(SkyPortalError) as err:
+        client(view_only_token).delete_localization(dateobs, skymap)
+    assert err.value.status_code == 404
 
-    status, data = api(
-        "DELETE",
-        f"localization/{dateobs}/name/{skymap}",
-        token=super_admin_token,
-    )
-    assert status == 200
+    sp.delete_localization(dateobs, skymap)
 
-    # delete the event
-    status, data = api(
-        "DELETE", "gcn_event/2019-04-25T08:18:05", token=super_admin_token
-    )
+    # delete the event (result was not checked before, so tolerate failure)
+    with suppress(SkyPortalError):
+        sp.delete_gcn_event("2019-04-25T08:18:05")
 
 
 def test_gcn_Fermi(super_admin_token, view_only_token):
+    sp = client(super_admin_token)
     datafile = (
         f"{os.path.dirname(__file__)}/../../data/GRB180116A_Fermi_GBM_Gnd_Pos.xml"
     )
     with open(datafile, "rb") as fid:
         payload = fid.read()
-    event_data = {"xml": payload}
+    event_data = GcnEventPost(xml=payload)
 
     dateobs = "2018-01-16 00:36:53"
-    status, data = api("GET", f"gcn_event/{dateobs}", token=super_admin_token)
+    try:
+        sp.fetch_gcn_event(dateobs)
+    except SkyPortalError as err:
+        if err.status_code == 404:
+            sp.post_gcn_event(event_data)
 
-    if status == 404:
-        status, data = api(
-            "POST", "gcn_event", data=event_data, token=super_admin_token
-        )
-        assert status == 200
-        assert data["status"] == "success"
-
-    params = {"include2DMap": True}
-    status, data = api("GET", f"gcn_event/{dateobs}", token=super_admin_token)
-    if status != 200:
-        print(data)
-    assert status == 200
-    data = data["data"]
-    assert data["dateobs"] == "2018-01-16T00:36:53"
-    assert "GRB" in data["tags"]
+    event = sp.fetch_gcn_event(dateobs)
+    assert event.dateobs.isoformat() == "2018-01-16T00:36:53"
+    assert "GRB" in event.tags
 
     skymap = "214.74000_28.14000_11.19000"
-    status, data = api(
-        "GET",
-        f"localization/{dateobs}/name/{skymap}",
-        token=super_admin_token,
-        params=params,
-    )
+    localization = sp.fetch_localization(dateobs, skymap, include_2d_map=True)
 
-    data = data["data"]
-    assert data["dateobs"] == "2018-01-16T00:36:53"
-    assert data["localization_name"] == "214.74000_28.14000_11.19000"
-    assert np.isclose(np.sum(data["flat_2d"]), 1)
+    assert localization.dateobs.isoformat() == "2018-01-16T00:36:53"
+    assert localization.localization_name == "214.74000_28.14000_11.19000"
+    assert np.isclose(np.sum(localization.flat_2d), 1)
 
-    status, data = api(
-        "DELETE",
-        f"localization/{dateobs}/name/{skymap}",
-        token=view_only_token,
-    )
-    assert status == 404
+    with pytest.raises(SkyPortalError) as err:
+        client(view_only_token).delete_localization(dateobs, skymap)
+    assert err.value.status_code == 404
 
-    status, data = api(
-        "DELETE",
-        f"localization/{dateobs}/name/{skymap}",
-        token=super_admin_token,
-    )
-    assert status == 200
+    sp.delete_localization(dateobs, skymap)
 
 
 def test_gcn_from_moc(super_admin_token):
+    sp = client(super_admin_token)
     name = str(uuid.uuid4())
-    post_data = {
-        "name": name,
-        "nickname": name,
-        "type": "gravitational-wave",
-        "fixed_location": True,
-        "lat": 0.0,
-        "lon": 0.0,
-    }
-
-    status, data = api("POST", "mmadetector", data=post_data, token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-    mmadetector_id = data["data"]["id"]
+    mmadetector_id = sp.post_mmadetector(
+        MMADetectorPost(
+            name=name,
+            nickname=name,
+            type="gravitational-wave",
+            fixed_location=True,
+            lat=0.0,
+            lon=0.0,
+        )
+    ).id
 
     skymap = f"{os.path.dirname(__file__)}/../../data/GRB220617A_IPN_map_hpx.fits.gz"
     dateobs = "2022-06-18T18:31:12"
@@ -203,88 +164,68 @@ def test_gcn_from_moc(super_admin_token):
     skymap, _, _ = from_url(skymap)
     properties = {"BNS": 0.9, "NSBH": 0.1}
 
-    event_data = {
-        "dateobs": dateobs,
-        "skymap": skymap,
-        "tags": tags,
-        "properties": properties,
-    }
+    event_data = GcnEventPost(
+        dateobs=dateobs,
+        skymap=skymap,
+        tags=tags,
+        properties=properties,
+    )
 
     dateobs = "2022-06-18 18:31:12"
-    status, data = api("GET", f"gcn_event/{dateobs}", token=super_admin_token)
-    if status == 404:
-        status, data = api(
-            "POST", "gcn_event", data=event_data, token=super_admin_token
-        )
-        assert status == 200
-        assert data["status"] == "success"
+    try:
+        sp.fetch_gcn_event(dateobs)
+    except SkyPortalError as err:
+        if err.status_code == 404:
+            sp.post_gcn_event(event_data)
 
-    status, data = api("GET", f"gcn_event/{dateobs}", token=super_admin_token)
-    assert status == 200
-    data = data["data"]
-    assert data["dateobs"] == "2022-06-18T18:31:12"
-    assert "IPN" in data["tags"]
-    assert name in [detector["name"] for detector in data["detectors"]]
-    properties_dict = data["properties"][0]
-    assert properties_dict["data"] == properties
+    event = sp.fetch_gcn_event(dateobs)
+    assert event.dateobs.isoformat() == "2022-06-18T18:31:12"
+    assert "IPN" in event.tags
+    assert name in [detector.name for detector in event.detectors]
+    properties_dict = event.properties[0]
+    assert properties_dict.data == properties
 
-    status, data = api("GET", f"mmadetector/{mmadetector_id}", token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-    data = data["data"]
-    assert "2022-06-18T18:31:12" in [event["dateobs"] for event in data["events"]]
+    mmadetector = sp.fetch_mmadetector(mmadetector_id)
+    assert "2022-06-18T18:31:12" in [event["dateobs"] for event in mmadetector.events]
 
-    params = {"gcnPropertiesFilter": "BNS: 0.5: gt, NSBH: 0.5: lt"}
-    status, data = api("GET", "gcn_event", token=super_admin_token, params=params)
-    assert status == 200
-    data = data["data"]
-    assert "2022-06-18T18:31:12" in [event["dateobs"] for event in data["events"]]
+    page = sp.fetch_gcn_events(gcn_properties_filter=["BNS: 0.5: gt", "NSBH: 0.5: lt"])
+    assert "2022-06-18T18:31:12" in [event.dateobs.isoformat() for event in page.events]
 
-    params = {"gcnPropertiesFilter": "BNS: 0.5: lt, NSBH: 0.5: lt"}
-    status, data = api("GET", "gcn_event", token=super_admin_token, params=params)
-    assert status == 200
-    data = data["data"]
-    assert "2022-06-18T18:31:12" not in [event["dateobs"] for event in data["events"]]
+    page = sp.fetch_gcn_events(gcn_properties_filter=["BNS: 0.5: lt", "NSBH: 0.5: lt"])
+    assert "2022-06-18T18:31:12" not in [
+        event.dateobs.isoformat() for event in page.events
+    ]
 
 
 def test_gcn_from_json(super_admin_token):
+    sp = client(super_admin_token)
     datafile = f"{os.path.dirname(__file__)}/../../data/EP240508.json"
     with open(datafile, "rb") as fid:
         payload = fid.read()
-    event_data = {"json": payload}
+    event_data = GcnEventPost(json_notice=json.loads(payload))
 
     dateobs = "2024-05-08T07:38:01"
-    status, data = api("GET", f"gcn_event/{dateobs}", token=super_admin_token)
-    if status == 404:
-        status, data = api(
-            "POST", "gcn_event", data=event_data, token=super_admin_token
-        )
-        assert status == 200
-        assert data["status"] == "success"
+    try:
+        sp.fetch_gcn_event(dateobs)
+    except SkyPortalError as err:
+        if err.status_code == 404:
+            sp.post_gcn_event(event_data)
 
     dateobs = "2024-05-08T07:38:01"
-    status, data = api("GET", f"gcn_event/{dateobs}", token=super_admin_token)
-    assert status == 200
-    data = data["data"]
-    assert data["dateobs"] == "2024-05-08T07:38:01"
-    assert "Einstein Probe" in data["tags"]
+    event = sp.fetch_gcn_event(dateobs)
+    assert event.dateobs.isoformat() == "2024-05-08T07:38:01"
+    assert "Einstein Probe" in event.tags
 
-    params = {"include2DMap": True}
     skymap = "229.83800_-29.74700_0.05090"
     n_retries = 0
     while True:
         try:
-            status, data = api(
-                "GET",
-                f"localization/{dateobs}/name/{skymap}",
-                token=super_admin_token,
-                params=params,
-            )
+            localization = sp.fetch_localization(dateobs, skymap, include_2d_map=True)
 
-            data = data["data"]
-            assert data.get("dateobs") == "2024-05-08T07:38:01"
-            assert data.get("localization_name") == skymap
-            assert np.isclose(np.sum(data.get("flat_2d", [])), 1)
+            assert localization.dateobs is not None
+            assert localization.dateobs.isoformat() == "2024-05-08T07:38:01"
+            assert localization.localization_name == skymap
+            assert np.isclose(np.sum(localization.flat_2d or []), 1)
             break
         except AssertionError as e:
             if n_retries == 5:
@@ -292,20 +233,15 @@ def test_gcn_from_json(super_admin_token):
             n_retries += 1
             time.sleep(2)
 
-    status, data = api(
-        "DELETE",
-        f"localization/{dateobs}/name/{skymap}",
-        token=super_admin_token,
-    )
-    assert status == 200
+    sp.delete_localization(dateobs, skymap)
 
-    # delete the event
-    status, data = api(
-        "DELETE", "gcn_event/2024-05-08T07:38:01", token=super_admin_token
-    )
+    # delete the event (result was not checked before, so tolerate failure)
+    with suppress(SkyPortalError):
+        sp.delete_gcn_event("2024-05-08T07:38:01")
 
 
 def test_gcn_from_igwn_json(super_admin_token):
+    sp = client(super_admin_token)
     # LVK IGWN gwalert JSON (replaces the retired GCN Classic LVC VOEvents). The
     # skymap is embedded in the alert as base64 and ingested directly.
     datafile = f"{os.path.dirname(__file__)}/../../data/igwn_gwalert_preliminary.json"
@@ -313,36 +249,25 @@ def test_gcn_from_igwn_json(super_admin_token):
         payload = fid.read()
 
     dateobs = "2026-06-05T11:57:26"
-    status, data = api("GET", f"gcn_event/{dateobs}", token=super_admin_token)
-    if status == 404:
-        status, data = api(
-            "POST", "gcn_event", data={"json": payload}, token=super_admin_token
-        )
-        assert status == 200, data
-        assert data["status"] == "success"
+    try:
+        sp.fetch_gcn_event(dateobs)
+    except SkyPortalError as err:
+        if err.status_code == 404:
+            sp.post_gcn_event(GcnEventPost(json_notice=json.loads(payload)))
 
-    status, data = api("GET", f"gcn_event/{dateobs}", token=super_admin_token)
-    assert status == 200
-    data = data["data"]
-    assert data["dateobs"] == dateobs
+    event = sp.fetch_gcn_event(dateobs)
+    assert event.dateobs.isoformat() == dateobs
     for tag in ("GW", "BNS", "Significant"):
-        assert tag in data["tags"]
-    assert "LVC#MS260605l" in data["aliases"]
+        assert tag in event.tags
+    assert "LVC#MS260605l" in event.aliases
 
     skymap = "MS260605l-PRELIMINARY.multiorder.fits"
-    params = {"include2DMap": True}
     n_retries = 0
     while True:
         try:
-            status, data = api(
-                "GET",
-                f"localization/{dateobs}/name/{skymap}",
-                token=super_admin_token,
-                params=params,
-            )
-            data = data["data"]
-            assert data.get("localization_name") == skymap
-            assert np.isclose(np.sum(data.get("flat_2d", [])), 1)
+            localization = sp.fetch_localization(dateobs, skymap, include_2d_map=True)
+            assert localization.localization_name == skymap
+            assert np.isclose(np.sum(localization.flat_2d or []), 1)
             break
         except AssertionError as e:
             if n_retries == 10:
@@ -354,84 +279,69 @@ def test_gcn_from_igwn_json(super_admin_token):
     datafile = f"{os.path.dirname(__file__)}/../../data/igwn_gwalert_retraction.json"
     with open(datafile, "rb") as fid:
         retraction = fid.read()
-    status, data = api(
-        "POST", "gcn_event", data={"json": retraction}, token=super_admin_token
-    )
-    assert status == 200, data
+    sp.post_gcn_event(GcnEventPost(json_notice=json.loads(retraction)))
 
     n_retries = 0
     while True:
-        status, data = api("GET", f"gcn_event/{dateobs}", token=super_admin_token)
-        assert status == 200
-        if "retracted" in data["data"]["tags"] or n_retries == 5:
+        event = sp.fetch_gcn_event(dateobs)
+        if "retracted" in event.tags or n_retries == 5:
             break
         n_retries += 1
         time.sleep(2)
-    assert "retracted" in data["data"]["tags"]
+    assert "retracted" in event.tags
 
-    api("DELETE", f"localization/{dateobs}/name/{skymap}", token=super_admin_token)
-    api("DELETE", f"gcn_event/{dateobs}", token=super_admin_token)
+    # cleanup (results were not checked before, so tolerate failure)
+    with suppress(SkyPortalError):
+        sp.delete_localization(dateobs, skymap)
+    with suppress(SkyPortalError):
+        sp.delete_gcn_event(dateobs)
 
 
 def test_gcn_from_polygon(super_admin_token):
+    sp = client(super_admin_token)
     localization_name = str(uuid.uuid4())
     dateobs = "2022-09-03T14:44:12"
     polygon = [(30.0, 60.0), (40.0, 60.0), (40.0, 70.0), (30.0, 70.0)]
     tags = ["IPN", "GRB"]
     skymap = {"polygon": polygon, "localization_name": localization_name}
 
-    event_data = {"dateobs": dateobs, "skymap": skymap, "tags": tags}
-
-    status, data = api("POST", "gcn_event", data=event_data, token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
+    sp.post_gcn_event(GcnEventPost(dateobs=dateobs, skymap=skymap, tags=tags))
 
     dateobs = "2022-09-03 14:44:12"
-    status, data = api("GET", f"gcn_event/{dateobs}", token=super_admin_token)
-    assert status == 200
-    data = data["data"]
-    assert data["dateobs"] == "2022-09-03T14:44:12"
-    assert "IPN" in data["tags"]
+    event = sp.fetch_gcn_event(dateobs)
+    assert event.dateobs.isoformat() == "2022-09-03T14:44:12"
+    assert "IPN" in event.tags
 
 
 def test_gcn_Swift(super_admin_token):
+    sp = client(super_admin_token)
     datafile = f"{os.path.dirname(__file__)}/../../data/SWIFT_1125809-092.xml"
     with open(datafile, "rb") as fid:
         payload = fid.read()
-    event_data_1 = {"xml": payload}
+    event_data_1 = GcnEventPost(xml=payload)
 
     datafile = f"{os.path.dirname(__file__)}/../../data/SWIFT_1125809-104.xml"
     with open(datafile, "rb") as fid:
         payload = fid.read()
-    event_data_2 = {"xml": payload}
+    event_data_2 = GcnEventPost(xml=payload)
 
     dateobs = "2022-09-30 11:11:52"
-    status, data = api("GET", f"gcn_event/{dateobs}", token=super_admin_token)
+    try:
+        sp.fetch_gcn_event(dateobs)
+    except SkyPortalError as err:
+        if err.status_code == 404:
+            sp.post_gcn_event(event_data_1)
+            sp.post_gcn_event(event_data_2)
 
-    if status == 404:
-        status, data = api(
-            "POST", "gcn_event", data=event_data_1, token=super_admin_token
-        )
-        assert status == 200
-        assert data["status"] == "success"
-
-        status, data = api(
-            "POST", "gcn_event", data=event_data_2, token=super_admin_token
-        )
-        assert status == 200
-        assert data["status"] == "success"
-
-    status, data = api("GET", f"gcn_event/{dateobs}", token=super_admin_token)
-    assert status == 200
-    data = data["data"]
-    assert data["dateobs"] == "2022-09-30T11:11:52"
+    event = sp.fetch_gcn_event(dateobs)
+    assert event.dateobs.isoformat() == "2022-09-30T11:11:52"
     assert any(
-        loc["localization_name"] == "64.71490_13.35000_0.00130"
-        for loc in data["localizations"]
+        loc.localization_name == "64.71490_13.35000_0.00130"
+        for loc in event.localizations
     )
     assert any(
-        loc["localization_name"] == "64.73730_13.35170_0.05000"
-        for loc in data["localizations"]
+        loc.localization_name == "64.73730_13.35170_0.05000"
+        for loc in event.localizations
     )
 
     # wait for the async tasks to finish before finishing the tests, which will delete the user
@@ -451,78 +361,61 @@ def test_gcn_summary_sources(
     dateobs = gcn_GW190814.dateobs.strftime("%Y-%m-%dT%H:%M:%S")
 
     obj_id = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id,
-            "ra": 24.6258,
-            "dec": -32.9024,
-            "redshift": 3,
-        },
-        token=upload_data_token,
+    client(upload_data_token).post_source(
+        SourcePost(
+            id=obj_id,
+            ra=24.6258,
+            dec=-32.9024,
+            redshift=3,
+        )
     )
-    assert status == 200
 
-    status, data = api("GET", f"sources/{obj_id}", token=view_only_token)
-    assert status == 200
+    client(view_only_token).fetch_source(obj_id)
 
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": obj_id,
-            "mjd": 58709 + 1,
-            "instrument_id": ztf_camera.id,
-            "flux": 12.24,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "ra": 24.6258,
-            "dec": -32.9024,
-            "ra_unc": 0.01,
-            "dec_unc": 0.01,
-        },
-        token=upload_data_token,
+    client(upload_data_token).post_photometry(
+        PhotometryPost(
+            obj_id=obj_id,
+            mjd=58709 + 1,
+            instrument_id=ztf_camera.id,
+            flux=12.24,
+            fluxerr=0.031,
+            zp=25.0,
+            magsys="ab",
+            filter="ztfg",
+            ra=24.6258,
+            dec=-32.9024,
+            ra_unc=0.01,
+            dec_unc=0.01,
+        )
     )
-    assert status == 200
-    assert data["status"] == "success"
 
     # get the gcn event summary
-    data = {
-        "title": "gcn summary",
-        "subject": "follow-up",
-        "userIds": super_admin_user.id,
-        "groupId": public_group.id,
-        "startDate": "2019-08-13 08:18:05",
-        "endDate": "2019-08-19 08:18:05",
-        "localizationCumprob": 0.99,
-        "numberDetections": 1,
-        "showSources": True,
-        "showGalaxies": False,
-        "showObservations": False,
-        "noText": False,
-    }
-
-    status, data = api(
-        "POST",
-        f"gcn_event/{dateobs}/summary",
-        data=data,
-        token=super_admin_token,
+    summary_id = (
+        client(super_admin_token)
+        .post_gcn_summary(
+            dateobs,
+            GcnSummaryPost(
+                title="gcn summary",
+                subject="follow-up",
+                user_ids=[super_admin_user.id],
+                group_id=public_group.id,
+                start_date="2019-08-13 08:18:05",
+                end_date="2019-08-19 08:18:05",
+                localization_cumprob=0.99,
+                number_detections=1,
+                show_sources=True,
+                show_galaxies=False,
+                show_observations=False,
+                no_text=False,
+            ),
+        )
+        .id
     )
-    assert status == 200
-    summary_id = data["data"]["id"]
 
     def summary_ready():
-        status, data = api(
-            "GET",
-            f"gcn_event/{dateobs}/summary/{summary_id}",
-            token=view_only_token,
-        )
-        assert status == 200
-        assert data["data"]["text"] != "pending"
-        return data["data"]["text"]
+        summary = client(view_only_token).fetch_gcn_summary(dateobs, summary_id)
+        assert summary.text != "pending"
+        return summary.text
 
     text = retry_until(summary_ready, timeout=200)
     lines = list(filter(None, text.split("\n")))
@@ -573,77 +466,60 @@ def test_gcn_summary_galaxies(
     public_group,
     gcn_GW190814,
 ):
+    sp = client(super_admin_token)
     dateobs = gcn_GW190814.dateobs.strftime("%Y-%m-%dT%H:%M:%S")
 
     catalog_name = "test_galaxy_catalog"
     # in case the catalog already exists, delete it.
-    status, data = api(
-        "DELETE", f"galaxy_catalog/{catalog_name}", token=super_admin_token
-    )
+    with suppress(SkyPortalError):
+        sp.delete_galaxy_catalog(catalog_name)
 
     datafile = f"{os.path.dirname(__file__)}/../../../../data/CLU_mini.hdf5"
-    data = {
-        "catalog_name": catalog_name,
-        "catalog_data": Table.read(datafile)
-        .to_pandas()
-        .replace({np.nan: None})
-        .to_dict(orient="list"),
-    }
-
-    status, data = api("POST", "galaxy_catalog", data=data, token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-
-    params = {"catalog_name": catalog_name}
+    sp.post_galaxy_catalog(
+        GalaxyCatalogPost(
+            catalog_name=catalog_name,
+            catalog_data=Table.read(datafile)
+            .to_pandas()
+            .replace({np.nan: None})
+            .to_dict(orient="list"),
+        )
+    )
 
     def galaxies_loaded():
-        status, data = api(
-            "GET", "galaxy_catalog", token=view_only_token, params=params
+        galaxies = (
+            client(view_only_token).fetch_galaxies(catalog_name=catalog_name).galaxies
         )
-        assert status == 200
-        galaxies = data["data"]["galaxies"]
         assert len(galaxies) == 92
         assert any(
-            d["name"] == "6dFgs gJ0001313-055904" and d["mstar"] == 336.60756522868667
-            for d in galaxies
+            galaxy.name == "6dFgs gJ0001313-055904"
+            and galaxy.mstar == 336.60756522868667
+            for galaxy in galaxies
         )
 
     retry_until(galaxies_loaded, timeout=80)
 
     # get the gcn event summary
-    data = {
-        "title": "gcn summary",
-        "subject": "follow-up",
-        "userIds": super_admin_user.id,
-        "groupId": public_group.id,
-        "startDate": "2019-08-13 08:18:05",
-        "endDate": "2019-08-19 08:18:05",
-        "localizationCumprob": 0.99,
-        "showSources": False,
-        "showGalaxies": True,
-        "showObservations": False,
-        "noText": False,
-    }
-
-    status, data = api(
-        "POST",
-        f"gcn_event/{dateobs}/summary",
-        data=data,
-        token=super_admin_token,
-    )
-    assert status == 200
-    summary_id = data["data"]["id"]
+    summary_id = sp.post_gcn_summary(
+        dateobs,
+        GcnSummaryPost(
+            title="gcn summary",
+            subject="follow-up",
+            user_ids=[super_admin_user.id],
+            group_id=public_group.id,
+            start_date="2019-08-13 08:18:05",
+            end_date="2019-08-19 08:18:05",
+            localization_cumprob=0.99,
+            show_sources=False,
+            show_galaxies=True,
+            show_observations=False,
+            no_text=False,
+        ),
+    ).id
 
     def summary_ready():
-        status, data = api(
-            "GET",
-            f"gcn_event/{dateobs}/summary/{summary_id}",
-            token=view_only_token,
-            params=params,
-        )
-        assert status == 200
-        assert data["data"]["text"] != "pending"
-        return data["data"]["text"]
+        summary = client(view_only_token).fetch_gcn_summary(dateobs, summary_id)
+        assert summary.text != "pending"
+        return summary.text
 
     lines = list(filter(None, retry_until(summary_ready, timeout=200).split("\n")))
 
@@ -684,9 +560,8 @@ def test_gcn_summary_galaxies(
         for line in lines[galaxy_idx:]
     ), lines[galaxy_idx:]
 
-    status, data = api(
-        "DELETE", f"galaxy_catalog/{catalog_name}", token=super_admin_token
-    )
+    with suppress(SkyPortalError):
+        sp.delete_galaxy_catalog(catalog_name)
 
 
 def test_gcn_instrument_field(
@@ -699,18 +574,14 @@ def test_gcn_instrument_field(
         "ZTF", super_admin_token, list(range(200, 250))
     )
 
-    status, data = api(
-        "GET",
-        f"gcn_event/{dateobs}/instrument/{instrument_id}",
-        token=super_admin_token,
+    fields = client(super_admin_token).fetch_gcn_event_instrument_fields(
+        dateobs, instrument_id
     )
-    assert status == 200
-    assert data["status"] == "success"
 
-    assert "field_ids" in data["data"]
-    assert "probabilities" in data["data"]
+    assert fields.field_ids
+    assert fields.probabilities
 
-    assert set(data["data"]["field_ids"]) == {201, 202, 246, 247}
+    assert set(fields.field_ids) == {201, 202, 246, 247}
 
     remove_telescope_and_instrument(telescope_id, instrument_id, super_admin_token)
 
@@ -722,165 +593,85 @@ def test_confirm_reject_source_in_gcn(
     upload_data_token,
     gcn_GW190814,
 ):
+    sp = client(upload_data_token)
     dateobs = gcn_GW190814.dateobs.strftime("%Y-%m-%dT%H:%M:%S")
 
     obj_id = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id,
-            "ra": 24.6258,
-            "dec": -32.9024,
-            "redshift": 3,
-        },
-        token=upload_data_token,
+    sp.post_source(
+        SourcePost(
+            id=obj_id,
+            ra=24.6258,
+            dec=-32.9024,
+            redshift=3,
+        )
     )
-    assert status == 200
 
-    status, data = api("GET", f"sources/{obj_id}", token=view_only_token)
-    assert status == 200
+    client(view_only_token).fetch_source(obj_id)
 
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": obj_id,
-            "mjd": 58709 + 1,
-            "instrument_id": ztf_camera.id,
-            "flux": 12.24,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "ra": 24.6258,
-            "dec": -32.9024,
-            "ra_unc": 0.01,
-            "dec_unc": 0.01,
-        },
-        token=upload_data_token,
+    sp.post_photometry(
+        PhotometryPost(
+            obj_id=obj_id,
+            mjd=58709 + 1,
+            instrument_id=ztf_camera.id,
+            flux=12.24,
+            fluxerr=0.031,
+            zp=25.0,
+            magsys="ab",
+            filter="ztfg",
+            ra=24.6258,
+            dec=-32.9024,
+            ra_unc=0.01,
+            dec_unc=0.01,
+        )
     )
-    assert status == 200
-    assert data["status"] == "success"
 
-    params = {
-        "sourcesIdList": obj_id,
-    }
-    status, data = api(
-        "GET",
-        f"sources_in_gcn/{dateobs}",
-        params=params,
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert len(data["data"]) == 0
+    sources = sp.fetch_gcn_event_sources(dateobs, source_ids=[obj_id])
+    assert len(sources) == 0
 
     # confirm source
-    params = {
-        "source_id": obj_id,
-        "localization_name": "LALInference.v1.fits.gz",
-        "localization_cumprob": 0.95,
-        "status": "confirmed",
-        "start_date": "2019-08-13 08:18:05",
-        "end_date": "2019-08-19 08:18:05",
-    }
-
     # vetting needs no GCN-specific ACL, just the ability to write data
-    status, data = api(
-        "POST",
-        f"sources_in_gcn/{dateobs}",
-        data=params,
-        token=upload_data_token,
+    sp.post_gcn_event_source(
+        dateobs,
+        GcnEventObjPost(
+            source_id=obj_id,
+            localization_name="LALInference.v1.fits.gz",
+            localization_cumprob=0.95,
+            status="confirmed",
+            start_date="2019-08-13 08:18:05",
+            end_date="2019-08-19 08:18:05",
+        ),
     )
-    assert status == 200, data
 
-    params = {
-        "sourcesIdList": obj_id,
-    }
-    status, data = api(
-        "GET",
-        f"sources_in_gcn/{dateobs}",
-        params=params,
-        token=upload_data_token,
-    )
-    assert status == 200
-    data = data["data"]
-    assert len(data) == 1
-    assert data[0]["obj_id"] == obj_id
-    assert data[0]["dateobs"] == dateobs
-    assert data[0]["status"] == "confirmed"
+    sources = sp.fetch_gcn_event_sources(dateobs, source_ids=[obj_id])
+    assert len(sources) == 1
+    assert sources[0].obj_id == obj_id
+    assert sources[0].dateobs.isoformat() == dateobs
+    assert sources[0].status == "confirmed"
 
     # find gcns associated to source
-    status, data = api(
-        "GET",
-        f"associated_gcns/{obj_id}",
-        token=upload_data_token,
-    )
-    assert status == 200
-    data = data["data"]
-    assert dateobs in data["gcns"]
+    gcns = sp.fetch_gcn_events_associated_with_source(obj_id)
+    assert dateobs in gcns
 
     # reject source
-    params = {
-        "status": "rejected",
-    }
+    sp.update_gcn_event_source(dateobs, obj_id, "rejected")
 
-    status, data = api(
-        "PATCH",
-        f"sources_in_gcn/{dateobs}/{obj_id}",
-        data=params,
-        token=upload_data_token,
-    )
-    assert status == 200, data
-
-    params = {
-        "sourcesIdList": obj_id,
-    }
-    status, data = api(
-        "GET",
-        f"sources_in_gcn/{dateobs}",
-        params=params,
-        token=upload_data_token,
-    )
-    assert status == 200
-    data = data["data"]
-    assert len(data) == 1
-    assert data[0]["obj_id"] == obj_id
-    assert data[0]["dateobs"] == dateobs
-    assert data[0]["status"] == "rejected"
+    sources = sp.fetch_gcn_event_sources(dateobs, source_ids=[obj_id])
+    assert len(sources) == 1
+    assert sources[0].obj_id == obj_id
+    assert sources[0].dateobs.isoformat() == dateobs
+    assert sources[0].status == "rejected"
 
     # verify that no gcns are associated to source
 
     # find no gcns associated to source
-    status, data = api(
-        "GET",
-        f"associated_gcns/{obj_id}",
-        token=upload_data_token,
-    )
-    assert status == 200
-    data = data["data"]
-    assert len(data["gcns"]) == 0
+    gcns = sp.fetch_gcn_events_associated_with_source(obj_id)
+    assert len(gcns) == 0
 
     # mark source as unknow (delete it from the table)
-    status, data = api(
-        "DELETE",
-        f"sources_in_gcn/{dateobs}/{obj_id}",
-        token=upload_data_token,
-    )
-    assert status == 200, data
+    sp.delete_gcn_event_source(dateobs, obj_id)
 
-    params = {
-        "sourcesIdList": obj_id,
-    }
-    status, data = api(
-        "GET",
-        f"sources_in_gcn/{dateobs}",
-        params=params,
-        token=upload_data_token,
-    )
-    assert status == 200
-    data = data["data"]
-    assert len(data) == 0
+    sources = sp.fetch_gcn_event_sources(dateobs, source_ids=[obj_id])
+    assert len(sources) == 0
 
 
 @pytest.mark.skipif(not tach_isonline, reason="GCN TACH is not online")
@@ -889,42 +680,36 @@ def test_gcn_tach(
     view_only_token,
     gcn_GRB180116A,
 ):
+    sp = client(super_admin_token)
     dateobs = gcn_GRB180116A.dateobs.strftime("%Y-%m-%dT%H:%M:%S")
-    status, data = api("GET", f"gcn_event/{dateobs}", token=super_admin_token)
-    assert status == 200
+    event = sp.fetch_gcn_event(dateobs)
 
-    data = data["data"]
-    assert "aliases" in data
-    assert "GRB180116A" not in data["aliases"]
-    aliases_len = len(data["aliases"])
+    assert event.aliases is not None
+    assert "GRB180116A" not in event.aliases
+    aliases_len = len(event.aliases)
 
-    status, data = api("POST", f"gcn_event/{dateobs}/tach", token=view_only_token)
-    assert status == 401
+    with pytest.raises(SkyPortalError) as err:
+        client(view_only_token).post_gcn_event_tach(dateobs)
+    assert err.value.status_code == 401
 
-    status, data = api("POST", f"gcn_event/{dateobs}/tach", token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
+    sp.post_gcn_event_tach(dateobs)
 
     for n_times in range(30):
-        status, data = api("GET", f"gcn_event/{dateobs}", token=super_admin_token)
-        if data["status"] == "success":
-            if len(data["data"]["aliases"]) > 1:
-                aliases = data["data"]["aliases"]
-                break
-            time.sleep(1)
+        event = sp.fetch_gcn_event(dateobs)
+        if len(event.aliases) > 1:
+            aliases = event.aliases
+            break
+        time.sleep(1)
 
     assert n_times < 29
     assert len(aliases) == aliases_len + 1
     assert "GRB180116A" in aliases
 
-    status, data = api("GET", f"gcn_event/{dateobs}/tach", token=super_admin_token)
+    tach = sp.fetch_gcn_event_tach(dateobs)
 
-    assert status == 200
-    assert data["status"] == "success"
-    data = data["data"]
-    assert len(data["aliases"]) == 2
-    assert len(data["circulars"]) == 3
-    assert data["tach_id"] is not None
+    assert len(tach.aliases) == 2
+    assert len(tach.circulars) == 3
+    assert tach.tach_id is not None
 
 
 def test_gcn_allocation_triggers(
@@ -933,44 +718,36 @@ def test_gcn_allocation_triggers(
     view_only_token,
     gcn_GRB180116A,
 ):
+    sp = client(super_admin_token)
     dateobs = gcn_GRB180116A.dateobs.strftime("%Y-%m-%dT%H:%M:%S")
 
-    status, data = api("GET", f"gcn_event/{dateobs}", token=super_admin_token)
-    assert status == 200
+    sp.fetch_gcn_event(dateobs)
 
     name = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "telescope",
-        data={
-            "name": name,
-            "nickname": name,
-            "lat": 0.0,
-            "lon": 0.0,
-            "elevation": 0.0,
-            "diameter": 10.0,
-        },
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    telescope_id = data["data"]["id"]
+    telescope_id = sp.post_telescope(
+        TelescopePost(
+            name=name,
+            nickname=name,
+            lat=0.0,
+            lon=0.0,
+            elevation=0.0,
+            diameter=10.0,
+        )
+    ).id
 
     instrument_name = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "instrument",
-        data={
-            "name": instrument_name,
-            "type": "imager",
-            "band": "Optical",
-            "filters": ["ztfr"],
-            "telescope_id": telescope_id,
-            "api_classname": "ZTFAPI",
-            "api_classname_obsplan": "ZTFMMAAPI",
-            "field_fov_type": "circle",
-            "field_fov_attributes": 3.0,
-            "sensitivity_data": {
+    instrument_id = sp.post_instrument(
+        InstrumentPost(
+            name=instrument_name,
+            type="imager",
+            band="Optical",
+            filters=["ztfr"],
+            telescope_id=telescope_id,
+            api_classname="ZTFAPI",
+            api_classname_obsplan="ZTFMMAAPI",
+            field_fov_type="circle",
+            field_fov_attributes=3.0,
+            sensitivity_data={
                 "ztfr": {
                     "limiting_magnitude": 20.3,
                     "magsys": "ab",
@@ -978,91 +755,67 @@ def test_gcn_allocation_triggers(
                     "zeropoint": 26.3,
                 }
             },
-        },
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    instrument_id = data["data"]["id"]
+        )
+    ).id
 
-    request_data = {
-        "group_id": public_group.id,
-        "instrument_id": instrument_id,
-        "pi": "Shri Kulkarni",
-        "hours_allocated": 200,
-        "validity_ranges": [
-            {
-                "start_date": "2021-02-27T00:00:00.000Z",
-                "end_date": "3021-07-20T00:00:00.000Z",
-            }
-        ],
-        "proposal_id": "COO-2020A-P01",
-        "default_share_group_ids": [public_group.id],
-    }
+    allocation_id = sp.post_allocation(
+        AllocationPost(
+            group_id=public_group.id,
+            instrument_id=instrument_id,
+            pi="Shri Kulkarni",
+            hours_allocated=200,
+            validity_ranges=[
+                {
+                    "start_date": "2021-02-27T00:00:00.000Z",
+                    "end_date": "3021-07-20T00:00:00.000Z",
+                }
+            ],
+            proposal_id="COO-2020A-P01",
+            default_share_group_ids=[public_group.id],
+        )
+    ).id
 
-    status, data = api("POST", "allocation", data=request_data, token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-    allocation_id = data["data"]["id"]
+    sp.fetch_allocation(allocation_id)
 
-    status, data = api("GET", f"allocation/{allocation_id}", token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
+    sp.update_gcn_event_trigger(dateobs, allocation_id, triggered=True)
 
-    status, data = api(
-        "PUT",
-        f"gcn_event/{dateobs}/triggered/{allocation_id}",
-        data={"triggered": True},
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-
-    status, data = api(
-        "PUT",
-        f"gcn_event/{dateobs}/triggered/{allocation_id}",
-        data={"triggered": False},
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp.update_gcn_event_trigger(dateobs, allocation_id, triggered=False)
 
     # now we verify that the view_only_token can't change the triggered status
-    status, data = api(
-        "PUT",
-        f"gcn_event/{dateobs}/triggered/{allocation_id}",
-        data={"triggered": True},
-        token=view_only_token,
-    )
-    assert status == 401
+    with pytest.raises(SkyPortalError) as err:
+        client(view_only_token).update_gcn_event_trigger(
+            dateobs, allocation_id, triggered=True
+        )
+    assert err.value.status_code == 401
 
-    status, data = api("GET", f"gcn_event/{dateobs}", token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-    assert data["data"]["gcn_triggers"][0]["allocation_id"] == allocation_id
-    assert data["data"]["gcn_triggers"][0]["triggered"] is False
+    event = sp.fetch_gcn_event(dateobs)
+    assert event.gcn_triggers[0].allocation_id == allocation_id
+    assert event.gcn_triggers[0].triggered is False
 
 
 def test_gcn_autogenerated_source_has_t0(super_admin_token):
     """A source auto-created from a tight localization carries the event time as t0."""
+    sp = client(super_admin_token)
     dateobs = (utcnow_naive() - timedelta(days=3)).replace(microsecond=0)
-    payload = {
-        "dateobs": dateobs.isoformat(),
-        # error well under SOURCE_RADIUS_THRESHOLD, so post_gcn_source fires
-        "skymap": {"ra": 42.0, "dec": 12.0, "error": 0.04},
-        # no group_ids -> sitewide public group, which post_gcn_source requires
-    }
-    status, data = api("POST", "gcn_event", data=payload, token=super_admin_token)
-    assert status == 200, data
+    sp.post_gcn_event(
+        GcnEventPost(
+            dateobs=dateobs.isoformat(),
+            # error well under SOURCE_RADIUS_THRESHOLD, so post_gcn_source fires
+            skymap={"ra": 42.0, "dec": 12.0, "error": 0.04},
+            # no group_ids -> sitewide public group, which post_gcn_source requires
+        )
+    )
 
     obj_id = f"GCN-{dateobs.strftime('%y%m%d_%H%M%S')}"
+    source = None
     for _ in range(30):
-        status, data = api("GET", f"sources/{obj_id}", token=super_admin_token)
-        if status == 200:
+        try:
+            source = sp.fetch_source(obj_id)
             break
-        time.sleep(1)
-    assert status == 200, f"source {obj_id} was never created: {data}"
-    assert data["data"]["t0"] == pytest.approx(Time(dateobs.isoformat()).mjd)
+        except SkyPortalError:
+            time.sleep(1)
+    assert source is not None, f"source {obj_id} was never created"
+    assert source.t0 == pytest.approx(Time(dateobs.isoformat()).mjd)
 
 
 def test_default_gcn_tag_matches_on_notice_type(super_admin_token, user):
@@ -1077,6 +830,7 @@ def test_default_gcn_tag_matches_on_notice_type(super_admin_token, user):
     pass when it ingests a new skymap, so re-posting an existing event does not
     exercise it.
     """
+    sp = client(super_admin_token)
     datafile = (
         f"{os.path.dirname(__file__)}/../../data/GRB180116A_Fermi_GBM_Gnd_Pos.xml"
     )
@@ -1084,14 +838,14 @@ def test_default_gcn_tag_matches_on_notice_type(super_admin_token, user):
         payload = fid.read()
     dateobs = "2018-01-16 00:36:53"
 
-    status, data = api(
-        "POST", "gcn_event", data={"xml": payload}, token=super_admin_token
-    )
-    assert status in (200, 400), data  # 400 if an earlier test already posted it
+    try:
+        sp.post_gcn_event(GcnEventPost(xml=payload))
+    except SkyPortalError as err:
+        # 400 if an earlier test already posted it
+        assert err.status_code == 400, str(err)
 
-    status, data = api("GET", f"gcn_event/{dateobs}", token=super_admin_token)
-    assert status == 200, data
-    notice_types = [n["notice_type"] for n in data["data"]["gcn_notices"]]
+    event = sp.fetch_gcn_event(dateobs)
+    notice_types = [n.notice_type for n in event.gcn_notices]
     assert notice_types, "event has no notices to match on"
 
     matching, nonmatching = str(uuid.uuid4()), str(uuid.uuid4())

--- a/skyportal/tests/api_tests/sources_candidates/test_gcn_crossmatch_api.py
+++ b/skyportal/tests/api_tests/sources_candidates/test_gcn_crossmatch_api.py
@@ -4,22 +4,25 @@ import uuid
 from datetime import timedelta
 
 import numpy as np
+import pytest
+from skyportal_py import SkyPortalError
+from skyportal_py.gcn_events import GcnEventPost
 
-from skyportal.tests import api
+from skyportal.tests import client
 from skyportal.utils.naive_datetime import utcnow_naive
 
 
 def _post_event(token, group_ids):
     dateobs = (utcnow_naive() - timedelta(hours=3)).replace(microsecond=0)
     ra, dec = float(np.random.uniform(0, 360)), float(np.random.uniform(-20, 20))
-    payload = {
-        "dateobs": dateobs.isoformat(),
-        "trigger_id": f"XM{uuid.uuid4().hex[:10]}",
-        "skymap": {"ra": ra, "dec": dec, "error": 0.2},
-        "group_ids": list(group_ids),
-    }
-    status, data = api("POST", "gcn_event", data=payload, token=token)
-    assert status == 200, data
+    client(token).post_gcn_event(
+        GcnEventPost(
+            dateobs=dateobs.isoformat(),
+            trigger_id=f"XM{uuid.uuid4().hex[:10]}",
+            skymap={"ra": ra, "dec": dec, "error": 0.2},
+            group_ids=list(group_ids),
+        )
+    )
     return dateobs.strftime("%Y-%m-%d %H:%M:%S")
 
 
@@ -27,11 +30,8 @@ def test_crossmatch_progress_readable_by_group_member(
     super_admin_token, public_group2, view_only_token_group2
 ):
     dateobs = _post_event(super_admin_token, [public_group2.id])
-    status, data = api(
-        "GET", f"gcn_event/{dateobs}/crossmatch", token=view_only_token_group2
-    )
-    assert status == 200, data
-    assert isinstance(data["data"], list)
+    states = client(view_only_token_group2).fetch_gcn_event_crossmatch(dateobs)
+    assert isinstance(states, list)
 
 
 def test_crossmatch_progress_hidden_from_non_members(
@@ -39,28 +39,24 @@ def test_crossmatch_progress_hidden_from_non_members(
 ):
     """A restricted event's crossmatch progress must not leak its existence."""
     dateobs = _post_event(super_admin_token, [public_group2.id])
-    status, data = api("GET", f"gcn_event/{dateobs}/crossmatch", token=view_only_token)
-    assert status in (400, 403, 404), data
+    with pytest.raises(SkyPortalError) as err:
+        client(view_only_token).fetch_gcn_event_crossmatch(dateobs)
+    assert err.value.status_code in (400, 403, 404)
 
 
 def test_requeue_requires_manage_gcns(
     super_admin_token, public_group2, view_only_token_group2
 ):
     dateobs = _post_event(super_admin_token, [public_group2.id])
-    status, data = api(
-        "POST", f"gcn_event/{dateobs}/crossmatch", token=view_only_token_group2
-    )
-    assert status in (400, 401, 403), data
+    with pytest.raises(SkyPortalError) as err:
+        client(view_only_token_group2).post_gcn_event_crossmatch(dateobs)
+    assert err.value.status_code in (400, 401, 403)
 
-    status, data = api(
-        "POST", f"gcn_event/{dateobs}/crossmatch", token=super_admin_token
-    )
-    assert status == 200, data
-    assert "filters_requeued" in data["data"], data
+    result = client(super_admin_token).post_gcn_event_crossmatch(dateobs)
+    assert result.filters_requeued is not None
 
 
 def test_requeue_unknown_event_errors(super_admin_token):
-    status, data = api(
-        "POST", "gcn_event/2001-01-01 00:00:00/crossmatch", token=super_admin_token
-    )
-    assert status == 400, data
+    with pytest.raises(SkyPortalError) as err:
+        client(super_admin_token).post_gcn_event_crossmatch("2001-01-01 00:00:00")
+    assert err.value.status_code == 400

--- a/skyportal/tests/api_tests/sources_candidates/test_gcn_crossmatch_geometry.py
+++ b/skyportal/tests/api_tests/sources_candidates/test_gcn_crossmatch_geometry.py
@@ -14,10 +14,11 @@ from datetime import timedelta
 
 import numpy as np
 import sqlalchemy as sa
+from skyportal_py.gcn_events import GcnEventPost
 
 from baselayer.app import models
 from skyportal.models import Localization
-from skyportal.tests import api
+from skyportal.tests import client
 from skyportal.utils.crossmatch import (
     contained_in_localization,
     search_cone,
@@ -61,15 +62,14 @@ def test_cone_containment_is_exact(super_admin_token, public_group2):
     """A cone localization resolves membership analytically."""
     dateobs = _unique_dateobs()
     ra, dec, error = 42.0, 12.0, 0.5
-    payload = {
-        "dateobs": dateobs.isoformat(),
-        "trigger_id": f"EP{uuid.uuid4().hex[:10]}",
-        "skymap": {"ra": ra, "dec": dec, "error": error},
-        "tags": ["EP"],
-        "group_ids": [public_group2.id],
-    }
-    status, data = api("POST", "gcn_event", data=payload, token=super_admin_token)
-    assert status == 200, data
+    payload = GcnEventPost(
+        dateobs=dateobs.isoformat(),
+        trigger_id=f"EP{uuid.uuid4().hex[:10]}",
+        skymap={"ra": ra, "dec": dec, "error": error},
+        tags=["EP"],
+        group_ids=[public_group2.id],
+    )
+    client(super_admin_token).post_gcn_event(payload)
 
     name = f"{ra:.5f}_{dec:.5f}_{error:.5f}"
     localization = _localization(dateobs, name)
@@ -109,14 +109,13 @@ def test_skymap_containment_uses_localization_tiles(super_admin_token, public_gr
         (ra0 + 2.0, dec0 + 2.0),
         (ra0 - 2.0, dec0 + 2.0),
     ]
-    payload = {
-        "dateobs": dateobs.isoformat(),
-        "skymap": {"polygon": polygon, "localization_name": name},
-        "tags": ["TEST"],
-        "group_ids": [public_group2.id],
-    }
-    status, data = api("POST", "gcn_event", data=payload, token=super_admin_token)
-    assert status == 200, data
+    payload = GcnEventPost(
+        dateobs=dateobs.isoformat(),
+        skymap={"polygon": polygon, "localization_name": name},
+        tags=["TEST"],
+        group_ids=[public_group2.id],
+    )
+    client(super_admin_token).post_gcn_event(payload)
 
     localization = _localization(dateobs, name)
     assert localization is not None

--- a/skyportal/tests/api_tests/sources_candidates/test_gcn_crossmatch_service.py
+++ b/skyportal/tests/api_tests/sources_candidates/test_gcn_crossmatch_service.py
@@ -12,6 +12,7 @@ import base64
 import gzip
 import io
 import uuid
+from contextlib import suppress
 from datetime import timedelta
 
 import numpy as np
@@ -19,6 +20,8 @@ import pytest
 import sqlalchemy as sa
 from astropy.io import fits
 from astropy.time import Time
+from skyportal_py import SkyPortalError
+from skyportal_py.gcn_events import GcnEventPost
 
 from baselayer.app import models
 from skyportal.broker_apis import GENERICBROKER
@@ -34,7 +37,7 @@ from skyportal.models import (
     Source,
     Thumbnail,
 )
-from skyportal.tests import api
+from skyportal.tests import client
 from skyportal.tests.fixtures import (
     FilterFactory,
     InstrumentFactory,
@@ -68,16 +71,15 @@ def _unique_id(prefix):
 def _post_event(token, group_ids, ra, dec):
     """A cone event recent enough to be inside the crossmatch window."""
     dateobs = (utcnow_naive() - timedelta(hours=6)).replace(microsecond=0)
-    payload = {
-        "dateobs": dateobs.isoformat(),
-        "trigger_id": f"XM{uuid.uuid4().hex[:10]}",
-        "skymap": {"ra": ra, "dec": dec, "error": ERROR},
-        "tags": ["TEST"],
-        "group_ids": list(group_ids),
-    }
-    status, data = api("POST", "gcn_event", data=payload, token=token)
-    assert status == 200, data
-    return dateobs, payload["trigger_id"]
+    payload = GcnEventPost(
+        dateobs=dateobs.isoformat(),
+        trigger_id=f"XM{uuid.uuid4().hex[:10]}",
+        skymap={"ra": ra, "dec": dec, "error": ERROR},
+        tags=["TEST"],
+        group_ids=list(group_ids),
+    )
+    client(token).post_gcn_event(payload)
+    return dateobs, payload.trigger_id
 
 
 @pytest.fixture()
@@ -86,7 +88,9 @@ def crossmatch_event(super_admin_token, public_group2):
     ra, dec = _unique_position()
     dateobs, trigger_id = _post_event(super_admin_token, [public_group2.id], ra, dec)
     yield dateobs, trigger_id, ra, dec
-    api("DELETE", f"gcn_event/{dateobs.isoformat()}", token=super_admin_token)
+    # result was not checked before, so tolerate failure
+    with suppress(SkyPortalError):
+        client(super_admin_token).delete_gcn_event(dateobs.isoformat())
 
 
 @pytest.fixture()
@@ -302,14 +306,13 @@ def test_crossmatch_skips_events_outside_the_age_window(
         - timedelta(days=400)
         - timedelta(seconds=int(np.random.randint(0, 10**5)))
     ).replace(microsecond=0)
-    payload = {
-        "dateobs": old_dateobs.isoformat(),
-        "trigger_id": f"XM{uuid.uuid4().hex[:10]}",
-        "skymap": {"ra": ra, "dec": dec, "error": ERROR},
-        "group_ids": [public_group2.id],
-    }
-    status, data = api("POST", "gcn_event", data=payload, token=super_admin_token)
-    assert status == 200, data
+    payload = GcnEventPost(
+        dateobs=old_dateobs.isoformat(),
+        trigger_id=f"XM{uuid.uuid4().hex[:10]}",
+        skymap={"ra": ra, "dec": dec, "error": ERROR},
+        group_ids=[public_group2.id],
+    )
+    client(super_admin_token).post_gcn_event(payload)
 
     obj_id = _unique_id("XM_old")
     recorded = {}
@@ -931,18 +934,14 @@ def test_crossmatch_searches_every_localization_of_an_event(
     dateobs, _ = _post_event(super_admin_token, [public_group2.id], ra_a, dec_a)
     # A second cone on the same event, exactly how a sibling EP source arrives:
     # posted under the same observation timestamp, which is the event's key.
-    status, data = api(
-        "POST",
-        "gcn_event",
-        data={
-            "dateobs": dateobs.isoformat(),
-            "skymap": {"ra": ra_b, "dec": dec_b, "error": ERROR},
-            "tags": ["TEST"],
-            "group_ids": [public_group2.id],
-        },
-        token=super_admin_token,
+    client(super_admin_token).post_gcn_event(
+        GcnEventPost(
+            dateobs=dateobs.isoformat(),
+            skymap={"ra": ra_b, "dec": dec_b, "error": ERROR},
+            tags=["TEST"],
+            group_ids=[public_group2.id],
+        )
     )
-    assert status == 200, data
 
     event_jd = float(Time(dateobs).jd)
     obj_a = _unique_id("XM_loc_a")

--- a/skyportal/tests/api_tests/sources_candidates/test_gcn_group_access.py
+++ b/skyportal/tests/api_tests/sources_candidates/test_gcn_group_access.py
@@ -16,8 +16,11 @@ import uuid
 from datetime import datetime, timedelta
 
 import numpy as np
+import pytest
+from skyportal_py import SkyPortalError
+from skyportal_py.gcn_events import GcnEventPost
 
-from skyportal.tests import api
+from skyportal.tests import api, client
 from skyportal.utils.naive_datetime import utcnow_naive
 
 # Wide enough that post_gcn_source does not fire (SOURCE_RADIUS_THRESHOLD is
@@ -41,17 +44,15 @@ def _post_cone_event(token, group_ids=None):
     dateobs = _unique_dateobs()
     ra, dec = float(np.random.uniform(0, 360)), float(np.random.uniform(-30, 30))
     tag = str(uuid.uuid4())
-    event_data = {
-        "dateobs": dateobs.isoformat(),
-        "skymap": {"ra": ra, "dec": dec, "error": CONE_ERROR_DEG},
-        "tags": [tag],
-    }
-    if group_ids is not None:
-        event_data["group_ids"] = group_ids
 
-    status, data = api("POST", "gcn_event", data=event_data, token=token)
-    assert status == 200, data
-    assert data["status"] == "success"
+    client(token).post_gcn_event(
+        GcnEventPost(
+            dateobs=dateobs.isoformat(),
+            skymap={"ra": ra, "dec": dec, "error": CONE_ERROR_DEG},
+            tags=[tag],
+            group_ids=group_ids,
+        )
+    )
 
     localization_name = f"{ra:.5f}_{dec:.5f}_{CONE_ERROR_DEG:.5f}"
     return dateobs.strftime("%Y-%m-%d %H:%M:%S"), localization_name, tag
@@ -64,16 +65,15 @@ def test_restricted_gcn_event_hidden_from_non_members(
     dateobs, _, _ = _post_cone_event(super_admin_token, group_ids=[public_group2.id])
 
     # a member of the owning group can read it
-    status, data = api("GET", f"gcn_event/{dateobs}", token=view_only_token_group2)
-    assert status == 200, data
+    client(view_only_token_group2).fetch_gcn_event(dateobs)
 
     # a user who is not in the owning group cannot
-    status, data = api("GET", f"gcn_event/{dateobs}", token=view_only_token)
-    assert status in (400, 403, 404), data
+    with pytest.raises(SkyPortalError) as err:
+        client(view_only_token).fetch_gcn_event(dateobs)
+    assert err.value.status_code in (400, 403, 404)
 
     # system admins bypass the restriction
-    status, data = api("GET", f"gcn_event/{dateobs}", token=super_admin_token)
-    assert status == 200, data
+    client(super_admin_token).fetch_gcn_event(dateobs)
 
 
 def test_gcn_event_defaults_to_public_group(
@@ -83,8 +83,7 @@ def test_gcn_event_defaults_to_public_group(
     dateobs, _, _ = _post_cone_event(super_admin_token)
 
     for token in (view_only_token, view_only_token_group2):
-        status, data = api("GET", f"gcn_event/{dateobs}", token=token)
-        assert status == 200, data
+        client(token).fetch_gcn_event(dateobs)
 
 
 def test_restricted_gcn_event_absent_from_listing(
@@ -95,15 +94,11 @@ def test_restricted_gcn_event_absent_from_listing(
 
     # filter by the event's unique tag so the assertion does not depend on
     # pagination or on how much other GCN data the test database holds
-    params = {"gcnTagKeep": tag}
+    page = client(view_only_token).fetch_gcn_events(gcn_tag_keep=[tag])
+    assert page.events == []
 
-    status, data = api("GET", "gcn_event", params=params, token=view_only_token)
-    assert status == 200, data
-    assert data["data"]["events"] == []
-
-    status, data = api("GET", "gcn_event", params=params, token=view_only_token_group2)
-    assert status == 200, data
-    listed = {e["dateobs"] for e in data["data"]["events"]}
+    page = client(view_only_token_group2).fetch_gcn_events(gcn_tag_keep=[tag])
+    listed = {e.dateobs.isoformat() for e in page.events}
     assert dateobs.replace(" ", "T") in listed
 
 
@@ -117,11 +112,10 @@ def test_localization_tags_listing_is_access_scoped(gcn_GW190425, view_only_toke
     guards both that scoping and that the endpoint still composes with
     .distinct() rather than erroring.
     """
-    status, data = api("GET", "localization/tags", token=view_only_token)
-    assert status == 200, data
+    tags = client(view_only_token).fetch_localization_tags()
     # gcn_GW190425's localization carries the "Test" tag and its event is
     # attached to the public group the token's user belongs to
-    assert "Test" in data["data"], data["data"]
+    assert "Test" in tags, tags
 
 
 def test_restricted_localization_hidden_from_non_members(
@@ -132,19 +126,11 @@ def test_restricted_localization_hidden_from_non_members(
         super_admin_token, group_ids=[public_group2.id]
     )
 
-    status, data = api(
-        "GET",
-        f"localization/{dateobs}/name/{localization_name}",
-        token=view_only_token_group2,
-    )
-    assert status == 200, data
+    client(view_only_token_group2).fetch_localization(dateobs, localization_name)
 
-    status, data = api(
-        "GET",
-        f"localization/{dateobs}/name/{localization_name}",
-        token=view_only_token,
-    )
-    assert status in (400, 403, 404), data
+    with pytest.raises(SkyPortalError) as err:
+        client(view_only_token).fetch_localization(dateobs, localization_name)
+    assert err.value.status_code in (400, 403, 404)
 
 
 def test_restricted_localization_does_not_leak_position_via_sources(
@@ -167,20 +153,20 @@ def test_restricted_localization_does_not_leak_position_via_sources(
     # ever exercising the access check.
     event_time = datetime.fromisoformat(dateobs.replace(" ", "T"))
     params = {
-        "localizationDateobs": dateobs,
-        "localizationName": localization_name,
-        "startDate": (event_time - timedelta(days=1)).isoformat(),
-        "endDate": (event_time + timedelta(days=1)).isoformat(),
+        "localization_dateobs": dateobs,
+        "localization_name": localization_name,
+        "start_date": (event_time - timedelta(days=1)).isoformat(),
+        "end_date": (event_time + timedelta(days=1)).isoformat(),
     }
 
     # a group2 member resolves the localization fine (proving the window and
     # names are valid, so the non-member failure below is about access only)
-    status, data = api("GET", "sources", params=params, token=view_only_token_group2)
-    assert status == 200, data
+    client(view_only_token_group2).fetch_sources(**params)
 
-    status, data = api("GET", "sources", params=params, token=view_only_token)
-    assert status == 400, data
-    assert "not found" in str(data.get("message", "")).lower(), data
+    with pytest.raises(SkyPortalError) as err:
+        client(view_only_token).fetch_sources(**params)
+    assert err.value.status_code == 400
+    assert "not found" in str(err.value).lower()
 
 
 def test_events_list_filters_by_group(
@@ -191,24 +177,16 @@ def test_events_list_filters_by_group(
     _, _, tag_b = _post_cone_event(super_admin_token)  # public group
 
     # restricted to group2: the group2 event is there
-    status, data = api(
-        "GET",
-        "gcn_event",
-        params={"groupIds": str(public_group2.id), "gcnTagKeep": tag_a},
-        token=view_only_token_group2,
+    page = client(view_only_token_group2).fetch_gcn_events(
+        group_ids=[public_group2.id], gcn_tag_keep=[tag_a]
     )
-    assert status == 200, data
-    assert len(data["data"]["events"]) == 1, data["data"]["events"]
+    assert len(page.events) == 1, page.events
 
     # ...and the public-group event is excluded by the same filter
-    status, data = api(
-        "GET",
-        "gcn_event",
-        params={"groupIds": str(public_group2.id), "gcnTagKeep": tag_b},
-        token=view_only_token_group2,
+    page = client(view_only_token_group2).fetch_gcn_events(
+        group_ids=[public_group2.id], gcn_tag_keep=[tag_b]
     )
-    assert status == 200, data
-    assert data["data"]["events"] == [], data["data"]["events"]
+    assert page.events == [], page.events
 
 
 def test_events_list_group_filter_cannot_widen_access(
@@ -217,17 +195,14 @@ def test_events_list_group_filter_cannot_widen_access(
     """Asking for a group you are not in returns nothing, not someone else's events."""
     _, _, tag = _post_cone_event(super_admin_token, group_ids=[public_group2.id])
 
-    status, data = api(
-        "GET",
-        "gcn_event",
-        params={"groupIds": str(public_group2.id), "gcnTagKeep": tag},
-        token=view_only_token,
+    page = client(view_only_token).fetch_gcn_events(
+        group_ids=[public_group2.id], gcn_tag_keep=[tag]
     )
-    assert status == 200, data
-    assert data["data"]["events"] == [], data["data"]["events"]
+    assert page.events == [], page.events
 
 
 def test_events_list_rejects_bad_group_ids(super_admin_token):
+    # raw api: intentionally malformed groupIds the typed client can't produce
     status, data = api(
         "GET", "gcn_event", params={"groupIds": "not-an-int"}, token=super_admin_token
     )

--- a/skyportal/tests/api_tests/sources_candidates/test_internal_key.py
+++ b/skyportal/tests/api_tests/sources_candidates/test_internal_key.py
@@ -1,4 +1,6 @@
-from skyportal.tests import api
+from skyportal_py.spectra import SpectrumPost
+
+from skyportal.tests import client
 
 # Obj.internal_key anonymizes objects in websocket refresh messages. It must only
 # reach clients that can already see the object (via source/candidate responses,
@@ -7,52 +9,39 @@ from skyportal.tests import api
 
 
 def test_internal_key_present_on_source_detail(view_only_token, public_source):
-    status, data = api("GET", f"sources/{public_source.id}", token=view_only_token)
-    assert status == 200
-    assert data["data"]["internal_key"] == public_source.internal_key
+    source = client(view_only_token).fetch_source(public_source.id)
+    assert source.internal_key == public_source.internal_key
 
 
 def test_internal_key_present_on_sources_list(view_only_token, public_source):
-    status, data = api(
-        "GET", "sources", params={"sourceID": public_source.id}, token=view_only_token
-    )
-    assert status == 200
-    row = next(s for s in data["data"]["sources"] if s["id"] == public_source.id)
-    assert row["internal_key"] == public_source.internal_key
+    page = client(view_only_token).fetch_sources(source_id=public_source.id)
+    row = next(s for s in page.sources if s.id == public_source.id)
+    assert row.internal_key == public_source.internal_key
 
 
 def test_internal_key_present_on_candidate(view_only_token, public_candidate):
-    status, data = api(
-        "GET", f"candidates/{public_candidate.id}", token=view_only_token
-    )
-    assert status == 200
-    assert data["data"]["internal_key"] == public_candidate.internal_key
+    candidate = client(view_only_token).fetch_candidate(public_candidate.id)
+    assert candidate.internal_key == public_candidate.internal_key
 
 
 def test_internal_key_not_leaked_via_spectra(
     upload_data_token, public_source, public_group, lris
 ):
-    status, data = api(
-        "POST",
-        "spectrum",
-        data={
-            "obj_id": public_source.id,
-            "observed_at": "2020-01-10T00:00:00",
-            "instrument_id": lris.id,
-            "wavelengths": [664, 665, 666],
-            "fluxes": [234.3, 232.1, 235.3],
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    sp = client(upload_data_token)
+    sp.post_spectrum(
+        SpectrumPost(
+            obj_id=public_source.id,
+            observed_at="2020-01-10T00:00:00",
+            instrument_id=lris.id,
+            wavelengths=[664, 665, 666],
+            fluxes=[234.3, 232.1, 235.3],
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
 
-    status, data = api(
-        "GET", f"sources/{public_source.id}/spectra", token=upload_data_token
-    )
-    assert status == 200
-    spectra = data["data"]["spectra"]
+    spectra = sp.fetch_spectra(public_source.id)
     assert len(spectra) > 0
+    # Spectrum forbids extra fields, so validation alone would reject leaked keys.
     for spectrum in spectra:
-        assert "internal_key" not in spectrum
-        assert "obj_internal_key" not in spectrum
+        assert not hasattr(spectrum, "internal_key")
+        assert not hasattr(spectrum, "obj_internal_key")

--- a/skyportal/tests/api_tests/sources_candidates/test_obj.py
+++ b/skyportal/tests/api_tests/sources_candidates/test_obj.py
@@ -1,4 +1,8 @@
-from skyportal.tests import api
+import pytest
+from skyportal_py import SkyPortalError
+from skyportal_py.photometry import PhotometryPost
+
+from skyportal.tests import client
 
 
 def test_delete_obj_non_admin(
@@ -11,62 +15,55 @@ def test_delete_obj_non_admin(
 ):
     # A manage_sources_token user cannot delete an obj from ObjFactory since things
     # like Photometry and Comments are created with other users as authors/owners
-    status, data = api("DELETE", f"objs/{public_obj.id}", token=manage_sources_token)
-    assert status == 400
+    sp_manage = client(manage_sources_token)
+    with pytest.raises(SkyPortalError) as err:
+        sp_manage.delete_obj(public_obj.id)
+    assert err.value.status_code == 400
     assert (
-        data["message"]
+        str(err.value)
         == f"Please remove all associated spectra from object with ID {public_obj.id} before removing."
     )
 
     # Now start with a fresh Obj with no associated data, and post photometry to it
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source_no_data.id),
-            "mjd": 58000.0,
-            "instrument_id": ztf_camera.id,
-            "flux": 12.24,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfi",
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    photometry_id = data["data"]["ids"][0]
+    sp_upload = client(upload_data_token)
+    photometry_id = sp_upload.post_photometry(
+        PhotometryPost(
+            obj_id=str(public_source_no_data.id),
+            mjd=58000.0,
+            instrument_id=ztf_camera.id,
+            flux=12.24,
+            fluxerr=0.031,
+            zp=25.0,
+            magsys="ab",
+            filter="ztfi",
+            group_ids=[public_group.id],
+        )
+    ).ids[0]
 
     # Since the owner is the upload_data_token user, the manage_sources_token user
     # won't be able to delete this Obj either
-    status, data = api(
-        "DELETE", f"objs/{public_source_no_data.id}", token=manage_sources_token
-    )
-    assert status == 400
-    assert data["message"] in [
+    with pytest.raises(SkyPortalError) as err:
+        sp_manage.delete_obj(public_source_no_data.id)
+    assert err.value.status_code == 400
+    assert str(err.value) in [
         f"Cannot find object with ID {public_source_no_data.id}.",
         f"Please remove all associated photometry from object with ID {public_source_no_data.id} before removing.",
     ]
 
     # Now delete the photometry blocking the delete
-    status, data = api("DELETE", f"photometry/{photometry_id}", token=upload_data_token)
-    assert status == 200
+    sp_upload.delete_photometry(photometry_id)
 
     # Now the manage_source_token user should be able to delete the Obj,
     # since they are a member of the group the associated Source is saved to,
     # that is the only data referencing the `public_source_no_data` Obj.
-    status, _ = api(
-        "DELETE", f"objs/{public_source_no_data.id}", token=manage_sources_token
-    )
-    assert status == 200
+    sp_manage.delete_obj(public_source_no_data.id)
 
 
 def test_delete_obj_system_admin(public_obj, super_admin_token):
-    status, data = api("DELETE", f"objs/{public_obj.id}", token=super_admin_token)
-    assert status == 400
+    with pytest.raises(SkyPortalError) as err:
+        client(super_admin_token).delete_obj(public_obj.id)
+    assert err.value.status_code == 400
     assert (
-        data["message"]
+        str(err.value)
         == f"Please remove all associated spectra from object with ID {public_obj.id} before removing."
     )

--- a/skyportal/tests/api_tests/sources_candidates/test_roid_sources.py
+++ b/skyportal/tests/api_tests/sources_candidates/test_roid_sources.py
@@ -5,19 +5,16 @@ import uuid
 
 import numpy as np
 import sqlalchemy as sa
+from skyportal_py.sources import SourcePost
 
 from skyportal.models import DBSession, Obj
-from skyportal.tests import api
+from skyportal.tests import client
 
 
 def make_source(obj_id, ra, dec, group_id, token, is_roid=False):
-    status, _ = api(
-        "POST",
-        "sources",
-        data={"id": obj_id, "ra": ra, "dec": dec, "group_ids": [group_id]},
-        token=token,
+    client(token).post_source(
+        SourcePost(id=obj_id, ra=ra, dec=dec, group_ids=[group_id])
     )
-    assert status == 200
     if is_roid:
         session = DBSession()
         obj = session.scalar(sa.select(Obj).where(Obj.id == obj_id))
@@ -36,11 +33,10 @@ def test_roid_has_no_duplicates(public_group, upload_data_token):
         static_id, ra + 0.0001, dec + 0.0005, public_group.id, upload_data_token
     )
 
-    status, data = api("GET", f"sources/{roid_id}", token=upload_data_token)
-    assert status == 200
-    assert data["data"]["duplicates"] == []
+    source = client(upload_data_token).fetch_source(roid_id)
+    assert source.duplicates == []
     # Positional galaxy association is equally meaningless for it.
-    assert data["data"]["galaxies"] is None
+    assert source.galaxies is None
 
 
 def test_roid_is_not_a_duplicate_of_a_static_source(public_group, upload_data_token):
@@ -59,9 +55,8 @@ def test_roid_is_not_a_duplicate_of_a_static_source(public_group, upload_data_to
         is_roid=True,
     )
 
-    status, data = api("GET", f"sources/{static_id}", token=upload_data_token)
-    assert status == 200
-    assert [d["obj_id"] for d in data["data"]["duplicates"]] == []
+    source = client(upload_data_token).fetch_source(static_id)
+    assert [d.obj_id for d in source.duplicates] == []
 
 
 def test_static_sources_still_duplicate_each_other(public_group, upload_data_token):
@@ -75,6 +70,5 @@ def test_static_sources_still_duplicate_each_other(public_group, upload_data_tok
         second_id, ra + 0.0001, dec + 0.0005, public_group.id, upload_data_token
     )
 
-    status, data = api("GET", f"sources/{first_id}", token=upload_data_token)
-    assert status == 200
-    assert [d["obj_id"] for d in data["data"]["duplicates"]] == [second_id]
+    source = client(upload_data_token).fetch_source(first_id)
+    assert [d.obj_id for d in source.duplicates] == [second_id]

--- a/skyportal/tests/api_tests/sources_candidates/test_scan_reports.py
+++ b/skyportal/tests/api_tests/sources_candidates/test_scan_reports.py
@@ -3,6 +3,15 @@ from types import SimpleNamespace
 
 import pytest
 import sqlalchemy as sa
+from skyportal_py import SkyPortalError
+from skyportal_py.assignments import AssignmentPost
+from skyportal_py.candidates import (
+    ScanReportPassedFiltersRange,
+    ScanReportPost,
+    ScanReportSavedCandidatesRange,
+)
+from skyportal_py.followup_requests import FollowupRequestPost
+from skyportal_py.gcn_events import GcnEventObjPost, GcnEventPost
 
 from skyportal.handlers.api.candidate.scan_report_item import _followup_request_type
 from skyportal.models import (
@@ -14,7 +23,7 @@ from skyportal.models import (
     Source,
     SuperObj,
 )
-from skyportal.tests import api
+from skyportal.tests import client
 from skyportal.tests.fixtures import CommentFactory, ObjFactory, PhotometryFactory
 from skyportal.utils.naive_datetime import utcnow_naive
 
@@ -51,6 +60,7 @@ def test_scan_report_item_includes_followup_and_assignment(
     cleanup_reports,
 ):
     now = utcnow_naive()
+    sp = client(upload_data_token)
 
     # An obj that is both a candidate (passed the filter) and a saved source, in range.
     obj = ObjFactory(groups=[public_group])
@@ -85,13 +95,11 @@ def test_scan_report_item_includes_followup_and_assignment(
     DBSession.commit()
 
     # A follow-up request (SEDM is an imaging spectrograph -> "spectroscopy").
-    status, data = api(
-        "POST",
-        "followup_request",
-        data={
-            "allocation_id": public_group_sedm_allocation.id,
-            "obj_id": obj.id,
-            "payload": {
+    sp.post_followup_request(
+        FollowupRequestPost(
+            allocation_id=public_group_sedm_allocation.id,
+            obj_id=obj.id,
+            payload={
                 "priority": 3,
                 "start_date": "3010-09-01",
                 "end_date": "3012-09-01",
@@ -100,19 +108,13 @@ def test_scan_report_item_includes_followup_and_assignment(
                 "maximum_airmass": 2,
                 "maximum_fwhm": 1.2,
             },
-        },
-        token=upload_data_token,
+        )
     )
-    assert status == 200, data
 
     # An observing-run assignment.
-    status, data = api(
-        "POST",
-        "assignment",
-        data={"run_id": red_transients_run.id, "obj_id": obj.id, "priority": "5"},
-        token=upload_data_token,
+    sp.post_assignment(
+        AssignmentPost(run_id=red_transients_run.id, obj_id=obj.id, priority="5")
     )
-    assert status == 200, data
 
     # A human comment left by the scanner (browser comments are non-bot), which the
     # report should auto-fill (#5526).
@@ -139,40 +141,30 @@ def test_scan_report_item_includes_followup_and_assignment(
     photstat.last_detected_filter = "ztfi"
     DBSession.commit()
 
-    window = {
-        "start_date": (now - timedelta(days=1)).isoformat(),
-        "end_date": (now + timedelta(days=1)).isoformat(),
-    }
-    status, data = api(
-        "POST",
-        "candidates/scan_reports",
-        data={
-            "group_ids": [public_group.id],
-            "passed_filters_range": window,
-            "saved_candidates_range": {
-                "start_saved_date": (now - timedelta(days=1)).isoformat(),
-                "end_saved_date": (now + timedelta(days=1)).isoformat(),
-            },
-        },
-        token=upload_data_token,
+    sp.post_scan_report(
+        ScanReportPost(
+            group_ids=[public_group.id],
+            passed_filters_range=ScanReportPassedFiltersRange(
+                start_date=(now - timedelta(days=1)).isoformat(),
+                end_date=(now + timedelta(days=1)).isoformat(),
+            ),
+            saved_candidates_range=ScanReportSavedCandidatesRange(
+                start_saved_date=(now - timedelta(days=1)).isoformat(),
+                end_saved_date=(now + timedelta(days=1)).isoformat(),
+            ),
+        )
     )
-    assert status == 200, data
 
-    status, data = api("GET", "candidates/scan_reports", token=upload_data_token)
-    assert status == 200, data
-    report_id = data["data"]["reports"][0]["id"]
+    report_id = sp.fetch_scan_reports().reports[0].id
     cleanup_reports.append(report_id)
 
-    status, data = api(
-        "GET", f"candidates/scan_reports/{report_id}/items", token=upload_data_token
-    )
-    assert status == 200, data
-    item = next(item for item in data["data"] if item["obj_id"] == obj.id)
+    items = sp.fetch_scan_report_items(report_id)
+    item = next(item for item in items if item.obj_id == obj.id)
 
     # The scanner's comment is auto-filled into the report item (#5526).
-    assert item["data"]["comment"] == comment_text
+    assert item.data["comment"] == comment_text
 
-    followups = item["data"]["followups"]
+    followups = item.data["followups"]
     assert followups is not None
     followup = next(
         f
@@ -184,7 +176,7 @@ def test_scan_report_item_includes_followup_and_assignment(
     assert followup["status"] is not None
     assert followup["requester"] == user.username
 
-    assignments = item["data"]["assignments"]
+    assignments = item.data["assignments"]
     assert assignments is not None
     assignment = next(
         a for a in assignments if a["instrument"] == red_transients_run.instrument.name
@@ -194,7 +186,7 @@ def test_scan_report_item_includes_followup_and_assignment(
     assert assignment["requester"] == user.username
 
     # First/peak/last detection per survey (mag, mjd, filter, days-ago), from PhotStat.
-    detections = item["data"]["detections_by_survey"]
+    detections = item.data["detections_by_survey"]
     assert detections is not None
     survey_detections = detections["ZTF"]
     assert survey_detections["first"]["mag"] == 18.9
@@ -222,6 +214,7 @@ def test_scan_report_item_includes_associated_objs(
     cleanup_reports,
 ):
     now = utcnow_naive()
+    sp = client(upload_data_token)
 
     obj = ObjFactory(groups=[public_group])
     # Another survey's detection of the same physical object (e.g. LSST), with
@@ -260,37 +253,27 @@ def test_scan_report_item_includes_associated_objs(
     assoc_photstat.last_detected_filter = "lssti"
     DBSession.commit()
 
-    window = {
-        "start_date": (now - timedelta(days=1)).isoformat(),
-        "end_date": (now + timedelta(days=1)).isoformat(),
-    }
-    status, data = api(
-        "POST",
-        "candidates/scan_reports",
-        data={
-            "group_ids": [public_group.id],
-            "passed_filters_range": window,
-            "saved_candidates_range": {
-                "start_saved_date": (now - timedelta(days=1)).isoformat(),
-                "end_saved_date": (now + timedelta(days=1)).isoformat(),
-            },
-        },
-        token=upload_data_token,
+    sp.post_scan_report(
+        ScanReportPost(
+            group_ids=[public_group.id],
+            passed_filters_range=ScanReportPassedFiltersRange(
+                start_date=(now - timedelta(days=1)).isoformat(),
+                end_date=(now + timedelta(days=1)).isoformat(),
+            ),
+            saved_candidates_range=ScanReportSavedCandidatesRange(
+                start_saved_date=(now - timedelta(days=1)).isoformat(),
+                end_saved_date=(now + timedelta(days=1)).isoformat(),
+            ),
+        )
     )
-    assert status == 200, data
 
-    status, data = api("GET", "candidates/scan_reports", token=upload_data_token)
-    assert status == 200, data
-    report_id = data["data"]["reports"][0]["id"]
+    report_id = sp.fetch_scan_reports().reports[0].id
     cleanup_reports.append(report_id)
 
-    status, data = api(
-        "GET", f"candidates/scan_reports/{report_id}/items", token=upload_data_token
-    )
-    assert status == 200, data
-    item = next(item for item in data["data"] if item["obj_id"] == obj.id)
+    items = sp.fetch_scan_report_items(report_id)
+    item = next(item for item in items if item.obj_id == obj.id)
 
-    associated_objs = item["data"]["associated_objs"]
+    associated_objs = item.data["associated_objs"]
     assert associated_objs is not None
     assoc = next(a for a in associated_objs if a["obj_id"] == assoc_obj.id)
     assert assoc["aliases"] == ["LSST_123"]
@@ -314,6 +297,7 @@ def test_scan_report_item_includes_previous_mag(
     cleanup_reports,
 ):
     now = utcnow_naive()
+    sp = client(upload_data_token)
 
     obj = ObjFactory(groups=[public_group])
     DBSession.add(
@@ -360,42 +344,32 @@ def test_scan_report_item_includes_previous_mag(
     photstat.last_detected_filter = current_point.filter
     DBSession.commit()
 
-    window = {
-        "start_date": (now - timedelta(days=1)).isoformat(),
-        "end_date": (now + timedelta(days=1)).isoformat(),
-    }
-    status, data = api(
-        "POST",
-        "candidates/scan_reports",
-        data={
-            "group_ids": [public_group.id],
-            "passed_filters_range": window,
-            "saved_candidates_range": {
-                "start_saved_date": (now - timedelta(days=1)).isoformat(),
-                "end_saved_date": (now + timedelta(days=1)).isoformat(),
-            },
-        },
-        token=upload_data_token,
+    sp.post_scan_report(
+        ScanReportPost(
+            group_ids=[public_group.id],
+            passed_filters_range=ScanReportPassedFiltersRange(
+                start_date=(now - timedelta(days=1)).isoformat(),
+                end_date=(now + timedelta(days=1)).isoformat(),
+            ),
+            saved_candidates_range=ScanReportSavedCandidatesRange(
+                start_saved_date=(now - timedelta(days=1)).isoformat(),
+                end_saved_date=(now + timedelta(days=1)).isoformat(),
+            ),
+        )
     )
-    assert status == 200, data
 
-    status, data = api("GET", "candidates/scan_reports", token=upload_data_token)
-    assert status == 200, data
-    report_id = data["data"]["reports"][0]["id"]
+    report_id = sp.fetch_scan_reports().reports[0].id
     cleanup_reports.append(report_id)
 
-    status, data = api(
-        "GET", f"candidates/scan_reports/{report_id}/items", token=upload_data_token
-    )
-    assert status == 200, data
-    item = next(item for item in data["data"] if item["obj_id"] == obj.id)
+    items = sp.fetch_scan_report_items(report_id)
+    item = next(item for item in items if item.obj_id == obj.id)
 
-    assert item["data"]["current_mjd"] == 60600.0
-    assert item["data"]["current_filter"] == "ztfg"
-    assert item["data"]["previous_mjd"] == 60500.0
-    assert item["data"]["previous_filter"] == "ztfg"
-    assert item["data"]["previous_mag"] is not None
-    assert item["data"]["previous_mag"] != item["data"]["current_mag"]
+    assert item.data["current_mjd"] == 60600.0
+    assert item.data["current_filter"] == "ztfg"
+    assert item.data["previous_mjd"] == 60500.0
+    assert item.data["previous_filter"] == "ztfg"
+    assert item.data["previous_mag"] is not None
+    assert item.data["previous_mag"] != item.data["current_mag"]
 
 
 def test_scan_report_rolling_window(
@@ -406,6 +380,7 @@ def test_scan_report_rolling_window(
     cleanup_reports,
 ):
     now = utcnow_naive()
+    sp = client(upload_data_token)
 
     obj = ObjFactory(groups=[public_group])
     DBSession.add(
@@ -422,28 +397,19 @@ def test_scan_report_rolling_window(
     DBSession.commit()
 
     # Rolling windows (hours) instead of absolute ranges — what a recurring caller uses.
-    status, data = api(
-        "POST",
-        "candidates/scan_reports",
-        data={
-            "group_ids": [public_group.id],
-            "passed_filters_window_hours": 48,
-            "saved_candidates_window_hours": 48,
-        },
-        token=upload_data_token,
+    sp.post_scan_report(
+        ScanReportPost(
+            group_ids=[public_group.id],
+            passed_filters_window_hours=48,
+            saved_candidates_window_hours=48,
+        )
     )
-    assert status == 200, data
 
-    status, data = api("GET", "candidates/scan_reports", token=upload_data_token)
-    assert status == 200, data
-    report_id = data["data"]["reports"][0]["id"]
+    report_id = sp.fetch_scan_reports().reports[0].id
     cleanup_reports.append(report_id)
 
-    status, data = api(
-        "GET", f"candidates/scan_reports/{report_id}/items", token=upload_data_token
-    )
-    assert status == 200, data
-    assert any(item["obj_id"] == obj.id for item in data["data"])
+    items = sp.fetch_scan_report_items(report_id)
+    assert any(item.obj_id == obj.id for item in items)
 
 
 def test_scan_report_item_comment_only_from_scanner(
@@ -455,6 +421,7 @@ def test_scan_report_item_comment_only_from_scanner(
     cleanup_reports,
 ):
     now = utcnow_naive()
+    sp = client(upload_data_token)
 
     obj = ObjFactory(groups=[public_group])
     DBSession.add(
@@ -480,71 +447,54 @@ def test_scan_report_item_comment_only_from_scanner(
     )
     DBSession.commit()
 
-    window = {
-        "start_date": (now - timedelta(days=1)).isoformat(),
-        "end_date": (now + timedelta(days=1)).isoformat(),
-    }
-    status, data = api(
-        "POST",
-        "candidates/scan_reports",
-        data={
-            "group_ids": [public_group.id],
-            "passed_filters_range": window,
-            "saved_candidates_range": {
-                "start_saved_date": (now - timedelta(days=1)).isoformat(),
-                "end_saved_date": (now + timedelta(days=1)).isoformat(),
-            },
-        },
-        token=upload_data_token,
+    sp.post_scan_report(
+        ScanReportPost(
+            group_ids=[public_group.id],
+            passed_filters_range=ScanReportPassedFiltersRange(
+                start_date=(now - timedelta(days=1)).isoformat(),
+                end_date=(now + timedelta(days=1)).isoformat(),
+            ),
+            saved_candidates_range=ScanReportSavedCandidatesRange(
+                start_saved_date=(now - timedelta(days=1)).isoformat(),
+                end_saved_date=(now + timedelta(days=1)).isoformat(),
+            ),
+        )
     )
-    assert status == 200, data
 
-    status, data = api("GET", "candidates/scan_reports", token=upload_data_token)
-    assert status == 200, data
-    report_id = data["data"]["reports"][0]["id"]
+    report_id = sp.fetch_scan_reports().reports[0].id
     cleanup_reports.append(report_id)
 
-    status, data = api(
-        "GET", f"candidates/scan_reports/{report_id}/items", token=upload_data_token
-    )
-    assert status == 200, data
-    item = next(item for item in data["data"] if item["obj_id"] == obj.id)
+    items = sp.fetch_scan_report_items(report_id)
+    item = next(item for item in items if item.obj_id == obj.id)
 
     # No comment by the scanner -> comment stays empty; followups/assignments empty too.
-    assert item["data"]["comment"] is None
-    assert item["data"]["followups"] is None
-    assert item["data"]["assignments"] is None
+    assert item.data["comment"] is None
+    assert item.data["followups"] is None
+    assert item.data["assignments"] is None
 
 
 def _generate_report(token, group_id, now, **extra):
     """Generate a report over a window wide enough to include `now`."""
-    window = {
-        "start_date": (now - timedelta(days=1)).isoformat(),
-        "end_date": (now + timedelta(days=1)).isoformat(),
-    }
-    return api(
-        "POST",
-        "candidates/scan_reports",
-        data={
-            "group_ids": [group_id],
-            "passed_filters_range": window,
-            "saved_candidates_range": {
-                "start_saved_date": (now - timedelta(days=1)).isoformat(),
-                "end_saved_date": (now + timedelta(days=1)).isoformat(),
-            },
+    client(token).post_scan_report(
+        ScanReportPost(
+            group_ids=[group_id],
+            passed_filters_range=ScanReportPassedFiltersRange(
+                start_date=(now - timedelta(days=1)).isoformat(),
+                end_date=(now + timedelta(days=1)).isoformat(),
+            ),
+            saved_candidates_range=ScanReportSavedCandidatesRange(
+                start_saved_date=(now - timedelta(days=1)).isoformat(),
+                end_saved_date=(now + timedelta(days=1)).isoformat(),
+            ),
             **extra,
-        },
-        token=token,
+        )
     )
 
 
 def _report_items(token):
-    status, data = api("GET", "candidates/scan_reports", token=token)
-    assert status == 200, data
-    report_id = data["data"]["reports"][0]["id"]
-    status, data = api("GET", f"candidates/scan_reports/{report_id}/items", token=token)
-    assert status == 200, data
-    return report_id, data["data"]
+    sp = client(token)
+    report_id = sp.fetch_scan_reports().reports[0].id
+    return report_id, sp.fetch_scan_report_items(report_id)
 
 
 def test_scan_report_scoped_to_gcn_event(
@@ -560,17 +510,13 @@ def test_scan_report_scoped_to_gcn_event(
     now = utcnow_naive()
     dateobs = (now - timedelta(days=2)).replace(microsecond=0)
 
-    status, data = api(
-        "POST",
-        "gcn_event",
-        data={
-            "dateobs": dateobs.isoformat(),
-            "skymap": {"ra": 120.0, "dec": 20.0, "error": 0.5},
-            "tags": ["Einstein Probe"],
-        },
-        token=super_admin_token,
+    client(super_admin_token).post_gcn_event(
+        GcnEventPost(
+            dateobs=dateobs.isoformat(),
+            skymap={"ra": 120.0, "dec": 20.0, "error": 0.5},
+            tags=["Einstein Probe"],
+        )
     )
-    assert status == 200, data
 
     # `matched` is associated with the event; `unrelated` is not.
     objs = {}
@@ -590,48 +536,43 @@ def test_scan_report_scoped_to_gcn_event(
         objs[key] = obj
     DBSession.commit()
 
-    status, data = api(
-        "POST",
-        f"sources_in_gcn/{dateobs.isoformat()}",
-        data={
-            "source_id": objs["matched"].id,
-            "status": "rejected",
-            "explanation": "rock",
-            "localization_name": "120.00000_20.00000_0.50000",
-            "localization_cumprob": 0.95,
-            "start_date": (dateobs - timedelta(days=1)).isoformat(),
-            "end_date": (dateobs + timedelta(days=31)).isoformat(),
-        },
-        token=super_admin_token,
+    client(super_admin_token).post_gcn_event_source(
+        dateobs.isoformat(),
+        GcnEventObjPost(
+            source_id=objs["matched"].id,
+            status="rejected",
+            explanation="rock",
+            localization_name="120.00000_20.00000_0.50000",
+            localization_cumprob=0.95,
+            start_date=(dateobs - timedelta(days=1)).isoformat(),
+            end_date=(dateobs + timedelta(days=31)).isoformat(),
+        ),
     )
-    assert status == 200, data
 
     # Unscoped: both objects are in the report, and neither carries gcn_match.
-    status, data = _generate_report(upload_data_token, public_group.id, now)
-    assert status == 200, data
+    _generate_report(upload_data_token, public_group.id, now)
     report_id, items = _report_items(upload_data_token)
     cleanup_reports.append(report_id)
-    ids = {item["obj_id"] for item in items}
+    ids = {item.obj_id for item in items}
     assert {objs["matched"].id, objs["unrelated"].id} <= ids
-    assert all(item["data"].get("gcn_match") is None for item in items)
+    assert all(item.data.get("gcn_match") is None for item in items)
 
     # Scoped to the event: only the associated object, with its verdict.
-    status, data = _generate_report(
+    _generate_report(
         upload_data_token,
         public_group.id,
         now,
         gcn_event_dateobs=dateobs.isoformat(),
     )
-    assert status == 200, data
     report_id, items = _report_items(upload_data_token)
     cleanup_reports.append(report_id)
 
-    ids = {item["obj_id"] for item in items}
+    ids = {item.obj_id for item in items}
     assert objs["matched"].id in ids
     assert objs["unrelated"].id not in ids, "unassociated object leaked into the report"
 
-    item = next(i for i in items if i["obj_id"] == objs["matched"].id)
-    match = item["data"]["gcn_match"]
+    item = next(i for i in items if i.obj_id == objs["matched"].id)
+    match = item.data["gcn_match"]
     assert match["status"] == "rejected"
     assert match["explanation"] == "rock"
 
@@ -641,14 +582,14 @@ def test_scan_report_rejects_inaccessible_gcn_event(
 ):
     """Scoping to an event the user cannot read is refused, not silently ignored."""
     now = utcnow_naive()
-    status, data = _generate_report(
-        upload_data_token,
-        public_group.id,
-        now,
-        gcn_event_dateobs=(now - timedelta(days=900)).isoformat(),
-    )
-    assert status == 400, data
-    assert "not found or not accessible" in data["message"]
+    with pytest.raises(SkyPortalError, match="not found or not accessible") as err:
+        _generate_report(
+            upload_data_token,
+            public_group.id,
+            now,
+            gcn_event_dateobs=(now - timedelta(days=900)).isoformat(),
+        )
+    assert err.value.status_code == 400
 
 
 def _followup_request_case(

--- a/skyportal/tests/api_tests/sources_candidates/test_scan_reports.py
+++ b/skyportal/tests/api_tests/sources_candidates/test_scan_reports.py
@@ -201,7 +201,7 @@ def test_scan_report_item_includes_followup_and_assignment(
 
     # Every group the obj is currently an active Source of, including
     # `public_group2` which isn't part of this report's own group_ids/window.
-    assert sorted(item["data"]["groups_saved_to"]) == sorted(
+    assert sorted(item.data["groups_saved_to"]) == sorted(
         [public_group.name, public_group2.name]
     )
 
@@ -280,7 +280,7 @@ def test_scan_report_item_includes_associated_objs(
 
     # The associated obj's own (LSST) detections are merged into
     # detections_by_survey under their own survey key, alongside `obj`'s (ZTF).
-    detections = item["data"]["detections_by_survey"]
+    detections = item.data["detections_by_survey"]
     assert detections is not None
     assert "LSST" in detections
     assert detections["LSST"]["first"]["mag"] == 19.5

--- a/skyportal/tests/api_tests/sources_candidates/test_sources.py
+++ b/skyportal/tests/api_tests/sources_candidates/test_sources.py
@@ -8,31 +8,39 @@ import numpy as np
 import numpy.testing as npt
 import pytest
 from astropy.time import Time
-from dateutil import parser
+from skyportal_py import SkyPortalError
+from skyportal_py.classifications import ClassificationPost
+from skyportal_py.followup_requests import FollowupRequestPost
+from skyportal_py.groups import GroupPost
+from skyportal_py.photometry import PhotometryPost
+from skyportal_py.sources import (
+    SourceGcnEventCrossmatchPost,
+    SourceNotificationPost,
+    SourcePost,
+)
+from skyportal_py.spectra import SpectrumPost
+from skyportal_py.taxonomies import TaxonomyPost
 from tdtax import __version__, taxonomy
 
 from skyportal.models import cosmo
-from skyportal.tests import api
+from skyportal.tests import api, client
 
 from ....utils.naive_datetime import utcnow_naive
 
 
 def test_source_list(view_only_token):
-    status, data = api("GET", "sources", token=view_only_token)
-    assert status == 200
-    assert data["status"] == "success"
+    client(view_only_token).fetch_sources()
 
 
 def test_source_existence(view_only_token, public_source):
-    status, _ = api("HEAD", f"sources/{public_source.id}", token=view_only_token)
-    assert status == 200
+    sp = client(view_only_token)
+    assert sp.source_exists(public_source.id)
 
-    status, _ = api("HEAD", f"sources/{public_source.id[:-1]}", token=view_only_token)
-
-    assert status == 404
+    assert not sp.source_exists(public_source.id[:-1])
 
 
 def test_token_user_retrieving_source(view_only_token, public_source):
+    # raw api: raw-JSON shape assertion the typed model would mask
     status, data = api("GET", f"sources/{public_source.id}", token=view_only_token)
     assert status == 200
     assert data["status"] == "success"
@@ -43,6 +51,7 @@ def test_token_user_retrieving_source(view_only_token, public_source):
 
 
 def test_token_user_retrieving_source_with_phot(view_only_token, public_source):
+    # raw api: raw-JSON shape assertion the typed model would mask
     status, data = api(
         "GET",
         f"sources/{public_source.id}",
@@ -58,16 +67,11 @@ def test_token_user_retrieving_source_with_phot(view_only_token, public_source):
 
 
 def test_token_user_retrieving_source_with_phot_exists(view_only_token, public_source):
-    status, data = api(
-        "GET",
-        f"sources/{public_source.id}",
-        params={"includePhotometryExists": "true"},
-        token=view_only_token,
+    source = client(view_only_token).fetch_source(
+        public_source.id, include_photometry_exists=True
     )
-    assert status == 200
-    assert data["status"] == "success"
     assert all(
-        k in data["data"]
+        getattr(source, k) is not None
         for k in [
             "ra",
             "dec",
@@ -82,6 +86,7 @@ def test_token_user_retrieving_source_with_phot_exists(view_only_token, public_s
 
 @pytest.mark.flaky(reruns=2)
 def test_token_user_retrieving_source_with_thumbnails(view_only_token, public_source):
+    # raw api: raw-JSON shape assertion the typed model would mask
     status, data = api(
         "GET",
         f"sources/{public_source.id}",
@@ -99,205 +104,141 @@ def test_token_user_retrieving_source_with_thumbnails(view_only_token, public_so
 def test_token_user_retrieving_source_without_nested(
     view_only_token, public_group, upload_data_token
 ):
+    sp = client(upload_data_token)
     obj_id1 = str(uuid.uuid4())
     obj_id2 = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id1,
-            "ra": 234.22,
-            "dec": -22.33,
-            "redshift": 3,
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    sp.post_source(
+        SourcePost(
+            id=obj_id1,
+            ra=234.22,
+            dec=-22.33,
+            redshift=3,
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id2,
-            "ra": 234.22,
-            "dec": -22.33,
-            "redshift": 3,
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    sp.post_source(
+        SourcePost(
+            id=obj_id2,
+            ra=234.22,
+            dec=-22.33,
+            redshift=3,
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
 
-    status, data = api(
-        "GET",
-        "sources",
-        params={"removeNested": True, "group_ids": [public_group.id]},
-        token=view_only_token,
+    page = client(view_only_token).fetch_sources(
+        remove_nested=True, group_ids=[public_group.id]
     )
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]["sources"]) == 2
+    assert len(page.sources) == 2
     assert all(
-        k in data["data"]["sources"][0]
+        getattr(page.sources[0], k) is not None
         for k in ["ra", "dec", "redshift", "created_at", "id"]
     )
+    # removeNested strips these keys; the typed model defaults them to empty lists
     assert all(
-        k not in data["data"]["sources"][0]
+        getattr(page.sources[0], k) == []
         for k in ["annotations", "groups", "thumbnails", "classifications"]
     )
 
 
 def test_duplicate_sources(public_group, upload_data_token, ztf_camera):
+    sp = client(upload_data_token)
     obj_id1 = str(uuid.uuid4())
     obj_id2 = str(uuid.uuid4())
     ra = 200.0 * np.random.random()
     dec = 90.0 * np.random.random()
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id1,
-            "ra": ra,
-            "dec": dec,
-            "redshift": 3,
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    sp.post_source(
+        SourcePost(
+            id=obj_id1,
+            ra=ra,
+            dec=dec,
+            redshift=3,
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id2,
-            "ra": ra + 0.0001,
-            "dec": dec + 0.0005,
-            "redshift": 3,
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    sp.post_source(
+        SourcePost(
+            id=obj_id2,
+            ra=ra + 0.0001,
+            dec=dec + 0.0005,
+            redshift=3,
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": obj_id1,
-            "mjd": 59801.4,
-            "instrument_id": ztf_camera.id,
-            "filter": "ztfg",
-            "group_ids": [public_group.id],
-            "mag": 12.4,
-            "magerr": 0.3,
-            "limiting_mag": 22,
-            "magsys": "ab",
-        },
-        token=upload_data_token,
+    sp.post_photometry(
+        PhotometryPost(
+            obj_id=obj_id1,
+            mjd=59801.4,
+            instrument_id=ztf_camera.id,
+            filter="ztfg",
+            group_ids=[public_group.id],
+            mag=12.4,
+            magerr=0.3,
+            limiting_mag=22,
+            magsys="ab",
+        )
     )
-    assert status == 200
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": obj_id2,
-            "mjd": 59801.3,
-            "instrument_id": ztf_camera.id,
-            "filter": "ztfg",
-            "group_ids": [public_group.id],
-            "mag": 12.4,
-            "magerr": 0.3,
-            "limiting_mag": 22,
-            "magsys": "ab",
-        },
-        token=upload_data_token,
+    sp.post_photometry(
+        PhotometryPost(
+            obj_id=obj_id2,
+            mjd=59801.3,
+            instrument_id=ztf_camera.id,
+            filter="ztfg",
+            group_ids=[public_group.id],
+            mag=12.4,
+            magerr=0.3,
+            limiting_mag=22,
+            magsys="ab",
+        )
     )
-    assert status == 200
 
-    status, data = api(
-        "GET",
-        f"sources/{obj_id1}",
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]["duplicates"]) == 1
-    assert "ra" in data["data"]["duplicates"][0]
-    assert "dec" in data["data"]["duplicates"][0]
-    assert "obj_id" in data["data"]["duplicates"][0]
-    assert "separation" in data["data"]["duplicates"][0]
-    assert data["data"]["duplicates"][0]["ra"] == ra + 0.0001
-    assert data["data"]["duplicates"][0]["dec"] == dec + 0.0005
-    assert data["data"]["duplicates"][0]["obj_id"] == obj_id2
-    assert np.isclose(data["data"]["duplicates"][0]["separation"], 1.82, atol=0.05)
+    source = sp.fetch_source(obj_id1)
+    assert len(source.duplicates) == 1
+    assert source.duplicates[0].ra == ra + 0.0001
+    assert source.duplicates[0].dec == dec + 0.0005
+    assert source.duplicates[0].obj_id == obj_id2
+    assert np.isclose(source.duplicates[0].separation, 1.82, atol=0.05)
 
-    status, data = api(
-        "GET",
-        f"sources/{obj_id2}",
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]["duplicates"]) == 1
-    assert "ra" in data["data"]["duplicates"][0]
-    assert "dec" in data["data"]["duplicates"][0]
-    assert "obj_id" in data["data"]["duplicates"][0]
-    assert "separation" in data["data"]["duplicates"][0]
-    assert data["data"]["duplicates"][0]["ra"] == ra
-    assert data["data"]["duplicates"][0]["dec"] == dec
-    assert data["data"]["duplicates"][0]["obj_id"] == obj_id1
-    assert np.isclose(data["data"]["duplicates"][0]["separation"], 1.82, atol=0.05)
+    source = sp.fetch_source(obj_id2)
+    assert len(source.duplicates) == 1
+    assert source.duplicates[0].ra == ra
+    assert source.duplicates[0].dec == dec
+    assert source.duplicates[0].obj_id == obj_id1
+    assert np.isclose(source.duplicates[0].separation, 1.82, atol=0.05)
 
 
 def test_token_user_update_source(super_admin_token, upload_data_token, public_source):
-    status, data = api(
-        "PATCH",
-        f"sources/{public_source.id}",
-        data={
-            "ra": 234.22,
-            "dec": -22.33,
-            "redshift": 3,
-            "transient": False,
-            "ra_dis": 2.3,
-        },
-        token=super_admin_token,
+    client(super_admin_token).update_source(
+        public_source.id,
+        ra=234.22,
+        dec=-22.33,
+        redshift=3,
+        transient=False,
+        ra_dis=2.3,
     )
-    assert status == 200
-    assert data["status"] == "success"
 
-    status, data = api("GET", f"sources/{public_source.id}", token=upload_data_token)
-    assert status == 200
-    assert data["status"] == "success"
-    npt.assert_almost_equal(data["data"]["ra"], 234.22)
-    npt.assert_almost_equal(data["data"]["redshift"], 3.0)
+    source = client(upload_data_token).fetch_source(public_source.id)
+    npt.assert_almost_equal(source.ra, 234.22)
+    npt.assert_almost_equal(source.redshift, 3.0)
     npt.assert_almost_equal(
-        cosmo.luminosity_distance(3.0).value, data["data"]["luminosity_distance"]
+        cosmo.luminosity_distance(3.0).value, source.luminosity_distance
     )
 
 
 def test_distance_modulus(super_admin_token, upload_data_token, public_source):
-    status, data = api(
-        "PATCH",
-        f"sources/{public_source.id}",
-        data={
-            "ra": 234.22,
-            "dec": -22.33,
-            "altdata": {"dm": 28.5},
-            "transient": False,
-            "ra_dis": 2.3,
-        },
-        token=super_admin_token,
+    client(super_admin_token).update_source(
+        public_source.id,
+        ra=234.22,
+        dec=-22.33,
+        altdata={"dm": 28.5},
+        transient=False,
+        ra_dis=2.3,
     )
-    assert status == 200
-    assert data["status"] == "success"
 
-    status, data = api("GET", f"sources/{public_source.id}", token=upload_data_token)
-    assert status == 200
-    assert data["status"] == "success"
-    npt.assert_almost_equal(10 ** ((28.5 / 5) - 5), data["data"]["luminosity_distance"])
-    npt.assert_almost_equal(28.5, data["data"]["dm"])
-    npt.assert_almost_equal(
-        10 ** ((28.5 / 5) - 5), data["data"]["angular_diameter_distance"]
-    )
+    source = client(upload_data_token).fetch_source(public_source.id)
+    npt.assert_almost_equal(10 ** ((28.5 / 5) - 5), source.luminosity_distance)
+    npt.assert_almost_equal(28.5, source.dm)
+    npt.assert_almost_equal(10 ** ((28.5 / 5) - 5), source.angular_diameter_distance)
 
 
 def test_parallax(super_admin_token, upload_data_token, public_source):
@@ -305,66 +246,46 @@ def test_parallax(super_admin_token, upload_data_token, public_source):
     d_pc = 1 / parallax
     dm = 5.0 * np.log10(d_pc / (10.0))
 
-    status, data = api(
-        "PATCH",
-        f"sources/{public_source.id}",
-        data={
-            "ra": 234.22,
-            "dec": -22.33,
-            "altdata": {"parallax": parallax},
-            "transient": False,
-            "ra_dis": 2.3,
-        },
-        token=super_admin_token,
+    client(super_admin_token).update_source(
+        public_source.id,
+        ra=234.22,
+        dec=-22.33,
+        altdata={"parallax": parallax},
+        transient=False,
+        ra_dis=2.3,
     )
-    assert status == 200
-    assert data["status"] == "success"
 
-    status, data = api("GET", f"sources/{public_source.id}", token=upload_data_token)
-    assert status == 200
-    assert data["status"] == "success"
+    source = client(upload_data_token).fetch_source(public_source.id)
 
-    npt.assert_almost_equal(dm, data["data"]["dm"])
+    npt.assert_almost_equal(dm, source.dm)
 
 
 def test_low_redshift(super_admin_token, upload_data_token, public_source):
-    status, data = api(
-        "PATCH",
-        f"sources/{public_source.id}",
-        data={
-            "ra": 234.22,
-            "dec": -22.33,
-            "transient": False,
-            "ra_dis": 2.3,
-            "redshift": 0.00001,
-        },
-        token=super_admin_token,
+    client(super_admin_token).update_source(
+        public_source.id,
+        ra=234.22,
+        dec=-22.33,
+        transient=False,
+        ra_dis=2.3,
+        redshift=0.00001,
     )
-    assert status == 200
-    assert data["status"] == "success"
 
-    status, data = api("GET", f"sources/{public_source.id}", token=upload_data_token)
-    assert status == 200
-    assert data["status"] == "success"
+    source = client(upload_data_token).fetch_source(public_source.id)
 
-    assert data["data"]["dm"] is None
+    assert source.dm is None
 
 
 def test_cannot_update_source_without_permission(view_only_token, public_source):
-    status, data = api(
-        "PATCH",
-        f"sources/{public_source.id}",
-        data={
-            "ra": 234.22,
-            "dec": -22.33,
-            "redshift": 3,
-            "transient": False,
-            "ra_dis": 2.3,
-        },
-        token=view_only_token,
-    )
-    assert status == 401
-    assert data["status"] == "error"
+    with pytest.raises(SkyPortalError) as err:
+        client(view_only_token).update_source(
+            public_source.id,
+            ra=234.22,
+            dec=-22.33,
+            redshift=3,
+            transient=False,
+            ra_dis=2.3,
+        )
+    assert err.value.status_code == 401
 
 
 def test_token_user_post_new_source(upload_data_token, view_only_token, public_group):
@@ -372,41 +293,37 @@ def test_token_user_post_new_source(upload_data_token, view_only_token, public_g
     alias = str(uuid.uuid4())
     origin = str(uuid.uuid4())
     t0 = datetime.now(UTC)
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id,
-            "ra": 234.22,
-            "dec": -22.33,
-            "redshift": 3,
-            "transient": False,
-            "ra_dis": 2.3,
-            "group_ids": [public_group.id],
-            "alias": [alias],
-            "origin": origin,
-        },
-        token=upload_data_token,
+    saved = client(upload_data_token).post_source(
+        SourcePost(
+            id=obj_id,
+            ra=234.22,
+            dec=-22.33,
+            redshift=3,
+            transient=False,
+            ra_dis=2.3,
+            group_ids=[public_group.id],
+            alias=[alias],
+            origin=origin,
+        )
     )
-    assert status == 200
-    assert data["data"]["id"] == obj_id
+    assert saved.id == obj_id
 
-    status, data = api("GET", f"sources/{obj_id}", token=view_only_token)
-    assert status == 200
-    assert data["data"]["id"] == obj_id
-    npt.assert_almost_equal(data["data"]["ra"], 234.22)
+    source = client(view_only_token).fetch_source(obj_id)
+    assert source.id == obj_id
+    npt.assert_almost_equal(source.ra, 234.22)
 
-    saved_at = parser.parse(data["data"]["groups"][0]["saved_at"] + " UTC")
+    saved_at = source.groups[0].saved_at.replace(tzinfo=UTC)
     assert abs(saved_at - t0) < timedelta(seconds=60)
 
-    assert alias == data["data"]["alias"][0]
-    assert origin == data["data"]["origin"]
+    assert alias == source.alias[0]
+    assert origin == source.origin
 
 
 def test_cannot_post_source_with_null_radec(
     upload_data_token, view_only_token, public_group
 ):
     obj_id = str(uuid.uuid4())
+    # raw api: intentionally malformed payload (explicit null ra/dec) the typed client can't produce
     status, data = api(
         "POST",
         "sources",
@@ -426,24 +343,19 @@ def test_cannot_post_source_with_null_radec(
 
 def test_add_source_without_group_id(upload_data_token, view_only_token, public_group):
     obj_id = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id,
-            "ra": 234.22,
-            "dec": -22.33,
-            "redshift": 3,
-            "transient": False,
-            "ra_dis": 2.3,
-        },
-        token=upload_data_token,
+    client(upload_data_token).post_source(
+        SourcePost(
+            id=obj_id,
+            ra=234.22,
+            dec=-22.33,
+            redshift=3,
+            transient=False,
+            ra_dis=2.3,
+        )
     )
-    assert status == 200
-    status, data = api("GET", f"sources/{obj_id}", token=view_only_token)
-    assert status == 200
-    assert data["data"]["id"] == obj_id
-    npt.assert_almost_equal(data["data"]["ra"], 234.22)
+    source = client(view_only_token).fetch_source(obj_id)
+    assert source.id == obj_id
+    npt.assert_almost_equal(source.ra, 234.22)
 
 
 def test_admin_save_source_as_other_user(
@@ -458,335 +370,212 @@ def test_admin_save_source_as_other_user(
 
     # we shouldn't be able to save as the super admin user using
     # the upload_data_token (which is not an admin token)
-    source_data = {
-        "id": obj_id,
-        "ra": 234.22,
-        "dec": -22.33,
-        "group_ids": [public_group.id],
-        "saver_per_group_id": {public_group.id: super_admin_user.id},
-    }
-    status, data = api(
-        "POST",
-        "sources",
-        data=source_data,
-        token=upload_data_token,
+    source_data = SourcePost(
+        id=obj_id,
+        ra=234.22,
+        dec=-22.33,
+        group_ids=[public_group.id],
+        saver_per_group_id={str(public_group.id): super_admin_user.id},
     )
-    assert status == 400
+    with pytest.raises(SkyPortalError) as err:
+        client(upload_data_token).post_source(source_data)
+    assert err.value.status_code == 400
     assert (
-        data["message"]
+        str(err.value)
         == "Failed to post source: You must be an admin to specify a saver_per_group_id field."
     )
 
     # now save it to the public group as the view only user, using the super admin token
-    source_data["saver_per_group_id"] = {public_group.id: view_only_user.id}
-    status, data = api(
-        "POST",
-        "sources",
-        data=source_data,
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["data"]["id"] == obj_id
+    source_data.saver_per_group_id = {str(public_group.id): view_only_user.id}
+    saved = client(super_admin_token).post_source(source_data)
+    assert saved.id == obj_id
 
     # check that the source was saved by the view only user successfully
-    status, data = api("GET", f"sources/{obj_id}", token=view_only_token)
-    assert status == 200
-    assert data["data"]["id"] == obj_id
-    assert len(data["data"]["groups"]) > 0
-    assert data["data"]["groups"][0]["saved_by"]["id"] == view_only_user.id
+    source = client(view_only_token).fetch_source(obj_id)
+    assert source.id == obj_id
+    assert len(source.groups) > 0
+    assert source.groups[0].saved_by.id == view_only_user.id
 
 
 def test_source_notifications_unauthorized(
     source_notification_user_token, public_group, public_source
 ):
-    status, data = api(
-        "POST",
-        "source_notifications",
-        data={
-            "groupIds": [public_group.id],
-            "sourceId": public_source.id,
-            "level": "hard",
-            "additionalNotes": "",
-        },
-        token=source_notification_user_token,
-    )
-    assert status == 401
-    assert "Unauthorized" in data["message"]
+    with pytest.raises(SkyPortalError, match="Unauthorized") as err:
+        client(source_notification_user_token).post_source_notification(
+            SourceNotificationPost(
+                group_ids=[public_group.id],
+                source_id=public_source.id,
+                level="hard",
+                additional_notes="",
+            )
+        )
+    assert err.value.status_code == 401
 
 
 def test_token_user_source_summary(
     public_group, public_source, view_only_token_two_groups, public_group2
 ):
     now = utcnow_naive().isoformat()
+    sp = client(view_only_token_two_groups)
 
-    status, data = api(
-        "GET",
-        f"sources?saveSummary=true&group_ids={public_group.id}",
-        token=view_only_token_two_groups,
-    )
-    assert status == 200
-    assert "sources" in data["data"]
-    sources = data["data"]["sources"]
+    sources = sp.fetch_sources_save_summary(group_ids=[public_group.id]).sources
 
     assert len(sources) == 1
     source = sources[0]
-    assert "ra" not in source
-    assert "dec" not in source
+    # save records carry no ra/dec; SavedSource forbids extra keys, so
+    # validation would fail if the server returned them
 
-    assert source["obj_id"] == public_source.id
-    assert source["group_id"] == public_group.id
+    assert source.obj_id == public_source.id
+    assert source.group_id == public_group.id
 
-    status, data = api(
-        "GET",
-        "sources",
-        params={
-            "saveSummary": "true",
-            "savedAfter": f"{now}",
-            "group_ids": f"{public_group.id}",
-        },
-        token=view_only_token_two_groups,
-    )
-    assert status == 200
-    assert "sources" in data["data"]
-    sources = data["data"]["sources"]
+    sources = sp.fetch_sources_save_summary(
+        saved_after=now, group_ids=[public_group.id]
+    ).sources
 
     assert len(sources) == 0
 
-    status, data = api(
-        "GET",
-        "sources",
-        params={"saveSummary": "true", "group_ids": f"{public_group2.id}"},
-        token=view_only_token_two_groups,
-    )
-    assert status == 200
-    assert "sources" in data["data"]
-    sources = data["data"]["sources"]
+    sources = sp.fetch_sources_save_summary(group_ids=[public_group2.id]).sources
     assert len(sources) == 0
 
-    status, data = api(
-        "GET",
-        "sources",
-        params={
-            "saveSummary": "true",
-            "savedBefore": f"{now}",
-            "group_ids": f"{public_group.id}",
-        },
-        token=view_only_token_two_groups,
-    )
-    assert status == 200
-    assert "sources" in data["data"]
-    sources = data["data"]["sources"]
+    sources = sp.fetch_sources_save_summary(
+        saved_before=now, group_ids=[public_group.id]
+    ).sources
 
     assert len(sources) == 1
     source = sources[0]
 
-    assert source["obj_id"] == public_source.id
-    assert source["group_id"] == public_group.id
+    assert source.obj_id == public_source.id
+    assert source.group_id == public_group.id
 
     # check the datetime formatting is properly validated
-    status, data = api(
-        "GET",
-        "sources",
-        params={
-            "saveSummary": "true",
-            "savedBefore": "2020-104-01T00:00:01.2412",
-            "group_ids": f"{public_group.id}",
-        },
-        token=view_only_token_two_groups,
-    )
-    assert status == 400
+    with pytest.raises(SkyPortalError) as err:
+        sp.fetch_sources_save_summary(
+            saved_before="2020-104-01T00:00:01.2412", group_ids=[public_group.id]
+        )
+    assert err.value.status_code == 400
 
 
 def test_source_summary_pagination(super_admin_user, super_admin_token):
+    sp = client(super_admin_token)
     group_name = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "groups",
-        data={"name": group_name, "group_admins": [super_admin_user.id]},
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    new_group_id = data["data"]["id"]
+    new_group_id = sp.post_group(
+        GroupPost(name=group_name, group_admins=[super_admin_user.id])
+    ).id
     ids = set()
     for _ in range(1, 51):
         id = str(uuid.uuid4())
         ids.add(id)
-        status, data = api(
-            "POST",
-            "sources",
-            data={
-                "id": id,
-                "ra": 234.22,
-                "dec": 22.33,
-                "group_ids": [new_group_id],
-            },
-            token=super_admin_token,
+        sp.post_source(
+            SourcePost(
+                id=id,
+                ra=234.22,
+                dec=22.33,
+                group_ids=[new_group_id],
+            )
         )
-        assert status == 200
-        assert data["status"] == "success"
 
-    status, data = api(
-        "GET",
-        f"sources?saveSummary=true&group_ids={new_group_id}",
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert "sources" in data["data"]
-    sources = data["data"]["sources"]
+    sources = sp.fetch_sources_save_summary(group_ids=[new_group_id]).sources
     assert len(sources) == 50
-    source = sources[0]
-    assert "ra" not in source
-    assert "dec" not in source
+    # save records carry no ra/dec; SavedSource forbids extra keys, so
+    # validation would fail if the server returned them
 
     fetched_ids = set()
     for i in range(1, 6):
-        status, data = api(
-            "GET",
-            f"sources?saveSummary=true&group_ids={new_group_id}&pageNumber={i}&numPerPage=10",
-            token=super_admin_token,
-        )
-        assert status == 200
-        assert "sources" in data["data"]
-        sources = data["data"]["sources"]
+        sources = sp.fetch_sources_save_summary(
+            group_ids=[new_group_id], page_number=i, num_per_page=10
+        ).sources
         assert len(sources) == 10
-        source = sources[0]
-        assert "ra" not in source
-        assert "dec" not in source
         for source in sources:
-            assert source["obj_id"] in ids
-            fetched_ids.add(source["obj_id"])
+            assert source.obj_id in ids
+            fetched_ids.add(source.obj_id)
 
     assert len(fetched_ids) == 50
 
 
 def test_sources_sorting(upload_data_token, view_only_token, public_group):
+    sp = client(upload_data_token)
     obj_id = str(uuid.uuid4())
     obj_id2 = str(uuid.uuid4())
     ra1 = 230
     ra2 = 240
 
     # Upload two new sources
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id,
-            "ra": ra1,
-            "dec": -22.33,
-            "redshift": 3,
-            "transient": False,
-            "ra_dis": 2.3,
-            "group_ids": [public_group.id],
-            "altdata": {"Einstein Radius": 0.2, "nested": {"key": 2}},
-        },
-        token=upload_data_token,
+    saved = sp.post_source(
+        SourcePost(
+            id=obj_id,
+            ra=ra1,
+            dec=-22.33,
+            redshift=3,
+            transient=False,
+            ra_dis=2.3,
+            group_ids=[public_group.id],
+            altdata={"Einstein Radius": 0.2, "nested": {"key": 2}},
+        )
     )
-    assert status == 200
-    assert data["data"]["id"] == obj_id
+    assert saved.id == obj_id
 
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id2,
-            "ra": ra2,
-            "dec": -22.33,
-            "redshift": 3,
-            "transient": False,
-            "ra_dis": 2.3,
-            "group_ids": [public_group.id],
-            "altdata": {"Einstein Radius": 0.3, "nested": {"key": 1}},
-        },
-        token=upload_data_token,
+    saved = sp.post_source(
+        SourcePost(
+            id=obj_id2,
+            ra=ra2,
+            dec=-22.33,
+            redshift=3,
+            transient=False,
+            ra_dis=2.3,
+            group_ids=[public_group.id],
+            altdata={"Einstein Radius": 0.3, "nested": {"key": 1}},
+        )
     )
-    assert status == 200
-    assert data["data"]["id"] == obj_id2
+    assert saved.id == obj_id2
 
     # Sort sources by ra, desc and check that source 2 is first
-    status, data = api(
-        "GET",
-        "sources",
-        params={"sortBy": "ra", "sortOrder": "desc", "group_ids": f"{public_group.id}"},
-        token=view_only_token,
+    page = client(view_only_token).fetch_sources(
+        sort_by="ra", sort_order="desc", group_ids=[public_group.id]
     )
-    assert status == 200
-    assert data["data"]["sources"][0]["id"] == obj_id2
-    npt.assert_almost_equal(data["data"]["sources"][0]["ra"], ra2)
-    assert data["data"]["sources"][1]["id"] == obj_id
-    npt.assert_almost_equal(data["data"]["sources"][1]["ra"], ra1)
+    assert page.sources[0].id == obj_id2
+    npt.assert_almost_equal(page.sources[0].ra, ra2)
+    assert page.sources[1].id == obj_id
+    npt.assert_almost_equal(page.sources[1].ra, ra1)
 
     # next let's sort by the altdata.Einstein Radius descending
-    status, data = api(
-        "GET",
-        "sources",
-        params={
-            "sortBy": "altdata.Einstein Radius",
-            "sortOrder": "desc",
-            "group_ids": f"{public_group.id}",
-        },
-        token=view_only_token,
+    page = client(view_only_token).fetch_sources(
+        sort_by="altdata.Einstein Radius",
+        sort_order="desc",
+        group_ids=[public_group.id],
     )
-    assert status == 200
-    assert data["data"]["sources"][0]["id"] == obj_id2
-    npt.assert_almost_equal(
-        data["data"]["sources"][0]["altdata"]["Einstein Radius"], 0.3
-    )
-    assert data["data"]["sources"][1]["id"] == obj_id
-    npt.assert_almost_equal(
-        data["data"]["sources"][1]["altdata"]["Einstein Radius"], 0.2
-    )
+    assert page.sources[0].id == obj_id2
+    npt.assert_almost_equal(page.sources[0].altdata["Einstein Radius"], 0.3)
+    assert page.sources[1].id == obj_id
+    npt.assert_almost_equal(page.sources[1].altdata["Einstein Radius"], 0.2)
 
     # let's try the same but ascending, which should reverse the order
-    status, data = api(
-        "GET",
-        "sources",
-        params={
-            "sortBy": "altdata.Einstein Radius",
-            "sortOrder": "asc",
-            "group_ids": f"{public_group.id}",
-        },
-        token=view_only_token,
+    page = client(view_only_token).fetch_sources(
+        sort_by="altdata.Einstein Radius",
+        sort_order="asc",
+        group_ids=[public_group.id],
     )
-    assert status == 200
-    assert data["data"]["sources"][0]["id"] == obj_id
-    npt.assert_almost_equal(
-        data["data"]["sources"][0]["altdata"]["Einstein Radius"], 0.2
-    )
-    assert data["data"]["sources"][1]["id"] == obj_id2
-    npt.assert_almost_equal(
-        data["data"]["sources"][1]["altdata"]["Einstein Radius"], 0.3
-    )
+    assert page.sources[0].id == obj_id
+    npt.assert_almost_equal(page.sources[0].altdata["Einstein Radius"], 0.2)
+    assert page.sources[1].id == obj_id2
+    npt.assert_almost_equal(page.sources[1].altdata["Einstein Radius"], 0.3)
 
     # let's try sorting on an altdata nested field
-    status, data = api(
-        "GET",
-        "sources",
-        params={
-            "sortBy": "altdata.nested.key",
-            "sortOrder": "asc",
-            "group_ids": f"{public_group.id}",
-        },
-        token=view_only_token,
+    page = client(view_only_token).fetch_sources(
+        sort_by="altdata.nested.key",
+        sort_order="asc",
+        group_ids=[public_group.id],
     )
-    assert status == 200
-    assert data["data"]["sources"][0]["id"] == obj_id2
-    assert data["data"]["sources"][1]["id"] == obj_id
+    assert page.sources[0].id == obj_id2
+    assert page.sources[1].id == obj_id
 
     # try it in descending order to validate
-    status, data = api(
-        "GET",
-        "sources",
-        params={
-            "sortBy": "altdata.nested.key",
-            "sortOrder": "desc",
-            "group_ids": f"{public_group.id}",
-        },
-        token=view_only_token,
+    page = client(view_only_token).fetch_sources(
+        sort_by="altdata.nested.key",
+        sort_order="desc",
+        group_ids=[public_group.id],
     )
-    assert status == 200
-    assert data["data"]["sources"][0]["id"] == obj_id
-    assert data["data"]["sources"][1]["id"] == obj_id2
+    assert page.sources[0].id == obj_id
+    assert page.sources[1].id == obj_id2
 
 
 def test_sources_sorting_by_annotation(
@@ -798,58 +587,36 @@ def test_sources_sorting_by_annotation(
     key = "t_E"
 
     for oid, ra in [(obj_id, 210), (obj_id2, 220)]:
-        status, data = api(
-            "POST",
-            "sources",
-            data={
-                "id": oid,
-                "ra": ra,
-                "dec": -22.33,
-                "group_ids": [public_group.id],
-            },
-            token=upload_data_token,
+        client(upload_data_token).post_source(
+            SourcePost(
+                id=oid,
+                ra=ra,
+                dec=-22.33,
+                group_ids=[public_group.id],
+            )
         )
-        assert status == 200
 
     # Values 9 and 10 are chosen so numeric and lexicographic order disagree.
     for oid, value in [(obj_id, 9), (obj_id2, 10)]:
-        status, data = api(
-            "POST",
-            f"sources/{oid}/annotations",
-            data={"origin": origin, "data": {key: value}},
-            token=annotation_token,
-        )
-        assert status == 200
+        client(annotation_token).post_annotation(oid, origin, {key: value})
 
     # Descending: 10 (obj_id2) must come first; a text sort would rank "9" first.
-    status, data = api(
-        "GET",
-        "sources",
-        params={
-            "sortBy": f"annotation.{origin}.{key}",
-            "sortOrder": "desc",
-            "group_ids": f"{public_group.id}",
-        },
-        token=super_admin_token,
+    page = client(super_admin_token).fetch_sources(
+        sort_by=f"annotation.{origin}.{key}",
+        sort_order="desc",
+        group_ids=[public_group.id],
     )
-    assert status == 200
-    assert data["data"]["sources"][0]["id"] == obj_id2
-    assert data["data"]["sources"][1]["id"] == obj_id
+    assert page.sources[0].id == obj_id2
+    assert page.sources[1].id == obj_id
 
     # Ascending reverses the order.
-    status, data = api(
-        "GET",
-        "sources",
-        params={
-            "sortBy": f"annotation.{origin}.{key}",
-            "sortOrder": "asc",
-            "group_ids": f"{public_group.id}",
-        },
-        token=super_admin_token,
+    page = client(super_admin_token).fetch_sources(
+        sort_by=f"annotation.{origin}.{key}",
+        sort_order="asc",
+        group_ids=[public_group.id],
     )
-    assert status == 200
-    assert data["data"]["sources"][0]["id"] == obj_id
-    assert data["data"]["sources"][1]["id"] == obj_id2
+    assert page.sources[0].id == obj_id
+    assert page.sources[1].id == obj_id2
 
 
 def test_sources_sorting_by_annotation_no_leakage(
@@ -870,51 +637,33 @@ def test_sources_sorting_by_annotation_no_leakage(
     key = "t_E"
 
     for oid, ra in [(obj_visible, 210), (obj_hidden, 220)]:
-        status, data = api(
-            "POST",
-            "sources",
-            data={
-                "id": oid,
-                "ra": ra,
-                "dec": -22.33,
-                "group_ids": [public_group.id],
-            },
-            token=upload_data_token,
+        client(upload_data_token).post_source(
+            SourcePost(
+                id=oid,
+                ra=ra,
+                dec=-22.33,
+                group_ids=[public_group.id],
+            )
         )
-        assert status == 200
 
     # Accessible annotation (small value) on obj_visible.
-    status, data = api(
-        "POST",
-        f"sources/{obj_visible}/annotations",
-        data={"origin": origin, "data": {key: 5}, "group_ids": [public_group.id]},
-        token=annotation_token,
+    client(annotation_token).post_annotation(
+        obj_visible, origin, {key: 5}, group_ids=[public_group.id]
     )
-    assert status == 200
 
     # Larger-valued annotation on obj_hidden, shared only with public_group2.
-    status, data = api(
-        "POST",
-        f"sources/{obj_hidden}/annotations",
-        data={"origin": origin, "data": {key: 100}, "group_ids": [public_group2.id]},
-        token=annotation_token_two_groups,
+    client(annotation_token_two_groups).post_annotation(
+        obj_hidden, origin, {key: 100}, group_ids=[public_group2.id]
     )
-    assert status == 200
 
     # A user who can access public_group2 (here the admin) sees the value 100
     # and sorts obj_hidden first when descending.
-    status, data = api(
-        "GET",
-        "sources",
-        params={
-            "sortBy": f"annotation.{origin}.{key}",
-            "sortOrder": "desc",
-            "group_ids": f"{public_group.id}",
-        },
-        token=super_admin_token,
+    page = client(super_admin_token).fetch_sources(
+        sort_by=f"annotation.{origin}.{key}",
+        sort_order="desc",
+        group_ids=[public_group.id],
     )
-    assert status == 200
-    ids = [s["id"] for s in data["data"]["sources"]]
+    ids = [s.id for s in page.sources]
     assert ids[0] == obj_hidden
     assert ids[1] == obj_visible
 
@@ -922,18 +671,12 @@ def test_sources_sorting_by_annotation_no_leakage(
     # value cannot influence the sort: obj_hidden has no accessible annotation
     # and sorts last (NULLS LAST), while obj_visible (value 5) comes first. If
     # the hidden value leaked, obj_hidden (value 100) would sort first here.
-    status, data = api(
-        "GET",
-        "sources",
-        params={
-            "sortBy": f"annotation.{origin}.{key}",
-            "sortOrder": "desc",
-            "group_ids": f"{public_group.id}",
-        },
-        token=view_only_token,
+    page = client(view_only_token).fetch_sources(
+        sort_by=f"annotation.{origin}.{key}",
+        sort_order="desc",
+        group_ids=[public_group.id],
     )
-    assert status == 200
-    ids = [s["id"] for s in data["data"]["sources"]]
+    ids = [s.id for s in page.sources]
     assert obj_visible in ids and obj_hidden in ids
     assert ids[0] == obj_visible
     assert ids[-1] == obj_hidden
@@ -950,76 +693,56 @@ def test_object_last_detected(
 ):
     # Some very high mjd to make this the latest point
     # This is not a detection though
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 99999.0,
-            "instrument_id": ztf_camera.id,
-            "mag": None,
-            "magerr": None,
-            "limiting_mag": 22.3,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    client(upload_data_token).post_photometry(
+        PhotometryPost(
+            obj_id=str(public_source.id),
+            mjd=99999.0,
+            instrument_id=ztf_camera.id,
+            mag=None,
+            magerr=None,
+            limiting_mag=22.3,
+            magsys="ab",
+            filter="ztfg",
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
-    assert data["status"] == "success"
 
     # Another high mjd, but this time a photometry point not visible to the user
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 99900.0,
-            "instrument_id": ztf_camera.id,
-            "mag": None,
-            "magerr": None,
-            "limiting_mag": 22.3,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "group_ids": [public_group2.id],
-        },
-        token=upload_data_token_two_groups,
+    client(upload_data_token_two_groups).post_photometry(
+        PhotometryPost(
+            obj_id=str(public_source.id),
+            mjd=99900.0,
+            instrument_id=ztf_camera.id,
+            mag=None,
+            magerr=None,
+            limiting_mag=22.3,
+            magsys="ab",
+            filter="ztfg",
+            group_ids=[public_group2.id],
+        )
     )
-    assert status == 200
-    assert data["status"] == "success"
 
     # A high mjd, but lower than the first point
     # Since this is a detection, it should be returned as "last_detected"
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 90000.0,
-            "instrument_id": ztf_camera.id,
-            "flux": 12.24,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    client(upload_data_token).post_photometry(
+        PhotometryPost(
+            obj_id=str(public_source.id),
+            mjd=90000.0,
+            instrument_id=ztf_camera.id,
+            flux=12.24,
+            fluxerr=0.031,
+            zp=25.0,
+            magsys="ab",
+            filter="ztfg",
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
-    assert data["status"] == "success"
 
-    status, data = api(
-        "GET",
-        f"sources/{public_source.id}",
-        params={"includeDetectionStats": "true"},
-        token=view_only_token,
+    source = client(view_only_token).fetch_source(
+        public_source.id, include_detection_stats=True
     )
-    assert status == 200
-    assert data["status"] == "success"
     assert arrow.get(
-        Time(data["data"]["photstats"][-1]["last_detected_mjd"], format="mjd").datetime
+        Time(source.photstats[-1].last_detected_mjd, format="mjd").datetime
     ) == arrow.get((90000.0 - 40_587) * 86400.0)
 
 
@@ -1028,138 +751,95 @@ def test_source_photometry_summary_info(
 ):
     pt1 = {"mjd": 58001.0, "flux": 13.24}
     pt2 = {"mjd": 58002.0, "flux": 15.24}
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source_no_data.id),
-            "mjd": [pt1["mjd"], pt2["mjd"]],
-            "instrument_id": ztf_camera.id,
-            "flux": [pt1["flux"], pt2["flux"]],
-            "fluxerr": [0.031, 0.031],
-            "filter": ["ztfg", "ztfg"],
-            "zp": [25.0, 25.0],
-            "magsys": ["ab", "ab"],
-            "ra": 264.1947917,
-            "dec": [50.5478333, 50.5478333],
-            "dec_unc": 0.2,
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    posted = client(upload_data_token).post_photometry(
+        PhotometryPost(
+            obj_id=str(public_source_no_data.id),
+            mjd=[pt1["mjd"], pt2["mjd"]],
+            instrument_id=ztf_camera.id,
+            flux=[pt1["flux"], pt2["flux"]],
+            fluxerr=[0.031, 0.031],
+            filter=["ztfg", "ztfg"],
+            zp=[25.0, 25.0],
+            magsys=["ab", "ab"],
+            ra=264.1947917,
+            dec=[50.5478333, 50.5478333],
+            dec_unc=0.2,
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]["ids"]) == 2
+    assert len(posted.ids) == 2
 
     mag1_ab = -2.5 * np.log10(pt1["flux"]) + 25.0
     mag2_ab = -2.5 * np.log10(pt2["flux"]) + 25.0
 
-    status, data = api(
-        "GET",
-        f"sources/{public_source_no_data.id}",
-        params={"includeDetectionStats": "true"},
-        token=view_only_token,
+    source = client(view_only_token).fetch_source(
+        public_source_no_data.id, include_detection_stats=True
     )
-    assert status == 200
-    assert data["status"] == "success"
 
-    assert data["data"]["photstats"][-1]["first_detected_mjd"] == pt1["mjd"]
-    assert data["data"]["photstats"][-1]["first_detected_mag"] == mag1_ab
-    assert data["data"]["photstats"][-1]["peak_mjd_global"] == pt2["mjd"]
-    assert data["data"]["photstats"][-1]["peak_mag_global"] == mag2_ab
+    assert source.photstats[-1].first_detected_mjd == pt1["mjd"]
+    assert source.photstats[-1].first_detected_mag == mag1_ab
+    assert source.photstats[-1].peak_mjd_global == pt2["mjd"]
+    assert source.photstats[-1].peak_mag_global == mag2_ab
 
 
 # Sources filtering tests
 def test_sources_filter_by_name_or_id(upload_data_token, view_only_token, public_group):
+    sp = client(upload_data_token)
     obj_id1 = str(uuid.uuid4())
     obj_id2 = str(uuid.uuid4())
 
     # Upload two new sources
-    status, data = api(
-        "POST",
-        "sources",
-        data={"id": obj_id1, "ra": 230, "dec": -22.33, "group_ids": [public_group.id]},
-        token=upload_data_token,
+    saved = sp.post_source(
+        SourcePost(id=obj_id1, ra=230, dec=-22.33, group_ids=[public_group.id])
     )
-    assert status == 200
-    assert data["data"]["id"] == obj_id1
-    status, data = api(
-        "POST",
-        "sources",
-        data={"id": obj_id2, "ra": 230, "dec": -22.33, "group_ids": [public_group.id]},
-        token=upload_data_token,
+    assert saved.id == obj_id1
+    saved = sp.post_source(
+        SourcePost(id=obj_id2, ra=230, dec=-22.33, group_ids=[public_group.id])
     )
-    assert status == 200
-    assert data["data"]["id"] == obj_id2
+    assert saved.id == obj_id2
 
     # Filter for obj 1 only, using a substring not matched in the other one
-    status, data = api(
-        "GET",
-        "sources",
-        params={"sourceID": f"{obj_id1[0:5]}", "group_ids": f"{public_group.id}"},
-        token=view_only_token,
+    page = client(view_only_token).fetch_sources(
+        source_id=obj_id1[0:5], group_ids=[public_group.id]
     )
-    assert status == 200
-    assert len(data["data"]["sources"]) == 1
-    assert data["data"]["sources"][0]["id"] == obj_id1
+    assert len(page.sources) == 1
+    assert page.sources[0].id == obj_id1
 
     # Filter for obj 1 only, rejecting object 2
-    status, data = api(
-        "GET",
-        "sources",
-        params={"rejectedSourceIDs": obj_id2, "group_ids": f"{public_group.id}"},
-        token=view_only_token,
+    page = client(view_only_token).fetch_sources(
+        rejected_source_ids=[obj_id2], group_ids=[public_group.id]
     )
-    assert status == 200
-    assert len(data["data"]["sources"]) == 1
-    assert data["data"]["sources"][0]["id"] == obj_id1
+    assert len(page.sources) == 1
+    assert page.sources[0].id == obj_id1
 
     # Reject object 1 and 2
-    status, data = api(
-        "GET",
-        "sources",
-        params={
-            "rejectedSourceIDs": f"{obj_id1},{obj_id2}",
-            "group_ids": f"{public_group.id}",
-        },
-        token=view_only_token,
+    page = client(view_only_token).fetch_sources(
+        rejected_source_ids=[obj_id1, obj_id2], group_ids=[public_group.id]
     )
-    assert status == 200
-    assert len(data["data"]["sources"]) == 0
+    assert len(page.sources) == 0
 
 
 def test_sources_filter_by_position(upload_data_token, view_only_token, public_group):
+    sp = client(upload_data_token)
     obj_id1 = str(uuid.uuid4())
     obj_id2 = str(uuid.uuid4())
 
     # Upload two new sources
-    status, data = api(
-        "POST",
-        "sources",
-        data={"id": obj_id1, "ra": 230, "dec": -22.33, "group_ids": [public_group.id]},
-        token=upload_data_token,
+    saved = sp.post_source(
+        SourcePost(id=obj_id1, ra=230, dec=-22.33, group_ids=[public_group.id])
     )
-    assert status == 200
-    assert data["data"]["id"] == obj_id1
-    status, data = api(
-        "POST",
-        "sources",
-        data={"id": obj_id2, "ra": 500, "dec": 0, "group_ids": [public_group.id]},
-        token=upload_data_token,
+    assert saved.id == obj_id1
+    saved = sp.post_source(
+        SourcePost(id=obj_id2, ra=500, dec=0, group_ids=[public_group.id])
     )
-    assert status == 200
-    assert data["data"]["id"] == obj_id2
+    assert saved.id == obj_id2
 
     # Filter for obj 1 only
-    status, data = api(
-        "GET",
-        "sources",
-        params={"ra": 229, "dec": -22, "radius": 5, "group_ids": f"{public_group.id}"},
-        token=view_only_token,
+    page = client(view_only_token).fetch_sources(
+        ra=229, dec=-22, radius=5, group_ids=[public_group.id]
     )
-    assert status == 200
-    assert len(data["data"]["sources"]) == 1
-    assert data["data"]["sources"][0]["id"] == obj_id1
+    assert len(page.sources) == 1
+    assert page.sources[0].id == obj_id1
 
 
 def test_sources_filter_by_position_small_radius(
@@ -1171,102 +851,62 @@ def test_sources_filter_by_position_small_radius(
     obj_id2 = str(uuid.uuid4())
     ra, dec = 100.0, 20.0
     for oid, d in [(obj_id1, dec), (obj_id2, dec + 3 / 3600)]:
-        status, data = api(
-            "POST",
-            "sources",
-            data={"id": oid, "ra": ra, "dec": d, "group_ids": [public_group.id]},
-            token=upload_data_token,
+        client(upload_data_token).post_source(
+            SourcePost(id=oid, ra=ra, dec=d, group_ids=[public_group.id])
         )
-        assert status == 200
 
     # 2 arcsec radius: only obj 1 (obj 2 is 3 arcsec away, outside).
-    status, data = api(
-        "GET",
-        "sources",
-        params={
-            "ra": ra,
-            "dec": dec,
-            "radius": 2 / 3600,
-            "group_ids": f"{public_group.id}",
-        },
-        token=view_only_token,
+    page = client(view_only_token).fetch_sources(
+        ra=ra, dec=dec, radius=2 / 3600, group_ids=[public_group.id]
     )
-    assert status == 200
-    assert {s["id"] for s in data["data"]["sources"]} == {obj_id1}
+    assert {s.id for s in page.sources} == {obj_id1}
 
     # 4 arcsec radius: both sources are within.
-    status, data = api(
-        "GET",
-        "sources",
-        params={
-            "ra": ra,
-            "dec": dec,
-            "radius": 4 / 3600,
-            "group_ids": f"{public_group.id}",
-        },
-        token=view_only_token,
+    page = client(view_only_token).fetch_sources(
+        ra=ra, dec=dec, radius=4 / 3600, group_ids=[public_group.id]
     )
-    assert status == 200
-    assert {s["id"] for s in data["data"]["sources"]} == {obj_id1, obj_id2}
+    assert {s.id for s in page.sources} == {obj_id1, obj_id2}
 
 
 def test_sources_filter_by_time_saved(upload_data_token, view_only_token, public_group):
+    sp = client(upload_data_token)
     obj_id1 = str(uuid.uuid4())
     obj_id2 = str(uuid.uuid4())
 
     # Upload two new sources
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id1,
-            "ra": 234.22,
-            "dec": -22.33,
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    saved = sp.post_source(
+        SourcePost(
+            id=obj_id1,
+            ra=234.22,
+            dec=-22.33,
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
-    assert data["data"]["id"] == obj_id1
+    assert saved.id == obj_id1
     test_time = datetime.now(UTC)
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id2,
-            "ra": 234.22,
-            "dec": -22.33,
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    saved = sp.post_source(
+        SourcePost(
+            id=obj_id2,
+            ra=234.22,
+            dec=-22.33,
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
-    assert data["data"]["id"] == obj_id2
+    assert saved.id == obj_id2
 
     # Filter for obj 1 only
-    status, data = api(
-        "GET",
-        "sources",
-        params={
-            "savedBefore": test_time.isoformat(),
-            "group_ids": f"{public_group.id}",
-        },
-        token=view_only_token,
+    page = client(view_only_token).fetch_sources(
+        saved_before=test_time.isoformat(), group_ids=[public_group.id]
     )
-    assert status == 200
-    assert len(data["data"]["sources"]) == 1
-    assert data["data"]["sources"][0]["id"] == obj_id1
+    assert len(page.sources) == 1
+    assert page.sources[0].id == obj_id1
 
     # Filter for obj 2 only
-    status, data = api(
-        "GET",
-        "sources",
-        params={"savedAfter": test_time.isoformat(), "group_ids": f"{public_group.id}"},
-        token=view_only_token,
+    page = client(view_only_token).fetch_sources(
+        saved_after=test_time.isoformat(), group_ids=[public_group.id]
     )
-    assert status == 200
-    assert len(data["data"]["sources"]) == 1
-    assert data["data"]["sources"][0]["id"] == obj_id2
+    assert len(page.sources) == 1
+    assert page.sources[0].id == obj_id2
 
 
 def test_sources_filter_by_saved_by_current_user(
@@ -1276,220 +916,153 @@ def test_sources_filter_by_saved_by_current_user(
     # public_group; only the former saves the source below.
     obj_id = str(uuid.uuid4())
 
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id,
-            "ra": 234.22,
-            "dec": -22.33,
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    saved = client(upload_data_token).post_source(
+        SourcePost(
+            id=obj_id,
+            ra=234.22,
+            dec=-22.33,
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
-    assert data["data"]["id"] == obj_id
+    assert saved.id == obj_id
 
     # The saver sees it when filtering to their own saves
-    status, data = api(
-        "GET",
-        "sources",
-        params={"savedByCurrentUser": "true", "group_ids": f"{public_group.id}"},
-        token=upload_data_token,
+    page = client(upload_data_token).fetch_sources(
+        saved_by_current_user=True, group_ids=[public_group.id]
     )
-    assert status == 200
-    assert obj_id in [s["id"] for s in data["data"]["sources"]]
+    assert obj_id in [s.id for s in page.sources]
 
     # Another group member who did not save it does not see it
-    status, data = api(
-        "GET",
-        "sources",
-        params={"savedByCurrentUser": "true", "group_ids": f"{public_group.id}"},
-        token=view_only_token2,
+    page = client(view_only_token2).fetch_sources(
+        saved_by_current_user=True, group_ids=[public_group.id]
     )
-    assert status == 200
-    assert obj_id not in [s["id"] for s in data["data"]["sources"]]
+    assert obj_id not in [s.id for s in page.sources]
 
 
 def test_sources_filter_by_time_spectrum(
     upload_data_token, view_only_token, public_group, lris
 ):
+    sp = client(upload_data_token)
     obj_id1 = str(uuid.uuid4())
     obj_id2 = str(uuid.uuid4())
 
     # Upload two new sources
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id1,
-            "ra": 234.22,
-            "dec": -22.33,
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    saved = sp.post_source(
+        SourcePost(
+            id=obj_id1,
+            ra=234.22,
+            dec=-22.33,
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
-    assert data["data"]["id"] == obj_id1
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id2,
-            "ra": 234.22,
-            "dec": -22.33,
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    assert saved.id == obj_id1
+    saved = sp.post_source(
+        SourcePost(
+            id=obj_id2,
+            ra=234.22,
+            dec=-22.33,
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
-    assert data["data"]["id"] == obj_id2
+    assert saved.id == obj_id2
 
     # Add spectrum to source 1
-    status, data = api(
-        "POST",
-        "spectrum",
-        data={
-            "obj_id": obj_id1,
-            "observed_at": str(datetime.now(UTC) - timedelta(days=1)),
-            "instrument_id": lris.id,
-            "wavelengths": [664, 665, 666],
-            "fluxes": [234.2, 232.1, 235.3],
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    sp.post_spectrum(
+        SpectrumPost(
+            obj_id=obj_id1,
+            observed_at=str(datetime.now(UTC) - timedelta(days=1)),
+            instrument_id=lris.id,
+            wavelengths=[664, 665, 666],
+            fluxes=[234.2, 232.1, 235.3],
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
-    assert data["status"] == "success"
 
     test_time = datetime.now(UTC)
     # Add spectrum to source 2
-    status, data = api(
-        "POST",
-        "spectrum",
-        data={
-            "obj_id": obj_id2,
-            "observed_at": str(datetime.now(UTC) + timedelta(days=1)),
-            "instrument_id": lris.id,
-            "wavelengths": [664, 665, 666],
-            "fluxes": [234.2, 232.1, 235.3],
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    sp.post_spectrum(
+        SpectrumPost(
+            obj_id=obj_id2,
+            observed_at=str(datetime.now(UTC) + timedelta(days=1)),
+            instrument_id=lris.id,
+            wavelengths=[664, 665, 666],
+            fluxes=[234.2, 232.1, 235.3],
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
-    assert data["status"] == "success"
 
     # Filter for obj 1 only
-    status, data = api(
-        "GET",
-        "sources",
-        params={
-            "hasSpectrumBefore": test_time.isoformat(),
-            "group_ids": f"{public_group.id}",
-        },
-        token=view_only_token,
+    page = client(view_only_token).fetch_sources(
+        has_spectrum_before=test_time.isoformat(), group_ids=[public_group.id]
     )
-    assert status == 200
-    assert len(data["data"]["sources"]) == 1
-    assert data["data"]["sources"][0]["id"] == obj_id1
+    assert len(page.sources) == 1
+    assert page.sources[0].id == obj_id1
 
     # Filter for obj 2 only
-    status, data = api(
-        "GET",
-        "sources",
-        params={
-            "hasSpectrumAfter": test_time.isoformat(),
-            "group_ids": f"{public_group.id}",
-        },
-        token=view_only_token,
+    page = client(view_only_token).fetch_sources(
+        has_spectrum_after=test_time.isoformat(), group_ids=[public_group.id]
     )
-    assert status == 200
-    assert len(data["data"]["sources"]) == 1
-    assert data["data"]["sources"][0]["id"] == obj_id2
+    assert len(page.sources) == 1
+    assert page.sources[0].id == obj_id2
 
 
 def test_sources_filter_by_last_detected(
     upload_data_token, view_only_token, public_group, ztf_camera
 ):
+    sp = client(upload_data_token)
     obj_id1 = str(uuid.uuid4())
     obj_id2 = str(uuid.uuid4())
 
     # Upload two new sources
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id1,
-            "ra": 234.22,
-            "dec": -22.33,
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    saved = sp.post_source(
+        SourcePost(
+            id=obj_id1,
+            ra=234.22,
+            dec=-22.33,
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
-    assert data["data"]["id"] == obj_id1
+    assert saved.id == obj_id1
 
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id2,
-            "ra": 234.22,
-            "dec": -22.33,
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    saved = sp.post_source(
+        SourcePost(
+            id=obj_id2,
+            ra=234.22,
+            dec=-22.33,
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
-    assert data["data"]["id"] == obj_id2
+    assert saved.id == obj_id2
 
     # Add a detection to obj 1
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": obj_id1,
-            "mjd": [59000.0],
-            "instrument_id": ztf_camera.id,
-            "flux": 12.24,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    sp.post_photometry(
+        PhotometryPost(
+            obj_id=obj_id1,
+            mjd=[59000.0],
+            instrument_id=ztf_camera.id,
+            flux=12.24,
+            fluxerr=0.031,
+            zp=25.0,
+            magsys="ab",
+            filter="ztfg",
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
-    assert data["status"] == "success"
 
     # Filter for obj 1 only
-    status, data = api(
-        "GET",
-        "sources",
-        params={
-            "startDate": arrow.get((58500 - 40_587) * 86400.0).isoformat(),
-            "group_ids": f"{public_group.id}",
-        },
-        token=view_only_token,
+    page = client(view_only_token).fetch_sources(
+        start_date=arrow.get((58500 - 40_587) * 86400.0).isoformat(),
+        group_ids=[public_group.id],
     )
-    assert status == 200
-    assert len(data["data"]["sources"]) == 1
-    assert data["data"]["sources"][0]["id"] == obj_id1
+    assert len(page.sources) == 1
+    assert page.sources[0].id == obj_id1
 
-    status, data = api(
-        "GET",
-        "sources",
-        params={
-            "endDate": arrow.get((59000 - 40_587) * 86400.0).isoformat(),
-            "group_ids": f"{public_group.id}",
-        },
-        token=view_only_token,
+    page = client(view_only_token).fetch_sources(
+        end_date=arrow.get((59000 - 40_587) * 86400.0).isoformat(),
+        group_ids=[public_group.id],
     )
-    assert status == 200
-    assert len(data["data"]["sources"]) == 1
-    assert data["data"]["sources"][0]["id"] == obj_id1
+    assert len(page.sources) == 1
+    assert page.sources[0].id == obj_id1
 
 
 def test_sources_filter_by_simbad_class(
@@ -1500,45 +1073,33 @@ def test_sources_filter_by_simbad_class(
     simbad_class = str(uuid.uuid4())
 
     # Upload two new sources
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id1,
-            "ra": 234.22,
-            "dec": -22.33,
-            "altdata": {"simbad": {"class": simbad_class}},
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    saved = client(upload_data_token).post_source(
+        SourcePost(
+            id=obj_id1,
+            ra=234.22,
+            dec=-22.33,
+            altdata={"simbad": {"class": simbad_class}},
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
-    assert data["data"]["id"] == obj_id1
+    assert saved.id == obj_id1
 
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id2,
-            "ra": 234.22,
-            "dec": -22.33,
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    saved = client(upload_data_token).post_source(
+        SourcePost(
+            id=obj_id2,
+            ra=234.22,
+            dec=-22.33,
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
-    assert data["data"]["id"] == obj_id2
+    assert saved.id == obj_id2
 
     # Filter for obj 1 only
-    status, data = api(
-        "GET",
-        "sources",
-        params={"simbadClass": simbad_class, "group_ids": f"{public_group.id}"},
-        token=view_only_token,
+    page = client(view_only_token).fetch_sources(
+        simbad_class=simbad_class, group_ids=[public_group.id]
     )
-    assert status == 200
-    assert len(data["data"]["sources"]) == 1
-    assert data["data"]["sources"][0]["id"] == obj_id1
+    assert len(page.sources) == 1
+    assert page.sources[0].id == obj_id1
 
 
 def test_sources_filter_by_classifications(
@@ -1551,102 +1112,71 @@ def test_sources_filter_by_classifications(
     # Post a source with a classification, and one without
     obj_id1 = str(uuid.uuid4())
     obj_id2 = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id1,
-            "ra": 234.22,
-            "dec": -22.33,
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    client(upload_data_token).post_source(
+        SourcePost(
+            id=obj_id1,
+            ra=234.22,
+            dec=-22.33,
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id2,
-            "ra": 234.22,
-            "dec": -22.33,
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    client(upload_data_token).post_source(
+        SourcePost(
+            id=obj_id2,
+            ra=234.22,
+            dec=-22.33,
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
 
     taxonomy_name = "test taxonomy" + str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "taxonomy",
-        data={
-            "name": taxonomy_name,
-            "hierarchy": taxonomy,
-            "group_ids": [public_group.id],
-            "provenance": f"tdtax_{__version__}",
-            "version": __version__,
-            "isLatest": True,
-        },
-        token=taxonomy_token,
+    taxonomy_id = (
+        client(taxonomy_token)
+        .post_taxonomy(
+            TaxonomyPost(
+                name=taxonomy_name,
+                hierarchy=taxonomy,
+                group_ids=[public_group.id],
+                provenance=f"tdtax_{__version__}",
+                version=__version__,
+                is_latest=True,
+            )
+        )
+        .taxonomy_id
     )
-    assert status == 200
-    taxonomy_id = data["data"]["taxonomy_id"]
 
-    status, data = api(
-        "POST",
-        "classification",
-        data={
-            "obj_id": obj_id1,
-            "classification": "Algol",
-            "taxonomy_id": taxonomy_id,
-            "probability": 1.0,
-            "group_ids": [public_group.id],
-        },
-        token=classification_token,
+    client(classification_token).post_classification(
+        ClassificationPost(
+            obj_id=obj_id1,
+            classification="Algol",
+            taxonomy_id=taxonomy_id,
+            probability=1.0,
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
 
-    status, data = api(
-        "POST",
-        "classification",
-        data={
-            "obj_id": obj_id2,
-            "classification": "AGN",
-            "taxonomy_id": taxonomy_id,
-            "probability": 1.0,
-            "group_ids": [public_group.id],
-        },
-        token=classification_token,
+    client(classification_token).post_classification(
+        ClassificationPost(
+            obj_id=obj_id2,
+            classification="AGN",
+            taxonomy_id=taxonomy_id,
+            probability=1.0,
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
 
     # Filter for sources with classification "Algol" - should only get obj_id1 back
-    status, data = api(
-        "GET",
-        "sources",
-        params={
-            "classifications": f"{taxonomy_name}: Algol",
-            "group_ids": f"{public_group.id}",
-        },
-        token=view_only_token,
+    page = client(view_only_token).fetch_sources(
+        classifications=[f"{taxonomy_name}: Algol"], group_ids=[public_group.id]
     )
-    assert status == 200
-    assert len(data["data"]["sources"]) == 1
-    assert data["data"]["sources"][0]["id"] == obj_id1
+    assert len(page.sources) == 1
+    assert page.sources[0].id == obj_id1
 
     # Filter for sources with nonclassification "Algol" - should at least get obj_id2 back
-    status, data = api(
-        "GET",
-        "sources",
-        params={
-            "nonclassifications": f"{taxonomy_name}: Algol",
-            "group_ids": f"{public_group.id}",
-        },
-        token=view_only_token,
+    page = client(view_only_token).fetch_sources(
+        nonclassifications=[f"{taxonomy_name}: Algol"], group_ids=[public_group.id]
     )
-    assert status == 200
-    assert any(source["id"] == obj_id2 for source in data["data"]["sources"])
+    assert any(source.id == obj_id2 for source in page.sources)
 
 
 def test_sources_filter_by_unclassified(
@@ -1658,157 +1188,110 @@ def test_sources_filter_by_unclassified(
 ):
     # Post a source with a classification, and one without
     obj_id = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id,
-            "ra": 234.22,
-            "dec": -22.33,
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    client(upload_data_token).post_source(
+        SourcePost(
+            id=obj_id,
+            ra=234.22,
+            dec=-22.33,
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
 
     taxonomy_name = "test taxonomy" + str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "taxonomy",
-        data={
-            "name": taxonomy_name,
-            "hierarchy": taxonomy,
-            "group_ids": [public_group.id],
-            "provenance": f"tdtax_{__version__}",
-            "version": __version__,
-            "isLatest": True,
-        },
-        token=taxonomy_token,
+    taxonomy_id = (
+        client(taxonomy_token)
+        .post_taxonomy(
+            TaxonomyPost(
+                name=taxonomy_name,
+                hierarchy=taxonomy,
+                group_ids=[public_group.id],
+                provenance=f"tdtax_{__version__}",
+                version=__version__,
+                is_latest=True,
+            )
+        )
+        .taxonomy_id
     )
-    assert status == 200
-    taxonomy_id = data["data"]["taxonomy_id"]
 
-    status, data = api(
-        "POST",
-        "classification",
-        data={
-            "obj_id": obj_id,
-            "classification": "Algol",
-            "taxonomy_id": taxonomy_id,
-            "probability": 1.0,
-            "group_ids": [public_group.id],
-        },
-        token=classification_token,
+    classification_id = (
+        client(classification_token)
+        .post_classification(
+            ClassificationPost(
+                obj_id=obj_id,
+                classification="Algol",
+                taxonomy_id=taxonomy_id,
+                probability=1.0,
+                group_ids=[public_group.id],
+            )
+        )
+        .classification_id
     )
-    assert status == 200
-    classification_id = data["data"]["classification_id"]
 
     # Filter for all sources
-    status, data = api(
-        "GET",
-        "sources",
-        params={
-            "unclassified": False,
-            "group_ids": f"{public_group.id}",
-        },
-        token=view_only_token,
+    page = client(view_only_token).fetch_sources(
+        unclassified=False, group_ids=[public_group.id]
     )
-    assert status == 200
-    assert len(data["data"]["sources"]) == 1
-    assert data["data"]["sources"][0]["id"] == obj_id
+    assert len(page.sources) == 1
+    assert page.sources[0].id == obj_id
 
     # Filter for unclassified sources
-    status, data = api(
-        "GET",
-        "sources",
-        params={
-            "unclassified": True,
-            "group_ids": f"{public_group.id}",
-        },
-        token=view_only_token,
+    page = client(view_only_token).fetch_sources(
+        unclassified=True, group_ids=[public_group.id]
     )
-    assert status == 200
-    assert len(data["data"]["sources"]) == 0
+    assert len(page.sources) == 0
 
     # now delete that classification
-    status, data = api(
-        "DELETE",
-        f"classification/{classification_id}",
-        token=classification_token,
-    )
-    assert status == 200
+    client(classification_token).delete_classification(classification_id)
 
     # now filter for unclassified sources again
-    status, data = api(
-        "GET",
-        "sources",
-        params={
-            "unclassified": True,
-            "group_ids": f"{public_group.id}",
-        },
-        token=view_only_token,
+    page = client(view_only_token).fetch_sources(
+        unclassified=True, group_ids=[public_group.id]
     )
-    assert status == 200
-    assert len(data["data"]["sources"]) == 1
-    assert data["data"]["sources"][0]["id"] == obj_id
+    assert len(page.sources) == 1
+    assert page.sources[0].id == obj_id
 
 
 def test_sources_filter_by_redshift(upload_data_token, view_only_token, public_group):
+    sp = client(upload_data_token)
     obj_id1 = str(uuid.uuid4())
     obj_id2 = str(uuid.uuid4())
 
     # Upload two new sources
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id1,
-            "ra": 234.22,
-            "dec": -22.33,
-            "redshift": 3,
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    saved = sp.post_source(
+        SourcePost(
+            id=obj_id1,
+            ra=234.22,
+            dec=-22.33,
+            redshift=3,
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
-    assert data["data"]["id"] == obj_id1
+    assert saved.id == obj_id1
 
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id2,
-            "ra": 234.22,
-            "dec": -22.33,
-            "redshift": 1,
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    saved = sp.post_source(
+        SourcePost(
+            id=obj_id2,
+            ra=234.22,
+            dec=-22.33,
+            redshift=1,
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
-    assert data["data"]["id"] == obj_id2
+    assert saved.id == obj_id2
 
     # Filter for obj 1 only
-    status, data = api(
-        "GET",
-        "sources",
-        params={"minRedshift": 2, "group_ids": f"{public_group.id}"},
-        token=view_only_token,
+    page = client(view_only_token).fetch_sources(
+        min_redshift=2, group_ids=[public_group.id]
     )
-    assert status == 200
-    assert len(data["data"]["sources"]) == 1
-    assert data["data"]["sources"][0]["id"] == obj_id1
+    assert len(page.sources) == 1
+    assert page.sources[0].id == obj_id1
 
     # Filter for obj 2 only
-    status, data = api(
-        "GET",
-        "sources",
-        params={"maxRedshift": 2, "group_ids": f"{public_group.id}"},
-        token=view_only_token,
+    page = client(view_only_token).fetch_sources(
+        max_redshift=2, group_ids=[public_group.id]
     )
-    assert status == 200
-    assert len(data["data"]["sources"]) == 1
-    assert data["data"]["sources"][0]["id"] == obj_id2
+    assert len(page.sources) == 1
+    assert page.sources[0].id == obj_id2
 
 
 def test_sources_filter_by_peak_mag(
@@ -1818,93 +1301,68 @@ def test_sources_filter_by_peak_mag(
     obj_id2 = str(uuid.uuid4())
 
     # Upload two new sources with differing large mags
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id1,
-            "ra": 234.22,
-            "dec": -22.33,
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    sp = client(upload_data_token)
+    saved = sp.post_source(
+        SourcePost(
+            id=obj_id1,
+            ra=234.22,
+            dec=-22.33,
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
-    assert data["data"]["id"] == obj_id1
+    assert saved.id == obj_id1
 
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": obj_id1,
-            "mjd": 58000.0,
-            "instrument_id": ztf_camera.id,
-            "mag": 55,
-            "magerr": 0.1,
-            "limiting_mag": 22.3,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    sp.post_photometry(
+        PhotometryPost(
+            obj_id=obj_id1,
+            mjd=58000.0,
+            instrument_id=ztf_camera.id,
+            mag=55,
+            magerr=0.1,
+            limiting_mag=22.3,
+            magsys="ab",
+            filter="ztfg",
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
-    assert data["status"] == "success"
 
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id2,
-            "ra": 234.22,
-            "dec": -22.33,
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    saved = sp.post_source(
+        SourcePost(
+            id=obj_id2,
+            ra=234.22,
+            dec=-22.33,
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
-    assert data["data"]["id"] == obj_id2
+    assert saved.id == obj_id2
 
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": obj_id2,
-            "mjd": 58000.0,
-            "instrument_id": ztf_camera.id,
-            "mag": 50,
-            "magerr": 0.1,
-            "limiting_mag": 22.3,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    sp.post_photometry(
+        PhotometryPost(
+            obj_id=obj_id2,
+            mjd=58000.0,
+            instrument_id=ztf_camera.id,
+            mag=50,
+            magerr=0.1,
+            limiting_mag=22.3,
+            magsys="ab",
+            filter="ztfg",
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
-    assert data["status"] == "success"
 
     # Filter for obj 1 only
-    status, data = api(
-        "GET",
-        "sources",
-        params={"minPeakMagnitude": 51, "group_ids": f"{public_group.id}"},
-        token=view_only_token,
+    page = client(view_only_token).fetch_sources(
+        min_peak_magnitude=51, group_ids=[public_group.id]
     )
-    assert status == 200
-    assert len(data["data"]["sources"]) == 1
-    assert data["data"]["sources"][0]["id"] == obj_id2
+    assert len(page.sources) == 1
+    assert page.sources[0].id == obj_id2
 
     # Filter for obj 2 only
-    status, data = api(
-        "GET",
-        "sources",
-        params={"maxPeakMagnitude": 51, "group_ids": f"{public_group.id}"},
-        token=view_only_token,
+    page = client(view_only_token).fetch_sources(
+        max_peak_magnitude=51, group_ids=[public_group.id]
     )
-    assert status == 200
-    assert len(data["data"]["sources"]) == 1
-    assert data["data"]["sources"][0]["id"] == obj_id1
+    assert len(page.sources) == 1
+    assert page.sources[0].id == obj_id1
 
 
 def test_sources_filter_by_latest_mag(
@@ -1914,93 +1372,68 @@ def test_sources_filter_by_latest_mag(
     obj_id2 = str(uuid.uuid4())
 
     # Upload two new sources with differing latest mags
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id1,
-            "ra": 234.22,
-            "dec": -22.33,
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    sp = client(upload_data_token)
+    saved = sp.post_source(
+        SourcePost(
+            id=obj_id1,
+            ra=234.22,
+            dec=-22.33,
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
-    assert data["data"]["id"] == obj_id1
+    assert saved.id == obj_id1
 
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": obj_id1,
-            "mjd": 59000.0,
-            "instrument_id": ztf_camera.id,
-            "mag": 25,
-            "magerr": 0.1,
-            "limiting_mag": 22.3,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    sp.post_photometry(
+        PhotometryPost(
+            obj_id=obj_id1,
+            mjd=59000.0,
+            instrument_id=ztf_camera.id,
+            mag=25,
+            magerr=0.1,
+            limiting_mag=22.3,
+            magsys="ab",
+            filter="ztfg",
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
-    assert data["status"] == "success"
 
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id2,
-            "ra": 234.22,
-            "dec": -22.33,
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    saved = sp.post_source(
+        SourcePost(
+            id=obj_id2,
+            ra=234.22,
+            dec=-22.33,
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
-    assert data["data"]["id"] == obj_id2
+    assert saved.id == obj_id2
 
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": obj_id2,
-            "mjd": 59000.0,
-            "instrument_id": ztf_camera.id,
-            "mag": 22,
-            "magerr": 0.1,
-            "limiting_mag": 22.3,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    sp.post_photometry(
+        PhotometryPost(
+            obj_id=obj_id2,
+            mjd=59000.0,
+            instrument_id=ztf_camera.id,
+            mag=22,
+            magerr=0.1,
+            limiting_mag=22.3,
+            magsys="ab",
+            filter="ztfg",
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
-    assert data["status"] == "success"
 
     # Filter for obj 1 only
-    status, data = api(
-        "GET",
-        "sources",
-        params={"maxLatestMagnitude": 23, "group_ids": f"{public_group.id}"},
-        token=view_only_token,
+    page = client(view_only_token).fetch_sources(
+        max_latest_magnitude=23, group_ids=[public_group.id]
     )
-    assert status == 200
-    assert len(data["data"]["sources"]) == 1
-    assert data["data"]["sources"][0]["id"] == obj_id1
+    assert len(page.sources) == 1
+    assert page.sources[0].id == obj_id1
 
     # Filter for obj 2 only
-    status, data = api(
-        "GET",
-        "sources",
-        params={"minLatestMagnitude": 23, "group_ids": f"{public_group.id}"},
-        token=view_only_token,
+    page = client(view_only_token).fetch_sources(
+        min_latest_magnitude=23, group_ids=[public_group.id]
     )
-    assert status == 200
-    assert len(data["data"]["sources"]) == 1
-    assert data["data"]["sources"][0]["id"] == obj_id2
+    assert len(page.sources) == 1
+    assert page.sources[0].id == obj_id2
 
 
 def test_sources_filter_by_has_tns_name(
@@ -2010,45 +1443,34 @@ def test_sources_filter_by_has_tns_name(
     obj_id2 = str(uuid.uuid4())
 
     # Upload two new sources
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id1,
-            "ra": 234.22,
-            "dec": -22.33,
-            "group_ids": [public_group.id],
-            "tns_name": "test_tns_name",
-        },
-        token=upload_data_token,
+    sp = client(upload_data_token)
+    saved = sp.post_source(
+        SourcePost(
+            id=obj_id1,
+            ra=234.22,
+            dec=-22.33,
+            group_ids=[public_group.id],
+            tns_name="test_tns_name",
+        )
     )
-    assert status == 200
-    assert data["data"]["id"] == obj_id1
+    assert saved.id == obj_id1
 
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id2,
-            "ra": 234.22,
-            "dec": -22.33,
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    saved = sp.post_source(
+        SourcePost(
+            id=obj_id2,
+            ra=234.22,
+            dec=-22.33,
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
-    assert data["data"]["id"] == obj_id2
+    assert saved.id == obj_id2
 
     # Filter for obj 1 only
-    status, data = api(
-        "GET",
-        "sources",
-        params={"hasTNSname": "true", "group_ids": f"{public_group.id}"},
-        token=view_only_token,
+    page = client(view_only_token).fetch_sources(
+        has_tns_name=True, group_ids=[public_group.id]
     )
-    assert status == 200
-    assert len(data["data"]["sources"]) == 1
-    assert data["data"]["sources"][0]["id"] == obj_id1
+    assert len(page.sources) == 1
+    assert page.sources[0].id == obj_id1
 
     # An explicit "false" must not enable the filter (it used to be truthy)
     status, data = api(
@@ -2069,15 +1491,11 @@ def test_sources_filter_by_has_spectrum(
     public_source_no_data,
 ):
     # Filter for obj 1 only, since the no data source will not have spectra
-    status, data = api(
-        "GET",
-        "sources",
-        params={"hasSpectrum": "true", "group_ids": f"{public_group.id}"},
-        token=view_only_token,
+    page = client(view_only_token).fetch_sources(
+        has_spectrum=True, group_ids=[public_group.id]
     )
-    assert status == 200
-    assert len(data["data"]["sources"]) == 1
-    assert data["data"]["sources"][0]["id"] == public_source.id
+    assert len(page.sources) == 1
+    assert page.sources[0].id == public_source.id
 
 
 def test_sources_hidden_photometry_not_leaked(
@@ -2090,62 +1508,49 @@ def test_sources_hidden_photometry_not_leaked(
 ):
     obj_id = str(public_source.id)
     # Post photometry to the object belonging to a different group
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": obj_id,
-            "mjd": 58000.0,
-            "instrument_id": ztf_camera.id,
-            "flux": 12.24,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "group_ids": [public_group2.id],
-            "altdata": {"some_key": "some_value"},
-        },
-        token=upload_data_token_two_groups,
+    photometry_id = (
+        client(upload_data_token_two_groups)
+        .post_photometry(
+            PhotometryPost(
+                obj_id=obj_id,
+                mjd=58000.0,
+                instrument_id=ztf_camera.id,
+                flux=12.24,
+                fluxerr=0.031,
+                zp=25.0,
+                magsys="ab",
+                filter="ztfg",
+                group_ids=[public_group2.id],
+                altdata={"some_key": "some_value"},
+            )
+        )
+        .ids[0]
     )
-    assert status == 200
-    assert data["status"] == "success"
-    photometry_id = data["data"]["ids"][0]
 
     # Check for single GET call as well
-    status, data = api(
-        "GET",
-        f"sources/{obj_id}",
-        params={"includePhotometry": "true"},
-        token=view_only_token,
-    )
-    assert status == 200
-    assert data["data"]["id"] == obj_id
-    assert len(public_source.photometry) - 1 == len(data["data"]["photometry"])
-    assert photometry_id not in (x["id"] for x in data["data"]["photometry"])
+    source = client(view_only_token).fetch_source(obj_id, include_photometry=True)
+    assert source.id == obj_id
+    assert len(public_source.photometry) - 1 == len(source.photometry)
+    assert photometry_id not in (x.id for x in source.photometry)
 
 
 def test_source_healpix(upload_data_token, view_only_token, public_group):
     obj_id = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id,
-            "ra": 229.9620403,
-            "dec": 34.8442757,
-            "redshift": 3,
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    client(upload_data_token).post_source(
+        SourcePost(
+            id=obj_id,
+            ra=229.9620403,
+            dec=34.8442757,
+            redshift=3,
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
 
-    status, data = api("GET", f"sources/{obj_id}", token=view_only_token)
-    assert status == 200
+    source = client(view_only_token).fetch_source(obj_id)
     healpix = ha.constants.HPX.lonlat_to_healpix(
         229.9620403 * u.deg, 34.8442757 * u.deg
     )
-    assert data["data"]["healpix"] == healpix
+    assert source.healpix == healpix
 
 
 def test_filter_sources_by_created_at(
@@ -2157,77 +1562,49 @@ def test_filter_sources_by_created_at(
     time_before_both = datetime.now(UTC)
 
     # Upload two new sources
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id1,
-            "ra": 234.22,
-            "dec": -22.33,
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    sp = client(upload_data_token)
+    saved = sp.post_source(
+        SourcePost(
+            id=obj_id1,
+            ra=234.22,
+            dec=-22.33,
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
-    assert data["data"]["id"] == obj_id1
+    assert saved.id == obj_id1
 
     partition_time = datetime.now(UTC)
 
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id2,
-            "ra": 234.22,
-            "dec": -22.33,
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    saved = sp.post_source(
+        SourcePost(
+            id=obj_id2,
+            ra=234.22,
+            dec=-22.33,
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
-    assert data["data"]["id"] == obj_id2
+    assert saved.id == obj_id2
 
     time_after_both = datetime.now(UTC)
 
     # Filter for obj 2 only
-    status, data = api(
-        "GET",
-        "sources",
-        params={
-            "createdOrModifiedAfter": str(partition_time),
-            "group_ids": f"{public_group.id}",
-        },
-        token=view_only_token,
+    page = client(view_only_token).fetch_sources(
+        created_or_modified_after=str(partition_time), group_ids=[public_group.id]
     )
-    assert status == 200
-    assert len(data["data"]["sources"]) == 1
-    assert data["data"]["sources"][0]["id"] == obj_id2
+    assert len(page.sources) == 1
+    assert page.sources[0].id == obj_id2
 
     # Fetch both
-    status, data = api(
-        "GET",
-        "sources",
-        params={
-            "createdOrModifiedAfter": str(time_before_both),
-            "group_ids": f"{public_group.id}",
-        },
-        token=view_only_token,
+    page = client(view_only_token).fetch_sources(
+        created_or_modified_after=str(time_before_both), group_ids=[public_group.id]
     )
-    assert status == 200
-    assert len(data["data"]["sources"]) == 2
+    assert len(page.sources) == 2
 
     # Filter both out
-    status, data = api(
-        "GET",
-        "sources",
-        params={
-            "createdOrModifiedAfter": str(time_after_both),
-            "group_ids": f"{public_group.id}",
-        },
-        token=view_only_token,
+    page = client(view_only_token).fetch_sources(
+        created_or_modified_after=str(time_after_both), group_ids=[public_group.id]
     )
-    assert status == 200
-    assert len(data["data"]["sources"]) == 0
+    assert len(page.sources) == 0
 
 
 def test_filter_sources_by_modified(
@@ -2239,113 +1616,64 @@ def test_filter_sources_by_modified(
     time_before_both = datetime.now(UTC)
 
     # Upload two new sources
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id1,
-            "ra": 234.22,
-            "dec": -22.33,
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    sp = client(upload_data_token)
+    saved = sp.post_source(
+        SourcePost(
+            id=obj_id1,
+            ra=234.22,
+            dec=-22.33,
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
-    assert data["data"]["id"] == obj_id1
+    assert saved.id == obj_id1
 
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id2,
-            "ra": 234.22,
-            "dec": -22.33,
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    saved = sp.post_source(
+        SourcePost(
+            id=obj_id2,
+            ra=234.22,
+            dec=-22.33,
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
-    assert data["data"]["id"] == obj_id2
+    assert saved.id == obj_id2
 
     partition_time = datetime.now(UTC)
 
-    status, data = api(
-        "PATCH",
-        f"sources/{obj_id2}",
-        data={
-            "ra": 234.11,
-            "dec": -22.11,
-        },
-        token=super_admin_token,
-    )
-    assert status == 200
+    client(super_admin_token).update_source(obj_id2, ra=234.11, dec=-22.11)
 
     time_after_both = datetime.now(UTC)
 
     # Filter for obj 2 only
-    status, data = api(
-        "GET",
-        "sources",
-        params={
-            "createdOrModifiedAfter": str(partition_time),
-            "group_ids": f"{public_group.id}",
-        },
-        token=view_only_token,
+    page = client(view_only_token).fetch_sources(
+        created_or_modified_after=str(partition_time), group_ids=[public_group.id]
     )
-    assert status == 200
-    assert len(data["data"]["sources"]) == 1
-    assert data["data"]["sources"][0]["id"] == obj_id2
+    assert len(page.sources) == 1
+    assert page.sources[0].id == obj_id2
 
     # Fetch both
-    status, data = api(
-        "GET",
-        "sources",
-        params={
-            "createdOrModifiedAfter": str(time_before_both),
-            "group_ids": f"{public_group.id}",
-        },
-        token=view_only_token,
+    page = client(view_only_token).fetch_sources(
+        created_or_modified_after=str(time_before_both), group_ids=[public_group.id]
     )
-    assert status == 200
-    assert len(data["data"]["sources"]) == 2
+    assert len(page.sources) == 2
 
     # Filter both out
-    status, data = api(
-        "GET",
-        "sources",
-        params={
-            "createdOrModifiedAfter": str(time_after_both),
-            "group_ids": f"{public_group.id}",
-        },
-        token=view_only_token,
+    page = client(view_only_token).fetch_sources(
+        created_or_modified_after=str(time_after_both), group_ids=[public_group.id]
     )
-    assert status == 200
-    assert len(data["data"]["sources"]) == 0
+    assert len(page.sources) == 0
 
 
 def test_token_user_retrieving_source_with_period_exists(
     view_only_token, public_source, annotation_token
 ):
-    status, data = api(
-        "POST",
-        f"sources/{public_source.id}/annotations",
-        data={
-            "origin": "kowalski",
-            "data": {"period": 1.5},
-        },
-        token=annotation_token,
+    client(annotation_token).post_annotation(
+        public_source.id, "kowalski", {"period": 1.5}
     )
-    assert status == 200
 
-    status, data = api(
-        "GET",
-        f"sources/{public_source.id}",
-        params={"includePeriodExists": "true"},
-        token=view_only_token,
+    source = client(view_only_token).fetch_source(
+        public_source.id, include_period_exists=True
     )
-    assert status == 200
-    assert data["status"] == "success"
-    assert data["data"]["period_exists"]
+    assert source.period_exists
 
 
 def test_token_user_retrieving_source_with_annotation_filter(
@@ -2354,123 +1682,74 @@ def test_token_user_retrieving_source_with_annotation_filter(
     annotation_name_1 = str(uuid.uuid4())
     annotation_name_2 = str(uuid.uuid4())
 
-    status, data = api(
-        "POST",
-        f"sources/{public_source.id}/annotations",
-        data={
-            "origin": "kowalski",
-            "data": {annotation_name_1: 1.5, annotation_name_2: 0.0},
-        },
-        token=annotation_token,
+    client(annotation_token).post_annotation(
+        public_source.id,
+        "kowalski",
+        {annotation_name_1: 1.5, annotation_name_2: 0.0},
     )
-    assert status == 200
 
-    status, data = api(
-        "POST",
-        f"sources/{public_source_two_groups.id}/annotations",
-        data={
-            "origin": "gloria",
-            "data": {annotation_name_1: 1.5, annotation_name_2: 1.0},
-        },
-        token=annotation_token,
+    client(annotation_token).post_annotation(
+        public_source_two_groups.id,
+        "gloria",
+        {annotation_name_1: 1.5, annotation_name_2: 1.0},
     )
-    assert status == 200
 
-    status, data = api(
-        "GET",
-        "sources",
-        params={
-            "annotationsFilter": f"{annotation_name_1}",
-            "sortBy": "saved_at",
-            "sortOrder": "desc",
-        },
-        token=super_admin_token,
+    sp = client(super_admin_token)
+    page = sp.fetch_sources(
+        annotations_filter=f"{annotation_name_1}",
+        sort_by="saved_at",
+        sort_order="desc",
     )
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]["sources"]) == 2
+    assert len(page.sources) == 2
 
-    status, data = api(
-        "GET",
-        "sources",
-        params={
-            "annotationsFilter": f"{annotation_name_1}:2.0:le",
-            "sortBy": "saved_at",
-            "sortOrder": "desc",
-        },
-        token=super_admin_token,
+    page = sp.fetch_sources(
+        annotations_filter=f"{annotation_name_1}:2.0:le",
+        sort_by="saved_at",
+        sort_order="desc",
     )
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]["sources"]) == 2
+    assert len(page.sources) == 2
 
-    status, data = api(
-        "GET",
-        "sources",
-        params={
-            "annotationsFilter": f"{annotation_name_1}:2.0:le",
-            "annotationsFilterOrigin": "kowalski",
-            "sortBy": "saved_at",
-            "sortOrder": "desc",
-        },
-        token=super_admin_token,
+    page = sp.fetch_sources(
+        annotations_filter=f"{annotation_name_1}:2.0:le",
+        annotations_filter_origin="kowalski",
+        sort_by="saved_at",
+        sort_order="desc",
     )
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]["sources"]) == 1
+    assert len(page.sources) == 1
 
-    status, data = api(
-        "GET",
-        "sources",
-        params={
-            "annotationsFilter": f"{annotation_name_1}:2.0:ge",
-            "sortBy": "saved_at",
-            "sortOrder": "desc",
-        },
-        token=super_admin_token,
+    page = sp.fetch_sources(
+        annotations_filter=f"{annotation_name_1}:2.0:ge",
+        sort_by="saved_at",
+        sort_order="desc",
     )
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]["sources"]) == 0
+    assert len(page.sources) == 0
 
-    status, data = api(
-        "GET",
-        "sources",
-        params={
-            "annotationsFilter": f"{annotation_name_1}:2.0:le,{annotation_name_2}:0.5:le",
-            "sortBy": "saved_at",
-            "sortOrder": "desc",
-        },
-        token=super_admin_token,
+    page = sp.fetch_sources(
+        annotations_filter=f"{annotation_name_1}:2.0:le,{annotation_name_2}:0.5:le",
+        sort_by="saved_at",
+        sort_order="desc",
     )
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]["sources"]) == 1
+    assert len(page.sources) == 1
 
 
 def test_add_source_redshift_origin(upload_data_token, view_only_token, public_group):
     obj_id = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id,
-            "ra": 234.22,
-            "dec": -22.33,
-            "redshift": 3,
-            "redshift_origin": "host-spectrum",
-            "transient": False,
-            "ra_dis": 2.3,
-        },
-        token=upload_data_token,
+    client(upload_data_token).post_source(
+        SourcePost(
+            id=obj_id,
+            ra=234.22,
+            dec=-22.33,
+            redshift=3,
+            redshift_origin="host-spectrum",
+            transient=False,
+            ra_dis=2.3,
+        )
     )
-    assert status == 200
-    status, data = api("GET", f"sources/{obj_id}", token=view_only_token)
-    assert status == 200
-    assert data["data"]["id"] == obj_id
+    source = client(view_only_token).fetch_source(obj_id)
+    assert source.id == obj_id
 
-    assert np.isclose(data["data"]["redshift"], 3)
-    assert data["data"]["redshift_origin"] == "host-spectrum"
+    assert np.isclose(source.redshift, 3)
+    assert source.redshift_origin == "host-spectrum"
 
 
 def test_token_user_retrieving_source_with_comment_filter(
@@ -2479,406 +1758,267 @@ def test_token_user_retrieving_source_with_comment_filter(
     comment_text = str(uuid.uuid4())
     comment_text_less = comment_text[:-4]
 
-    status, data = api(
-        "POST",
-        f"sources/{public_source.id}/comments",
-        data={
-            "text": comment_text,
-        },
-        token=comment_token,
-    )
-    assert status == 200
+    client(comment_token).post_comment(public_source.id, comment_text)
 
-    status, data = api(
-        "POST",
-        f"sources/{public_source_two_groups.id}/comments",
-        data={
-            "text": comment_text_less,
-        },
-        token=comment_token,
-    )
-    assert status == 200
+    client(comment_token).post_comment(public_source_two_groups.id, comment_text_less)
 
-    status, data = api(
-        "GET",
-        "sources",
-        params={
-            "commentsFilter": f"{comment_text_less}",
-            "sortBy": "saved_at",
-            "sortOrder": "desc",
-        },
-        token=super_admin_token,
+    page = client(super_admin_token).fetch_sources(
+        comments_filter=f"{comment_text_less}",
+        sort_by="saved_at",
+        sort_order="desc",
     )
-    assert status == 200
-    assert data["status"] == "success"
     # we support partial matches now, so we should get 2 sources here
-    assert len(data["data"]["sources"]) == 2
+    assert len(page.sources) == 2
 
-    status, data = api(
-        "GET",
-        "sources",
-        params={
-            "commentsFilter": f"{comment_text}",
-            "sortBy": "saved_at",
-            "sortOrder": "desc",
-        },
-        token=super_admin_token,
+    page = client(super_admin_token).fetch_sources(
+        comments_filter=f"{comment_text}",
+        sort_by="saved_at",
+        sort_order="desc",
     )
-    assert status == 200
-    assert data["status"] == "success"
     # but only one source here with the full comment
-    assert len(data["data"]["sources"]) == 1
+    assert len(page.sources) == 1
 
 
 def test_patch_healpix(
     super_admin_token, upload_data_token, view_only_token, public_group
 ):
     obj_id = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id,
-            "redshift": 3,
-            "group_ids": [public_group.id],
-            "ra": 234.22,
-            "dec": -22.33,
-        },
-        token=upload_data_token,
+    client(upload_data_token).post_source(
+        SourcePost(
+            id=obj_id,
+            redshift=3,
+            group_ids=[public_group.id],
+            ra=234.22,
+            dec=-22.33,
+        )
     )
-    assert status == 200
 
-    assert status == 200
-    status, data = api("GET", f"sources/{obj_id}", token=view_only_token)
-    assert status == 200
-    assert data["data"]["id"] == obj_id
-    assert data["data"]["healpix"] == 3120579787410559663
+    source = client(view_only_token).fetch_source(obj_id)
+    assert source.id == obj_id
+    assert source.healpix == 3120579787410559663
 
-    status, data = api(
-        "PATCH",
-        f"sources/{obj_id}",
-        data={
-            "ra": 230.22,
-            "dec": -22.33,
-            "transient": False,
-            "ra_dis": 2.3,
-            "redshift": 0.00001,
-        },
-        token=super_admin_token,
+    client(super_admin_token).update_source(
+        obj_id,
+        ra=230.22,
+        dec=-22.33,
+        transient=False,
+        ra_dis=2.3,
+        redshift=0.00001,
     )
-    assert status == 200
-    assert data["status"] == "success"
 
-    status, data = api("GET", f"sources/{obj_id}", token=view_only_token)
-    assert status == 200
-    assert data["data"]["id"] == obj_id
-    assert data["data"]["healpix"] == 3126137476541327364
+    source = client(view_only_token).fetch_source(obj_id)
+    assert source.id == obj_id
+    assert source.healpix == 3126137476541327364
 
 
 def test_filter_followup_request(
     upload_data_token, view_only_token, public_group, public_group_sedm_allocation
 ):
     obj_id = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id,
-            "ra": 234.22,
-            "dec": -22.33,
-        },
-        token=upload_data_token,
+    client(upload_data_token).post_source(
+        SourcePost(
+            id=obj_id,
+            ra=234.22,
+            dec=-22.33,
+        )
     )
-    assert status == 200
-    status, data = api("GET", f"sources/{obj_id}", token=view_only_token)
-    assert status == 200
-    assert data["data"]["id"] == obj_id
+    source = client(view_only_token).fetch_source(obj_id)
+    assert source.id == obj_id
 
-    request_data = {
-        "allocation_id": public_group_sedm_allocation.id,
-        "obj_id": obj_id,
-        "payload": {
-            "priority": 5,
-            "start_date": "3010-09-01",
-            "end_date": "3012-09-01",
-            "observation_type": "IFU",
-            "exposure_time": 300,
-            "maximum_airmass": 2,
-            "maximum_fwhm": 1.2,
-        },
-    }
-
-    status, data = api(
-        "POST", "followup_request", data=request_data, token=upload_data_token
+    client(upload_data_token).post_followup_request(
+        FollowupRequestPost(
+            allocation_id=public_group_sedm_allocation.id,
+            obj_id=obj_id,
+            payload={
+                "priority": 5,
+                "start_date": "3010-09-01",
+                "end_date": "3012-09-01",
+                "observation_type": "IFU",
+                "exposure_time": 300,
+                "maximum_airmass": 2,
+                "maximum_fwhm": 1.2,
+            },
+        )
     )
-    assert status == 200
-    assert data["status"] == "success"
 
-    params = {
-        "hasFollowupRequest": True,
-    }
-    status, data = api("GET", "sources", token=view_only_token, params=params)
-    assert status == 200
-    assert any(obj["id"] == obj_id for obj in data["data"]["sources"])
+    page = client(view_only_token).fetch_sources(has_followup_request=True)
+    assert any(obj.id == obj_id for obj in page.sources)
 
 
 def test_add_and_delete_source_label(upload_data_token, view_only_token, public_group):
     obj_id = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id,
-            "ra": 234.22,
-            "dec": -22.33,
-        },
-        token=upload_data_token,
+    client(upload_data_token).post_source(
+        SourcePost(
+            id=obj_id,
+            ra=234.22,
+            dec=-22.33,
+        )
     )
-    assert status == 200
 
-    params = {"includeLabellers": True}
-    status, data = api("GET", f"sources/{obj_id}", token=view_only_token, params=params)
-    assert status == 200
-    assert data["data"]["id"] == obj_id
+    source = client(view_only_token).fetch_source(obj_id, include_labellers=True)
+    assert source.id == obj_id
 
-    assert len(data["data"]["labellers"]) == 0
+    assert len(source.labellers) == 0
 
-    status, data = api(
-        "POST",
-        f"sources/{obj_id}/labels",
-        data={
-            "groupIds": [public_group.id],
-        },
-        token=upload_data_token,
-    )
-    assert status == 200
+    client(upload_data_token).post_source_labels(obj_id, [public_group.id])
 
-    params = {"includeLabellers": True}
-    status, data = api("GET", f"sources/{obj_id}", token=view_only_token, params=params)
-    assert status == 200
-    assert data["data"]["id"] == obj_id
+    source = client(view_only_token).fetch_source(obj_id, include_labellers=True)
+    assert source.id == obj_id
 
-    assert len(data["data"]["labellers"]) == 1
+    assert len(source.labellers) == 1
 
-    status, data = api(
-        "DELETE",
-        f"sources/{obj_id}/labels",
-        data={
-            "groupIds": [public_group.id],
-        },
-        token=upload_data_token,
-    )
-    assert status == 200
+    client(upload_data_token).delete_source_labels(obj_id, [public_group.id])
 
-    params = {"includeLabellers": True}
-    status, data = api("GET", f"sources/{obj_id}", token=view_only_token, params=params)
-    assert status == 200
-    assert data["data"]["id"] == obj_id
+    source = client(view_only_token).fetch_source(obj_id, include_labellers=True)
+    assert source.id == obj_id
 
-    assert len(data["data"]["labellers"]) == 0
+    assert len(source.labellers) == 0
 
 
 def test_copy_photometry_sources(
     public_group, upload_data_token, ztf_camera, view_only_token
 ):
+    sp = client(upload_data_token)
     obj_id1 = str(uuid.uuid4())
     obj_id2 = str(uuid.uuid4())
     ra = 200.0 * np.random.random()
     dec = 89.0 * np.random.random()
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id1,
-            "ra": ra,
-            "dec": dec,
-            "redshift": 3,
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    sp.post_source(
+        SourcePost(
+            id=obj_id1,
+            ra=ra,
+            dec=dec,
+            redshift=3,
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id2,
-            "ra": ra + 0.0001,
-            "dec": dec + 0.0005,
-            "redshift": 3,
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    sp.post_source(
+        SourcePost(
+            id=obj_id2,
+            ra=ra + 0.0001,
+            dec=dec + 0.0005,
+            redshift=3,
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": obj_id1,
-            "mjd": 59801.4,
-            "instrument_id": ztf_camera.id,
-            "filter": "ztfg",
-            "group_ids": [public_group.id],
-            "mag": 12.4,
-            "magerr": 0.3,
-            "limiting_mag": 22,
-            "magsys": "ab",
-        },
-        token=upload_data_token,
+    sp.post_photometry(
+        PhotometryPost(
+            obj_id=obj_id1,
+            mjd=59801.4,
+            instrument_id=ztf_camera.id,
+            filter="ztfg",
+            group_ids=[public_group.id],
+            mag=12.4,
+            magerr=0.3,
+            limiting_mag=22,
+            magsys="ab",
+        )
     )
-    assert status == 200
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": obj_id2,
-            "mjd": 59801.3,
-            "instrument_id": ztf_camera.id,
-            "filter": "ztfg",
-            "group_ids": [public_group.id],
-            "mag": 12.4,
-            "magerr": 0.3,
-            "limiting_mag": 22,
-            "magsys": "ab",
-        },
-        token=upload_data_token,
+    sp.post_photometry(
+        PhotometryPost(
+            obj_id=obj_id2,
+            mjd=59801.3,
+            instrument_id=ztf_camera.id,
+            filter="ztfg",
+            group_ids=[public_group.id],
+            mag=12.4,
+            magerr=0.3,
+            limiting_mag=22,
+            magsys="ab",
+        )
     )
-    assert status == 200
 
-    status, data = api(
-        "POST",
-        f"sources/{obj_id1}/copy_photometry",
-        data={
-            "origin_id": obj_id2,
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
-    )
-    assert status == 200
+    sp.post_source_photometry_copy(obj_id1, obj_id2, [public_group.id])
 
-    status, data = api(
-        "GET",
-        f"sources/{obj_id1}",
-        params={"includePhotometry": "true"},
-        token=view_only_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    assert any(np.isclose(p["mjd"], 59801.3) for p in data["data"]["photometry"])
+    source = client(view_only_token).fetch_source(obj_id1, include_photometry=True)
+    assert any(np.isclose(p.mjd, 59801.3) for p in source.photometry)
 
 
 def test_deduplicate_photometry(
     public_group, upload_data_token, ztf_camera, view_only_token
 ):
+    sp = client(upload_data_token)
     obj_id = str(uuid.uuid4())
     ra = 200.0 * np.random.random()
     dec = 89.0 * np.random.random()
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id,
-            "ra": ra,
-            "dec": dec,
-            "redshift": 3,
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    sp.post_source(
+        SourcePost(
+            id=obj_id,
+            ra=ra,
+            dec=dec,
+            redshift=3,
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": obj_id,
-            "mjd": 59801.4,
-            "instrument_id": ztf_camera.id,
-            "filter": "ztfg",
-            "group_ids": [public_group.id],
-            "mag": 12.4,
-            "magerr": 0.3,
-            "limiting_mag": 22,
-            "magsys": "ab",
-        },
-        token=upload_data_token,
+    sp.post_photometry(
+        PhotometryPost(
+            obj_id=obj_id,
+            mjd=59801.4,
+            instrument_id=ztf_camera.id,
+            filter="ztfg",
+            group_ids=[public_group.id],
+            mag=12.4,
+            magerr=0.3,
+            limiting_mag=22,
+            magsys="ab",
+        )
     )
-    assert status == 200
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": obj_id,
-            "mjd": 59801.4,
-            "instrument_id": ztf_camera.id,
-            "filter": "ztfg",
-            "group_ids": [public_group.id],
-            "mag": 12.8,
-            "magerr": 0.3,
-            "limiting_mag": 22,
-            "magsys": "ab",
-        },
-        token=upload_data_token,
+    sp.post_photometry(
+        PhotometryPost(
+            obj_id=obj_id,
+            mjd=59801.4,
+            instrument_id=ztf_camera.id,
+            filter="ztfg",
+            group_ids=[public_group.id],
+            mag=12.8,
+            magerr=0.3,
+            limiting_mag=22,
+            magsys="ab",
+        )
     )
-    assert status == 200
 
-    status, data = api(
-        "GET",
-        f"sources/{obj_id}",
-        params={"includePhotometry": "true"},
-        token=view_only_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]["photometry"]) == 2
+    source = client(view_only_token).fetch_source(obj_id, include_photometry=True)
+    assert len(source.photometry) == 2
 
-    status, data = api(
-        "GET",
-        f"sources/{obj_id}",
-        params={"includePhotometry": "true", "deduplicatePhotometry": "true"},
-        token=view_only_token,
+    source = client(view_only_token).fetch_source(
+        obj_id, include_photometry=True, deduplicate_photometry=True
     )
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]["photometry"]) == 1
+    assert len(source.photometry) == 1
     # should be the second one (which is first in the list)
-    assert np.isclose(data["data"]["photometry"][0]["mag"], 12.8)
+    assert np.isclose(source.photometry[0].mag, 12.8)
 
 
 def test_source_gcn_crossmatch_event_filters(upload_data_token, public_source):
+    sp = client(upload_data_token)
     # The crossmatch endpoint accepts GCN/localization tag+property cuts. A
     # malformed property filter is rejected synchronously (before the async
     # crossmatch), via the shared apply_gcn_event_filters helper.
-    status, data = api(
-        "POST",
-        f"sources/{public_source.id}/gcn_event",
-        data={
-            "startDate": "2019-08-13T08:18:05",
-            "endDate": "2019-08-19T08:18:05",
-            "gcnPropertiesFilter": ["BNS:0.5"],  # 2 parts -> invalid (needs 1 or 3)
-        },
-        token=upload_data_token,
-    )
-    assert status == 400
-    assert "gcnPropertiesFilter" in data["message"]
+    with pytest.raises(SkyPortalError, match="gcnPropertiesFilter") as err:
+        sp.post_source_gcn_event_crossmatch(
+            public_source.id,
+            SourceGcnEventCrossmatchPost(
+                start_date="2019-08-13T08:18:05",
+                end_date="2019-08-19T08:18:05",
+                gcn_properties_filter=["BNS:0.5"],  # 2 parts -> invalid (needs 1 or 3)
+            ),
+        )
+    assert err.value.status_code == 400
 
     # Well-formed tag/property cuts are accepted (no matching events in range is
     # reported separately, so just confirm the filter params parse and apply).
-    status, data = api(
-        "POST",
-        f"sources/{public_source.id}/gcn_event",
-        data={
-            "startDate": "2019-08-13T08:18:05",
-            "endDate": "2019-08-19T08:18:05",
-            "gcnTagKeep": ["GW"],
-            "gcnPropertiesFilter": ["FAR:1.0:lt"],
-        },
-        token=upload_data_token,
-    )
     # No GCN events exist in that window in this test, so the endpoint reports
     # that rather than a filter error.
-    assert status == 400
-    assert "Cannot find GcnEvents" in data["message"]
+    with pytest.raises(SkyPortalError, match="Cannot find GcnEvents") as err:
+        sp.post_source_gcn_event_crossmatch(
+            public_source.id,
+            SourceGcnEventCrossmatchPost(
+                start_date="2019-08-13T08:18:05",
+                end_date="2019-08-19T08:18:05",
+                gcn_tag_keep=["GW"],
+                gcn_properties_filter=["FAR:1.0:lt"],
+            ),
+        )
+    assert err.value.status_code == 400
 
 
 def test_source_gcn_crossmatch_returns_associated_events(
@@ -2916,14 +2056,10 @@ def test_source_gcn_crossmatch_returns_associated_events(
     session.commit()
 
     try:
-        status, data = api(
-            "GET",
-            f"sources/{public_source.id}",
-            params={"includeGCNCrossmatches": "true"},
-            token=super_admin_token,
+        source = client(super_admin_token).fetch_source(
+            public_source.id, include_gcn_crossmatches=True
         )
-        assert status == 200, data
-        crossmatches = data["data"]["gcn_crossmatch"]
+        crossmatches = source.gcn_crossmatch
         found = {arrow.get(c["dateobs"]).naive for c in crossmatches}
         assert dateobs in found, crossmatches
         assert rejected_dateobs in found, (

--- a/skyportal/tests/api_tests/sources_candidates/test_sources.py
+++ b/skyportal/tests/api_tests/sources_candidates/test_sources.py
@@ -70,17 +70,10 @@ def test_token_user_retrieving_source_with_phot_exists(view_only_token, public_s
     source = client(view_only_token).fetch_source(
         public_source.id, include_photometry_exists=True
     )
+    # the original asserted key presence; dm can legitimately be null
+    assert source.photometry_exists is not None
     assert all(
-        getattr(source, k) is not None
-        for k in [
-            "ra",
-            "dec",
-            "redshift",
-            "dm",
-            "created_at",
-            "id",
-            "photometry_exists",
-        ]
+        getattr(source, k) is not None for k in ["ra", "dec", "created_at", "id"]
     )
 
 

--- a/skyportal/tests/api_tests/sources_candidates/test_sources.py
+++ b/skyportal/tests/api_tests/sources_candidates/test_sources.py
@@ -1466,14 +1466,10 @@ def test_sources_filter_by_has_tns_name(
     assert page.sources[0].id == obj_id1
 
     # An explicit "false" must not enable the filter (it used to be truthy)
-    status, data = api(
-        "GET",
-        "sources",
-        params={"hasTNSname": "false", "group_ids": f"{public_group.id}"},
-        token=view_only_token,
+    page = client(view_only_token).fetch_sources(
+        has_tns_name=False, group_ids=[public_group.id]
     )
-    assert status == 200
-    returned_ids = {s["id"] for s in data["data"]["sources"]}
+    returned_ids = {s.id for s in page.sources}
     assert {obj_id1, obj_id2}.issubset(returned_ids)
 
 

--- a/skyportal/tests/api_tests/sources_candidates/test_streams.py
+++ b/skyportal/tests/api_tests/sources_candidates/test_streams.py
@@ -1,196 +1,121 @@
 import uuid
 
-from skyportal.tests import api
+import pytest
+from skyportal_py import SkyPortalError
+
+from skyportal.tests import client
 
 
 def test_token_user_post_new_stream(super_admin_token, public_stream):
-    status, data = api(
-        "POST",
-        "streams",
-        data={
-            "name": str(uuid.uuid4()),
-            "altdata": {"collection": "ZTF_alerts", "selector": [1, 2, 3]},
-        },
-        token=super_admin_token,
-    )
-    assert status == 200
-    stream_id = data["data"]["id"]
+    sp = client(super_admin_token)
+    stream_id = sp.post_stream(
+        str(uuid.uuid4()),
+        altdata={"collection": "ZTF_alerts", "selector": [1, 2, 3]},
+    ).id
 
-    status, data = api("GET", f"streams/{stream_id}", token=super_admin_token)
-    assert status == 200
-    assert data["data"]["id"] == stream_id
+    assert sp.fetch_stream(stream_id).id == stream_id
 
 
 def test_token_user_update_stream(super_admin_token, public_stream):
+    sp = client(super_admin_token)
     new_name = str(uuid.uuid4())
-    status, data = api(
-        "PATCH",
-        f"streams/{public_stream.id}",
-        data={"name": new_name},
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp.update_stream(public_stream.id, new_name)
 
-    status, data = api("GET", f"streams/{public_stream.id}", token=super_admin_token)
-    assert status == 200
-    assert data["data"]["name"] == new_name
+    assert sp.fetch_stream(public_stream.id).name == new_name
 
 
 def test_token_user_delete_stream(super_admin_token, public_stream):
-    status, data = api(
-        "POST",
-        "streams",
-        data={
-            "name": str(uuid.uuid4()),
-            "altdata": {"collection": "ZTF_alerts", "selector": [1, 2, 3]},
-        },
-        token=super_admin_token,
-    )
-    assert status == 200
-    stream_id = data["data"]["id"]
+    sp = client(super_admin_token)
+    stream_id = sp.post_stream(
+        str(uuid.uuid4()),
+        altdata={"collection": "ZTF_alerts", "selector": [1, 2, 3]},
+    ).id
 
-    status, data = api("DELETE", f"streams/{stream_id}", token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
+    sp.delete_stream(stream_id)
 
 
 def test_super_admin_grant_delete_user_stream_access(
     super_admin_token, user, public_stream2
 ):
-    status, data = api(
-        "POST",
-        f"streams/{public_stream2.id}/users",
-        data={"user_id": user.id},
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-
-    status, data = api(
-        "DELETE",
-        f"streams/{public_stream2.id}/users/{user.id}",
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp = client(super_admin_token)
+    sp.post_stream_user(public_stream2.id, user.id)
+    sp.delete_stream_user(public_stream2.id, user.id)
 
 
 def test_group_admin_cannot_grant_delete_user_stream_access(
     group_admin_token, user, public_stream, public_stream2
 ):
+    sp = client(group_admin_token)
     # Non-admins cannot grant access to other users (public_stream2 is not
     # auto-join), so the handler rejects the request.
-    status, data = api(
-        "POST",
-        f"streams/{public_stream2.id}/users",
-        data={"user_id": user.id},
-        token=group_admin_token,
-    )
-    assert status == 400
-    assert "Insufficient permissions" in data["message"]
+    with pytest.raises(SkyPortalError, match="Insufficient permissions") as err:
+        sp.post_stream_user(public_stream2.id, user.id)
+    assert err.value.status_code == 400
 
-    status, data = api(
-        "DELETE", f"streams/{public_stream.id}/users/{user.id}", token=group_admin_token
-    )
-    assert status == 401
+    with pytest.raises(SkyPortalError) as err:
+        sp.delete_stream_user(public_stream.id, user.id)
+    assert err.value.status_code == 401
 
 
 def test_user_cannot_grant_self_stream_access(view_only_token, user, public_stream2):
     # public_stream2 is not auto-join, so a user cannot add themselves.
-    status, data = api(
-        "POST",
-        f"streams/{public_stream2.id}/users",
-        data={"user_id": user.id},
-        token=view_only_token,
-    )
-    assert status == 400
-    assert "Insufficient permissions" in data["message"]
+    with pytest.raises(SkyPortalError, match="Insufficient permissions") as err:
+        client(view_only_token).post_stream_user(public_stream2.id, user.id)
+    assert err.value.status_code == 400
 
 
 def test_auto_join_stream_visible_to_non_member(
     super_admin_token, view_only_token, user, public_stream2
 ):
+    sp = client(view_only_token)
     # public_stream2 is not one of the user's streams and is not auto-join, so
     # the user cannot see it...
-    status, data = api("GET", f"streams/{public_stream2.id}", token=view_only_token)
-    assert status == 400
-    assert "Could not retrieve stream" in data["message"]
+    with pytest.raises(SkyPortalError, match="Could not retrieve stream") as err:
+        sp.fetch_stream(public_stream2.id)
+    assert err.value.status_code == 400
 
-    status, listing = api("GET", "streams", token=view_only_token)
-    assert status == 200
-    assert public_stream2.id not in [s["id"] for s in listing["data"]]
+    assert public_stream2.id not in [s.id for s in sp.fetch_streams()]
 
     # ...but once flagged auto-join it becomes visible (for discovery/joining),
     # even though the user is not yet a member.
-    status, data = api(
-        "PATCH",
-        f"streams/{public_stream2.id}",
-        data={"name": public_stream2.name, "auto_join": True},
-        token=super_admin_token,
+    client(super_admin_token).update_stream(
+        public_stream2.id, public_stream2.name, auto_join=True
     )
-    assert status == 200
 
-    status, data = api("GET", f"streams/{public_stream2.id}", token=view_only_token)
-    assert status == 200
-    assert data["data"]["id"] == public_stream2.id
-    assert data["data"]["auto_join"] is True
+    stream = sp.fetch_stream(public_stream2.id)
+    assert stream.id == public_stream2.id
+    assert stream.auto_join is True
 
-    status, listing = api("GET", "streams", token=view_only_token)
-    assert status == 200
-    assert public_stream2.id in [s["id"] for s in listing["data"]]
+    assert public_stream2.id in [s.id for s in sp.fetch_streams()]
 
 
 def test_user_can_self_join_auto_join_stream(
     super_admin_token, view_only_token, user, public_stream2
 ):
     # Flag the stream as auto-join
-    status, data = api(
-        "PATCH",
-        f"streams/{public_stream2.id}",
-        data={"name": public_stream2.name, "auto_join": True},
-        token=super_admin_token,
+    client(super_admin_token).update_stream(
+        public_stream2.id, public_stream2.name, auto_join=True
     )
-    assert status == 200
 
     # The user can now add themselves
-    status, data = api(
-        "POST",
-        f"streams/{public_stream2.id}/users",
-        data={"user_id": user.id},
-        token=view_only_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp = client(view_only_token)
+    sp.post_stream_user(public_stream2.id, user.id)
 
     # ...and the stream is now readable by (accessible to) the user
-    status, data = api("GET", f"streams/{public_stream2.id}", token=view_only_token)
-    assert status == 200
-    assert data["data"]["id"] == public_stream2.id
+    assert sp.fetch_stream(public_stream2.id).id == public_stream2.id
 
     # ...and shows up among the user's own streams in their profile
-    status, data = api("GET", "internal/profile", token=view_only_token)
-    assert status == 200
-    assert public_stream2.id in [s["id"] for s in data["data"]["streams"]]
+    assert public_stream2.id in [s.id for s in sp.fetch_profile().streams]
 
 
 def test_user_cannot_add_other_user_to_auto_join_stream(
     super_admin_token, view_only_token, user2, public_stream2
 ):
     # Even on an auto-join stream, a non-admin may add only themselves.
-    status, data = api(
-        "PATCH",
-        f"streams/{public_stream2.id}",
-        data={"name": public_stream2.name, "auto_join": True},
-        token=super_admin_token,
+    client(super_admin_token).update_stream(
+        public_stream2.id, public_stream2.name, auto_join=True
     )
-    assert status == 200
 
-    status, data = api(
-        "POST",
-        f"streams/{public_stream2.id}/users",
-        data={"user_id": user2.id},
-        token=view_only_token,
-    )
-    assert status == 400
-    assert "Insufficient permissions" in data["message"]
+    with pytest.raises(SkyPortalError, match="Insufficient permissions") as err:
+        client(view_only_token).post_stream_user(public_stream2.id, user2.id)
+    assert err.value.status_code == 400

--- a/skyportal/tests/api_tests/sources_candidates/test_super_obj.py
+++ b/skyportal/tests/api_tests/sources_candidates/test_super_obj.py
@@ -14,28 +14,31 @@ import uuid
 
 import sqlalchemy as sa
 from PIL import Image
+from skyportal_py.classifications import ClassificationPost
+from skyportal_py.photometry import PhotometryPost
+from skyportal_py.taxonomies import TaxonomyPost
+from skyportal_py.thumbnails import ThumbnailPost
 from tdtax import __version__, taxonomy
 
 from skyportal.models import DBSession, Obj, SuperObj
-from skyportal.tests import api
+from skyportal.tests import client
 
 
 def _post_thumbnail(token, obj_id, ttype, survey):
     buf = io.BytesIO()
     Image.new("RGB", (16, 16), (10, 20, 30)).save(buf, format="PNG")
-    status, data = api(
-        "POST",
-        "thumbnail",
-        data={
-            "obj_id": obj_id,
-            "data": base64.b64encode(buf.getvalue()).decode("utf-8"),
-            "ttype": ttype,
-            "survey": survey,
-        },
-        token=token,
+    return (
+        client(token)
+        .post_thumbnail(
+            ThumbnailPost(
+                obj_id=obj_id,
+                data=base64.b64encode(buf.getvalue()).decode("utf-8"),
+                ttype=ttype,
+                survey=survey,
+            )
+        )
+        .id
     )
-    assert status == 200, data
-    return data["data"]["id"]
 
 
 def _link_super_obj(obj_ids):
@@ -63,63 +66,60 @@ def _link_super_obj(obj_ids):
 
 
 def _obj_ids(entries):
-    return {e["obj_id"] for e in entries}
+    return {e.obj_id for e in entries}
 
 
 def _post_taxonomy(token, group_ids):
-    status, data = api(
-        "POST",
-        "taxonomy",
-        data={
-            "name": "test taxonomy" + str(uuid.uuid4()),
-            "hierarchy": taxonomy,
-            "group_ids": group_ids,
-            "provenance": f"tdtax_{__version__}",
-            "version": __version__,
-            "isLatest": True,
-        },
-        token=token,
+    return (
+        client(token)
+        .post_taxonomy(
+            TaxonomyPost(
+                name="test taxonomy" + str(uuid.uuid4()),
+                hierarchy=taxonomy,
+                group_ids=group_ids,
+                provenance=f"tdtax_{__version__}",
+                version=__version__,
+                is_latest=True,
+            )
+        )
+        .taxonomy_id
     )
-    assert status == 200, data
-    return data["data"]["taxonomy_id"]
 
 
 def _post_classification(token, obj_id, taxonomy_id, group_ids, classification):
-    status, data = api(
-        "POST",
-        "classification",
-        data={
-            "obj_id": obj_id,
-            "classification": classification,
-            "taxonomy_id": taxonomy_id,
-            "probability": 1.0,
-            "group_ids": group_ids,
-        },
-        token=token,
+    return (
+        client(token)
+        .post_classification(
+            ClassificationPost(
+                obj_id=obj_id,
+                classification=classification,
+                taxonomy_id=taxonomy_id,
+                probability=1.0,
+                group_ids=group_ids,
+            )
+        )
+        .classification_id
     )
-    assert status == 200, data
-    return data["data"]["classification_id"]
 
 
 def _post_photometry(token, obj_id, instrument_id, group_ids, mjd):
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": obj_id,
-            "mjd": mjd,
-            "instrument_id": instrument_id,
-            "flux": 12.24,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "group_ids": group_ids,
-        },
-        token=token,
+    return (
+        client(token)
+        .post_photometry(
+            PhotometryPost(
+                obj_id=obj_id,
+                mjd=mjd,
+                instrument_id=instrument_id,
+                flux=12.24,
+                fluxerr=0.031,
+                zp=25.0,
+                magsys="ab",
+                filter="ztfg",
+                group_ids=group_ids,
+            )
+        )
+        .ids[0]
     )
-    assert status == 200, data
-    return data["data"]["ids"][0]
 
 
 def _seed_obj(token, obj_id, group_id, taxonomy_id, label):
@@ -127,45 +127,18 @@ def _seed_obj(token, obj_id, group_id, taxonomy_id, label):
     scoped to group_id. label distinguishes this obj's entries."""
     _post_classification(token, obj_id, taxonomy_id, [group_id], "RRab")
 
-    status, data = api(
-        "POST",
-        f"sources/{obj_id}/annotations",
-        data={
-            "origin": f"origin_{label}",
-            "data": {f"key_{label}": label},
-            "group_ids": [group_id],
-        },
-        token=token,
+    sp = client(token)
+    sp.post_annotation(
+        obj_id,
+        f"origin_{label}",
+        {f"key_{label}": label},
+        group_ids=[group_id],
     )
-    assert status == 200, data
 
-    status, data = api(
-        "POST",
-        f"sources/{obj_id}/comments",
-        data={"text": f"comment_{label}", "group_ids": [group_id]},
-        token=token,
-    )
-    assert status == 200, data
+    sp.post_comment(obj_id, f"comment_{label}", group_ids=[group_id])
 
-    status, data = api(
-        "POST",
-        "objtagoption",
-        data={"name": f"Tag{label}{uuid.uuid4().hex[:8]}"},
-        token=token,
-    )
-    assert status == 200, data
-    objtagoption_id = data["data"]["id"]
-    status, data = api(
-        "POST",
-        "objtag",
-        data={
-            "objtagoption_id": objtagoption_id,
-            "obj_id": obj_id,
-            "group_ids": [group_id],
-        },
-        token=token,
-    )
-    assert status == 200, data
+    objtagoption_id = sp.post_obj_tag_option(f"Tag{label}{uuid.uuid4().hex[:8]}").id
+    sp.post_obj_tag(obj_id, objtagoption_id, group_ids=[group_id])
 
 
 def test_super_obj_flag_on_without_super_obj_is_noop(
@@ -184,39 +157,24 @@ def test_super_obj_flag_on_without_super_obj_is_noop(
     _seed_obj(super_admin_token, obj1, public_group.id, taxonomy_id, "solo")
     _post_photometry(super_admin_token, obj1, ztf_camera.id, [public_group.id], 58000.0)
 
+    sp = client(super_admin_token)
+
     # Embedded source response: flag on, but no SuperObj -> own entries only.
-    status, data = api(
-        "GET",
-        f"sources/{obj1}?includeSuperObjs=true&includeComments=true",
-        token=super_admin_token,
-    )
-    assert status == 200, data
-    src = data["data"]
+    src = sp.fetch_source(obj1, include_super_objs=True, include_comments=True)
     for key in ["classifications", "annotations", "comments", "tags"]:
-        assert _obj_ids(src[key]) == {obj1}, f"{key} changed for a non-meta source"
+        assert _obj_ids(getattr(src, key)) == {obj1}, (
+            f"{key} changed for a non-meta source"
+        )
 
     # Per-type endpoints: flag on is likewise a no-op.
-    status, data = api(
-        "GET",
-        f"sources/{obj1}/classifications?includeSuperObjs=true",
-        token=super_admin_token,
-    )
-    assert status == 200, data
-    assert _obj_ids(data["data"]) == {obj1}
+    classes = sp.fetch_classifications(obj1, include_super_objs=True)
+    assert _obj_ids(classes) == {obj1}
 
-    status, data = api(
-        "GET", f"objtag?obj_id={obj1}&includeSuperObjs=true", token=super_admin_token
-    )
-    assert status == 200, data
-    assert _obj_ids(data["data"]) == {obj1}
+    tags = sp.fetch_obj_tags(obj_id=obj1, include_super_objs=True)
+    assert _obj_ids(tags) == {obj1}
 
-    status, data = api(
-        "GET",
-        f"sources/{obj1}/photometry?includeSuperObjsPhotometry=true",
-        token=super_admin_token,
-    )
-    assert status == 200, data
-    assert {p["obj_id"] for p in data["data"]} == {obj1}
+    points = sp.fetch_photometry(obj1, include_super_objs_photometry=True)
+    assert {p.obj_id for p in points} == {obj1}
 
 
 def test_super_obj_photometry_aggregation_and_rls(
@@ -242,26 +200,21 @@ def test_super_obj_photometry_aggregation_and_rls(
 
     super_obj_id, teardown = _link_super_obj([obj1, obj2])
     try:
-        url = f"sources/{obj1}/photometry"
-
         # --- Flag off: only the source's own photometry ---
-        status, data = api("GET", url, token=super_admin_token)
-        assert status == 200, data
-        assert {p["obj_id"] for p in data["data"]} == {obj1}
+        points = client(super_admin_token).fetch_photometry(obj1)
+        assert {p.obj_id for p in points} == {obj1}
 
         # --- Flag on, admin: union across both linked Objs, with provenance ---
-        status, data = api(
-            "GET", f"{url}?includeSuperObjsPhotometry=true", token=super_admin_token
+        points = client(super_admin_token).fetch_photometry(
+            obj1, include_super_objs_photometry=True
         )
-        assert status == 200, data
-        assert {p["obj_id"] for p in data["data"]} == {obj1, obj2}
+        assert {p.obj_id for p in points} == {obj1, obj2}
 
         # --- Flag on, RLS: a group1-only user must NOT see group2's points ---
-        status, data = api(
-            "GET", f"{url}?includeSuperObjsPhotometry=true", token=view_only_token
+        points = client(view_only_token).fetch_photometry(
+            obj1, include_super_objs_photometry=True
         )
-        assert status == 200, data
-        assert {p["obj_id"] for p in data["data"]} == {obj1}
+        assert {p.obj_id for p in points} == {obj1}
     finally:
         teardown()
 
@@ -296,50 +249,41 @@ def test_super_obj_classification_aggregation_and_rls(
     super_obj_id, teardown = _link_super_obj([obj1, obj2])
     try:
         # --- Flag off: behavior is unchanged (only the source's own class.) ---
-        status, data = api("GET", f"sources/{obj1}", token=super_admin_token)
-        assert status == 200, data
-        classes = data["data"]["classifications"]
-        assert {c["classification"] for c in classes} == {"RRab"}
-        assert all(c["obj_id"] == obj1 for c in classes)
+        classes = client(super_admin_token).fetch_source(obj1).classifications
+        assert {c.classification for c in classes} == {"RRab"}
+        assert all(c.obj_id == obj1 for c in classes)
 
         # --- Flag on, admin: union across both linked Objs, with provenance ---
-        status, data = api(
-            "GET", f"sources/{obj1}?includeSuperObjs=true", token=super_admin_token
+        classes = (
+            client(super_admin_token)
+            .fetch_source(obj1, include_super_objs=True)
+            .classifications
         )
-        assert status == 200, data
-        classes = data["data"]["classifications"]
-        assert {c["classification"] for c in classes} == {"RRab", "RRc"}
-        by_class = {c["classification"]: c["obj_id"] for c in classes}
+        assert {c.classification for c in classes} == {"RRab", "RRc"}
+        by_class = {c.classification: c.obj_id for c in classes}
         assert by_class["RRab"] == obj1
         assert by_class["RRc"] == obj2  # provenance: traceable to source B
 
         # --- Flag on, RLS: a group1-only user must NOT see group2's class. ---
-        status, data = api(
-            "GET", f"sources/{obj1}?includeSuperObjs=true", token=view_only_token
+        classes = (
+            client(view_only_token)
+            .fetch_source(obj1, include_super_objs=True)
+            .classifications
         )
-        assert status == 200, data
-        classes = data["data"]["classifications"]
-        assert {c["classification"] for c in classes} == {"RRab"}
-        assert all(c["obj_id"] == obj1 for c in classes)
+        assert {c.classification for c in classes} == {"RRab"}
+        assert all(c.obj_id == obj1 for c in classes)
 
         # --- Per-type endpoint honors the same flag (admin: union) ---
-        status, data = api(
-            "GET",
-            f"sources/{obj1}/classifications?includeSuperObjs=true",
-            token=super_admin_token,
+        classes = client(super_admin_token).fetch_classifications(
+            obj1, include_super_objs=True
         )
-        assert status == 200, data
-        classes = data["data"]
-        assert {c["classification"] for c in classes} == {"RRab", "RRc"}
+        assert {c.classification for c in classes} == {"RRab", "RRc"}
 
         # --- Per-type endpoint, RLS: group1-only user sees only its own ---
-        status, data = api(
-            "GET",
-            f"sources/{obj1}/classifications?includeSuperObjs=true",
-            token=view_only_token,
+        classes = client(view_only_token).fetch_classifications(
+            obj1, include_super_objs=True
         )
-        assert status == 200, data
-        assert {c["classification"] for c in data["data"]} == {"RRab"}
+        assert {c.classification for c in classes} == {"RRab"}
     finally:
         teardown()
 
@@ -367,52 +311,40 @@ def test_super_obj_all_aggregations_and_rls(
     super_obj_id, teardown = _link_super_obj([obj1, obj2])
     try:
         # --- Flag off: each type is just the source's own (no aggregation) ---
-        status, data = api(
-            "GET", f"sources/{obj1}?includeComments=true", token=super_admin_token
-        )
-        assert status == 200, data
-        src = data["data"]
+        src = client(super_admin_token).fetch_source(obj1, include_comments=True)
         for key in ["classifications", "annotations", "comments", "tags"]:
-            assert _obj_ids(src[key]) == {obj1}, f"{key} should be obj1-only when off"
+            assert _obj_ids(getattr(src, key)) == {obj1}, (
+                f"{key} should be obj1-only when off"
+            )
 
         # --- Flag on, admin: every type is the union across both linked Objs ---
-        status, data = api(
-            "GET",
-            f"sources/{obj1}?includeSuperObjs=true&includeComments=true",
-            token=super_admin_token,
+        src = client(super_admin_token).fetch_source(
+            obj1, include_super_objs=True, include_comments=True
         )
-        assert status == 200, data
-        src = data["data"]
         for key in ["classifications", "annotations", "comments", "tags"]:
-            assert _obj_ids(src[key]) == {obj1, obj2}, f"{key} union missing a source"
+            assert _obj_ids(getattr(src, key)) == {obj1, obj2}, (
+                f"{key} union missing a source"
+            )
 
         # --- Flag on, RLS: a group1-only user sees only the group1 source ---
-        status, data = api(
-            "GET",
-            f"sources/{obj1}?includeSuperObjs=true&includeComments=true",
-            token=view_only_token,
+        src = client(view_only_token).fetch_source(
+            obj1, include_super_objs=True, include_comments=True
         )
-        assert status == 200, data
-        src = data["data"]
         for key in ["classifications", "annotations", "comments", "tags"]:
-            assert _obj_ids(src[key]) == {obj1}, f"{key} leaked a forbidden source"
+            assert _obj_ids(getattr(src, key)) == {obj1}, (
+                f"{key} leaked a forbidden source"
+            )
 
         # --- Per-type tag endpoint honors the flag + RLS too ---
-        status, data = api(
-            "GET",
-            f"objtag?obj_id={obj1}&includeSuperObjs=true",
-            token=super_admin_token,
+        tags = client(super_admin_token).fetch_obj_tags(
+            obj_id=obj1, include_super_objs=True
         )
-        assert status == 200, data
-        assert _obj_ids(data["data"]) == {obj1, obj2}
+        assert _obj_ids(tags) == {obj1, obj2}
 
-        status, data = api(
-            "GET",
-            f"objtag?obj_id={obj1}&includeSuperObjs=true",
-            token=view_only_token,
+        tags = client(view_only_token).fetch_obj_tags(
+            obj_id=obj1, include_super_objs=True
         )
-        assert status == 200, data
-        assert _obj_ids(data["data"]) == {obj1}
+        assert _obj_ids(tags) == {obj1}
     finally:
         teardown()
 
@@ -432,31 +364,21 @@ def test_super_obj_thumbnail_aggregation(
     _post_thumbnail(super_admin_token, obj1, "new", "ZTF")
     _post_thumbnail(super_admin_token, obj2, "new", "LSST")
 
-    def new_pairs(payload):
-        return {
-            (t.get("survey"), t["obj_id"])
-            for t in payload["data"]["thumbnails"]
-            if t["type"] == "new"
-        }
+    def new_pairs(source):
+        return {(t.survey, t.obj_id) for t in source.thumbnails if t.type == "new"}
 
     super_obj_id, teardown = _link_super_obj([obj1, obj2])
     try:
         # Flag off: only the source's own cutout (survey-tagged), not the link's.
-        status, data = api(
-            "GET", f"sources/{obj1}?includeThumbnails=true", token=super_admin_token
-        )
-        assert status == 200, data
-        pairs = new_pairs(data)
+        source = client(super_admin_token).fetch_source(obj1, include_thumbnails=True)
+        pairs = new_pairs(source)
         assert ("ZTF", obj1) in pairs
         assert not any(oid == obj2 for _, oid in pairs)
 
         # Flag on: both surveys' cutouts, each carrying its survey label.
-        status, data = api(
-            "GET",
-            f"sources/{obj1}?includeThumbnails=true&includeSuperObjs=true",
-            token=super_admin_token,
+        source = client(super_admin_token).fetch_source(
+            obj1, include_thumbnails=True, include_super_objs=True
         )
-        assert status == 200, data
-        assert {("ZTF", obj1), ("LSST", obj2)} <= new_pairs(data)
+        assert {("ZTF", obj1), ("LSST", obj2)} <= new_pairs(source)
     finally:
         teardown()

--- a/skyportal/tests/api_tests/sources_candidates/test_super_obj_api.py
+++ b/skyportal/tests/api_tests/sources_candidates/test_super_obj_api.py
@@ -1,180 +1,123 @@
 import uuid
 
-from skyportal.tests import api
+import pytest
+from skyportal_py import SkyPortalError
+
+from skyportal.tests import client
 
 
 def test_super_obj_create_and_retrieve(
     super_admin_token, public_source, public_source_two_groups
 ):
+    sp = client(super_admin_token)
     name = f"asteroid-{uuid.uuid4().hex}"
-    status, data = api(
-        "POST",
-        "super_objs",
-        data={
-            "name": name,
-            "is_roid": True,
-            "obj_ids": [public_source.id, public_source_two_groups.id],
-        },
-        token=super_admin_token,
-    )
-    assert status == 200
-    super_obj_id = data["data"]["id"]
+    super_obj_id = sp.post_super_obj(
+        name=name,
+        is_roid=True,
+        obj_ids=[public_source.id, public_source_two_groups.id],
+    ).id
 
-    status, data = api("GET", f"super_objs/{super_obj_id}", token=super_admin_token)
-    assert status == 200
-    assert data["data"]["name"] == name
-    assert data["data"]["is_roid"] is True
-    assert {obj["id"] for obj in data["data"]["objs"]} == {
+    super_obj = sp.fetch_super_obj(super_obj_id)
+    assert super_obj.name == name
+    assert super_obj.is_roid is True
+    assert {obj.id for obj in super_obj.objs} == {
         public_source.id,
         public_source_two_groups.id,
     }
 
 
 def test_super_obj_filters(super_admin_token, public_source):
+    sp = client(super_admin_token)
     name = f"asteroid-{uuid.uuid4().hex}"
-    status, data = api(
-        "POST",
-        "super_objs",
-        data={"name": name, "is_roid": True, "obj_ids": [public_source.id]},
-        token=super_admin_token,
-    )
-    assert status == 200
-    super_obj_id = data["data"]["id"]
+    super_obj_id = sp.post_super_obj(
+        name=name, is_roid=True, obj_ids=[public_source.id]
+    ).id
 
-    status, data = api("GET", f"super_objs?name={name}", token=super_admin_token)
-    assert status == 200
-    assert [s["id"] for s in data["data"]] == [super_obj_id]
+    assert [s.id for s in sp.fetch_super_objs(name=name)] == [super_obj_id]
 
-    status, data = api(
-        "GET", f"super_objs?objID={public_source.id}", token=super_admin_token
-    )
-    assert status == 200
-    assert super_obj_id in [s["id"] for s in data["data"]]
+    assert super_obj_id in [s.id for s in sp.fetch_super_objs(obj_id=public_source.id)]
 
-    status, data = api(
-        "GET", f"super_objs?name={name}&isRoid=false", token=super_admin_token
-    )
-    assert status == 200
-    assert data["data"] == []
+    assert sp.fetch_super_objs(name=name, is_roid=False) == []
 
 
 def test_super_obj_membership_updates(
     super_admin_token, public_source, public_source_two_groups
 ):
-    status, data = api(
-        "POST",
-        "super_objs",
-        data={"name": f"asteroid-{uuid.uuid4().hex}", "obj_ids": [public_source.id]},
-        token=super_admin_token,
-    )
-    assert status == 200
-    super_obj_id = data["data"]["id"]
+    sp = client(super_admin_token)
+    super_obj_id = sp.post_super_obj(
+        name=f"asteroid-{uuid.uuid4().hex}", obj_ids=[public_source.id]
+    ).id
 
-    status, _ = api(
-        "PATCH",
-        f"super_objs/{super_obj_id}",
-        data={"add_obj_ids": [public_source_two_groups.id]},
-        token=super_admin_token,
-    )
-    assert status == 200
+    sp.update_super_obj(super_obj_id, add_obj_ids=[public_source_two_groups.id])
 
-    status, data = api("GET", f"super_objs/{super_obj_id}", token=super_admin_token)
-    assert {obj["id"] for obj in data["data"]["objs"]} == {
+    super_obj = sp.fetch_super_obj(super_obj_id)
+    assert {obj.id for obj in super_obj.objs} == {
         public_source.id,
         public_source_two_groups.id,
     }
 
     # adding the same Obj again must not duplicate it
-    status, _ = api(
-        "PATCH",
-        f"super_objs/{super_obj_id}",
-        data={"add_obj_ids": [public_source_two_groups.id]},
-        token=super_admin_token,
-    )
-    assert status == 200
+    sp.update_super_obj(super_obj_id, add_obj_ids=[public_source_two_groups.id])
 
-    status, data = api("GET", f"super_objs/{super_obj_id}", token=super_admin_token)
-    assert len(data["data"]["objs"]) == 2
+    assert len(sp.fetch_super_obj(super_obj_id).objs) == 2
 
-    status, _ = api(
-        "PATCH",
-        f"super_objs/{super_obj_id}",
-        data={"remove_obj_ids": [public_source.id]},
-        token=super_admin_token,
-    )
-    assert status == 200
+    sp.update_super_obj(super_obj_id, remove_obj_ids=[public_source.id])
 
-    status, data = api("GET", f"super_objs/{super_obj_id}", token=super_admin_token)
-    assert [obj["id"] for obj in data["data"]["objs"]] == [public_source_two_groups.id]
+    assert [obj.id for obj in sp.fetch_super_obj(super_obj_id).objs] == [
+        public_source_two_groups.id
+    ]
 
 
 def test_super_obj_rejects_conflicting_membership_args(
     super_admin_token, public_source
 ):
-    status, data = api(
-        "POST",
-        "super_objs",
-        data={"name": f"asteroid-{uuid.uuid4().hex}"},
-        token=super_admin_token,
-    )
-    assert status == 200
-    super_obj_id = data["data"]["id"]
+    sp = client(super_admin_token)
+    super_obj_id = sp.post_super_obj(name=f"asteroid-{uuid.uuid4().hex}").id
 
-    status, data = api(
-        "PATCH",
-        f"super_objs/{super_obj_id}",
-        data={"obj_ids": [public_source.id], "add_obj_ids": [public_source.id]},
-        token=super_admin_token,
-    )
-    assert status == 400
+    with pytest.raises(SkyPortalError) as err:
+        sp.update_super_obj(
+            super_obj_id,
+            obj_ids=[public_source.id],
+            add_obj_ids=[public_source.id],
+        )
+    assert err.value.status_code == 400
 
 
 def test_super_obj_rejects_unknown_obj(super_admin_token):
-    status, data = api(
-        "POST",
-        "super_objs",
-        data={"name": f"asteroid-{uuid.uuid4().hex}", "obj_ids": ["does-not-exist"]},
-        token=super_admin_token,
-    )
-    assert status == 400
+    with pytest.raises(SkyPortalError) as err:
+        client(super_admin_token).post_super_obj(
+            name=f"asteroid-{uuid.uuid4().hex}", obj_ids=["does-not-exist"]
+        )
+    assert err.value.status_code == 400
 
 
 def test_super_obj_delete_leaves_objs(super_admin_token, public_source):
     """Deleting a SuperObj must not delete the Objs it links."""
-    status, data = api(
-        "POST",
-        "super_objs",
-        data={"name": f"asteroid-{uuid.uuid4().hex}", "obj_ids": [public_source.id]},
-        token=super_admin_token,
-    )
-    assert status == 200
-    super_obj_id = data["data"]["id"]
+    sp = client(super_admin_token)
+    super_obj_id = sp.post_super_obj(
+        name=f"asteroid-{uuid.uuid4().hex}", obj_ids=[public_source.id]
+    ).id
 
-    status, _ = api("DELETE", f"super_objs/{super_obj_id}", token=super_admin_token)
-    assert status == 200
+    sp.delete_super_obj(super_obj_id)
 
-    status, _ = api("GET", f"super_objs/{super_obj_id}", token=super_admin_token)
-    assert status == 400
+    with pytest.raises(SkyPortalError) as err:
+        sp.fetch_super_obj(super_obj_id)
+    assert err.value.status_code == 400
 
-    status, data = api("GET", f"sources/{public_source.id}", token=super_admin_token)
-    assert status == 200
-    assert data["data"]["id"] == public_source.id
+    assert sp.fetch_source(public_source.id).id == public_source.id
 
 
 def test_super_obj_delete_requires_admin(
     super_admin_token, upload_data_token, public_source
 ):
-    status, data = api(
-        "POST",
-        "super_objs",
-        data={"name": f"asteroid-{uuid.uuid4().hex}", "obj_ids": [public_source.id]},
-        token=upload_data_token,
+    super_obj_id = (
+        client(upload_data_token)
+        .post_super_obj(name=f"asteroid-{uuid.uuid4().hex}", obj_ids=[public_source.id])
+        .id
     )
-    assert status == 200
-    super_obj_id = data["data"]["id"]
 
-    status, _ = api("DELETE", f"super_objs/{super_obj_id}", token=upload_data_token)
-    assert status == 401
+    with pytest.raises(SkyPortalError) as err:
+        client(upload_data_token).delete_super_obj(super_obj_id)
+    assert err.value.status_code == 401
 
-    status, _ = api("DELETE", f"super_objs/{super_obj_id}", token=super_admin_token)
-    assert status == 200
+    client(super_admin_token).delete_super_obj(super_obj_id)

--- a/skyportal/tests/api_tests/spectra_misc/test_annotations_on_photometry.py
+++ b/skyportal/tests/api_tests/spectra_misc/test_annotations_on_photometry.py
@@ -1,31 +1,34 @@
-from skyportal.tests import api, assert_api, assert_api_fail
+import pytest
+from skyportal_py import SkyPortalError
+from skyportal_py.photometry import PhotometryPost
+
+from skyportal.tests import api, assert_api_fail, client
 
 
 def test_add_and_retrieve_annotation_group_id(
     annotation_token, upload_data_token, public_source, public_group, ztf_camera
 ):
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 58000.0,
-            "instrument_id": ztf_camera.id,
-            "flux": 12.24,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "group_ids": [public_group.id],
-            "altdata": {"some_key": "some_value"},
-        },
-        token=upload_data_token,
+    photometry_id = (
+        client(upload_data_token)
+        .post_photometry(
+            PhotometryPost(
+                obj_id=str(public_source.id),
+                mjd=58000.0,
+                instrument_id=ztf_camera.id,
+                flux=12.24,
+                fluxerr=0.031,
+                zp=25.0,
+                magsys="ab",
+                filter="ztfg",
+                group_ids=[public_group.id],
+                altdata={"some_key": "some_value"},
+            )
+        )
+        .ids[0]
     )
-    assert_api(status, data)
-
-    photometry_id = data["data"]["ids"][0]
 
     # try posting without an origin...
+    # raw api: intentionally malformed payload the typed client can't produce (missing origin)
     status, data = api(
         "POST",
         f"photometry/{photometry_id}/annotations",
@@ -38,6 +41,7 @@ def test_add_and_retrieve_annotation_group_id(
     assert_api_fail(status, data, 400, "origin: Field required")
 
     # this should not work, since "origin" is empty
+    # raw api: intentionally malformed payload the typed client can't produce (empty origin)
     status, data = api(
         "POST",
         f"photometry/{photometry_id}/annotations",
@@ -53,44 +57,36 @@ def test_add_and_retrieve_annotation_group_id(
     assert "origin: String should match pattern" in data["message"]
 
     # first time adding an annotation to this object from Kowalski
-    status, data = api(
-        "POST",
-        f"photometry/{photometry_id}/annotations",
-        data={
-            "origin": "kowalski",
-            "data": {"offset_from_host_galaxy": 1.5},
-            "group_ids": [public_group.id],
-        },
-        token=annotation_token,
+    annotation_id = (
+        client(annotation_token)
+        .post_annotation(
+            photometry_id,
+            "kowalski",
+            {"offset_from_host_galaxy": 1.5},
+            resource_type="photometry",
+            group_ids=[public_group.id],
+        )
+        .annotation_id
     )
-
-    assert status == 200
-    annotation_id = data["data"]["annotation_id"]
 
     # this should not work, since "origin" Kowalski was already posted to this object
     # instead, try updating the existing annotation if you have new information!
-    status, data = api(
-        "POST",
-        f"photometry/{photometry_id}/annotations",
-        data={
-            "origin": "kowalski",
-            "data": {"offset_from_host_galaxy": 1.5},
-            "group_ids": [public_group.id],
-        },
-        token=annotation_token,
+    with pytest.raises(
+        SkyPortalError, match="duplicate key value violates unique constraint"
+    ) as err:
+        client(annotation_token).post_annotation(
+            photometry_id,
+            "kowalski",
+            {"offset_from_host_galaxy": 1.5},
+            resource_type="photometry",
+            group_ids=[public_group.id],
+        )
+    assert err.value.status_code in [500, 400]
+
+    annotation = client(annotation_token).fetch_annotation(
+        photometry_id, annotation_id, resource_type="photometry"
     )
-
-    assert status in [500, 400]
-    assert "duplicate key value violates unique constraint" in data["message"]
-
-    status, data = api(
-        "GET",
-        f"photometry/{photometry_id}/annotations/{annotation_id}",
-        token=annotation_token,
-    )
-
-    assert status == 200
-    assert data["data"]["data"]["offset_from_host_galaxy"] == 1.5
+    assert annotation.data["offset_from_host_galaxy"] == 1.5
 
 
 def test_add_and_retrieve_annotation_group_access(
@@ -102,175 +98,137 @@ def test_add_and_retrieve_annotation_group_access(
     annotation_token,
     ztf_camera,
 ):
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source_two_groups.id),
-            "mjd": 58000.0,
-            "instrument_id": ztf_camera.id,
-            "flux": 12.24,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "group_ids": [public_group2.id],
-            "altdata": {"some_key": "some_value"},
-        },
-        token=upload_data_token_two_groups,
+    sp_two_groups = client(annotation_token_two_groups)
+    sp = client(annotation_token)
+    photometry_id = (
+        client(upload_data_token_two_groups)
+        .post_photometry(
+            PhotometryPost(
+                obj_id=str(public_source_two_groups.id),
+                mjd=58000.0,
+                instrument_id=ztf_camera.id,
+                flux=12.24,
+                fluxerr=0.031,
+                zp=25.0,
+                magsys="ab",
+                filter="ztfg",
+                group_ids=[public_group2.id],
+                altdata={"some_key": "some_value"},
+            )
+        )
+        .ids[0]
     )
-    assert_api(status, data)
 
-    photometry_id = data["data"]["ids"][0]
-
-    status, data = api(
-        "POST",
-        f"photometry/{photometry_id}/annotations",
-        data={
-            "origin": "IPAC",
-            "data": {"distance_from_host": 7.4},
-            "group_ids": [public_group2.id],
-        },
-        token=annotation_token_two_groups,
-    )
-    assert status == 200
-    annotation_id = data["data"]["annotation_id"]
+    annotation_id = sp_two_groups.post_annotation(
+        photometry_id,
+        "IPAC",
+        {"distance_from_host": 7.4},
+        resource_type="photometry",
+        group_ids=[public_group2.id],
+    ).annotation_id
 
     # This token belongs to public_group2
-    status, data = api(
-        "GET",
-        f"photometry/{photometry_id}/annotations/{annotation_id}",
-        token=annotation_token_two_groups,
+    annotation = sp_two_groups.fetch_annotation(
+        photometry_id, annotation_id, resource_type="photometry"
     )
-    assert status == 200
-    assert data["data"]["data"]["distance_from_host"] == 7.4
+    assert annotation.data["distance_from_host"] == 7.4
 
     # This token does not belong to public_group2
-    status, data = api(
-        "GET",
-        f"photometry/{photometry_id}/annotations/{annotation_id}",
-        token=annotation_token,
-    )
-    assert status == 403
+    with pytest.raises(SkyPortalError) as err:
+        sp.fetch_annotation(photometry_id, annotation_id, resource_type="photometry")
+    assert err.value.status_code == 403
 
     # Both tokens should be able to view this annotation, but not the underlying photometry
-    status, data = api(
-        "POST",
-        f"photometry/{photometry_id}/annotations",
-        data={
-            "origin": "kowalski",
-            "data": {"ACAI_class": "type Ia"},
-            "group_ids": [public_group.id, public_group2.id],
-        },
-        token=annotation_token_two_groups,
-    )
-    assert status == 200
-    annotation_id = data["data"]["annotation_id"]
+    annotation_id = sp_two_groups.post_annotation(
+        photometry_id,
+        "kowalski",
+        {"ACAI_class": "type Ia"},
+        resource_type="photometry",
+        group_ids=[public_group.id, public_group2.id],
+    ).annotation_id
 
-    status, data = api(
-        "GET",
-        f"photometry/{photometry_id}/annotations/{annotation_id}",
-        token=annotation_token_two_groups,
+    annotation = sp_two_groups.fetch_annotation(
+        photometry_id, annotation_id, resource_type="photometry"
     )
-    assert status == 200
-    assert data["data"]["data"]["ACAI_class"] == "type Ia"
+    assert annotation.data["ACAI_class"] == "type Ia"
 
-    status, data = api(
-        "GET",
-        f"photometry/{photometry_id}/annotations/{annotation_id}",
-        token=annotation_token,
-    )
-    assert status == 403  # the underlying photometry is not accessible to group1
+    # the underlying photometry is not accessible to group1
+    with pytest.raises(SkyPortalError) as err:
+        sp.fetch_annotation(photometry_id, annotation_id, resource_type="photometry")
+    assert err.value.status_code == 403
 
     # post new photometry with an annotation, open to both groups
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source_two_groups.id),
-            "mjd": 58001.0,
-            "instrument_id": ztf_camera.id,
-            "flux": 12.24,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "group_ids": [public_group.id, public_group2.id],
-            "altdata": {"some_key": "some_value"},
-        },
-        token=upload_data_token_two_groups,
+    photometry_id = (
+        client(upload_data_token_two_groups)
+        .post_photometry(
+            PhotometryPost(
+                obj_id=str(public_source_two_groups.id),
+                mjd=58001.0,
+                instrument_id=ztf_camera.id,
+                flux=12.24,
+                fluxerr=0.031,
+                zp=25.0,
+                magsys="ab",
+                filter="ztfg",
+                group_ids=[public_group.id, public_group2.id],
+                altdata={"some_key": "some_value"},
+            )
+        )
+        .ids[0]
     )
-    assert_api(status, data)
 
-    photometry_id = data["data"]["ids"][0]
-
-    status, data = api(
-        "POST",
-        f"photometry/{photometry_id}/annotations",
-        data={
-            "origin": "kowalski",
-            "data": {"ACAI_class": "type Ia"},
-            "group_ids": [public_group2.id],
-        },
-        token=annotation_token_two_groups,
-    )
-    assert status == 200
-    annotation_id = data["data"]["annotation_id"]
+    annotation_id = sp_two_groups.post_annotation(
+        photometry_id,
+        "kowalski",
+        {"ACAI_class": "type Ia"},
+        resource_type="photometry",
+        group_ids=[public_group2.id],
+    ).annotation_id
 
     # token for group1 can view the photometry but cannot see the annotation
-    status, data = api(
-        "GET",
-        f"photometry/{photometry_id}/annotations/{annotation_id}",
-        token=annotation_token,
-    )
-    assert status == 403
+    with pytest.raises(SkyPortalError) as err:
+        sp.fetch_annotation(photometry_id, annotation_id, resource_type="photometry")
+    assert err.value.status_code == 403
 
     # Both tokens should be able to view annotation after updating group list
-    status, data = api(
-        "PUT",
-        f"photometry/{photometry_id}/annotations/{annotation_id}",
-        data={
-            "data": {"ACAI_class": "type IIn"},
-            "group_ids": [public_group.id, public_group2.id],
-        },
-        token=annotation_token_two_groups,
+    sp_two_groups.update_annotation(
+        photometry_id,
+        annotation_id,
+        {"ACAI_class": "type IIn"},
+        resource_type="photometry",
+        group_ids=[public_group.id, public_group2.id],
     )
-    assert status == 200
 
     # the new annotation on the new photometry should now accessible
-    status, data = api(
-        "GET",
-        f"photometry/{photometry_id}/annotations/{annotation_id}",
-        token=annotation_token,
+    annotation = sp.fetch_annotation(
+        photometry_id, annotation_id, resource_type="photometry"
     )
-    assert status == 200
-    assert data["data"]["data"]["ACAI_class"] == "type IIn"
+    assert annotation.data["ACAI_class"] == "type IIn"
 
 
 def test_cannot_add_annotation_without_permission(
     view_only_token, upload_data_token, public_source, ztf_camera
 ):
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 58000.0,
-            "instrument_id": ztf_camera.id,
-            "flux": 12.24,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "group_ids": "all",
-            "altdata": {"some_key": "some_value"},
-        },
-        token=upload_data_token,
+    photometry_id = (
+        client(upload_data_token)
+        .post_photometry(
+            PhotometryPost(
+                obj_id=str(public_source.id),
+                mjd=58000.0,
+                instrument_id=ztf_camera.id,
+                flux=12.24,
+                fluxerr=0.031,
+                zp=25.0,
+                magsys="ab",
+                filter="ztfg",
+                group_ids="all",
+                altdata={"some_key": "some_value"},
+            )
+        )
+        .ids[0]
     )
-    assert_api(status, data)
 
-    photometry_id = data["data"]["ids"][0]
-
+    # raw api: intentionally malformed request (singular "annotation" route) the typed client can't produce
     status, data = api(
         "POST",
         f"photometry/{photometry_id}/annotation",
@@ -284,129 +242,98 @@ def test_cannot_add_annotation_without_permission(
 def test_delete_annotation(
     annotation_token, upload_data_token, public_source, ztf_camera
 ):
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 58000.0,
-            "instrument_id": ztf_camera.id,
-            "flux": 12.24,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "group_ids": "all",
-            "altdata": {"some_key": "some_value"},
-        },
-        token=upload_data_token,
+    sp = client(annotation_token)
+    photometry_id = (
+        client(upload_data_token)
+        .post_photometry(
+            PhotometryPost(
+                obj_id=str(public_source.id),
+                mjd=58000.0,
+                instrument_id=ztf_camera.id,
+                flux=12.24,
+                fluxerr=0.031,
+                zp=25.0,
+                magsys="ab",
+                filter="ztfg",
+                group_ids="all",
+                altdata={"some_key": "some_value"},
+            )
+        )
+        .ids[0]
     )
-    assert_api(status, data)
 
-    photometry_id = data["data"]["ids"][0]
+    annotation_id = sp.post_annotation(
+        photometry_id, "kowalski", {"gaia_G": 14.5}, resource_type="photometry"
+    ).annotation_id
 
-    status, data = api(
-        "POST",
-        f"photometry/{photometry_id}/annotations",
-        data={"origin": "kowalski", "data": {"gaia_G": 14.5}},
-        token=annotation_token,
+    annotation = sp.fetch_annotation(
+        photometry_id, annotation_id, resource_type="photometry"
     )
-    assert status == 200
-    annotation_id = data["data"]["annotation_id"]
-
-    status, data = api(
-        "GET",
-        f"photometry/{photometry_id}/annotations/{annotation_id}",
-        token=annotation_token,
-    )
-    assert status == 200
-    assert data["data"]["data"]["gaia_G"] == 14.5
+    assert annotation.data["gaia_G"] == 14.5
 
     # try to delete using the wrong photometry ID
-    status, data = api(
-        "DELETE",
-        f"photometry/{photometry_id + 1}/annotations/{annotation_id}",
-        token=annotation_token,
-    )
-    assert status == 400
-    assert (
-        "Annotation resource ID does not match resource ID given in path"
-        in data["message"]
-    )
+    with pytest.raises(
+        SkyPortalError,
+        match="Annotation resource ID does not match resource ID given in path",
+    ) as err:
+        sp.delete_annotation(
+            photometry_id + 1, annotation_id, resource_type="photometry"
+        )
+    assert err.value.status_code == 400
 
-    status, data = api(
-        "DELETE",
-        f"photometry/{photometry_id}/annotations/{annotation_id}",
-        token=annotation_token,
-    )
-    assert status == 200
+    sp.delete_annotation(photometry_id, annotation_id, resource_type="photometry")
 
-    status, data = api(
-        "GET",
-        f"photometry/{photometry_id}/annotations/{annotation_id}",
-        token=annotation_token,
-    )
-    assert status == 403
+    with pytest.raises(SkyPortalError) as err:
+        sp.fetch_annotation(photometry_id, annotation_id, resource_type="photometry")
+    assert err.value.status_code == 403
 
 
 def test_fetch_all_photometry_annotations(
     annotation_token, upload_data_token, public_source, public_group, ztf_camera
 ):
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 58000.0,
-            "instrument_id": ztf_camera.id,
-            "flux": 12.24,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "group_ids": "all",
-            "altdata": {"some_key": "some_value"},
-        },
-        token=upload_data_token,
+    photometry_id = (
+        client(upload_data_token)
+        .post_photometry(
+            PhotometryPost(
+                obj_id=str(public_source.id),
+                mjd=58000.0,
+                instrument_id=ztf_camera.id,
+                flux=12.24,
+                fluxerr=0.031,
+                zp=25.0,
+                magsys="ab",
+                filter="ztfg",
+                group_ids="all",
+                altdata={"some_key": "some_value"},
+            )
+        )
+        .ids[0]
     )
-    assert_api(status, data)
 
-    photometry_id = data["data"]["ids"][0]
-
-    status, data = api(
-        "POST",
-        f"photometry/{photometry_id}/annotations",
-        data={
-            "origin": "kowalski",
-            "data": {"gaia_G": 15.7},
-            "group_ids": [public_group.id],
-        },
-        token=annotation_token,
+    sp = client(annotation_token)
+    sp.post_annotation(
+        photometry_id,
+        "kowalski",
+        {"gaia_G": 15.7},
+        resource_type="photometry",
+        group_ids=[public_group.id],
     )
-    assert status == 200
 
-    status, data = api(
-        "POST",
-        f"photometry/{photometry_id}/annotations",
-        data={
-            "origin": "SEDM",
-            "data": {"redshift": 0.07},
-            "group_ids": [public_group.id],
-        },
-        token=annotation_token,
+    sp.post_annotation(
+        photometry_id,
+        "SEDM",
+        {"redshift": 0.07},
+        resource_type="photometry",
+        group_ids=[public_group.id],
     )
-    assert status == 200
 
-    status, data = api(
-        "GET",
-        f"photometry/{photometry_id}/annotations",
-        token=upload_data_token,
+    annotations = client(upload_data_token).fetch_annotations(
+        photometry_id, resource_type="photometry"
     )
 
     # make sure the dictionaries are sorted
-    data["data"] = sorted(data["data"], key=lambda x: x["origin"])
+    annotations = sorted(annotations, key=lambda x: x.origin)
 
-    assert status == 200
-    assert len(data["data"]) == 2
-    assert data["data"][0]["data"]["redshift"] == 0.07
-    assert data["data"][1]["data"]["gaia_G"] == 15.7
+    assert len(annotations) == 2
+    assert annotations[0].data["redshift"] == 0.07
+    assert annotations[1].data["gaia_G"] == 15.7

--- a/skyportal/tests/api_tests/spectra_misc/test_annotations_on_spectrum.py
+++ b/skyportal/tests/api_tests/spectra_misc/test_annotations_on_spectrum.py
@@ -1,28 +1,31 @@
 import datetime
 
-from skyportal.tests import api
+import pytest
+from skyportal_py import SkyPortalError
+from skyportal_py.spectra import SpectrumPost
+
+from skyportal.tests import api, client
 
 
 def test_add_and_retrieve_annotation_group_id(
     annotation_token, upload_data_token, public_source, public_group, lris
 ):
-    status, data = api(
-        "POST",
-        "spectrum",
-        data={
-            "obj_id": str(public_source.id),
-            "observed_at": str(datetime.datetime.now()),
-            "instrument_id": lris.id,
-            "wavelengths": [664, 665, 666],
-            "fluxes": [234.2, 232.1, 235.3],
-        },
-        token=upload_data_token,
+    spectrum_id = (
+        client(upload_data_token)
+        .post_spectrum(
+            SpectrumPost(
+                obj_id=str(public_source.id),
+                observed_at=str(datetime.datetime.now()),
+                instrument_id=lris.id,
+                wavelengths=[664, 665, 666],
+                fluxes=[234.2, 232.1, 235.3],
+            )
+        )
+        .id
     )
-    assert status == 200
-    assert data["status"] == "success"
-    spectrum_id = data["data"]["id"]
 
     # try posting without an origin...
+    # raw api: intentionally malformed payload the typed client can't produce (missing origin)
     status, data = api(
         "POST",
         f"spectra/{spectrum_id}/annotations",
@@ -36,6 +39,7 @@ def test_add_and_retrieve_annotation_group_id(
     assert "origin: Field required" in data["message"]
 
     # this should not work, since "origin" is empty
+    # raw api: intentionally malformed payload the typed client can't produce (empty origin)
     status, data = api(
         "POST",
         f"spectra/{spectrum_id}/annotations",
@@ -51,44 +55,36 @@ def test_add_and_retrieve_annotation_group_id(
     assert "origin: String should match pattern" in data["message"]
 
     # first time adding an annotation to this object from Kowalski
-    status, data = api(
-        "POST",
-        f"spectra/{spectrum_id}/annotations",
-        data={
-            "origin": "kowalski",
-            "data": {"offset_from_host_galaxy": 1.5},
-            "group_ids": [public_group.id],
-        },
-        token=annotation_token,
+    annotation_id = (
+        client(annotation_token)
+        .post_annotation(
+            spectrum_id,
+            "kowalski",
+            {"offset_from_host_galaxy": 1.5},
+            resource_type="spectra",
+            group_ids=[public_group.id],
+        )
+        .annotation_id
     )
-
-    assert status == 200
-    annotation_id = data["data"]["annotation_id"]
 
     # this should not work, since "origin" Kowalski was already posted to this object
     # instead, try updating the existing annotation if you have new information!
-    status, data = api(
-        "POST",
-        f"spectra/{spectrum_id}/annotations",
-        data={
-            "origin": "kowalski",
-            "data": {"offset_from_host_galaxy": 1.5},
-            "group_ids": [public_group.id],
-        },
-        token=annotation_token,
+    with pytest.raises(
+        SkyPortalError, match="duplicate key value violates unique constraint"
+    ) as err:
+        client(annotation_token).post_annotation(
+            spectrum_id,
+            "kowalski",
+            {"offset_from_host_galaxy": 1.5},
+            resource_type="spectra",
+            group_ids=[public_group.id],
+        )
+    assert err.value.status_code in [500, 400]
+
+    annotation = client(annotation_token).fetch_annotation(
+        spectrum_id, annotation_id, resource_type="spectra"
     )
-
-    assert status in [500, 400]
-    assert "duplicate key value violates unique constraint" in data["message"]
-
-    status, data = api(
-        "GET",
-        f"spectra/{spectrum_id}/annotations/{annotation_id}",
-        token=annotation_token,
-    )
-
-    assert status == 200
-    assert data["data"]["data"]["offset_from_host_galaxy"] == 1.5
+    assert annotation.data["offset_from_host_galaxy"] == 1.5
 
 
 def test_add_and_retrieve_annotation_group_access(
@@ -100,163 +96,125 @@ def test_add_and_retrieve_annotation_group_access(
     annotation_token,
     lris,
 ):
-    status, data = api(
-        "POST",
-        "spectrum",
-        data={
-            "obj_id": str(public_source_two_groups.id),
-            "observed_at": str(datetime.datetime.now()),
-            "instrument_id": lris.id,
-            "wavelengths": [664, 665, 666],
-            "fluxes": [234.2, 232.1, 235.3],
-            "group_ids": [public_group2.id],
-        },
-        token=upload_data_token_two_groups,
+    sp_two_groups = client(annotation_token_two_groups)
+    sp = client(annotation_token)
+    spectrum_id = (
+        client(upload_data_token_two_groups)
+        .post_spectrum(
+            SpectrumPost(
+                obj_id=str(public_source_two_groups.id),
+                observed_at=str(datetime.datetime.now()),
+                instrument_id=lris.id,
+                wavelengths=[664, 665, 666],
+                fluxes=[234.2, 232.1, 235.3],
+                group_ids=[public_group2.id],
+            )
+        )
+        .id
     )
-    assert status == 200
-    assert data["status"] == "success"
-    spectrum_id = data["data"]["id"]
 
-    status, data = api(
-        "POST",
-        f"spectra/{spectrum_id}/annotations",
-        data={
-            "origin": "IPAC",
-            "data": {"distance_from_host": 7.4},
-            "group_ids": [public_group2.id],
-        },
-        token=annotation_token_two_groups,
-    )
-    assert status == 200
-    annotation_id = data["data"]["annotation_id"]
+    annotation_id = sp_two_groups.post_annotation(
+        spectrum_id,
+        "IPAC",
+        {"distance_from_host": 7.4},
+        resource_type="spectra",
+        group_ids=[public_group2.id],
+    ).annotation_id
 
     # This token belongs to public_group2
-    status, data = api(
-        "GET",
-        f"spectra/{spectrum_id}/annotations/{annotation_id}",
-        token=annotation_token_two_groups,
+    annotation = sp_two_groups.fetch_annotation(
+        spectrum_id, annotation_id, resource_type="spectra"
     )
-    assert status == 200
-    assert data["data"]["data"]["distance_from_host"] == 7.4
+    assert annotation.data["distance_from_host"] == 7.4
 
     # This token does not belong to public_group2
-    status, data = api(
-        "GET",
-        f"spectra/{spectrum_id}/annotations/{annotation_id}",
-        token=annotation_token,
-    )
-    assert status == 403
+    with pytest.raises(SkyPortalError) as err:
+        sp.fetch_annotation(spectrum_id, annotation_id, resource_type="spectra")
+    assert err.value.status_code == 403
 
     # Both tokens should be able to view this annotation, but not the underlying spectrum
-    status, data = api(
-        "POST",
-        f"spectra/{spectrum_id}/annotations",
-        data={
-            "origin": "kowalski",
-            "data": {"ACAI_class": "type Ia"},
-            "group_ids": [public_group.id, public_group2.id],
-        },
-        token=annotation_token_two_groups,
-    )
-    assert status == 200
-    annotation_id = data["data"]["annotation_id"]
+    annotation_id = sp_two_groups.post_annotation(
+        spectrum_id,
+        "kowalski",
+        {"ACAI_class": "type Ia"},
+        resource_type="spectra",
+        group_ids=[public_group.id, public_group2.id],
+    ).annotation_id
 
-    status, data = api(
-        "GET",
-        f"spectra/{spectrum_id}/annotations/{annotation_id}",
-        token=annotation_token_two_groups,
+    annotation = sp_two_groups.fetch_annotation(
+        spectrum_id, annotation_id, resource_type="spectra"
     )
-    assert status == 200
-    assert data["data"]["data"]["ACAI_class"] == "type Ia"
+    assert annotation.data["ACAI_class"] == "type Ia"
 
-    status, data = api(
-        "GET",
-        f"spectra/{spectrum_id}/annotations/{annotation_id}",
-        token=annotation_token,
-    )
-    assert status == 403  # the underlying spectrum is not accessible to group1
+    # the underlying spectrum is not accessible to group1
+    with pytest.raises(SkyPortalError) as err:
+        sp.fetch_annotation(spectrum_id, annotation_id, resource_type="spectra")
+    assert err.value.status_code == 403
 
     # post a new spectrum with an annotation, open to both groups
-    status, data = api(
-        "POST",
-        "spectrum",
-        data={
-            "obj_id": str(public_source_two_groups.id),
-            "observed_at": str(datetime.datetime.now()),
-            "instrument_id": lris.id,
-            "wavelengths": [664, 665, 666],
-            "fluxes": [234.2, 232.1, 235.3],
-            "group_ids": [public_group.id, public_group2.id],
-        },
-        token=upload_data_token_two_groups,
+    spectrum_id = (
+        client(upload_data_token_two_groups)
+        .post_spectrum(
+            SpectrumPost(
+                obj_id=str(public_source_two_groups.id),
+                observed_at=str(datetime.datetime.now()),
+                instrument_id=lris.id,
+                wavelengths=[664, 665, 666],
+                fluxes=[234.2, 232.1, 235.3],
+                group_ids=[public_group.id, public_group2.id],
+            )
+        )
+        .id
     )
-    assert status == 200
-    assert data["status"] == "success"
-    spectrum_id = data["data"]["id"]
 
-    status, data = api(
-        "POST",
-        f"spectra/{spectrum_id}/annotations",
-        data={
-            "origin": "kowalski",
-            "data": {"ACAI_class": "type Ia"},
-            "group_ids": [public_group2.id],
-        },
-        token=annotation_token_two_groups,
-    )
-    assert status == 200
-    annotation_id = data["data"]["annotation_id"]
+    annotation_id = sp_two_groups.post_annotation(
+        spectrum_id,
+        "kowalski",
+        {"ACAI_class": "type Ia"},
+        resource_type="spectra",
+        group_ids=[public_group2.id],
+    ).annotation_id
 
     # token for group1 can view the spectrum but cannot see the annotation
-    status, data = api(
-        "GET",
-        f"spectra/{spectrum_id}/annotations/{annotation_id}",
-        token=annotation_token,
-    )
-    assert status == 403
+    with pytest.raises(SkyPortalError) as err:
+        sp.fetch_annotation(spectrum_id, annotation_id, resource_type="spectra")
+    assert err.value.status_code == 403
 
     # Both tokens should be able to view annotation after updating group list
-    status, data = api(
-        "PUT",
-        f"spectra/{spectrum_id}/annotations/{annotation_id}",
-        data={
-            "data": {"ACAI_class": "type IIn"},
-            "group_ids": [public_group.id, public_group2.id],
-        },
-        token=annotation_token_two_groups,
+    sp_two_groups.update_annotation(
+        spectrum_id,
+        annotation_id,
+        {"ACAI_class": "type IIn"},
+        resource_type="spectra",
+        group_ids=[public_group.id, public_group2.id],
     )
-    assert status == 200
 
     # the new annotation on the new spectrum should now accessible
-    status, data = api(
-        "GET",
-        f"spectra/{spectrum_id}/annotations/{annotation_id}",
-        token=annotation_token,
+    annotation = sp.fetch_annotation(
+        spectrum_id, annotation_id, resource_type="spectra"
     )
-    assert status == 200
-    assert data["data"]["data"]["ACAI_class"] == "type IIn"
+    assert annotation.data["ACAI_class"] == "type IIn"
 
 
 def test_cannot_add_annotation_without_permission(
     view_only_token, upload_data_token, public_source, lris
 ):
-    status, data = api(
-        "POST",
-        "spectrum",
-        data={
-            "obj_id": str(public_source.id),
-            "observed_at": str(datetime.datetime.now()),
-            "instrument_id": lris.id,
-            "wavelengths": [664, 665, 666],
-            "fluxes": [234.2, 232.1, 235.3],
-            "group_ids": "all",
-        },
-        token=upload_data_token,
+    spectrum_id = (
+        client(upload_data_token)
+        .post_spectrum(
+            SpectrumPost(
+                obj_id=str(public_source.id),
+                observed_at=str(datetime.datetime.now()),
+                instrument_id=lris.id,
+                wavelengths=[664, 665, 666],
+                fluxes=[234.2, 232.1, 235.3],
+                group_ids="all",
+            )
+        )
+        .id
     )
-    assert status == 200
-    assert data["status"] == "success"
-    spectrum_id = data["data"]["id"]
 
+    # raw api: intentionally malformed request (singular "annotation" route) the typed client can't produce
     status, data = api(
         "POST",
         f"spectra/{spectrum_id}/annotation",
@@ -268,120 +226,87 @@ def test_cannot_add_annotation_without_permission(
 
 
 def test_delete_annotation(annotation_token, upload_data_token, public_source, lris):
-    status, data = api(
-        "POST",
-        "spectrum",
-        data={
-            "obj_id": str(public_source.id),
-            "observed_at": str(datetime.datetime.now()),
-            "instrument_id": lris.id,
-            "wavelengths": [664, 665, 666],
-            "fluxes": [234.2, 232.1, 235.3],
-            "group_ids": "all",
-        },
-        token=upload_data_token,
+    sp = client(annotation_token)
+    spectrum_id = (
+        client(upload_data_token)
+        .post_spectrum(
+            SpectrumPost(
+                obj_id=str(public_source.id),
+                observed_at=str(datetime.datetime.now()),
+                instrument_id=lris.id,
+                wavelengths=[664, 665, 666],
+                fluxes=[234.2, 232.1, 235.3],
+                group_ids="all",
+            )
+        )
+        .id
     )
-    assert status == 200
-    assert data["status"] == "success"
-    spectrum_id = data["data"]["id"]
 
-    status, data = api(
-        "POST",
-        f"spectra/{spectrum_id}/annotations",
-        data={"origin": "kowalski", "data": {"gaia_G": 14.5}},
-        token=annotation_token,
-    )
-    assert status == 200
-    annotation_id = data["data"]["annotation_id"]
+    annotation_id = sp.post_annotation(
+        spectrum_id, "kowalski", {"gaia_G": 14.5}, resource_type="spectra"
+    ).annotation_id
 
-    status, data = api(
-        "GET",
-        f"spectra/{spectrum_id}/annotations/{annotation_id}",
-        token=annotation_token,
+    annotation = sp.fetch_annotation(
+        spectrum_id, annotation_id, resource_type="spectra"
     )
-    assert status == 200
-    assert data["data"]["data"]["gaia_G"] == 14.5
+    assert annotation.data["gaia_G"] == 14.5
 
     # try to delete using the wrong spectrum ID
-    status, data = api(
-        "DELETE",
-        f"spectra/{spectrum_id + 1}/annotations/{annotation_id}",
-        token=annotation_token,
-    )
-    assert status == 400
-    assert (
-        "Annotation resource ID does not match resource ID given in path"
-        in data["message"]
-    )
+    with pytest.raises(
+        SkyPortalError,
+        match="Annotation resource ID does not match resource ID given in path",
+    ) as err:
+        sp.delete_annotation(spectrum_id + 1, annotation_id, resource_type="spectra")
+    assert err.value.status_code == 400
 
-    status, data = api(
-        "DELETE",
-        f"spectra/{spectrum_id}/annotations/{annotation_id}",
-        token=annotation_token,
-    )
-    assert status == 200
+    sp.delete_annotation(spectrum_id, annotation_id, resource_type="spectra")
 
-    status, data = api(
-        "GET",
-        f"spectra/{spectrum_id}/annotations/{annotation_id}",
-        token=annotation_token,
-    )
-    assert status == 403
+    with pytest.raises(SkyPortalError) as err:
+        sp.fetch_annotation(spectrum_id, annotation_id, resource_type="spectra")
+    assert err.value.status_code == 403
 
 
 def test_fetch_all_spectrum_annotations(
     annotation_token, upload_data_token, public_source, public_group, lris
 ):
-    status, data = api(
-        "POST",
-        "spectrum",
-        data={
-            "obj_id": str(public_source.id),
-            "observed_at": str(datetime.datetime.now()),
-            "instrument_id": lris.id,
-            "wavelengths": [664, 665, 666],
-            "fluxes": [234.2, 232.1, 235.3],
-        },
-        token=upload_data_token,
+    spectrum_id = (
+        client(upload_data_token)
+        .post_spectrum(
+            SpectrumPost(
+                obj_id=str(public_source.id),
+                observed_at=str(datetime.datetime.now()),
+                instrument_id=lris.id,
+                wavelengths=[664, 665, 666],
+                fluxes=[234.2, 232.1, 235.3],
+            )
+        )
+        .id
     )
-    assert status == 200
-    assert data["status"] == "success"
-    spectrum_id = data["data"]["id"]
 
-    status, data = api(
-        "POST",
-        f"spectra/{spectrum_id}/annotations",
-        data={
-            "origin": "kowalski",
-            "data": {"gaia_G": 15.7},
-            "group_ids": [public_group.id],
-        },
-        token=annotation_token,
+    sp = client(annotation_token)
+    sp.post_annotation(
+        spectrum_id,
+        "kowalski",
+        {"gaia_G": 15.7},
+        resource_type="spectra",
+        group_ids=[public_group.id],
     )
-    assert status == 200
 
-    status, data = api(
-        "POST",
-        f"spectra/{spectrum_id}/annotations",
-        data={
-            "origin": "SEDM",
-            "data": {"redshift": 0.07},
-            "group_ids": [public_group.id],
-        },
-        token=annotation_token,
+    sp.post_annotation(
+        spectrum_id,
+        "SEDM",
+        {"redshift": 0.07},
+        resource_type="spectra",
+        group_ids=[public_group.id],
     )
-    assert status == 200
 
-    status, data = api(
-        "GET",
-        f"spectra/{spectrum_id}/annotations",
-        token=upload_data_token,
+    annotations = client(upload_data_token).fetch_annotations(
+        spectrum_id, resource_type="spectra"
     )
 
     # make sure the dictionaries are sorted
-    data["data"] = sorted(data["data"], key=lambda x: x["origin"])
+    annotations = sorted(annotations, key=lambda x: x.origin)
 
-    assert status == 200
-    assert len(data["data"]) == 2
-    assert data["data"][0]["data"]["redshift"] == 0.07
-    assert data["data"][1]["data"]["gaia_G"] == 15.7
+    assert len(annotations) == 2
+    assert annotations[0].data["redshift"] == 0.07
+    assert annotations[1].data["gaia_G"] == 15.7

--- a/skyportal/tests/api_tests/spectra_misc/test_color_mag.py
+++ b/skyportal/tests/api_tests/spectra_misc/test_color_mag.py
@@ -1,259 +1,177 @@
-from skyportal.tests import api
+from skyportal.tests import client
 
 
 def test_post_retrieve_color_mag_data(annotation_token, user, public_source):
-    status, data = api(
-        "POST",
-        f"sources/{public_source.id}/annotations",
-        data={
-            "origin": "gaiadr3.gaia_source",
-            "data": {
-                "Mag_G": 15.1,
-                "Mag_Bp": 16.1,
-                "Mag_Rp": 14.0,
-                "Plx": 20,
-            },
+    sp = client(annotation_token)
+    annotation_id = sp.post_annotation(
+        public_source.id,
+        "gaiadr3.gaia_source",
+        {
+            "Mag_G": 15.1,
+            "Mag_Bp": 16.1,
+            "Mag_Rp": 14.0,
+            "Plx": 20,
         },
-        token=annotation_token,
-    )
-    assert status == 200
-    annotation_id = data["data"]["annotation_id"]
+    ).annotation_id
 
-    status, data = api(
-        "GET",
-        f"sources/{public_source.id}/color_mag",
-        token=annotation_token,
-        params={"includeColorMagnitude": True},
-    )
+    color_mag = sp.fetch_source_color_mag(public_source.id)
 
-    assert status == 200
-    assert data["data"][0]["origin"] == "gaiadr3.gaia_source"
-    assert abs(data["data"][0]["abs_mag"] - 11.6) < 0.1
-    assert abs(data["data"][0]["color"] - 2.1) < 0.1
+    assert color_mag[0].origin == "gaiadr3.gaia_source"
+    assert abs(color_mag[0].abs_mag - 11.6) < 0.1
+    assert abs(color_mag[0].color - 2.1) < 0.1
 
     # add absorption by an edit to the annotation
-    status, data = api(
-        "PUT",
-        f"sources/{public_source.id}/annotations/{annotation_id}",
-        data={
-            "origin": "gaiadr3.gaia_source",
-            "data": {
-                "Mag_G": 15.1,
-                "Mag_Bp": 16.1,
-                "Mag_Rp": 14.0,
-                "Plx": 20,
-                "A_G": 0.3,
-            },
+    sp.update_annotation(
+        public_source.id,
+        annotation_id,
+        {
+            "Mag_G": 15.1,
+            "Mag_Bp": 16.1,
+            "Mag_Rp": 14.0,
+            "Plx": 20,
+            "A_G": 0.3,
         },
-        token=annotation_token,
-    )
-    assert status == 200
-
-    status, data = api(
-        "GET", f"sources/{public_source.id}/color_mag", token=annotation_token
     )
 
-    assert status == 200
-    assert data["data"][0]["origin"] == "gaiadr3.gaia_source"
-    assert abs(data["data"][0]["abs_mag"] - 11.9) < 0.1
-    assert abs(data["data"][0]["color"] - 2.1) < 0.1
+    color_mag = sp.fetch_source_color_mag(public_source.id)
+
+    assert color_mag[0].origin == "gaiadr3.gaia_source"
+    assert abs(color_mag[0].abs_mag - 11.9) < 0.1
+    assert abs(color_mag[0].color - 2.1) < 0.1
 
     # replace the magnitude in apparent bands with the absolute mag and color
-    status, data = api(
-        "PUT",
-        f"sources/{public_source.id}/annotations/{annotation_id}",
-        data={
-            "origin": "gaiadr3.gaia_source",
-            "data": {
-                "Mag_G": 15.1,
-                "Mag_Bp": 16.1,
-                "Mag_Rp": 14.0,
-                "Plx": 20,
-                "Abs_mag_G": 12.5,
-                "color": 1.8,
-            },
-            # note the additional keys should override the existing data only when asking for them in the query
+    sp.update_annotation(
+        public_source.id,
+        annotation_id,
+        {
+            "Mag_G": 15.1,
+            "Mag_Bp": 16.1,
+            "Mag_Rp": 14.0,
+            "Plx": 20,
+            "Abs_mag_G": 12.5,
+            "color": 1.8,
         },
-        token=annotation_token,
+        # note the additional keys should override the existing data only when asking for them in the query
     )
-    assert status == 200
 
     # here we are not requesting the abs-mag and color, so the response should be the same as before
-    status, data = api(
-        "GET", f"sources/{public_source.id}/color_mag", token=annotation_token
-    )
+    color_mag = sp.fetch_source_color_mag(public_source.id)
 
-    assert status == 200
-    assert data["data"][0]["origin"] == "gaiadr3.gaia_source"
-    assert abs(data["data"][0]["abs_mag"] - 11.6) < 0.1
-    assert abs(data["data"][0]["color"] - 2.1) < 0.1
+    assert color_mag[0].origin == "gaiadr3.gaia_source"
+    assert abs(color_mag[0].abs_mag - 11.6) < 0.1
+    assert abs(color_mag[0].color - 2.1) < 0.1
 
     # here the request asks for the specific keys for abs-mag and color
-    status, data = api(
-        "GET",
-        f"sources/{public_source.id}/color_mag",
-        params={"absoluteMagKey": "abs_mag_g", "colorKey": "color"},
-        token=annotation_token,
+    color_mag = sp.fetch_source_color_mag(
+        public_source.id, absolute_mag_key="abs_mag_g", color_key="color"
     )
 
-    assert status == 200
-    assert data["data"][0]["origin"] == "gaiadr3.gaia_source"
-    assert abs(data["data"][0]["abs_mag"] - 12.5) < 0.1
-    assert abs(data["data"][0]["color"] - 1.8) < 0.1
+    assert color_mag[0].origin == "gaiadr3.gaia_source"
+    assert abs(color_mag[0].abs_mag - 12.5) < 0.1
+    assert abs(color_mag[0].color - 1.8) < 0.1
 
     # check that the source also provides the same info (with default keys!)
-    status, data = api(
-        "GET",
-        f"sources/{public_source.id}",
-        token=annotation_token,
-        params={"includeColorMagnitude": True},
+    source = client(annotation_token).fetch_source(
+        public_source.id, include_color_magnitude=True
     )
-
-    assert status == 200
-    assert data["data"]["color_magnitude"][0]["origin"] == "gaiadr3.gaia_source"
-    assert abs(data["data"]["color_magnitude"][0]["abs_mag"] - 11.6) < 0.1
-    assert abs(data["data"]["color_magnitude"][0]["color"] - 2.1) < 0.1
+    assert source.color_magnitude[0].origin == "gaiadr3.gaia_source"
+    assert abs(source.color_magnitude[0].abs_mag - 11.6) < 0.1
+    assert abs(source.color_magnitude[0].color - 2.1) < 0.1
 
 
 def test_change_color_mag_keys(annotation_token, user, public_source):
-    status, data = api(
-        "POST",
-        f"sources/{public_source.id}/annotations",
-        data={
-            "origin": "gaiadr3.gaia_source",
-            "data": {"MagG": 15.1, "MagBp": 16.1, "MagRp": 14.0, "Plx": 20},
-        },
-        token=annotation_token,
-    )
-    assert status == 200
-    annotation_id = data["data"]["annotation_id"]
+    sp = client(annotation_token)
+    annotation_id = sp.post_annotation(
+        public_source.id,
+        "gaiadr3.gaia_source",
+        {"MagG": 15.1, "MagBp": 16.1, "MagRp": 14.0, "Plx": 20},
+    ).annotation_id
 
-    status, data = api(
-        "GET", f"sources/{public_source.id}/color_mag", token=annotation_token
-    )
+    color_mag = sp.fetch_source_color_mag(public_source.id)
 
-    assert status == 200
-    assert data["data"][0]["origin"] == "gaiadr3.gaia_source"
-    assert abs(data["data"][0]["abs_mag"] - 11.6) < 0.1
-    assert abs(data["data"][0]["color"] - 2.1) < 0.1
+    assert color_mag[0].origin == "gaiadr3.gaia_source"
+    assert abs(color_mag[0].abs_mag - 11.6) < 0.1
+    assert abs(color_mag[0].color - 2.1) < 0.1
 
     # change the keys, replace capital letters with underscores
-    status, data = api(
-        "PUT",
-        f"sources/{public_source.id}/annotations/{annotation_id}",
-        data={
-            "origin": "gaiadr3.gaia_source",
-            "data": {"mag_g": 15.1, "mag_bp": 16.1, "mag_rp": 14.0, "plx": 20},
-        },
-        token=annotation_token,
-    )
-    assert status == 200
-
-    status, data = api(
-        "GET", f"sources/{public_source.id}/color_mag", token=annotation_token
+    sp.update_annotation(
+        public_source.id,
+        annotation_id,
+        {"mag_g": 15.1, "mag_bp": 16.1, "mag_rp": 14.0, "plx": 20},
     )
 
-    assert status == 200
-    assert data["data"][0]["origin"] == "gaiadr3.gaia_source"
-    assert abs(data["data"][0]["abs_mag"] - 11.6) < 0.1
-    assert abs(data["data"][0]["color"] - 2.1) < 0.1
+    color_mag = sp.fetch_source_color_mag(public_source.id)
+
+    assert color_mag[0].origin == "gaiadr3.gaia_source"
+    assert abs(color_mag[0].abs_mag - 11.6) < 0.1
+    assert abs(color_mag[0].color - 2.1) < 0.1
 
     # change the keys to completely new names, rename the catalog as well
-    status, data = api(
-        "PUT",
-        f"sources/{public_source.id}/annotations/{annotation_id}",
-        data={
-            "origin": "wise_colors",
-            "data": {"mag4.6": 15.1, "Mag_3.3": 16.1, "Mag_12": 14.0, "plx": 20},
-        },
-        token=annotation_token,
-    )
-    assert status == 200
-
-    status, data = api(
-        "GET",
-        f"sources/{public_source.id}/color_mag",
-        params={
-            "catalog": "wise",
-            "apparentMagKey": "Mag_4.6",
-            "blueMagKey": "Mag_3.3",
-            "redMagKey": "Mag_12",
-        },
-        token=annotation_token,
+    sp.update_annotation(
+        public_source.id,
+        annotation_id,
+        {"mag4.6": 15.1, "Mag_3.3": 16.1, "Mag_12": 14.0, "plx": 20},
+        origin="wise_colors",
     )
 
-    assert status == 200
-    assert data["data"][0]["origin"] == "wise_colors"
-    assert abs(data["data"][0]["abs_mag"] - 11.6) < 0.1
-    assert abs(data["data"][0]["color"] - 2.1) < 0.1
+    color_mag = sp.fetch_source_color_mag(
+        public_source.id,
+        catalog="wise",
+        apparent_mag_key="Mag_4.6",
+        blue_mag_key="Mag_3.3",
+        red_mag_key="Mag_12",
+    )
+
+    assert color_mag[0].origin == "wise_colors"
+    assert abs(color_mag[0].abs_mag - 11.6) < 0.1
+    assert abs(color_mag[0].color - 2.1) < 0.1
 
 
 def test_add_multiple_color_mag_annotations(annotation_token, user, public_source):
-    status, data = api(
-        "POST",
-        f"sources/{public_source.id}/annotations",
-        data={
-            "origin": "gaiadr1.gaia_source",
-            "data": {"MagG": 15.1, "MagBp": 16.1, "MagRp": 14.0, "Plx": 20},
-        },
-        token=annotation_token,
-    )
-    assert status == 200
-
-    status, data = api(
-        "GET", f"sources/{public_source.id}/color_mag", token=annotation_token
+    sp = client(annotation_token)
+    sp.post_annotation(
+        public_source.id,
+        "gaiadr1.gaia_source",
+        {"MagG": 15.1, "MagBp": 16.1, "MagRp": 14.0, "Plx": 20},
     )
 
-    assert status == 200
-    assert data["data"][0]["origin"] == "gaiadr1.gaia_source"
-    assert abs(data["data"][0]["abs_mag"] - 11.6) < 0.1
-    assert abs(data["data"][0]["color"] - 2.1) < 0.1
+    color_mag = sp.fetch_source_color_mag(public_source.id)
+
+    assert color_mag[0].origin == "gaiadr1.gaia_source"
+    assert abs(color_mag[0].abs_mag - 11.6) < 0.1
+    assert abs(color_mag[0].color - 2.1) < 0.1
 
     # post from a second origin
-    status, data = api(
-        "POST",
-        f"sources/{public_source.id}/annotations",
-        data={
-            "origin": "gaiadr2.gaia_source",
-            "data": {"MagG": 15.2, "MagBp": 16.2, "MagRp": 14.0, "Plx": 20},
-        },
-        token=annotation_token,
+    sp.post_annotation(
+        public_source.id,
+        "gaiadr2.gaia_source",
+        {"MagG": 15.2, "MagBp": 16.2, "MagRp": 14.0, "Plx": 20},
     )
-    assert status == 200
 
     # post from a third origin
-    status, data = api(
-        "POST",
-        f"sources/{public_source.id}/annotations",
-        data={
-            "origin": "gaiadr3.gaia_source",
-            "data": {"MagG": 15.3, "MagBp": 16.3, "MagRp": 14.0, "Plx": 5},
-        },
-        token=annotation_token,
-    )
-    assert status == 200
-
-    status, data = api(
-        "GET", f"sources/{public_source.id}/color_mag", token=annotation_token
+    sp.post_annotation(
+        public_source.id,
+        "gaiadr3.gaia_source",
+        {"MagG": 15.3, "MagBp": 16.3, "MagRp": 14.0, "Plx": 5},
     )
 
-    assert status == 200
+    color_mag = sp.fetch_source_color_mag(public_source.id)
 
     # make sure the dictionaries are sorted
-    data["data"] = sorted(data["data"], key=lambda x: x["origin"])
-    assert len(data["data"]) == 3
+    color_mag = sorted(color_mag, key=lambda x: x.origin)
+    assert len(color_mag) == 3
 
     # make sure the first one still exists
-    assert data["data"][0]["origin"] == "gaiadr1.gaia_source"
-    assert abs(data["data"][0]["abs_mag"] - 11.6) < 0.1
-    assert abs(data["data"][0]["color"] - 2.1) < 0.1
+    assert color_mag[0].origin == "gaiadr1.gaia_source"
+    assert abs(color_mag[0].abs_mag - 11.6) < 0.1
+    assert abs(color_mag[0].color - 2.1) < 0.1
 
     # make sure the second one still exists
-    assert data["data"][1]["origin"] == "gaiadr2.gaia_source"
-    assert abs(data["data"][1]["abs_mag"] - 11.7) < 0.1
-    assert abs(data["data"][1]["color"] - 2.2) < 0.1
+    assert color_mag[1].origin == "gaiadr2.gaia_source"
+    assert abs(color_mag[1].abs_mag - 11.7) < 0.1
+    assert abs(color_mag[1].color - 2.2) < 0.1
 
     # make sure the last was added
-    assert data["data"][2]["origin"] == "gaiadr3.gaia_source"
-    assert abs(data["data"][2]["abs_mag"] - 8.8) < 0.1
-    assert abs(data["data"][2]["color"] - 2.3) < 0.1
+    assert color_mag[2].origin == "gaiadr3.gaia_source"
+    assert abs(color_mag[2].abs_mag - 8.8) < 0.1
+    assert abs(color_mag[2].color - 2.3) < 0.1

--- a/skyportal/tests/api_tests/spectra_misc/test_db_stats.py
+++ b/skyportal/tests/api_tests/spectra_misc/test_db_stats.py
@@ -1,18 +1,20 @@
-from skyportal.tests import api
+import pytest
+from skyportal_py import SkyPortalError
+
+from skyportal.tests import client
 
 
 def test_db_stats(
     super_admin_token, public_source, public_group, public_candidate, user
 ):
-    status, data = api("GET", "db_stats", token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-    assert isinstance(data["data"]["Number of candidates"], int)
-    assert isinstance(data["data"]["Number of users"], int)
+    stats = client(super_admin_token).fetch_db_stats()
+    assert isinstance(stats["Number of candidates"], int)
+    assert isinstance(stats["Number of users"], int)
 
 
 def test_db_stats_access_denied(
     view_only_token, public_source, public_group, public_candidate, user
 ):
-    status, data = api("GET", "db_stats", token=view_only_token)
-    assert status == 401
+    with pytest.raises(SkyPortalError) as err:
+        client(view_only_token).fetch_db_stats()
+    assert err.value.status_code == 401

--- a/skyportal/tests/api_tests/spectra_misc/test_dbinfo.py
+++ b/skyportal/tests/api_tests/spectra_misc/test_dbinfo.py
@@ -1,11 +1,13 @@
 import skyportal
-from skyportal.tests import api
+from skyportal.tests import api, client
 
 
 def test_db_info(view_only_token):
+    info = client(view_only_token).fetch_dbinfo()
+    assert isinstance(info.source_table_empty, bool)
+    assert isinstance(info.postgres_version, str)
+
+    # raw api: the envelope-level version key is stripped by the typed client
     status, data = api("GET", "internal/dbinfo", token=view_only_token)
     assert status == 200
-    assert data["status"] == "success"
-    assert isinstance(data["data"]["source_table_empty"], bool)
-    assert isinstance(data["data"]["postgres_version"], str)
     assert data["version"] == skyportal.__version__

--- a/skyportal/tests/api_tests/spectra_misc/test_default_share_groups.py
+++ b/skyportal/tests/api_tests/spectra_misc/test_default_share_groups.py
@@ -1,4 +1,6 @@
-from skyportal.tests import api
+from skyportal_py.spectra import SpectrumPost
+
+from skyportal.tests import client
 
 
 def test_upload_without_groups_shares_with_uploader_only(
@@ -7,23 +9,18 @@ def test_upload_without_groups_shares_with_uploader_only(
     # With misc.share_data_with_public_group_by_default off (the default, and the
     # test config), a data product uploaded without group_ids is shared only with
     # the uploader's single-user group -- not the sitewide or any other group.
-    status, data = api(
-        "POST",
-        "spectrum",
-        data={
-            "obj_id": public_source.id,
-            "observed_at": "2020-01-10T00:00:00",
-            "instrument_id": lris.id,
-            "wavelengths": [664, 665, 666],
-            "fluxes": [234.3, 232.1, 235.3],
-        },
-        token=upload_data_token,
-    )
-    assert status == 200, data
-    spectrum_id = data["data"]["id"]
+    sp = client(upload_data_token)
+    spectrum_id = sp.post_spectrum(
+        SpectrumPost(
+            obj_id=public_source.id,
+            observed_at="2020-01-10T00:00:00",
+            instrument_id=lris.id,
+            wavelengths=[664, 665, 666],
+            fluxes=[234.3, 232.1, 235.3],
+        )
+    ).id
 
-    status, data = api("GET", f"spectrum/{spectrum_id}", token=upload_data_token)
-    assert status == 200, data
-    group_ids = {g["id"] for g in data["data"]["groups"]}
+    spectrum = sp.fetch_spectrum(spectrum_id)
+    group_ids = {g.id for g in spectrum.groups}
     assert group_ids == {user.single_user_group.id}
     assert public_group.id not in group_ids

--- a/skyportal/tests/api_tests/spectra_misc/test_earthquake.py
+++ b/skyportal/tests/api_tests/spectra_misc/test_earthquake.py
@@ -1,182 +1,126 @@
+import contextlib
 import os
 import uuid
+from datetime import datetime
 
 import numpy as np
+import pytest
+from skyportal_py import SkyPortalError
+from skyportal_py.earthquakes import EarthquakePost
+from skyportal_py.mmadetectors import MMADetectorPost
 
-from skyportal.tests import api
+from skyportal.tests import client
 
 
 def test_earthquake_predictions_and_measurements(super_admin_token, view_only_token):
+    sp = client(super_admin_token)
     name = str(uuid.uuid4())
-    post_data = {
-        "name": name,
-        "nickname": name,
-        "type": "gravitational-wave",
-        "fixed_location": True,
-        "lat": 0.0,
-        "lon": 0.0,
-    }
-
-    status, data = api("POST", "mmadetector", data=post_data, token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-    detector_id = data["data"]["id"]
+    detector_id = sp.post_mmadetector(
+        MMADetectorPost(
+            name=name,
+            nickname=name,
+            type="gravitational-wave",
+            fixed_location=True,
+            lat=0.0,
+            lon=0.0,
+        )
+    ).id
 
     event_id = str(uuid.uuid4())
-    data = {
-        "event_id": event_id,
-        "latitude": 39.3648333,
-        "longitude": -123.2506667,
-        "depth": 7380.0,
-        "magnitude": 2.93,
-        "date": "2020-08-19 02:00:39",
-    }
+    event_id = sp.post_earthquake(
+        EarthquakePost(
+            event_id=event_id,
+            latitude=39.3648333,
+            longitude=-123.2506667,
+            depth=7380.0,
+            magnitude=2.93,
+            date="2020-08-19 02:00:39",
+        )
+    ).id
 
-    status, data = api("POST", "earthquake", data=data, token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-    event_id = data["data"]["id"]
+    sp.post_earthquake_prediction(event_id, detector_id)
 
-    status, data = api(
-        "POST",
-        f"earthquake/{event_id}/mmadetector/{detector_id}/predictions",
-        data=post_data,
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp.post_earthquake_measurement(event_id, detector_id, rfamp=1e-5, lockloss=1)
 
-    measurement_data = {"rfamp": 1e-5, "lockloss": 1}
-    status, data = api(
-        "POST",
-        f"earthquake/{event_id}/mmadetector/{detector_id}/measurements",
-        token=super_admin_token,
-        data=measurement_data,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    event = sp.fetch_earthquake(event_id)
+    predictions = event.predictions
+    assert predictions[0].p == datetime(2020, 8, 19, 3, 47, 22, 163374)
+    assert predictions[0].r2p0 == datetime(2020, 8, 19, 3, 47, 22, 163374)
+    measurements = event.measurements
+    assert np.isclose(measurements[0].rfamp, 1e-5)
+    assert measurements[0].lockloss == 1
 
-    status, data = api("GET", f"earthquake/{event_id}", token=super_admin_token)
-    assert status == 200
-    data = data["data"]
-    predictions = data["predictions"]
-    assert predictions[0]["p"] == "2020-08-19T03:47:22.163374"
-    assert predictions[0]["r2p0"] == "2020-08-19T03:47:22.163374"
-    measurements = data["measurements"]
-    assert np.isclose(measurements[0]["rfamp"], 1e-5)
-    assert measurements[0]["lockloss"] == 1
+    sp.update_earthquake_measurement(event_id, detector_id, rfamp=1e-3, lockloss=0)
 
-    measurement_data = {"rfamp": 1e-3, "lockloss": 0}
-    status, data = api(
-        "PATCH",
-        f"earthquake/{event_id}/mmadetector/{detector_id}/measurements",
-        token=super_admin_token,
-        data=measurement_data,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    event = sp.fetch_earthquake(event_id)
+    measurements = event.measurements
+    assert np.isclose(measurements[0].rfamp, 1e-3)
+    assert measurements[0].lockloss == 0
 
-    status, data = api("GET", f"earthquake/{event_id}", token=super_admin_token)
-    assert status == 200
-    data = data["data"]
-    measurements = data["measurements"]
-    assert np.isclose(measurements[0]["rfamp"], 1e-3)
-    assert measurements[0]["lockloss"] == 0
+    sp.delete_earthquake_measurement(event_id, detector_id)
 
-    status, data = api(
-        "DELETE",
-        f"earthquake/{event_id}/mmadetector/{detector_id}/measurements",
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-
-    status, data = api("GET", f"earthquake/{event_id}", token=super_admin_token)
-    assert status == 200
-    data = data["data"]
-    measurements = data["measurements"]
+    event = sp.fetch_earthquake(event_id)
+    measurements = event.measurements
     assert len(measurements) == 0
 
 
 def test_earthquake_quakeml(super_admin_token, view_only_token):
+    sp = client(super_admin_token)
     datafile = f"{os.path.dirname(__file__)}/../../data/quakeml.xml"
     with open(datafile, "rb") as fid:
         payload = fid.read()
-    data = {"xml": payload}
 
-    status, data = api("POST", "earthquake", data=data, token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-    event_id = data["data"]["id"]
+    event_id = sp.post_earthquake(EarthquakePost(xml=payload)).id
 
-    status, data = api("GET", f"earthquake/{event_id}", token=super_admin_token)
-    assert status == 200
-    data = data["data"]
-    data = data["notices"][0]
-    assert data["date"] == "2020-08-19T02:00:39"
-    assert np.isclose(data["lat"], 39.3648333)
-    assert np.isclose(data["lon"], -123.2506667)
-    assert np.isclose(data["magnitude"], 2.93)
-    assert np.isclose(data["depth"], 7380.0)
+    event = sp.fetch_earthquake(event_id)
+    notice = event.notices[0]
+    assert notice.date == datetime(2020, 8, 19, 2, 0, 39)
+    assert np.isclose(notice.lat, 39.3648333)
+    assert np.isclose(notice.lon, -123.2506667)
+    assert np.isclose(notice.magnitude, 2.93)
+    assert np.isclose(notice.depth, 7380.0)
 
-    params = {
-        "startDate": "2020-01-01T00:00:00",
-        "endDate": "2021-01-01T00:00:00",
-    }
+    page = sp.fetch_earthquakes(
+        start_date="2020-01-01T00:00:00",
+        end_date="2021-01-01T00:00:00",
+    )
+    assert len(page.events) > 0
+    notice = page.events[0].notices[0]
+    assert notice.date == datetime(2020, 8, 19, 2, 0, 39)
+    assert np.isclose(notice.lat, 39.3648333)
+    assert np.isclose(notice.lon, -123.2506667)
+    assert np.isclose(notice.magnitude, 2.93)
+    assert np.isclose(notice.depth, 7380.0)
 
-    status, data = api("GET", "earthquake", token=super_admin_token, params=params)
-    assert status == 200
-    data = data["data"]
-    assert len(data["events"]) > 0
-    data = data["events"][0]
-    data = data["notices"][0]
-    assert data["date"] == "2020-08-19T02:00:39"
-    assert np.isclose(data["lat"], 39.3648333)
-    assert np.isclose(data["lon"], -123.2506667)
-    assert np.isclose(data["magnitude"], 2.93)
-    assert np.isclose(data["depth"], 7380.0)
-
-    params = {
-        "startDate": "2021-01-01T00:00:00",
-        "endDate": "2022-01-01T00:00:00",
-    }
-
-    status, data = api("GET", "earthquake", token=super_admin_token, params=params)
-    assert status == 200
-    data = data["data"]
-    assert len(data["events"]) == 0
+    page = sp.fetch_earthquakes(
+        start_date="2021-01-01T00:00:00",
+        end_date="2022-01-01T00:00:00",
+    )
+    assert len(page.events) == 0
 
 
 def test_earthquake_dictionary(super_admin_token, view_only_token):
-    data = {
-        "event_id": "quakeml:nc.anss.org-Event-NC-73446401",
-        "latitude": 39.3648333,
-        "longitude": -123.2506667,
-        "depth": 7380.0,
-        "magnitude": 2.93,
-        "date": "2020-08-19 02:00:39",
-    }
+    sp = client(super_admin_token)
+    event_id = sp.post_earthquake(
+        EarthquakePost(
+            event_id="quakeml:nc.anss.org-Event-NC-73446401",
+            latitude=39.3648333,
+            longitude=-123.2506667,
+            depth=7380.0,
+            magnitude=2.93,
+            date="2020-08-19 02:00:39",
+        )
+    ).id
 
-    status, data = api("POST", "earthquake", data=data, token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-    event_id = data["data"]["id"]
+    event = sp.fetch_earthquake(event_id)
+    assert event.notices[0].date == datetime(2020, 8, 19, 2, 0, 39)
 
-    status, data = api("GET", f"earthquake/{event_id}", token=super_admin_token)
-    assert status == 200
-    data = data["data"]
-    data = data["notices"][0]
-    assert data["date"] == "2020-08-19T02:00:39"
+    with pytest.raises(SkyPortalError, match="Earthquake event not found") as err:
+        client(view_only_token).delete_earthquake(event_id)
+    assert err.value.status_code == 404
 
-    status, data = api(
-        "DELETE", f"earthquake/{event_id}", data=data, token=view_only_token
-    )
-    assert data["message"] == "Earthquake event not found"
-    assert status == 404
+    sp.delete_earthquake(event_id)
 
-    status, data = api(
-        "DELETE", f"earthquake/{event_id}", data=data, token=super_admin_token
-    )
-    assert data["status"] == "success"
-
-    status, data = api("GET", f"earthquake/{event_id}", token=super_admin_token)
+    # original test issues this GET without checking the response
+    with contextlib.suppress(SkyPortalError):
+        sp.fetch_earthquake(event_id)

--- a/skyportal/tests/api_tests/spectra_misc/test_enum_types.py
+++ b/skyportal/tests/api_tests/spectra_misc/test_enum_types.py
@@ -1,11 +1,9 @@
-from skyportal.tests import api
+from skyportal.tests import client
 
 
 def test_enum_types_api(upload_data_token, super_admin_token):
     # get the enum types
-    status, data = api("GET", "enum_types", token=upload_data_token)
-    assert status == 200
-    assert data["status"] == "success"
+    enum_types = client(upload_data_token).fetch_enum_types()
 
     enum_types_list = [
         "ALLOWED_SPECTRUM_TYPES",
@@ -16,4 +14,4 @@ def test_enum_types_api(upload_data_token, super_admin_token):
         "ALLOWED_API_CLASSNAMES",
     ]
 
-    assert all(enum_type in data["data"] for enum_type in enum_types_list)
+    assert all(enum_type in enum_types for enum_type in enum_types_list)

--- a/skyportal/tests/api_tests/spectra_misc/test_finders.py
+++ b/skyportal/tests/api_tests/spectra_misc/test_finders.py
@@ -1,100 +1,62 @@
 import pytest
+from skyportal_py import SkyPortalError
 
-from skyportal.tests import api
+from skyportal.tests import api, client
 
 
 @pytest.mark.xfail(strict=False)
 def test_finder(upload_data_token, public_source):
-    status, data = api(
-        "PATCH",
-        f"sources/{public_source.id}",
-        data={"ra": 234.22, "dec": -22.33},
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp = client(upload_data_token)
+    sp.update_source(public_source.id, ra=234.22, dec=-22.33)
 
-    response = api(
-        "GET",
-        f"sources/{public_source.id}/finder",
-        params={"imsize": "2"},
-        token=upload_data_token,
-        raw_response=True,
-    )
-    status = response.status_code
-    data = response.text
-    assert status == 200
-    assert isinstance(data, str)
-    assert data[0:10].find("PDF") != -1
-    assert response.headers.get("Content-Type", "Empty").find("application/pdf") != -1
+    data = sp.fetch_source_finder(public_source.id, imsize=2)
+    assert isinstance(data, bytes)
+    assert data[0:10].find(b"PDF") != -1
 
     # try an image source we dont know about
-    status, data = api(
-        "GET",
-        f"sources/{public_source.id}/finder",
-        params={"image_source": "whoknows"},
-        token=upload_data_token,
-    )
-    assert status == 400
+    with pytest.raises(SkyPortalError) as err:
+        sp.fetch_source_finder(public_source.id, image_source="whoknows")
+    assert err.value.status_code == 400
 
     # try an image too big
-    status, data = api(
-        "GET",
-        f"sources/{public_source.id}/finder",
-        params={"imsize": "30"},
-        token=upload_data_token,
-    )
-    assert status == 400
+    with pytest.raises(SkyPortalError) as err:
+        sp.fetch_source_finder(public_source.id, imsize=30)
+    assert err.value.status_code == 400
 
 
 def test_finder_chart_facilities(upload_data_token):
-    status, data = api(
-        "GET",
-        "finder_chart/facilities",
-        token=upload_data_token,
-    )
-    assert status == 200
-    facilities = data["data"]
+    facilities = client(upload_data_token).fetch_finder_chart_facilities()
     assert "Keck" in facilities
     for params in facilities.values():
-        assert "mag_min" in params
-        assert "mag_limit" in params
-        assert params["mag_min"] < params["mag_limit"]
+        assert params.mag_min is not None
+        assert params.mag_limit is not None
+        assert params.mag_min < params.mag_limit
 
 
 def test_finder_rejects_invalid_parameters(upload_data_token, public_source):
-    status, data = api(
-        "GET",
-        f"sources/{public_source.id}/finder",
-        params={"image_source": "whoknows"},
-        token=upload_data_token,
-    )
-    assert status == 400
-    assert "Invalid image source" in data["message"]
+    sp = client(upload_data_token)
+    with pytest.raises(SkyPortalError, match="Invalid image source") as err:
+        sp.fetch_source_finder(public_source.id, image_source="whoknows")
+    assert err.value.status_code == 400
 
-    status, data = api(
-        "GET",
-        f"sources/{public_source.id}/finder",
-        params={"imsize": "30"},
-        token=upload_data_token,
-    )
-    assert status == 400
-    assert "imsize" in data["message"]
-    assert "outside the allowed range" in data["message"]
+    with pytest.raises(SkyPortalError) as err:
+        sp.fetch_source_finder(public_source.id, imsize=30)
+    assert err.value.status_code == 400
+    assert "imsize" in str(err.value)
+    assert "outside the allowed range" in str(err.value)
 
 
 def test_finder_offset_star_mag_range(upload_data_token, public_source):
     # An inverted range (bright end fainter than the faint end) is rejected.
-    status, data = api(
-        "GET",
-        f"sources/{public_source.id}/finder",
-        params={"mag_min": "18", "mag_limit": "12"},
-        token=upload_data_token,
-    )
-    assert status == 400
-    assert "mag_min" in data["message"]
+    with pytest.raises(SkyPortalError) as err:
+        client(upload_data_token).fetch_source_finder(
+            public_source.id, mag_min=18, mag_limit=12
+        )
+    assert err.value.status_code == 400
+    assert "mag_min" in str(err.value)
 
     # Non-numeric magnitude bounds are rejected.
+    # raw api: intentionally malformed query (non-numeric mag_min) the typed client can't produce
     status, data = api(
         "GET",
         f"sources/{public_source.id}/finder",
@@ -106,64 +68,40 @@ def test_finder_offset_star_mag_range(upload_data_token, public_source):
 
 @pytest.mark.xfail(strict=False)
 def test_unsourced_finder(upload_data_token):
+    sp = client(upload_data_token)
     # get a finder by gaia ID
-    response = api(
-        "GET",
-        "unsourced_finder",
-        params={
-            "catalog_id": "3905335598144227200",
-            "location_type": "gaia_dr3",
-            "image_source": "ps1",
-            "output_type": "pdf",
-            "obstime": "2012-02-28",
-            "use_ztfref": False,
-        },
-        token=upload_data_token,
-        raw_response=True,
+    data = sp.fetch_unsourced_finding_chart(
+        location_type="gaia_dr3",
+        catalog_id="3905335598144227200",
+        image_source="ps1",
+        output_type="pdf",
+        obstime="2012-02-28",
+        use_ztfref=False,
     )
-    status = response.status_code
-    data = response.text
-    assert status == 200
-    assert isinstance(data, str)
-    assert data[0:10].find("PDF") != -1
-    assert response.headers.get("Content-Type", "Empty").find("application/pdf") != -1
+    assert isinstance(data, bytes)
+    assert data[0:10].find(b"PDF") != -1
 
     # get a finder by position
-    response = api(
-        "GET",
-        "unsourced_finder",
-        params={
-            "location_type": "pos",
-            "ra": 234.22,
-            "dec": -22.33,
-            "image_source": "ps1",
-            "output_type": "pdf",
-            "obstime": "2020-02-28",
-            "use_ztfref": False,
-        },
-        token=upload_data_token,
-        raw_response=True,
+    data = sp.fetch_unsourced_finding_chart(
+        location_type="pos",
+        ra=234.22,
+        dec=-22.33,
+        image_source="ps1",
+        output_type="pdf",
+        obstime="2020-02-28",
+        use_ztfref=False,
     )
-    status = response.status_code
-    data = response.text
-    assert status == 200
-    assert isinstance(data, str)
-    assert data[0:10].find("PDF") != -1
-    assert response.headers.get("Content-Type", "Empty").find("application/pdf") != -1
+    assert isinstance(data, bytes)
+    assert data[0:10].find(b"PDF") != -1
 
     # try a bad Gaia ID
-    response = api(
-        "GET",
-        "unsourced_finder",
-        params={
-            "catalog_id": "-1",
-            "location_type": "gaia_dr3",
-            "image_source": "ps1",
-            "output_type": "pdf",
-            "obstime": "2012-02-28",
-            "use_ztfref": False,
-        },
-        token=upload_data_token,
-        raw_response=True,
-    )
-    assert response.status_code == 400
+    with pytest.raises(SkyPortalError) as err:
+        sp.fetch_unsourced_finding_chart(
+            location_type="gaia_dr3",
+            catalog_id="-1",
+            image_source="ps1",
+            output_type="pdf",
+            obstime="2012-02-28",
+            use_ztfref=False,
+        )
+    assert err.value.status_code == 400

--- a/skyportal/tests/api_tests/spectra_misc/test_galaxy.py
+++ b/skyportal/tests/api_tests/spectra_misc/test_galaxy.py
@@ -1,48 +1,44 @@
+import contextlib
 import os
 import time
 import uuid
 
 import numpy as np
+import pytest
 from astropy.table import Table
+from skyportal_py import SkyPortalError
+from skyportal_py.galaxies import GalaxyCatalogPost
+from skyportal_py.sources import SourcePost
 
-from skyportal.tests import api
+from skyportal.tests import client
 
 
 def test_galaxy(super_admin_token, view_only_token, gcn_GW190814):
+    sp_admin = client(super_admin_token)
+    sp_view = client(view_only_token)
     dateobs = gcn_GW190814.dateobs.strftime("%Y-%m-%dT%H:%M:%S")
 
     catalog_name = "test_galaxy_catalog"
     # in case the catalog already exists, delete it.
-    status, data = api(
-        "DELETE", f"galaxy_catalog/{catalog_name}", token=super_admin_token
-    )
+    with contextlib.suppress(SkyPortalError):
+        sp_admin.delete_galaxy_catalog(catalog_name)
 
     datafile = f"{os.path.dirname(__file__)}/../../../../data/CLU_mini.hdf5"
-    data = {
-        "catalog_name": catalog_name,
-        "catalog_data": Table.read(datafile)
-        .to_pandas()
-        .replace({np.nan: None})
-        .to_dict(orient="list"),
-    }
+    catalog_data = (
+        Table.read(datafile).to_pandas().replace({np.nan: None}).to_dict(orient="list")
+    )
 
-    status, data = api("POST", "galaxy_catalog", data=data, token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-
-    params = {"catalog_name": catalog_name}
+    sp_admin.post_galaxy_catalog(
+        GalaxyCatalogPost(catalog_name=catalog_name, catalog_data=catalog_data)
+    )
 
     nretries = 0
     galaxies_loaded = False
     while nretries < 40:
-        status, data = api(
-            "GET", "galaxy_catalog", token=view_only_token, params=params
-        )
-        assert status == 200
-        data = data["data"]["galaxies"]
-        if len(data) == 92 and any(
-            d["name"] == "6dFgs gJ0001313-055904" and d["mstar"] == 336.60756522868667
-            for d in data
+        galaxies = sp_view.fetch_galaxies(catalog_name=catalog_name).galaxies
+        if len(galaxies) == 92 and any(
+            g.name == "6dFgs gJ0001313-055904" and g.mstar == 336.60756522868667
+            for g in galaxies
         ):
             galaxies_loaded = True
             break
@@ -52,23 +48,20 @@ def test_galaxy(super_admin_token, view_only_token, gcn_GW190814):
     assert nretries < 40
     assert galaxies_loaded
 
-    params = {
-        "includeGeoJSON": True,
-        "catalog_name": catalog_name,
-        "localizationDateobs": dateobs,
-        "localizationCumprob": 0.45,
-    }
+    page = sp_view.fetch_galaxies(
+        catalog_name=catalog_name,
+        include_geojson=True,
+        localization_dateobs=dateobs,
+        localization_cumprob=0.45,
+    )
 
-    status, data = api("GET", "galaxy_catalog", token=view_only_token, params=params)
-    assert status == 200
-
-    geojson = data["data"]["geojson"]
-    data = data["data"]["galaxies"]
+    geojson = page.geojson
+    galaxies = page.galaxies
 
     # now we have restricted to only 3/92 being in localization
-    assert len(data) == 3
+    assert len(galaxies) == 3
     assert any(
-        d["name"] == "MCG -04-03-023" and d["mstar"] == 20113219211.26844 for d in data
+        g.name == "MCG -04-03-023" and g.mstar == 20113219211.26844 for g in galaxies
     )
 
     # The GeoJSON takes the form of
@@ -86,78 +79,61 @@ def test_galaxy(super_admin_token, view_only_token, gcn_GW190814):
         for d in geojson["features"]
     )
 
-    status, data = api(
-        "DELETE", f"galaxy_catalog/{catalog_name}", token=super_admin_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp_admin.delete_galaxy_catalog(catalog_name)
 
-    params = {"catalog_name": catalog_name}
-
-    status, data = api("GET", "galaxy_catalog", token=view_only_token, params=params)
-    assert status == 400
-    assert f"Catalog with name {catalog_name} not found" in data["message"]
+    with pytest.raises(
+        SkyPortalError, match=f"Catalog with name {catalog_name} not found"
+    ) as err:
+        sp_view.fetch_galaxies(catalog_name=catalog_name)
+    assert err.value.status_code == 400
 
 
 def test_source_host(
     super_admin_token, upload_data_token, view_only_token, public_group
 ):
+    sp_admin = client(super_admin_token)
+    sp_view = client(view_only_token)
     catalog_name = "test_galaxy_catalog"
 
     # in case the catalog already exists, delete it.
-    status, data = api(
-        "DELETE", f"galaxy_catalog/{catalog_name}", token=super_admin_token
-    )
+    with contextlib.suppress(SkyPortalError):
+        sp_admin.delete_galaxy_catalog(catalog_name)
 
     obj_id = str(uuid.uuid4())
     alias = str(uuid.uuid4())
     origin = str(uuid.uuid4())
 
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id,
-            "ra": 24.332952,
-            "dec": -33.331228,
-            "redshift": 3,
-            "transient": False,
-            "ra_dis": 2.3,
-            "group_ids": [public_group.id],
-            "alias": [alias],
-            "origin": origin,
-        },
-        token=upload_data_token,
+    resp = client(upload_data_token).post_source(
+        SourcePost(
+            id=obj_id,
+            ra=24.332952,
+            dec=-33.331228,
+            redshift=3,
+            transient=False,
+            ra_dis=2.3,
+            group_ids=[public_group.id],
+            alias=[alias],
+            origin=origin,
+        )
     )
-    assert status == 200
-    assert data["data"]["id"] == obj_id
+    assert resp.id == obj_id
 
     datafile = f"{os.path.dirname(__file__)}/../../../../data/CLU_mini.hdf5"
-    data = {
-        "catalog_name": catalog_name,
-        "catalog_data": Table.read(datafile)
-        .to_pandas()
-        .replace({np.nan: None})
-        .to_dict(orient="list"),
-    }
+    catalog_data = (
+        Table.read(datafile).to_pandas().replace({np.nan: None}).to_dict(orient="list")
+    )
 
-    status, data = api("POST", "galaxy_catalog", data=data, token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-
-    params = {"catalog_name": catalog_name}
+    sp_admin.post_galaxy_catalog(
+        GalaxyCatalogPost(catalog_name=catalog_name, catalog_data=catalog_data)
+    )
 
     nretries = 0
     galaxies_loaded = False
     while nretries < 40:
-        status, data = api(
-            "GET", "galaxy_catalog", token=view_only_token, params=params
-        )
-        assert status == 200
-        data = data["data"]["galaxies"]
-        if len(data) == 92 and any(
-            d["name"] == "6dFgs gJ0001313-055904" and d["mstar"] == 336.60756522868667
-            for d in data
+        galaxies = sp_view.fetch_galaxies(catalog_name=catalog_name).galaxies
+        if len(galaxies) == 92 and any(
+            g.name == "6dFgs gJ0001313-055904" and g.mstar == 336.60756522868667
+            for g in galaxies
         ):
             galaxies_loaded = True
             break
@@ -167,7 +143,6 @@ def test_source_host(
     assert nretries < 40
     assert galaxies_loaded
 
-    status, data = api("GET", f"sources/{obj_id}", token=view_only_token)
-    assert status == 200
-    assert data["data"]["id"] == obj_id
-    assert "GALEXASC J013719.93-331951.1" in data["data"]["galaxies"]
+    source = sp_view.fetch_source(obj_id)
+    assert source.id == obj_id
+    assert "GALEXASC J013719.93-331951.1" in source.galaxies

--- a/skyportal/tests/api_tests/spectra_misc/test_recurring_api.py
+++ b/skyportal/tests/api_tests/spectra_misc/test_recurring_api.py
@@ -3,7 +3,11 @@ import time
 import uuid
 from datetime import timedelta
 
-from skyportal.tests import api
+import pytest
+from skyportal_py import SkyPortalError
+from skyportal_py.recurring_apis import RecurringAPIPost
+
+from skyportal.tests import client
 
 from ....utils.naive_datetime import utcnow_naive
 
@@ -14,6 +18,7 @@ def test_post_and_verify_recurring_api(
     next_call = utcnow_naive() + timedelta(seconds=1)
     obj_id = str(uuid.uuid4())
 
+    sp = client(super_admin_token)
     request_data = {
         "next_call": next_call.strftime("%Y-%m-%dT%H:%M:%S"),
         "call_delay": 0.001,
@@ -22,14 +27,8 @@ def test_post_and_verify_recurring_api(
         "payload": "{Test incorrect payload}",
     }
 
-    status, data = api(
-        "POST",
-        "recurring_api",
-        data=request_data,
-        token=super_admin_token,
-    )
-    assert status == 400
-    assert data["message"] == "payload must be a valid JSON string"
+    with pytest.raises(SkyPortalError, match="payload must be a valid JSON string"):
+        sp.post_recurring_api(RecurringAPIPost(**request_data))
 
     request_data["payload"] = json.dumps(
         {
@@ -41,37 +40,18 @@ def test_post_and_verify_recurring_api(
         }
     )
 
-    endpoint = "recurring_api"
-    status, data = api(
-        "POST",
-        endpoint,
-        data=request_data,
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    recurring_api_id = data["data"]["id"]
+    recurring_api_id = sp.post_recurring_api(RecurringAPIPost(**request_data)).id
 
-    endpoint = f"recurring_api/{recurring_api_id}"
-    status, data = api(
-        "GET",
-        endpoint,
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp.fetch_recurring_api(recurring_api_id)
 
-    endpoint = f"sources/{obj_id}"
+    source = None
     n_retries = 0
     while n_retries < 10:
-        status, data = api(
-            "GET",
-            endpoint,
-            token=view_only_token,
-        )
-        if data["status"] == "success":
+        try:
+            source = client(view_only_token).fetch_source(obj_id)
             break
-        time.sleep(15)
-        n_retries += 1
+        except SkyPortalError:
+            time.sleep(15)
+            n_retries += 1
     assert n_retries < 10
-    assert status == 200
+    assert source is not None

--- a/skyportal/tests/api_tests/spectra_misc/test_sharing.py
+++ b/skyportal/tests/api_tests/spectra_misc/test_sharing.py
@@ -1,4 +1,8 @@
-from skyportal.tests import api
+import pytest
+from skyportal_py import SkyPortalError
+from skyportal_py.photometry import PhotometryPost
+
+from skyportal.tests import client
 
 
 def test_sharing_photometry(
@@ -11,57 +15,35 @@ def test_sharing_photometry(
 ):
     upload_data_token = upload_data_token_two_groups
     public_source = public_source_two_groups
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 58000.0,
-            "instrument_id": ztf_camera.id,
-            "flux": 12.24,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "group_ids": [public_group2.id],
-        },
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp = client(upload_data_token)
+    photometry_id = sp.post_photometry(
+        PhotometryPost(
+            obj_id=str(public_source.id),
+            mjd=58000.0,
+            instrument_id=ztf_camera.id,
+            flux=12.24,
+            fluxerr=0.031,
+            zp=25.0,
+            magsys="ab",
+            filter="ztfg",
+            group_ids=[public_group2.id],
+        )
+    ).ids[0]
 
-    photometry_id = data["data"]["ids"][0]
-    status, data = api(
-        "GET", f"photometry/{photometry_id}?format=flux", token=upload_data_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp.fetch_photometry_point(photometry_id, format="flux")
 
-    status, data = api(
-        "GET", f"photometry/{photometry_id}?format=flux", token=view_only_token
-    )
     # `view_only_token only` belongs to `public_group`, but not `public_group2`
-    assert status == 400
-    assert data["status"] == "error"
-    assert "Cannot find photometry point with ID" in data["message"]
+    with pytest.raises(
+        SkyPortalError, match="Cannot find photometry point with ID"
+    ) as err:
+        client(view_only_token).fetch_photometry_point(photometry_id, format="flux")
+    assert err.value.status_code == 400
 
-    status, data = api(
-        "POST",
-        "sharing",
-        data={"photometryIDs": [photometry_id], "groupIDs": [public_group.id]},
-        token=upload_data_token,
-    )
+    sp.post_sharing([public_group.id], photometry_ids=[photometry_id])
 
-    assert status == 200
-    assert data["status"] == "success"
-
-    status, data = api(
-        "GET", f"photometry/{photometry_id}?format=flux", token=view_only_token
-    )
     # `view_only_token only` belongs to `public_group`, but not `public_group2`
-    assert status == 200
-    assert data["status"] == "success"
-    assert data["data"]["obj_id"] == public_source.id
+    point = client(view_only_token).fetch_photometry_point(photometry_id, format="flux")
+    assert point.obj_id == public_source.id
 
 
 def test_sharing_photometry_with_foreign_group(
@@ -73,57 +55,37 @@ def test_sharing_photometry_with_foreign_group(
     ztf_camera,
 ):
     public_source = public_source_two_groups
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 58000.0,
-            "instrument_id": ztf_camera.id,
-            "flux": 12.24,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "group_ids": [public_group2.id],
-        },
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp = client(upload_data_token)
+    photometry_id = sp.post_photometry(
+        PhotometryPost(
+            obj_id=str(public_source.id),
+            mjd=58000.0,
+            instrument_id=ztf_camera.id,
+            flux=12.24,
+            fluxerr=0.031,
+            zp=25.0,
+            magsys="ab",
+            filter="ztfg",
+            group_ids=[public_group2.id],
+        )
+    ).ids[0]
 
-    photometry_id = data["data"]["ids"][0]
-    status, data = api(
-        "GET", f"photometry/{photometry_id}?format=flux", token=upload_data_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp.fetch_photometry_point(photometry_id, format="flux")
 
-    status, data = api(
-        "GET", f"photometry/{photometry_id}?format=flux", token=view_only_token2
-    )
     # `view_only_token only` belongs to `public_group`, but not `public_group2`
-    assert status == 400
-    assert data["status"] == "error"
-    assert "Cannot find photometry point with ID" in data["message"]
+    with pytest.raises(
+        SkyPortalError, match="Cannot find photometry point with ID"
+    ) as err:
+        client(view_only_token2).fetch_photometry_point(photometry_id, format="flux")
+    assert err.value.status_code == 400
 
-    status, data = api(
-        "POST",
-        "sharing",
-        data={"photometryIDs": [photometry_id], "groupIDs": [public_group.id]},
-        token=upload_data_token,
-    )
+    sp.post_sharing([public_group.id], photometry_ids=[photometry_id])
 
-    assert status == 200
-    assert data["status"] == "success"
-
-    status, data = api(
-        "GET", f"photometry/{photometry_id}?format=flux", token=view_only_token2
-    )
     # `view_only_token only` belongs to `public_group`, but not `public_group2`
-    assert status == 200
-    assert data["status"] == "success"
-    assert data["data"]["obj_id"] == public_source.id
+    point = client(view_only_token2).fetch_photometry_point(
+        photometry_id, format="flux"
+    )
+    assert point.obj_id == public_source.id
 
 
 def test_cannot_share_unowned_photometry(
@@ -135,42 +97,29 @@ def test_cannot_share_unowned_photometry(
     view_only_token_group2,
     ztf_camera,
 ):
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 58000.0,
-            "instrument_id": ztf_camera.id,
-            "flux": 12.24,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp = client(upload_data_token)
+    photometry_id = sp.post_photometry(
+        PhotometryPost(
+            obj_id=str(public_source.id),
+            mjd=58000.0,
+            instrument_id=ztf_camera.id,
+            flux=12.24,
+            fluxerr=0.031,
+            zp=25.0,
+            magsys="ab",
+            filter="ztfg",
+            group_ids=[public_group.id],
+        )
+    ).ids[0]
 
-    photometry_id = data["data"]["ids"][0]
-    status, data = api(
-        "GET", f"photometry/{photometry_id}?format=flux", token=upload_data_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp.fetch_photometry_point(photometry_id, format="flux")
 
-    status, data = api(
-        "POST",
-        "sharing",
-        data={"photometryIDs": [photometry_id], "groupIDs": [public_group2.id]},
-        token=upload_data_token_two_groups,
-    )
-
-    assert status == 400
-    assert data["status"] == "error"
-    assert "owner" in data["message"].lower()
+    with pytest.raises(SkyPortalError) as err:
+        client(upload_data_token_two_groups).post_sharing(
+            [public_group2.id], photometry_ids=[photometry_id]
+        )
+    assert err.value.status_code == 400
+    assert "owner" in str(err.value).lower()
 
 
 def test_system_admin_can_share_unowned_photometry(
@@ -182,69 +131,49 @@ def test_system_admin_can_share_unowned_photometry(
     view_only_token_group2,
     ztf_camera,
 ):
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(public_source.id),
-            "mjd": 58000.0,
-            "instrument_id": ztf_camera.id,
-            "flux": 12.24,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp = client(upload_data_token)
+    photometry_id = sp.post_photometry(
+        PhotometryPost(
+            obj_id=str(public_source.id),
+            mjd=58000.0,
+            instrument_id=ztf_camera.id,
+            flux=12.24,
+            fluxerr=0.031,
+            zp=25.0,
+            magsys="ab",
+            filter="ztfg",
+            group_ids=[public_group.id],
+        )
+    ).ids[0]
 
-    photometry_id = data["data"]["ids"][0]
-    status, data = api(
-        "GET", f"photometry/{photometry_id}?format=flux", token=upload_data_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp.fetch_photometry_point(photometry_id, format="flux")
 
-    status, data = api(
-        "POST",
-        "sharing",
-        data={"photometryIDs": [photometry_id], "groupIDs": [public_group2.id]},
-        token=super_admin_token,
+    client(super_admin_token).post_sharing(
+        [public_group2.id], photometry_ids=[photometry_id]
     )
 
-    assert status == 200
-    assert data["status"] == "success"
-
-    status, data = api(
-        "GET", f"photometry/{photometry_id}?format=flux", token=view_only_token_group2
-    )
     # `view_only_token only` belongs to `public_group`, but not `public_group2`
-    assert status == 200
-    assert data["status"] == "success"
+    client(view_only_token_group2).fetch_photometry_point(photometry_id, format="flux")
 
 
 def _upload_photometry(token, obj_id, group_id, instrument_id):
-    status, data = api(
-        "POST",
-        "photometry",
-        data={
-            "obj_id": str(obj_id),
-            "mjd": 58000.0,
-            "instrument_id": instrument_id,
-            "flux": 12.24,
-            "fluxerr": 0.031,
-            "zp": 25.0,
-            "magsys": "ab",
-            "filter": "ztfg",
-            "group_ids": [group_id],
-        },
-        token=token,
+    return (
+        client(token)
+        .post_photometry(
+            PhotometryPost(
+                obj_id=str(obj_id),
+                mjd=58000.0,
+                instrument_id=instrument_id,
+                flux=12.24,
+                fluxerr=0.031,
+                zp=25.0,
+                magsys="ab",
+                filter="ztfg",
+                group_ids=[group_id],
+            )
+        )
+        .ids[0]
     )
-    assert status == 200
-    return data["data"]["ids"][0]
 
 
 def test_can_share_grants_sharing_of_unowned_photometry(
@@ -263,37 +192,24 @@ def test_can_share_grants_sharing_of_unowned_photometry(
     )
 
     # Without `can_share_photometry` in the point's group, a non-owner is refused.
-    status, data = api(
-        "POST",
-        "sharing",
-        data={"photometryIDs": [photometry_id], "groupIDs": [public_group2.id]},
-        token=upload_data_token_two_groups,
-    )
-    assert status == 400
-    assert data["status"] == "error"
+    with pytest.raises(SkyPortalError) as err:
+        client(upload_data_token_two_groups).post_sharing(
+            [public_group2.id], photometry_ids=[photometry_id]
+        )
+    assert err.value.status_code == 400
 
-    status, data = api(
-        "PATCH",
-        f"groups/{public_group.id}/users",
-        data={"userID": user_two_groups.id, "canSharePhotometry": True},
-        token=super_admin_token,
+    client(super_admin_token).update_group_user(
+        public_group.id, user_two_groups.id, can_share_photometry=True
     )
-    assert status == 200
 
-    status, data = api(
-        "POST",
-        "sharing",
-        data={"photometryIDs": [photometry_id], "groupIDs": [public_group2.id]},
-        token=upload_data_token_two_groups,
+    client(upload_data_token_two_groups).post_sharing(
+        [public_group2.id], photometry_ids=[photometry_id]
     )
-    assert status == 200
-    assert data["status"] == "success"
 
-    status, data = api(
-        "GET", f"photometry/{photometry_id}?format=flux", token=view_only_token_group2
+    point = client(view_only_token_group2).fetch_photometry_point(
+        photometry_id, format="flux"
     )
-    assert status == 200
-    assert data["data"]["obj_id"] == public_source.id
+    assert point.obj_id == public_source.id
 
 
 def test_can_share_does_not_apply_to_spectra(
@@ -304,25 +220,15 @@ def test_can_share_does_not_apply_to_spectra(
     public_group,
     public_group2,
 ):
-    status, data = api(
-        "PATCH",
-        f"groups/{public_group.id}/users",
-        data={"userID": user_two_groups.id, "canSharePhotometry": True},
-        token=super_admin_token,
+    client(super_admin_token).update_group_user(
+        public_group.id, user_two_groups.id, can_share_photometry=True
     )
-    assert status == 200
 
-    status, data = api(
-        "POST",
-        "sharing",
-        data={
-            "spectrumIDs": [public_source_spectrum.id],
-            "groupIDs": [public_group2.id],
-        },
-        token=upload_data_token_two_groups,
-    )
-    assert status == 400
-    assert data["status"] == "error"
+    with pytest.raises(SkyPortalError) as err:
+        client(upload_data_token_two_groups).post_sharing(
+            [public_group2.id], spectrum_ids=[public_source_spectrum.id]
+        )
+    assert err.value.status_code == 400
 
 
 def test_can_share_photometry_limited_to_own_groups(
@@ -339,38 +245,19 @@ def test_can_share_photometry_limited_to_own_groups(
         upload_data_token, public_source.id, public_group.id, ztf_camera.id
     )
 
-    status, data = api(
-        "PATCH",
-        f"groups/{public_group.id}/users",
-        data={"userID": user_two_groups.id, "canSharePhotometry": True},
-        token=super_admin_token,
+    client(super_admin_token).update_group_user(
+        public_group.id, user_two_groups.id, can_share_photometry=True
     )
-    assert status == 200
 
     # `user_two_groups` is not a member of `public_group_no_streams`, so it cannot
     # receive a point they do not own.
-    status, data = api(
-        "POST",
-        "sharing",
-        data={
-            "photometryIDs": [photometry_id],
-            "groupIDs": [public_group_no_streams.id],
-        },
-        token=upload_data_token_two_groups,
-    )
-    assert status == 400
-    assert data["status"] == "error"
-    assert "not a member of" in data["message"]
+    with pytest.raises(SkyPortalError, match="not a member of") as err:
+        client(upload_data_token_two_groups).post_sharing(
+            [public_group_no_streams.id], photometry_ids=[photometry_id]
+        )
+    assert err.value.status_code == 400
 
     # The owner is not restricted.
-    status, data = api(
-        "POST",
-        "sharing",
-        data={
-            "photometryIDs": [photometry_id],
-            "groupIDs": [public_group_no_streams.id],
-        },
-        token=upload_data_token,
+    client(upload_data_token).post_sharing(
+        [public_group_no_streams.id], photometry_ids=[photometry_id]
     )
-    assert status == 200
-    assert data["status"] == "success"

--- a/skyportal/tests/api_tests/spectra_misc/test_spatial_catalog.py
+++ b/skyportal/tests/api_tests/spectra_misc/test_spatial_catalog.py
@@ -4,8 +4,10 @@ import uuid
 
 import pandas as pd
 import pytest
+from skyportal_py import SkyPortalError
+from skyportal_py.sources import SourcePost
 
-from skyportal.tests import api
+from skyportal.tests import client
 
 
 @pytest.mark.flaky(reruns=3)
@@ -17,54 +19,39 @@ def test_spatial_catalog(super_admin_token, upload_data_token, view_only_token):
     entries = [str(uuid.uuid4()) for _ in range(len(data_out))]
     data_out["name"] = entries
 
-    data = {
-        "catalog_name": catalog_name,
-        "catalog_data": data_out.to_dict(orient="list"),
-    }
-
-    status, data = api("POST", "spatial_catalog", data=data, token=super_admin_token)
-    assert status == 200
-
-    catalog_id = data["data"]["id"]
+    sp_admin = client(super_admin_token)
+    catalog_id = sp_admin.post_spatial_catalog(
+        catalog_name, data_out.to_dict(orient="list")
+    ).id
 
     # wait for catalog to load
     for n_times in range(26):
-        status, data = api(
-            "GET", f"spatial_catalog/{catalog_id}", token=super_admin_token
-        )
-        if data["status"] == "success" and len(data["data"]["entries"]) == 2:
+        catalog = sp_admin.fetch_spatial_catalog(catalog_id)
+        if catalog.entries is not None and len(catalog.entries) == 2:
             break
         time.sleep(2)
     assert n_times < 25
 
     obj_id = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "sources",
-        data={
-            "id": obj_id,
-            "ra": 33.043637,
-            "dec": 53.36078,
-        },
-        token=upload_data_token,
+    client(upload_data_token).post_source(
+        SourcePost(
+            id=obj_id,
+            ra=33.043637,
+            dec=53.36078,
+        )
     )
-    assert status == 200
 
-    status, data = api("GET", f"sources/{obj_id}", token=view_only_token)
-    assert status == 200
+    client(view_only_token).fetch_source(obj_id)
 
-    params = {
-        "spatialCatalogName": catalog_name,
-        "spatialCatalogEntryName": entries[1],
-    }
-    status, data = api("GET", "sources", token=view_only_token, params=params)
-    assert len(data["data"]["sources"]) >= 1
-    assert any(source["id"] == obj_id for source in data["data"]["sources"])
-
-    status, data = api(
-        "DELETE", f"spatial_catalog/{catalog_id}", data=data, token=super_admin_token
+    page = client(view_only_token).fetch_sources(
+        spatial_catalog_name=catalog_name,
+        spatial_catalog_entry_name=entries[1],
     )
-    assert status == 200
+    assert len(page.sources) >= 1
+    assert any(source.id == obj_id for source in page.sources)
 
-    status, data = api("GET", f"spatial_catalog/{catalog_id}", token=super_admin_token)
-    assert status == 400
+    sp_admin.delete_spatial_catalog(catalog_id)
+
+    with pytest.raises(SkyPortalError) as err:
+        sp_admin.fetch_spatial_catalog(catalog_id)
+    assert err.value.status_code == 400

--- a/skyportal/tests/api_tests/spectra_misc/test_spectrum.py
+++ b/skyportal/tests/api_tests/spectra_misc/test_spectrum.py
@@ -6,130 +6,76 @@ from glob import glob
 
 import arrow
 import numpy as np
+import pytest
 import yaml
+from skyportal_py import SkyPortalError
+from skyportal_py.groups import GroupPost
+from skyportal_py.spectra import (
+    SpectrumAsciiParse,
+    SpectrumAsciiPost,
+    SpectrumPost,
+    SpectrumUpdate,
+)
 
 from skyportal.enum_types import ALLOWED_SPECTRUM_TYPES, default_spectrum_type
-from skyportal.tests import api
+from skyportal.tests import api, client
 
 from ....utils.naive_datetime import utcnow_naive
 
 
 def test_spectrum_put(super_admin_user, super_admin_token, public_source, lris):
+    sp = client(super_admin_token)
+
     # make groups that must be unique to this test
-    status, data = api(
-        "POST",
-        "groups",
-        data={
-            "name": str(uuid.uuid4()),
-            "group_admins": [super_admin_user.id],
-        },
-        token=super_admin_token,
-    )
+    group_id1 = sp.post_group(
+        GroupPost(
+            name=str(uuid.uuid4()),
+            group_admins=[super_admin_user.id],
+        )
+    ).id
 
-    assert status == 200
-    assert data["status"] == "success"
-    group_id1 = data["data"]["id"]
+    group_id2 = sp.post_group(
+        GroupPost(
+            name=str(uuid.uuid4()),
+            group_admins=[super_admin_user.id],
+        )
+    ).id
 
-    status, data = api(
-        "POST",
-        "groups",
-        data={
-            "name": str(uuid.uuid4()),
-            "group_admins": [super_admin_user.id],
-        },
-        token=super_admin_token,
-    )
-
-    assert status == 200
-    assert data["status"] == "success"
-    group_id2 = data["data"]["id"]
-
-    status, data = api(
-        "POST",
-        "spectrum",
-        data={
-            "obj_id": public_source.id,
-            "observed_at": "2020-01-10T00:00:00",
-            "instrument_id": lris.id,
-            "wavelengths": [664, 665, 666],
-            "fluxes": [234.3, 232.1, 235.3],
-            "group_ids": [group_id1],
-        },
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    spectrum_id = data["data"]["id"]
-
-    assert status == 200
-    assert data["status"] == "success"
+    spectrum_id = sp.post_spectrum(
+        SpectrumPost(
+            obj_id=public_source.id,
+            observed_at="2020-01-10T00:00:00",
+            instrument_id=lris.id,
+            wavelengths=[664, 665, 666],
+            fluxes=[234.3, 232.1, 235.3],
+            group_ids=[group_id1],
+        )
+    ).id
 
     # update only the label
     custom_label = str(uuid.uuid4())
-    status, data = api(
-        "PUT",
-        f"spectrum/{spectrum_id}",
-        data={
-            "label": custom_label,
-        },
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp.update_spectrum(spectrum_id, SpectrumUpdate(label=custom_label))
 
-    status, data = api(
-        "GET",
-        f"spectrum/{spectrum_id}",
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    assert data["data"]["label"] == custom_label
-    group_ids = [g["id"] for g in data["data"]["groups"]]
+    spectrum = sp.fetch_spectrum(spectrum_id)
+    assert spectrum.label == custom_label
+    group_ids = [g.id for g in spectrum.groups]
     assert group_id1 in group_ids
     assert group_id2 not in group_ids
 
     # update the group IDs (should ADD group2, not remove group1)
-    status, data = api(
-        "PUT",
-        f"spectrum/{spectrum_id}",
-        data={"group_ids": [group_id2]},
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp.update_spectrum(spectrum_id, SpectrumUpdate(group_ids=[group_id2]))
 
-    status, data = api(
-        "GET",
-        f"spectrum/{spectrum_id}",
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    assert data["data"]["label"] == custom_label
-    group_ids = [g["id"] for g in data["data"]["groups"]]
+    spectrum = sp.fetch_spectrum(spectrum_id)
+    assert spectrum.label == custom_label
+    group_ids = [g.id for g in spectrum.groups]
     assert group_id1 in group_ids  # PUT is only allowed to remove groups
     assert group_id2 in group_ids
-    num_groups = len(data["data"]["groups"])
+    num_groups = len(spectrum.groups)
 
     # adding the same group ID doesn't make redundant groups
-    status, data = api(
-        "PUT",
-        f"spectrum/{spectrum_id}",
-        data={"group_ids": [group_id1]},
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp.update_spectrum(spectrum_id, SpectrumUpdate(group_ids=[group_id1]))
 
-    status, data = api(
-        "GET",
-        f"spectrum/{spectrum_id}",
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    assert num_groups == len(data["data"]["groups"])
+    assert num_groups == len(sp.fetch_spectrum(spectrum_id).groups)
 
 
 def test_spectrum_filtering_obj_groups(
@@ -139,158 +85,87 @@ def test_spectrum_filtering_obj_groups(
     public_source_two_groups,
     lris,
 ):
+    sp = client(super_admin_token)
+
     # make groups that must be unique to this test
-    status, data = api(
-        "POST",
-        "groups",
-        data={
-            "name": str(uuid.uuid4()),
-            "group_admins": [super_admin_user.id],
-        },
-        token=super_admin_token,
-    )
+    group_id1 = sp.post_group(
+        GroupPost(
+            name=str(uuid.uuid4()),
+            group_admins=[super_admin_user.id],
+        )
+    ).id
 
-    assert status == 200
-    assert data["status"] == "success"
-    group_id1 = data["data"]["id"]
+    group_id2 = sp.post_group(
+        GroupPost(
+            name=str(uuid.uuid4()),
+            group_admins=[super_admin_user.id],
+        )
+    ).id
 
-    status, data = api(
-        "POST",
-        "groups",
-        data={
-            "name": str(uuid.uuid4()),
-            "group_admins": [super_admin_user.id],
-        },
-        token=super_admin_token,
-    )
+    spectrum_id1 = sp.post_spectrum(
+        SpectrumPost(
+            obj_id=public_source.id,
+            observed_at="2020-01-10T00:00:00",
+            instrument_id=lris.id,
+            wavelengths=[664, 665, 666],
+            fluxes=[234.3, 232.1, 235.3],
+            group_ids=[group_id1],
+        )
+    ).id
 
-    assert status == 200
-    assert data["status"] == "success"
-    group_id2 = data["data"]["id"]
-
-    status, data = api(
-        "POST",
-        "spectrum",
-        data={
-            "obj_id": public_source.id,
-            "observed_at": "2020-01-10T00:00:00",
-            "instrument_id": lris.id,
-            "wavelengths": [664, 665, 666],
-            "fluxes": [234.3, 232.1, 235.3],
-            "group_ids": [group_id1],
-        },
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    spectrum_id1 = data["data"]["id"]
-
-    assert status == 200
-    assert data["status"] == "success"
-
-    status, data = api(
-        "POST",
-        "spectrum",
-        data={
-            "obj_id": public_source_two_groups.id,
-            "observed_at": str(datetime.datetime.now()),
-            "instrument_id": lris.id,
-            "wavelengths": [664, 665, 666],
-            "fluxes": [434.7, 432.1, 435.3],
-            "group_ids": [group_id1, group_id2],
-        },
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    spectrum_id2 = data["data"]["id"]
+    spectrum_id2 = sp.post_spectrum(
+        SpectrumPost(
+            obj_id=public_source_two_groups.id,
+            observed_at=str(datetime.datetime.now()),
+            instrument_id=lris.id,
+            wavelengths=[664, 665, 666],
+            fluxes=[434.7, 432.1, 435.3],
+            group_ids=[group_id1, group_id2],
+        )
+    ).id
 
     # filter on groups:
-    status, data = api(
-        "GET",
-        "spectra",
-        params={"groupIDs": group_id1},  # should get both spectra
-        token=super_admin_token,
+    spectra = sp.fetch_spectra_query(group_ids=[group_id1])  # should get both spectra
+    assert len(spectra) == 2
+    assert spectra[0].id == spectrum_id1
+    assert spectra[1].id == spectrum_id2
+    assert spectra[0].fluxes[0] == 234.3
+    assert spectra[1].fluxes[0] == 434.7
+
+    spectra = sp.fetch_spectra_query(
+        group_ids=[group_id1, group_id2]  # should get both spectra
     )
+    assert len(spectra) == 2
+    assert spectra[0].id == spectrum_id1
+    assert spectra[1].id == spectrum_id2
 
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]) == 2
-    assert data["data"][0]["id"] == spectrum_id1
-    assert data["data"][1]["id"] == spectrum_id2
-    assert data["data"][0]["fluxes"][0] == 234.3
-    assert data["data"][1]["fluxes"][0] == 434.7
-
-    status, data = api(
-        "GET",
-        "spectra",
-        params={"groupIDs": f"{group_id1}, {group_id2}"},  # should get both spectra
-        token=super_admin_token,
+    spectra = sp.fetch_spectra_query(
+        group_ids=[group_id2]  # should get only second spectrum
     )
-
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]) == 2
-    assert data["data"][0]["id"] == spectrum_id1
-    assert data["data"][1]["id"] == spectrum_id2
-
-    status, data = api(
-        "GET",
-        "spectra",
-        params={"groupIDs": group_id2},  # should get only second spectrum
-        token=super_admin_token,
-    )
-
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]) == 1
-    assert data["data"][0]["id"] == spectrum_id2
+    assert len(spectra) == 1
+    assert spectra[0].id == spectrum_id2
 
     # test objID
-    status, data = api(
-        "GET",
-        "spectra",
-        params={
-            "groupIDs": group_id1,
-            "objID": public_source.id,  # should get only first spectrum
-        },
-        token=super_admin_token,
+    spectra = sp.fetch_spectra_query(
+        group_ids=[group_id1],
+        obj_id=public_source.id,  # should get only first spectrum
     )
+    assert len(spectra) == 1
+    assert spectra[0].id == spectrum_id1
 
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]) == 1
-    assert data["data"][0]["id"] == spectrum_id1
-
-    status, data = api(
-        "GET",
-        "spectra",
-        params={
-            "groupIDs": group_id1,
-            # partial match to second spectrum
-            "objID": public_source_two_groups.id[5:15],
-        },
-        token=super_admin_token,
+    spectra = sp.fetch_spectra_query(
+        group_ids=[group_id1],
+        # partial match to second spectrum
+        obj_id=public_source_two_groups.id[5:15],
     )
+    assert len(spectra) == 1
+    assert spectra[0].id == spectrum_id2
 
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]) == 1
-    assert data["data"][0]["id"] == spectrum_id2
-
-    status, data = api(
-        "GET",
-        "spectra",
-        params={
-            "groupIDs": group_id1,
-            "objID": "ZTF2022abcdef",  # should not match anything
-        },
-        token=super_admin_token,
+    spectra = sp.fetch_spectra_query(
+        group_ids=[group_id1],
+        obj_id="ZTF2022abcdef",  # should not match anything
     )
-
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]) == 0
+    assert len(spectra) == 0
 
 
 def test_spectrum_filtering_time_ranges(
@@ -299,124 +174,77 @@ def test_spectrum_filtering_time_ranges(
     public_source,
     lris,
 ):
-    # make a group that is unique to this test
-    status, data = api(
-        "POST",
-        "groups",
-        data={
-            "name": str(uuid.uuid4()),
-            "group_admins": [super_admin_user.id],
-        },
-        token=super_admin_token,
-    )
+    sp = client(super_admin_token)
 
-    assert status == 200
-    assert data["status"] == "success"
-    group_id = data["data"]["id"]
+    # make a group that is unique to this test
+    group_id = sp.post_group(
+        GroupPost(
+            name=str(uuid.uuid4()),
+            group_admins=[super_admin_user.id],
+        )
+    ).id
 
     # post two spectra at different times
-    status, data = api(
-        "POST",
-        "spectrum",
-        data={
-            "obj_id": public_source.id,
-            "observed_at": "2020-01-10T00:00:00",
-            "instrument_id": lris.id,
-            "wavelengths": [664, 665, 666],
-            "fluxes": [234.3, 232.1, 235.3],
-            "group_ids": [group_id],
-        },
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    spectrum_id1 = data["data"]["id"]
+    spectrum_id1 = sp.post_spectrum(
+        SpectrumPost(
+            obj_id=public_source.id,
+            observed_at="2020-01-10T00:00:00",
+            instrument_id=lris.id,
+            wavelengths=[664, 665, 666],
+            fluxes=[234.3, 232.1, 235.3],
+            group_ids=[group_id],
+        )
+    ).id
 
     time_after_posting_first_spec = str(utcnow_naive())
 
-    status, data = api(
-        "POST",
-        "spectrum",
-        data={
-            "obj_id": public_source.id,
-            "observed_at": time_after_posting_first_spec,
-            "instrument_id": lris.id,
-            "wavelengths": [664, 665, 666],
-            "fluxes": [434.7, 432.1, 435.3],
-            "group_ids": [group_id],
-        },
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    spectrum_id2 = data["data"]["id"]
+    spectrum_id2 = sp.post_spectrum(
+        SpectrumPost(
+            obj_id=public_source.id,
+            observed_at=time_after_posting_first_spec,
+            instrument_id=lris.id,
+            wavelengths=[664, 665, 666],
+            fluxes=[434.7, 432.1, 435.3],
+            group_ids=[group_id],
+        )
+    ).id
 
-    status, data = api(
-        "GET",
-        "spectra",
-        params={
-            "groupIDs": group_id,
-            "observedBefore": "2021-01-10T00:00:00",  # one year after 1st spectrum
-        },
-        token=super_admin_token,
+    spectra = sp.fetch_spectra_query(
+        group_ids=[group_id],
+        observed_before="2021-01-10T00:00:00",  # one year after 1st spectrum
     )
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]) == 1
-    assert data["data"][0]["id"] == spectrum_id1
-    assert data["data"][0]["fluxes"][0] == 234.3
-    assert data["data"][0]["obj_id"] == public_source.id
+    assert len(spectra) == 1
+    assert spectra[0].id == spectrum_id1
+    assert spectra[0].fluxes[0] == 234.3
+    assert spectra[0].obj_id == public_source.id
 
     # test open ended range that includes second spectrum
-    status, data = api(
-        "GET",
-        "spectra",
-        params={
-            "groupIDs": group_id,
-            "observedAfter": time_after_posting_first_spec,
-        },
-        token=super_admin_token,
+    spectra = sp.fetch_spectra_query(
+        group_ids=[group_id],
+        observed_after=time_after_posting_first_spec,
     )
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]) == 1
-    assert data["data"][0]["id"] == spectrum_id2
-    assert data["data"][0]["fluxes"][0] == 434.7
-    assert data["data"][0]["obj_id"] == public_source.id
+    assert len(spectra) == 1
+    assert spectra[0].id == spectrum_id2
+    assert spectra[0].fluxes[0] == 434.7
+    assert spectra[0].obj_id == public_source.id
 
     # test open ended range that includes both spectra
-    status, data = api(
-        "GET",
-        "spectra",
-        params={
-            "groupIDs": group_id,
-            "observedAfter": "2020-01-01T00:00:00",
-        },
-        token=super_admin_token,
+    spectra = sp.fetch_spectra_query(
+        group_ids=[group_id],
+        observed_after="2020-01-01T00:00:00",
     )
-
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]) == 2
+    assert len(spectra) == 2
 
     # test various date formats
     # can't parse this: 'T00:00:00&plus;00:00'
     dates = ["", "T00:00:00+00:00", "T00:00:00Z"]
     for d in dates:
-        status, data = api(
-            "GET",
-            "spectra",
-            params={
-                "groupIDs": group_id,
-                "observedAfter": f"2020-01-15{d}",  # should get only second spectrum
-            },
-            token=super_admin_token,
+        spectra = sp.fetch_spectra_query(
+            group_ids=[group_id],
+            observed_after=f"2020-01-15{d}",  # should get only second spectrum
         )
-
-        assert status == 200
-        assert data["status"] == "success"
-        assert len(data["data"]) == 1
-        assert data["data"][0]["id"] == spectrum_id2
+        assert len(spectra) == 1
+        assert spectra[0].id == spectrum_id2
 
 
 def test_spectrum_filtering_id_lists(
@@ -430,118 +258,71 @@ def test_spectrum_filtering_id_lists(
     public_source_group2_followup_request,
     public_assignment,
 ):
-    # make a group that is unique to this test
-    status, data = api(
-        "POST",
-        "groups",
-        data={
-            "name": str(uuid.uuid4()),
-            "group_admins": [super_admin_user.id],
-        },
-        token=super_admin_token,
-    )
+    sp = client(super_admin_token)
 
-    assert status == 200
-    assert data["status"] == "success"
-    group_id = data["data"]["id"]
+    # make a group that is unique to this test
+    group_id = sp.post_group(
+        GroupPost(
+            name=str(uuid.uuid4()),
+            group_admins=[super_admin_user.id],
+        )
+    ).id
 
     # post two spectra with very different properties
-    status, data = api(
-        "POST",
-        "spectrum",
-        data={
-            "obj_id": public_source.id,
-            "observed_at": "2020-01-10T00:00:00",
-            "instrument_id": lris.id,
-            "wavelengths": [664, 665, 666],
-            "fluxes": [234.3, 232.1, 235.3],
-            "group_ids": [group_id],
-            "followup_request_id": public_source_followup_request.id,
-            "assignment_id": public_assignment.id,
-        },
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    spectrum_id1 = data["data"]["id"]
+    spectrum_id1 = sp.post_spectrum(
+        SpectrumPost(
+            obj_id=public_source.id,
+            observed_at="2020-01-10T00:00:00",
+            instrument_id=lris.id,
+            wavelengths=[664, 665, 666],
+            fluxes=[234.3, 232.1, 235.3],
+            group_ids=[group_id],
+            followup_request_id=public_source_followup_request.id,
+            assignment_id=public_assignment.id,
+        )
+    ).id
 
-    status, data = api(
-        "POST",
-        "spectrum",
-        data={
-            "obj_id": public_source.id,
-            "observed_at": str(utcnow_naive()),
-            "instrument_id": sedm.id,
-            "wavelengths": [664, 665, 666],
-            "fluxes": [434.7, 432.1, 435.3],
-            "group_ids": [group_id],
-            "followup_request_id": public_source_group2_followup_request.id,
-        },
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    spectrum_id2 = data["data"]["id"]
+    spectrum_id2 = sp.post_spectrum(
+        SpectrumPost(
+            obj_id=public_source.id,
+            observed_at=str(utcnow_naive()),
+            instrument_id=sedm.id,
+            wavelengths=[664, 665, 666],
+            fluxes=[434.7, 432.1, 435.3],
+            group_ids=[group_id],
+            followup_request_id=public_source_group2_followup_request.id,
+        )
+    ).id
 
     # test instrument IDs
-    status, data = api(
-        "GET",
-        "spectra",
-        params={
-            "groupIDs": group_id,
-            "instrumentIDs": lris.id,  # should get only first spectrum
-        },
-        token=super_admin_token,
+    spectra = sp.fetch_spectra_query(
+        group_ids=[group_id],
+        instrument_ids=[lris.id],  # should get only first spectrum
     )
+    assert len(spectra) == 1
+    assert spectra[0].id == spectrum_id1
 
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]) == 1
-    assert data["data"][0]["id"] == spectrum_id1
-
-    status, data = api(
-        "GET",
-        "spectra",
-        params={
-            "groupIDs": group_id,
-            "instrumentIDs": sedm.id,  # should get only second spectrum
-        },
-        token=super_admin_token,
+    spectra = sp.fetch_spectra_query(
+        group_ids=[group_id],
+        instrument_ids=[sedm.id],  # should get only second spectrum
     )
+    assert len(spectra) == 1
+    assert spectra[0].id == spectrum_id2
 
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]) == 1
-    assert data["data"][0]["id"] == spectrum_id2
-
-    status, data = api(
-        "GET",
-        "spectra",
-        params={
-            "groupIDs": group_id,
-            "instrumentIDs": f"{lris.id}, {sedm.id}",  # should get both
-        },
-        token=super_admin_token,
+    spectra = sp.fetch_spectra_query(
+        group_ids=[group_id],
+        instrument_ids=[lris.id, sedm.id],  # should get both
     )
+    assert len(spectra) == 2
 
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]) == 2
+    with pytest.raises(SkyPortalError, match="Not all Instrument IDs") as err:
+        sp.fetch_spectra_query(
+            group_ids=[group_id],
+            instrument_ids=[lris.id, sedm.id, lris.id * sedm.id],  # should fail
+        )
+    assert err.value.status_code == 400
 
-    status, data = api(
-        "GET",
-        "spectra",
-        params={
-            "groupIDs": group_id,
-            "instrumentIDs": f"{lris.id}, {sedm.id}, {lris.id * sedm.id}",  # should fail
-        },
-        token=super_admin_token,
-    )
-
-    assert status == 400
-    assert data["status"] == "error"
-    assert "Not all Instrument IDs" in data["message"]
-
+    # raw api: intentionally malformed payload the typed client can't produce
     status, data = api(
         "GET",
         "spectra",
@@ -557,94 +338,52 @@ def test_spectrum_filtering_id_lists(
     assert "Could not parse all elements to integers" in data["message"]
 
     # test followup request IDs
-    status, data = api(
-        "GET",
-        "spectra",
-        params={
-            "groupIDs": group_id,
-            "followupRequestIDs": public_source_followup_request.id,  # should get only first spectrum
-        },
-        token=super_admin_token,
+    spectra = sp.fetch_spectra_query(
+        group_ids=[group_id],
+        # should get only first spectrum
+        followup_request_ids=[public_source_followup_request.id],
     )
+    assert len(spectra) == 1
+    assert spectra[0].id == spectrum_id1
 
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]) == 1
-    assert data["data"][0]["id"] == spectrum_id1
-
-    status, data = api(
-        "GET",
-        "spectra",
-        params={
-            "groupIDs": group_id,
-            "followupRequestIDs": public_source_group2_followup_request.id,  # should only get second spectrum
-        },
-        token=super_admin_token,
+    spectra = sp.fetch_spectra_query(
+        group_ids=[group_id],
+        # should only get second spectrum
+        followup_request_ids=[public_source_group2_followup_request.id],
     )
+    assert len(spectra) == 1
+    assert spectra[0].id == spectrum_id2
 
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]) == 1
-    assert data["data"][0]["id"] == spectrum_id2
-
-    status, data = api(
-        "GET",
-        "spectra",
-        params={
-            "groupIDs": group_id,
+    with pytest.raises(SkyPortalError, match="Not all FollowupRequest IDs") as err:
+        sp.fetch_spectra_query(
+            group_ids=[group_id],
             # should get error
-            "followupRequestIDs": public_source_group2_followup_request.id * 10,
-        },
-        token=super_admin_token,
-    )
+            followup_request_ids=[public_source_group2_followup_request.id * 10],
+        )
+    assert err.value.status_code == 400
 
-    assert status == 400
-    assert data["status"] == "error"
-    assert "Not all FollowupRequest IDs" in data["message"]
-
-    status, data = api(
-        "GET",
-        "spectra",
-        params={
-            "groupIDs": group_id,
-            "followupRequestIDs": public_source_group2_followup_request.id,
-        },
-        token=comment_token,  # should fail due to permission to see followup request
-    )
-
-    assert status == 400
-    assert data["status"] == "error"
-    assert "Not all FollowupRequest IDs" in data["message"]
+    with pytest.raises(SkyPortalError, match="Not all FollowupRequest IDs") as err:
+        # should fail due to permission to see followup request
+        client(comment_token).fetch_spectra_query(
+            group_ids=[group_id],
+            followup_request_ids=[public_source_group2_followup_request.id],
+        )
+    assert err.value.status_code == 400
 
     # test assignments
-    status, data = api(
-        "GET",
-        "spectra",
-        params={
-            "groupIDs": group_id,
-            "assignmentIDs": public_assignment.id,  # should get only first spectrum
-        },
-        token=super_admin_token,
+    spectra = sp.fetch_spectra_query(
+        group_ids=[group_id],
+        assignment_ids=[public_assignment.id],  # should get only first spectrum
     )
+    assert len(spectra) == 1
+    assert spectra[0].id == spectrum_id1
 
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]) == 1
-    assert data["data"][0]["id"] == spectrum_id1
-
-    status, data = api(
-        "GET",
-        "spectra",
-        params={
-            "groupIDs": group_id,
-            "assignmentIDs": public_assignment.id * 10,  # should fail
-        },
-        token=super_admin_token,
-    )
-
-    assert status == 400
-    assert data["status"] == "error"
-    assert "Not all ClassicalAssignment IDs" in data["message"]
+    with pytest.raises(SkyPortalError, match="Not all ClassicalAssignment IDs") as err:
+        sp.fetch_spectra_query(
+            group_ids=[group_id],
+            assignment_ids=[public_assignment.id * 10],  # should fail
+        )
+    assert err.value.status_code == 400
 
 
 def test_spectrum_filtering_origin_label_type(
@@ -653,179 +392,101 @@ def test_spectrum_filtering_origin_label_type(
     public_source,
     lris,
 ):
-    # make a group that is unique to this test
-    status, data = api(
-        "POST",
-        "groups",
-        data={
-            "name": str(uuid.uuid4()),
-            "group_admins": [super_admin_user.id],
-        },
-        token=super_admin_token,
-    )
+    sp = client(super_admin_token)
 
-    assert status == 200
-    assert data["status"] == "success"
-    group_id = data["data"]["id"]
+    # make a group that is unique to this test
+    group_id = sp.post_group(
+        GroupPost(
+            name=str(uuid.uuid4()),
+            group_admins=[super_admin_user.id],
+        )
+    ).id
 
     # post two spectra with very different properties
     custom_label = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "spectrum",
-        data={
-            "obj_id": public_source.id,
-            "observed_at": "2020-01-10T00:00:00",
-            "instrument_id": lris.id,
-            "wavelengths": [664, 665, 666],
-            "fluxes": [234.3, 232.1, 235.3],
-            "group_ids": [group_id],
-            "label": custom_label,
-            "origin": "Keck telescope",
-        },
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    spectrum_id1 = data["data"]["id"]
+    spectrum_id1 = sp.post_spectrum(
+        SpectrumPost(
+            obj_id=public_source.id,
+            observed_at="2020-01-10T00:00:00",
+            instrument_id=lris.id,
+            wavelengths=[664, 665, 666],
+            fluxes=[234.3, 232.1, 235.3],
+            group_ids=[group_id],
+            label=custom_label,
+            origin="Keck telescope",
+        )
+    ).id
 
-    status, data = api(
-        "POST",
-        "spectrum",
-        data={
-            "obj_id": public_source.id,
-            "observed_at": str(utcnow_naive()),
-            "instrument_id": lris.id,
-            "wavelengths": [664, 665, 666],
-            "fluxes": [434.7, 432.1, 435.3],
-            "group_ids": [group_id],
-            "type": "host",
-            "origin": "Palomar 60 inch",
-        },
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    spectrum_id2 = data["data"]["id"]
+    spectrum_id2 = sp.post_spectrum(
+        SpectrumPost(
+            obj_id=public_source.id,
+            observed_at=str(utcnow_naive()),
+            instrument_id=lris.id,
+            wavelengths=[664, 665, 666],
+            fluxes=[434.7, 432.1, 435.3],
+            group_ids=[group_id],
+            type="host",
+            origin="Palomar 60 inch",
+        )
+    ).id
 
     # test origin
-    status, data = api(
-        "GET",
-        "spectra",
-        params={
-            "groupIDs": group_id,
-            "origin": "Keck",  # should get only first spectrum
-        },
-        token=super_admin_token,
+    spectra = sp.fetch_spectra_query(
+        group_ids=[group_id],
+        origin=["Keck"],  # should get only first spectrum
     )
+    assert len(spectra) == 1
+    assert spectra[0].id == spectrum_id1
 
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]) == 1
-    assert data["data"][0]["id"] == spectrum_id1
-
-    status, data = api(
-        "GET",
-        "spectra",
-        params={
-            "groupIDs": group_id,
-            "origin": ["Gemini", "VLT"],  # should get nothing
-        },
-        token=super_admin_token,
+    spectra = sp.fetch_spectra_query(
+        group_ids=[group_id],
+        origin=["Gemini", "VLT"],  # should get nothing
     )
-
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]) == 0
+    assert len(spectra) == 0
 
     # test label
-    status, data = api(
-        "GET",
-        "spectra",
-        params={
-            "groupIDs": group_id,
-            "label": custom_label,  # should get only first spectrum
-        },
-        token=super_admin_token,
+    spectra = sp.fetch_spectra_query(
+        group_ids=[group_id],
+        label=[custom_label],  # should get only first spectrum
     )
+    assert len(spectra) == 1
+    assert spectra[0].id == spectrum_id1
 
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]) == 1
-    assert data["data"][0]["id"] == spectrum_id1
-
-    status, data = api(
-        "GET",
-        "spectra",
-        params={
-            "groupIDs": group_id,
-            "label": ["one", "two", "three"],  # should get nothing
-        },
-        token=super_admin_token,
+    spectra = sp.fetch_spectra_query(
+        group_ids=[group_id],
+        label=["one", "two", "three"],  # should get nothing
     )
-
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]) == 0
+    assert len(spectra) == 0
 
     # test type
-    status, data = api(
-        "GET",
-        "spectra",
-        params={
-            "groupIDs": group_id,
-            "type": "source",  # should get only first spectrum (default type)
-        },
-        token=super_admin_token,
+    spectra = sp.fetch_spectra_query(
+        group_ids=[group_id],
+        spectrum_type=["source"],  # should get only first spectrum (default type)
     )
+    assert len(spectra) == 1
+    assert spectra[0].id == spectrum_id1
 
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]) == 1
-    assert data["data"][0]["id"] == spectrum_id1
-
-    status, data = api(
-        "GET",
-        "spectra",
-        params={
-            "groupIDs": group_id,
-            "type": "host",  # should get only second spectrum
-        },
-        token=super_admin_token,
+    spectra = sp.fetch_spectra_query(
+        group_ids=[group_id],
+        spectrum_type=["host"],  # should get only second spectrum
     )
+    assert len(spectra) == 1
+    assert spectra[0].id == spectrum_id2
 
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]) == 1
-    assert data["data"][0]["id"] == spectrum_id2
-
-    status, data = api(
-        "GET",
-        "spectra",
-        params={
-            "groupIDs": group_id,
-            "type": "host_center",  # should get nothing
-        },
-        token=super_admin_token,
+    spectra = sp.fetch_spectra_query(
+        group_ids=[group_id],
+        spectrum_type=["host_center"],  # should get nothing
     )
+    assert len(spectra) == 0
 
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]) == 0
-
-    status, data = api(
-        "GET",
-        "spectra",
-        params={
-            "groupIDs": group_id,
-            "type": "rainbow",  # should get error, (allowed enum)
-        },
-        token=super_admin_token,
-    )
-
-    assert status == 400
-    assert data["status"] == "error"
-    assert "not in list of allowed spectrum types" in data["message"]
+    with pytest.raises(
+        SkyPortalError, match="not in list of allowed spectrum types"
+    ) as err:
+        sp.fetch_spectra_query(
+            group_ids=[group_id],
+            spectrum_type=["rainbow"],  # should get error, (allowed enum)
+        )
+    assert err.value.status_code == 400
 
 
 def test_spectrum_filtering_comments(
@@ -836,127 +497,83 @@ def test_spectrum_filtering_comments(
     public_source,
     lris,
 ):
-    # make a group that is unique to this test
-    status, data = api(
-        "POST",
-        "groups",
-        data={
-            "name": str(uuid.uuid4()),
-            # "group_admins": [super_admin_user.id],
-        },
-        token=upload_data_token,
-    )
+    sp = client(super_admin_token)
 
-    assert status == 200
-    assert data["status"] == "success"
-    group_id = data["data"]["id"]
+    # make a group that is unique to this test
+    group_id = (
+        client(upload_data_token)
+        .post_group(
+            GroupPost(
+                name=str(uuid.uuid4()),
+                # group_admins=[super_admin_user.id],
+            )
+        )
+        .id
+    )
 
     # post two spectra with very different properties
-    status, data = api(
-        "POST",
-        "spectrum",
-        data={
-            "obj_id": public_source.id,
-            "observed_at": "2020-01-10T00:00:00",
-            "instrument_id": lris.id,
-            "wavelengths": [664, 665, 666],
-            "fluxes": [234.3, 232.1, 235.3],
-            "group_ids": [group_id],
-        },
-        token=upload_data_token,
+    spectrum_id1 = (
+        client(upload_data_token)
+        .post_spectrum(
+            SpectrumPost(
+                obj_id=public_source.id,
+                observed_at="2020-01-10T00:00:00",
+                instrument_id=lris.id,
+                wavelengths=[664, 665, 666],
+                fluxes=[234.3, 232.1, 235.3],
+                group_ids=[group_id],
+            )
+        )
+        .id
     )
-    assert status == 200
-    assert data["status"] == "success"
-    spectrum_id1 = data["data"]["id"]
 
     comment_text = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        f"spectra/{spectrum_id1}/comments",
-        data={"text": comment_text, "group_ids": [group_id]},
-        token=comment_token,
+    client(comment_token).post_comment(
+        spectrum_id1, comment_text, resource_type="spectra", group_ids=[group_id]
     )
-
-    assert status == 200
-    assert data["status"] == "success"
 
     time.sleep(2)
     time_after_posting_first_spec = str(utcnow_naive())
 
-    status, data = api(
-        "POST",
-        "spectrum",
-        data={
-            "obj_id": public_source.id,
-            "observed_at": time_after_posting_first_spec,
-            "instrument_id": lris.id,
-            "wavelengths": [664, 665, 666],
-            "fluxes": [434.7, 432.1, 435.3],
-            "group_ids": [group_id],
-        },
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    spectrum_id2 = data["data"]["id"]
-
-    status, data = api(
-        "POST",
-        f"spectra/{spectrum_id2}/comments",
-        data={
-            "text": "looks like Ia.",
-            "group_ids": [group_id],
-        },
-        token=super_admin_token,
+    spectrum_id2 = (
+        client(upload_data_token)
+        .post_spectrum(
+            SpectrumPost(
+                obj_id=public_source.id,
+                observed_at=time_after_posting_first_spec,
+                instrument_id=lris.id,
+                wavelengths=[664, 665, 666],
+                fluxes=[434.7, 432.1, 435.3],
+                group_ids=[group_id],
+            )
+        )
+        .id
     )
 
-    assert status == 200
-    assert data["status"] == "success"
-
-    status, data = api(
-        "GET",
-        "spectra",
-        params={
-            "groupIDs": group_id,
-            "commentsFilter": comment_text[10:20],  # should get first spectrum
-        },
-        token=super_admin_token,
+    sp.post_comment(
+        spectrum_id2, "looks like Ia.", resource_type="spectra", group_ids=[group_id]
     )
 
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]) == 1
-    assert data["data"][0]["id"] == spectrum_id1
-
-    status, data = api(
-        "GET",
-        "spectra",
-        params={
-            "groupIDs": group_id,
-            # should get second spectrum
-            "commentsFilterAuthor": super_admin_user.username[8:16],
-        },
-        token=super_admin_token,
+    spectra = sp.fetch_spectra_query(
+        group_ids=[group_id],
+        comments_filter=[comment_text[10:20]],  # should get first spectrum
     )
+    assert len(spectra) == 1
+    assert spectra[0].id == spectrum_id1
 
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]) == 1
-    assert data["data"][0]["id"] == spectrum_id2
-
-    status, data = api(
-        "GET",
-        "spectra",
-        params={
-            "groupIDs": group_id,
-            "commentsFilterAuthor": str(uuid.uuid4()),  # should get nothing
-        },
-        token=super_admin_token,
+    spectra = sp.fetch_spectra_query(
+        group_ids=[group_id],
+        # should get second spectrum
+        comments_filter_author=[super_admin_user.username[8:16]],
     )
+    assert len(spectra) == 1
+    assert spectra[0].id == spectrum_id2
 
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]) == 0
+    spectra = sp.fetch_spectra_query(
+        group_ids=[group_id],
+        comments_filter_author=[str(uuid.uuid4())],  # should get nothing
+    )
+    assert len(spectra) == 0
     time_offset = (utcnow_naive() - datetime.datetime.now()) / datetime.timedelta(
         hours=1
     )
@@ -966,35 +583,19 @@ def test_spectrum_filtering_comments(
         .shift(seconds=-1)
         .shift(hours=time_offset)
     )
-    status, data = api(
-        "GET",
-        "spectra",
-        params={
-            "groupIDs": group_id,
-            "commentsFilterBefore": comment_created_time,  # should get first spectrum
-        },
-        token=super_admin_token,
+    spectra = sp.fetch_spectra_query(
+        group_ids=[group_id],
+        comments_filter_before=comment_created_time,  # should get first spectrum
     )
+    assert len(spectra) == 1
+    assert spectra[0].id == spectrum_id1
 
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]) == 1
-    assert data["data"][0]["id"] == spectrum_id1
-
-    status, data = api(
-        "GET",
-        "spectra",
-        params={
-            "groupIDs": group_id,
-            "commentsFilterAfter": comment_created_time,  # should get second spectrum
-        },
-        token=super_admin_token,
+    spectra = sp.fetch_spectra_query(
+        group_ids=[group_id],
+        comments_filter_after=comment_created_time,  # should get second spectrum
     )
-
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]) == 1
-    assert data["data"][0]["id"] == spectrum_id2
+    assert len(spectra) == 1
+    assert spectra[0].id == spectrum_id2
 
 
 def test_minimal_spectrum(
@@ -1004,74 +605,52 @@ def test_minimal_spectrum(
     public_assignment,
     public_source_followup_request,
 ):
+    sp = client(super_admin_token)
+
     # make a group that is unique to this test
-    status, data = api(
-        "POST",
-        "groups",
-        data={
-            "name": str(uuid.uuid4()),
-            # "group_admins": [super_admin_user.id],
-        },
-        token=super_admin_token,
-    )
+    group_id = sp.post_group(
+        GroupPost(
+            name=str(uuid.uuid4()),
+            # group_admins=[super_admin_user.id],
+        )
+    ).id
 
-    assert status == 200
-    assert data["status"] == "success"
-    group_id = data["data"]["id"]
-
-    status, data = api(
-        "POST",
-        "spectrum",
-        data={
-            "obj_id": public_source.id,
-            "observed_at": "2020-01-10T00:00:00",
-            "instrument_id": lris.id,
-            "wavelengths": [664, 665, 666],
-            "fluxes": [234.3, 232.1, 235.3],
-            "group_ids": [group_id],
-            "followup_request_id": public_source_followup_request.id,
-            "assignment_id": public_assignment.id,
-            "origin": str(uuid.uuid4()),
-            "type": "host",
-            "label": str(uuid.uuid4()),
-            "altdata": {"one": 1, "two": 2},
-        },
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    spectrum_id = data["data"]["id"]
+    spectrum_id = sp.post_spectrum(
+        SpectrumPost(
+            obj_id=public_source.id,
+            observed_at="2020-01-10T00:00:00",
+            instrument_id=lris.id,
+            wavelengths=[664, 665, 666],
+            fluxes=[234.3, 232.1, 235.3],
+            group_ids=[group_id],
+            followup_request_id=public_source_followup_request.id,
+            assignment_id=public_assignment.id,
+            origin=str(uuid.uuid4()),
+            type="host",
+            label=str(uuid.uuid4()),
+            altdata={"one": 1, "two": 2},
+        )
+    ).id
 
     # post a comment and an annotation as well
-    status, data = api(
-        "POST",
-        f"spectra/{spectrum_id}/comments",
-        data={"text": str(uuid.uuid4()), "group_ids": [group_id]},
-        token=super_admin_token,
+    sp.post_comment(
+        spectrum_id, str(uuid.uuid4()), resource_type="spectra", group_ids=[group_id]
     )
 
-    assert status == 200
-    assert data["status"] == "success"
-
-    status, data = api(
-        "POST",
-        f"spectra/{spectrum_id}/annotations",
-        data={
-            "data": {
-                "Gaia_Rp": 14.7,
-                "Gaia_Bp": 15.2,
-                "Gaia_G": 14.9,
-                "period": 13.4,
-            },
-            "origin": "Kowalski",
-            "group_ids": [group_id],
+    sp.post_annotation(
+        spectrum_id,
+        "Kowalski",
+        {
+            "Gaia_Rp": 14.7,
+            "Gaia_Bp": 15.2,
+            "Gaia_G": 14.9,
+            "period": 13.4,
         },
-        token=super_admin_token,
+        resource_type="spectra",
+        group_ids=[group_id],
     )
 
-    assert status == 200
-    assert data["status"] == "success"
-
+    # raw api: compares raw JSON key sets, which typed models normalize away
     status, data = api(
         "GET",
         f"spectra/{spectrum_id}",
@@ -1084,6 +663,7 @@ def test_minimal_spectrum(
     assert data["data"]["id"] == spectrum_id
     single_spec = data["data"]
 
+    # raw api: compares raw JSON key sets, which typed models normalize away
     status, data = api(
         "GET",
         "spectra",
@@ -1099,6 +679,7 @@ def test_minimal_spectrum(
     assert len(data["data"]) == 1
     full_spec = data["data"][0]
 
+    # raw api: compares raw JSON key sets, which typed models normalize away
     status, data = api(
         "GET",
         "spectra",
@@ -1150,177 +731,134 @@ def test_minimal_spectrum(
 
 
 def test_include_original_file(upload_data_token, public_source, public_group, lris):
+    sp = client(upload_data_token)
+
     # upload via the ASCII endpoint so original_file_string is populated
     ascii_content = "4000 0.01\n4500 0.02\n5000 0.005\n5500 0.006\n6000 0.01\n"
-    status, data = api(
-        "POST",
-        "spectrum/ascii",
-        data={
-            "obj_id": str(public_source.id),
-            "observed_at": "2020-02-01T00:00:00",
-            "instrument_id": lris.id,
-            "group_ids": [public_group.id],
-            "ascii": ascii_content,
-            "filename": f"{uuid.uuid4()}.ascii",
-        },
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    spectrum_id = data["data"]["id"]
+    spectrum_id = sp.post_spectrum_ascii(
+        SpectrumAsciiPost(
+            obj_id=str(public_source.id),
+            observed_at="2020-02-01T00:00:00",
+            instrument_id=lris.id,
+            group_ids=[public_group.id],
+            ascii=ascii_content,
+            filename=f"{uuid.uuid4()}.ascii",
+        )
+    ).id
 
     # --- list endpoint (SpectrumHandler.get, multiple) ---
     # default: original_file_string omitted, rest of full payload intact
-    status, data = api(
-        "GET", "spectra", params={"objID": public_source.id}, token=upload_data_token
+    spec = next(
+        s
+        for s in sp.fetch_spectra_query(obj_id=public_source.id)
+        if s.id == spectrum_id
     )
-    assert status == 200
-    spec = next(s for s in data["data"] if s["id"] == spectrum_id)
-    assert "original_file_string" not in spec
+    assert spec.original_file_string is None
     # full payload otherwise unchanged
-    assert "wavelengths" in spec and "fluxes" in spec
-    assert spec["original_file_filename"] is not None
+    assert spec.wavelengths and spec.fluxes
+    assert spec.original_file_filename is not None
 
     # includeOriginalFile=true: field present and equal to what was uploaded
-    status, data = api(
-        "GET",
-        "spectra",
-        params={"objID": public_source.id, "includeOriginalFile": True},
-        token=upload_data_token,
+    spec = next(
+        s
+        for s in sp.fetch_spectra_query(
+            obj_id=public_source.id, include_original_file=True
+        )
+        if s.id == spectrum_id
     )
-    assert status == 200
-    spec = next(s for s in data["data"] if s["id"] == spectrum_id)
-    assert spec["original_file_string"] == ascii_content
+    assert spec.original_file_string == ascii_content
 
     # explicit includeOriginalFile=false behaves like the default
-    status, data = api(
-        "GET",
-        "spectra",
-        params={"objID": public_source.id, "includeOriginalFile": False},
-        token=upload_data_token,
+    spec = next(
+        s
+        for s in sp.fetch_spectra_query(
+            obj_id=public_source.id, include_original_file=False
+        )
+        if s.id == spectrum_id
     )
-    assert status == 200
-    spec = next(s for s in data["data"] if s["id"] == spectrum_id)
-    assert "original_file_string" not in spec
+    assert spec.original_file_string is None
 
     # --- single endpoint (SpectrumHandler.get, single) ---
-    status, data = api("GET", f"spectra/{spectrum_id}", token=upload_data_token)
-    assert status == 200
-    assert "original_file_string" not in data["data"]
+    assert sp.fetch_spectrum(spectrum_id).original_file_string is None
 
-    status, data = api(
-        "GET",
-        f"spectra/{spectrum_id}",
-        params={"includeOriginalFile": True},
-        token=upload_data_token,
+    assert (
+        sp.fetch_spectrum(spectrum_id, include_original_file=True).original_file_string
+        == ascii_content
     )
-    assert status == 200
-    assert data["data"]["original_file_string"] == ascii_content
 
     # --- object spectra endpoint (ObjSpectraHandler.get) ---
-    status, data = api(
-        "GET", f"sources/{public_source.id}/spectra", token=upload_data_token
-    )
-    assert status == 200
-    spec = next(s for s in data["data"]["spectra"] if s["id"] == spectrum_id)
-    assert "original_file_string" not in spec
+    spec = next(s for s in sp.fetch_spectra(public_source.id) if s.id == spectrum_id)
+    assert spec.original_file_string is None
 
-    status, data = api(
-        "GET",
-        f"sources/{public_source.id}/spectra",
-        params={"includeOriginalFile": True},
-        token=upload_data_token,
+    spec = next(
+        s
+        for s in sp.fetch_spectra(public_source.id, include_original_file=True)
+        if s.id == spectrum_id
     )
-    assert status == 200
-    spec = next(s for s in data["data"]["spectra"] if s["id"] == spectrum_id)
-    assert spec["original_file_string"] == ascii_content
+    assert spec.original_file_string == ascii_content
 
 
 def test_token_user_get_range_spectrum(
     upload_data_token, public_source, public_group, lris
 ):
-    # post two spectra at two different dates
-    status, data = api(
-        "POST",
-        "spectrum",
-        data={
-            "obj_id": str(public_source.id),
-            "observed_at": "2020-01-10T00:00:00",
-            "instrument_id": lris.id,
-            "wavelengths": [664, 665, 666],
-            "fluxes": [234.2, 232.1, 235.3],
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp = client(upload_data_token)
 
-    status, data = api(
-        "POST",
-        "spectrum",
-        data={
-            "obj_id": str(public_source.id),
-            "observed_at": str(datetime.datetime.now()),
-            "instrument_id": lris.id,
-            "wavelengths": [664, 665, 666],
-            "fluxes": [434.2, 432.1, 435.3],
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    # post two spectra at two different dates
+    sp.post_spectrum(
+        SpectrumPost(
+            obj_id=str(public_source.id),
+            observed_at="2020-01-10T00:00:00",
+            instrument_id=lris.id,
+            wavelengths=[664, 665, 666],
+            fluxes=[234.2, 232.1, 235.3],
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
-    assert data["status"] == "success"
+
+    sp.post_spectrum(
+        SpectrumPost(
+            obj_id=str(public_source.id),
+            observed_at=str(datetime.datetime.now()),
+            instrument_id=lris.id,
+            wavelengths=[664, 665, 666],
+            fluxes=[434.2, 432.1, 435.3],
+            group_ids=[public_group.id],
+        )
+    )
 
     # test range that includes first spectrum
-    status, data = api(
-        "GET",
-        f"spectrum/range?instrument_ids={lris.id}"
-        f"&min_date=2020-01-01T00:00:00&max_date=2020-01-15T00:00:00",
-        token=upload_data_token,
+    spectra = sp.fetch_spectra_range(
+        instrument_ids=[lris.id],
+        min_date="2020-01-01T00:00:00",
+        max_date="2020-01-15T00:00:00",
     )
-    assert status == 200
-    assert len(data["data"]) == 1
-    assert data["status"] == "success"
-    assert data["data"][0]["fluxes"][0] == 234.2
-    assert data["data"][0]["obj_id"] == public_source.id
+    assert len(spectra) == 1
+    assert spectra[0].fluxes[0] == 234.2
+    assert spectra[0].obj_id == public_source.id
 
     # test open ended range that includes second spectrum
-    status, data = api(
-        "GET",
-        f"spectrum/range?instrument_ids={lris.id}&min_date=2020-01-15T00:00:00",
-        token=upload_data_token,
+    spectra = sp.fetch_spectra_range(
+        instrument_ids=[lris.id], min_date="2020-01-15T00:00:00"
     )
-    assert status == 200
-    assert len(data["data"]) == 1
-    assert data["status"] == "success"
-    assert data["data"][0]["fluxes"][0] == 434.2
-    assert data["data"][0]["obj_id"] == public_source.id
+    assert len(spectra) == 1
+    assert spectra[0].fluxes[0] == 434.2
+    assert spectra[0].obj_id == public_source.id
 
     # test open ended range that includes both spectra
-    status, data = api(
-        "GET",
-        f"spectrum/range?instrument_ids={lris.id}&min_date=2020-01-01T00:00:00",
-        token=upload_data_token,
+    spectra = sp.fetch_spectra_range(
+        instrument_ids=[lris.id], min_date="2020-01-01T00:00:00"
     )
-    assert status == 200
-    assert len(data["data"]) == 2
-    assert data["status"] == "success"
+    assert len(spectra) == 2
 
     # test legal variations on input isot format
     # 2020-01-15
-    status, data = api(
-        "GET",
-        f"spectrum/range?instrument_ids={lris.id}&min_date=2020-01-15",
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert len(data["data"]) == 1
-    assert data["status"] == "success"
-    assert data["data"][0]["fluxes"][0] == 434.2
-    assert data["data"][0]["obj_id"] == public_source.id
+    spectra = sp.fetch_spectra_range(instrument_ids=[lris.id], min_date="2020-01-15")
+    assert len(spectra) == 1
+    assert spectra[0].fluxes[0] == 434.2
+    assert spectra[0].obj_id == public_source.id
 
     # 2020-01-15T00:00:00+00:00
+    # raw api: intentionally malformed query string ('&plus;' splits the param) the typed client can't produce
     status, data = api(
         "GET",
         f"spectrum/range?instrument_ids={lris.id}&min_date=2020-01-15T00:00:00&plus;00:00",
@@ -1333,60 +871,46 @@ def test_token_user_get_range_spectrum(
     assert data["data"][0]["obj_id"] == public_source.id
 
     # 2020-01-15T00:00:00Z
-    status, data = api(
-        "GET",
-        f"spectrum/range?instrument_ids={lris.id}&min_date=2020-01-15T00:00:00Z",
-        token=upload_data_token,
+    spectra = sp.fetch_spectra_range(
+        instrument_ids=[lris.id], min_date="2020-01-15T00:00:00Z"
     )
-    assert status == 200
-    assert len(data["data"]) == 1
-    assert data["status"] == "success"
-    assert data["data"][0]["fluxes"][0] == 434.2
-    assert data["data"][0]["obj_id"] == public_source.id
+    assert len(spectra) == 1
+    assert spectra[0].fluxes[0] == 434.2
+    assert spectra[0].obj_id == public_source.id
 
     # test with no instrument ids
-    status, data = api(
-        "GET",
-        "spectrum/range?min_date=2020-01-01T00:00:00&max_date=2020-02-01",
-        token=upload_data_token,
+    spectra = sp.fetch_spectra_range(
+        min_date="2020-01-01T00:00:00", max_date="2020-02-01"
     )
-    assert status == 200
-    assert len(data["data"]) == 1
-    assert data["status"] == "success"
-    assert data["data"][0]["fluxes"][0] == 234.2
-    assert data["data"][0]["obj_id"] == public_source.id
+    assert len(spectra) == 1
+    assert spectra[0].fluxes[0] == 234.2
+    assert spectra[0].obj_id == public_source.id
 
 
 def test_token_user_post_get_spectrum_data(
     upload_data_token, public_source, public_group, lris
 ):
-    status, data = api(
-        "POST",
-        "spectrum",
-        data={
-            "obj_id": str(public_source.id),
-            "observed_at": str(datetime.datetime.now()),
-            "instrument_id": lris.id,
-            "wavelengths": [664, 665, 666],
-            "fluxes": [234.2, 232.1, 235.3],
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp = client(upload_data_token)
+    spectrum_id = sp.post_spectrum(
+        SpectrumPost(
+            obj_id=str(public_source.id),
+            observed_at=str(datetime.datetime.now()),
+            instrument_id=lris.id,
+            wavelengths=[664, 665, 666],
+            fluxes=[234.2, 232.1, 235.3],
+            group_ids=[public_group.id],
+        )
+    ).id
 
-    spectrum_id = data["data"]["id"]
-    status, data = api("GET", f"spectrum/{spectrum_id}", token=upload_data_token)
-    assert status == 200
-    assert data["status"] == "success"
-    assert data["data"]["fluxes"][0] == 234.2
-    assert data["data"]["obj_id"] == public_source.id
+    spectrum = sp.fetch_spectrum(spectrum_id)
+    assert spectrum.fluxes[0] == 234.2
+    assert spectrum.obj_id == public_source.id
 
 
 def test_token_user_post_spectrum_no_instrument_id(
     upload_data_token, public_source, public_group
 ):
+    # raw api: intentionally malformed payload the typed client can't produce
     status, data = api(
         "POST",
         "spectrum",
@@ -1410,183 +934,133 @@ def test_token_user_post_spectrum_no_instrument_id(
 def test_token_user_post_spectrum_all_groups(
     upload_data_token, public_source_two_groups, lris
 ):
-    status, data = api(
-        "POST",
-        "spectrum",
-        data={
-            "obj_id": str(public_source_two_groups.id),
-            "observed_at": str(datetime.datetime.now()),
-            "instrument_id": lris.id,
-            "wavelengths": [664, 665, 666],
-            "fluxes": [234.2, 232.1, 235.3],
-            "group_ids": "all",
-        },
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp = client(upload_data_token)
+    spectrum_id = sp.post_spectrum(
+        SpectrumPost(
+            obj_id=str(public_source_two_groups.id),
+            observed_at=str(datetime.datetime.now()),
+            instrument_id=lris.id,
+            wavelengths=[664, 665, 666],
+            fluxes=[234.2, 232.1, 235.3],
+            group_ids="all",
+        )
+    ).id
 
-    spectrum_id = data["data"]["id"]
-    status, data = api("GET", f"spectrum/{spectrum_id}", token=upload_data_token)
-    assert status == 200
-    assert data["status"] == "success"
-    assert data["data"]["fluxes"][0] == 234.2
-    assert data["data"]["obj_id"] == public_source_two_groups.id
+    spectrum = sp.fetch_spectrum(spectrum_id)
+    assert spectrum.fluxes[0] == 234.2
+    assert spectrum.obj_id == public_source_two_groups.id
 
 
 def test_token_user_post_spectrum_no_access(
     view_only_token, public_source, public_group, lris
 ):
-    status, data = api(
-        "POST",
-        "spectrum",
-        data={
-            "obj_id": str(public_source.id),
-            "observed_at": str(datetime.datetime.now()),
-            "instrument_id": lris.id,
-            "wavelengths": [664, 665, 666],
-            "fluxes": [234.2, 232.1, 235.3],
-            "group_ids": [public_group.id],
-        },
-        token=view_only_token,
-    )
-    assert status == 401
-    assert data["status"] == "error"
+    with pytest.raises(SkyPortalError) as err:
+        client(view_only_token).post_spectrum(
+            SpectrumPost(
+                obj_id=str(public_source.id),
+                observed_at=str(datetime.datetime.now()),
+                instrument_id=lris.id,
+                wavelengths=[664, 665, 666],
+                fluxes=[234.2, 232.1, 235.3],
+                group_ids=[public_group.id],
+            )
+        )
+    assert err.value.status_code == 401
 
 
 def test_token_user_update_spectrum(
     upload_data_token, public_source, public_group, lris
 ):
-    status, data = api(
-        "POST",
-        "spectrum",
-        data={
-            "obj_id": str(public_source.id),
-            "observed_at": str(datetime.datetime.now()),
-            "instrument_id": lris.id,
-            "wavelengths": [664, 665, 666],
-            "fluxes": [234.2, 232.1, 235.3],
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp = client(upload_data_token)
+    spectrum_id = sp.post_spectrum(
+        SpectrumPost(
+            obj_id=str(public_source.id),
+            observed_at=str(datetime.datetime.now()),
+            instrument_id=lris.id,
+            wavelengths=[664, 665, 666],
+            fluxes=[234.2, 232.1, 235.3],
+            group_ids=[public_group.id],
+        )
+    ).id
 
-    spectrum_id = data["data"]["id"]
-    status, data = api("GET", f"spectrum/{spectrum_id}", token=upload_data_token)
-    assert status == 200
-    assert data["status"] == "success"
-    assert data["data"]["fluxes"][0] == 234.2
+    assert sp.fetch_spectrum(spectrum_id).fluxes[0] == 234.2
 
-    status, data = api(
-        "PUT",
-        f"spectrum/{spectrum_id}",
-        data={
-            "fluxes": [222.2, 232.1, 235.3],
-            "observed_at": str(datetime.datetime.now()),
-            "wavelengths": [664, 665, 666],
-            "group_ids": "all",
-        },
-        token=upload_data_token,
+    sp.update_spectrum(
+        spectrum_id,
+        SpectrumUpdate(
+            fluxes=[222.2, 232.1, 235.3],
+            observed_at=str(datetime.datetime.now()),
+            wavelengths=[664, 665, 666],
+            group_ids="all",
+        ),
     )
 
-    assert status == 200
-    assert data["status"] == "success"
-
-    status, data = api("GET", f"spectrum/{spectrum_id}", token=upload_data_token)
-    assert status == 200
-    assert data["status"] == "success"
-    assert data["data"]["fluxes"][0] == 222.2
+    spectrum = sp.fetch_spectrum(spectrum_id)
+    assert spectrum.fluxes[0] == 222.2
     # test that length of groups is greater than 1 after adding all groups to the spectrum
-    assert len(data["data"]["groups"]) > 1
+    assert len(spectrum.groups) > 1
 
 
 def test_token_user_cannot_update_unowned_spectrum(
     upload_data_token, manage_sources_token, public_source, public_group, lris
 ):
-    status, data = api(
-        "POST",
-        "spectrum",
-        data={
-            "obj_id": str(public_source.id),
-            "observed_at": str(datetime.datetime.now()),
-            "instrument_id": lris.id,
-            "wavelengths": [664, 665, 666],
-            "fluxes": [234.2, 232.1, 235.3],
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp = client(upload_data_token)
+    spectrum_id = sp.post_spectrum(
+        SpectrumPost(
+            obj_id=str(public_source.id),
+            observed_at=str(datetime.datetime.now()),
+            instrument_id=lris.id,
+            wavelengths=[664, 665, 666],
+            fluxes=[234.2, 232.1, 235.3],
+            group_ids=[public_group.id],
+        )
+    ).id
 
-    spectrum_id = data["data"]["id"]
-    status, data = api("GET", f"spectrum/{spectrum_id}", token=upload_data_token)
-    assert status == 200
-    assert data["status"] == "success"
-    assert data["data"]["fluxes"][0] == 234.2
+    assert sp.fetch_spectrum(spectrum_id).fluxes[0] == 234.2
 
-    status, data = api(
-        "PUT",
-        f"spectrum/{spectrum_id}",
-        data={
-            "fluxes": [222.2, 232.1, 235.3],
-            "observed_at": str(datetime.datetime.now()),
-            "wavelengths": [664, 665, 666],
-        },
-        token=manage_sources_token,
-    )
-
-    assert status == 401
-    assert data["status"] == "error"
+    with pytest.raises(SkyPortalError) as err:
+        client(manage_sources_token).update_spectrum(
+            spectrum_id,
+            SpectrumUpdate(
+                fluxes=[222.2, 232.1, 235.3],
+                observed_at=str(datetime.datetime.now()),
+                wavelengths=[664, 665, 666],
+            ),
+        )
+    assert err.value.status_code == 401
 
 
 def test_admin_can_update_unowned_spectrum_data(
     upload_data_token, super_admin_token, public_source, public_group, lris
 ):
-    status, data = api(
-        "POST",
-        "spectrum",
-        data={
-            "obj_id": str(public_source.id),
-            "observed_at": str(datetime.datetime.now()),
-            "instrument_id": lris.id,
-            "wavelengths": [664, 665, 666],
-            "fluxes": [234.2, 232.1, 235.3],
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
+    sp = client(upload_data_token)
+    spectrum_id = sp.post_spectrum(
+        SpectrumPost(
+            obj_id=str(public_source.id),
+            observed_at=str(datetime.datetime.now()),
+            instrument_id=lris.id,
+            wavelengths=[664, 665, 666],
+            fluxes=[234.2, 232.1, 235.3],
+            group_ids=[public_group.id],
+        )
+    ).id
+
+    assert sp.fetch_spectrum(spectrum_id).fluxes[0] == 234.2
+
+    client(super_admin_token).update_spectrum(
+        spectrum_id,
+        SpectrumUpdate(
+            fluxes=[222.2, 232.1, 235.3],
+            observed_at=str(datetime.datetime.now()),
+            wavelengths=[664, 665, 666],
+            group_ids=[2, 3],
+        ),
     )
-    assert status == 200
-    assert data["status"] == "success"
 
-    spectrum_id = data["data"]["id"]
-    status, data = api("GET", f"spectrum/{spectrum_id}", token=upload_data_token)
-    assert status == 200
-    assert data["status"] == "success"
-    assert data["data"]["fluxes"][0] == 234.2
-
-    status, data = api(
-        "PUT",
-        f"spectrum/{spectrum_id}",
-        data={
-            "fluxes": [222.2, 232.1, 235.3],
-            "observed_at": str(datetime.datetime.now()),
-            "wavelengths": [664, 665, 666],
-            "group_ids": [2, 3],
-        },
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-
-    status, data = api("GET", f"spectrum/{spectrum_id}", token=upload_data_token)
-    assert status == 200
-    assert data["status"] == "success"
-    assert data["data"]["fluxes"][0] == 222.2
+    spectrum = sp.fetch_spectrum(spectrum_id)
+    assert spectrum.fluxes[0] == 222.2
     # check if length of groups is 4 after adding permission to two groups (groups with id 2 and 3) because two groups already have permission to this spectrum (groups with id 1405 and 1406)
-    assert len(data["data"]["groups"]) == 4
+    assert len(spectrum.groups) == 4
 
 
 def test_spectrum_owner_id_is_unmodifiable(
@@ -1597,28 +1071,21 @@ def test_spectrum_owner_id_is_unmodifiable(
     public_group,
     lris,
 ):
-    status, data = api(
-        "POST",
-        "spectrum",
-        data={
-            "obj_id": str(public_source.id),
-            "observed_at": str(datetime.datetime.now()),
-            "instrument_id": lris.id,
-            "wavelengths": [664, 665, 666],
-            "fluxes": [234.2, 232.1, 235.3],
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp = client(upload_data_token)
+    spectrum_id = sp.post_spectrum(
+        SpectrumPost(
+            obj_id=str(public_source.id),
+            observed_at=str(datetime.datetime.now()),
+            instrument_id=lris.id,
+            wavelengths=[664, 665, 666],
+            fluxes=[234.2, 232.1, 235.3],
+            group_ids=[public_group.id],
+        )
+    ).id
 
-    spectrum_id = data["data"]["id"]
-    status, data = api("GET", f"spectrum/{spectrum_id}", token=upload_data_token)
-    assert status == 200
-    assert data["status"] == "success"
-    assert data["data"]["fluxes"][0] == 234.2
+    assert sp.fetch_spectrum(spectrum_id).fluxes[0] == 234.2
 
+    # raw api: intentionally malformed payload the typed client can't produce
     status, data = api(
         "PUT",
         f"spectrum/{spectrum_id}",
@@ -1633,97 +1100,77 @@ def test_spectrum_owner_id_is_unmodifiable(
 def test_user_cannot_delete_unowned_spectrum_data(
     upload_data_token, manage_sources_token, public_source, public_group, lris
 ):
-    status, data = api(
-        "POST",
-        "spectrum",
-        data={
-            "obj_id": str(public_source.id),
-            "observed_at": str(datetime.datetime.now()),
-            "instrument_id": lris.id,
-            "wavelengths": [664, 665, 666],
-            "fluxes": [234.2, 232.1, 235.3],
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp = client(upload_data_token)
+    spectrum_id = sp.post_spectrum(
+        SpectrumPost(
+            obj_id=str(public_source.id),
+            observed_at=str(datetime.datetime.now()),
+            instrument_id=lris.id,
+            wavelengths=[664, 665, 666],
+            fluxes=[234.2, 232.1, 235.3],
+            group_ids=[public_group.id],
+        )
+    ).id
 
-    spectrum_id = data["data"]["id"]
-    status, data = api("GET", f"spectrum/{spectrum_id}", token=upload_data_token)
-    assert status == 200
-    assert data["status"] == "success"
-    assert data["data"]["fluxes"][0] == 234.2
-    assert data["data"]["obj_id"] == public_source.id
+    spectrum = sp.fetch_spectrum(spectrum_id)
+    assert spectrum.fluxes[0] == 234.2
+    assert spectrum.obj_id == public_source.id
 
-    status, data = api("DELETE", f"spectrum/{spectrum_id}", token=manage_sources_token)
-    assert status == 401
+    with pytest.raises(SkyPortalError) as err:
+        client(manage_sources_token).delete_spectrum(spectrum_id)
+    assert err.value.status_code == 401
 
 
 def test_user_can_delete_owned_spectrum_data(
     upload_data_token, public_source, public_group, lris
 ):
-    status, data = api(
-        "POST",
-        "spectrum",
-        data={
-            "obj_id": str(public_source.id),
-            "observed_at": str(datetime.datetime.now()),
-            "instrument_id": lris.id,
-            "wavelengths": [664, 665, 666],
-            "fluxes": [234.2, 232.1, 235.3],
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp = client(upload_data_token)
+    spectrum_id = sp.post_spectrum(
+        SpectrumPost(
+            obj_id=str(public_source.id),
+            observed_at=str(datetime.datetime.now()),
+            instrument_id=lris.id,
+            wavelengths=[664, 665, 666],
+            fluxes=[234.2, 232.1, 235.3],
+            group_ids=[public_group.id],
+        )
+    ).id
 
-    spectrum_id = data["data"]["id"]
-    status, data = api("GET", f"spectrum/{spectrum_id}", token=upload_data_token)
-    assert status == 200
-    assert data["status"] == "success"
-    assert data["data"]["fluxes"][0] == 234.2
-    assert data["data"]["obj_id"] == public_source.id
+    spectrum = sp.fetch_spectrum(spectrum_id)
+    assert spectrum.fluxes[0] == 234.2
+    assert spectrum.obj_id == public_source.id
 
-    status, data = api("DELETE", f"spectrum/{spectrum_id}", token=upload_data_token)
-    assert status == 200
+    sp.delete_spectrum(spectrum_id)
 
-    status, data = api("GET", f"spectrum/{spectrum_id}", token=upload_data_token)
-    assert status == 403
+    with pytest.raises(SkyPortalError) as err:
+        sp.fetch_spectrum(spectrum_id)
+    assert err.value.status_code == 403
 
 
 def test_admin_can_delete_unowned_spectrum_data(
     upload_data_token, super_admin_token, public_source, public_group, lris
 ):
-    status, data = api(
-        "POST",
-        "spectrum",
-        data={
-            "obj_id": str(public_source.id),
-            "observed_at": str(datetime.datetime.now()),
-            "instrument_id": lris.id,
-            "wavelengths": [664, 665, 666],
-            "fluxes": [234.2, 232.1, 235.3],
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp = client(upload_data_token)
+    spectrum_id = sp.post_spectrum(
+        SpectrumPost(
+            obj_id=str(public_source.id),
+            observed_at=str(datetime.datetime.now()),
+            instrument_id=lris.id,
+            wavelengths=[664, 665, 666],
+            fluxes=[234.2, 232.1, 235.3],
+            group_ids=[public_group.id],
+        )
+    ).id
 
-    spectrum_id = data["data"]["id"]
-    status, data = api("GET", f"spectrum/{spectrum_id}", token=upload_data_token)
-    assert status == 200
-    assert data["status"] == "success"
-    assert data["data"]["fluxes"][0] == 234.2
-    assert data["data"]["obj_id"] == public_source.id
+    spectrum = sp.fetch_spectrum(spectrum_id)
+    assert spectrum.fluxes[0] == 234.2
+    assert spectrum.obj_id == public_source.id
 
-    status, data = api("DELETE", f"spectrum/{spectrum_id}", token=super_admin_token)
-    assert status == 200
+    client(super_admin_token).delete_spectrum(spectrum_id)
 
-    status, data = api("GET", f"spectrum/{spectrum_id}", token=upload_data_token)
-    assert status == 403
+    with pytest.raises(SkyPortalError) as err:
+        sp.fetch_spectrum(spectrum_id)
+    assert err.value.status_code == 403
 
 
 def test_jsonify_spectrum_header(
@@ -1731,23 +1178,18 @@ def test_jsonify_spectrum_header(
 ):
     for filename in glob(f"{os.path.dirname(__file__)}/../../data/ZTF*.ascii.head"):
         with open(filename[:-5]) as f:
-            status, data = api(
-                "POST",
-                "spectrum/parse/ascii",
-                data={
-                    "fluxerr_column": (
+            parsed = client(upload_data_token).parse_spectrum_ascii(
+                SpectrumAsciiParse(
+                    fluxerr_column=(
                         3
                         if "ZTF20abpuxna_20200915_Keck1_v1.ascii" in filename
                         else 2
                         if "P60" in filename
                         else None
                     ),
-                    "ascii": f.read(),
-                },
-                token=upload_data_token,
+                    ascii=f.read(),
+                )
             )
-        assert status == 200
-        assert data["status"] == "success"
 
         answer = yaml.safe_load(open(filename))
 
@@ -1755,10 +1197,10 @@ def test_jsonify_spectrum_header(
         for key in answer:
             # special keys
             if key not in ["COMMENT", "END", "HISTORY"]:
-                if isinstance(data["data"]["altdata"][key], dict):
-                    value = data["data"]["altdata"][key]["value"]
+                if isinstance(parsed.altdata[key], dict):
+                    value = parsed.altdata[key]["value"]
                 else:
-                    value = data["data"]["altdata"][key]
+                    value = parsed.altdata[key]
                 if isinstance(answer[key], str | int):
                     assert str(value) == str(answer[key])
                 elif isinstance(answer[key], datetime.datetime):
@@ -1774,52 +1216,36 @@ def test_jsonify_spectrum_header(
 def test_can_post_spectrum_no_groups(
     upload_data_token, public_source, public_group, lris
 ):
-    status, data = api(
-        "POST",
-        "spectrum",
-        data={
-            "obj_id": str(public_source.id),
-            "observed_at": str(datetime.datetime.now()),
-            "instrument_id": lris.id,
-            "wavelengths": [664, 665, 666],
-            "fluxes": [234.2, 232.1, 235.3],
-        },
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp = client(upload_data_token)
+    spectrum_id = sp.post_spectrum(
+        SpectrumPost(
+            obj_id=str(public_source.id),
+            observed_at=str(datetime.datetime.now()),
+            instrument_id=lris.id,
+            wavelengths=[664, 665, 666],
+            fluxes=[234.2, 232.1, 235.3],
+        )
+    ).id
 
-    spectrum_id = data["data"]["id"]
-    status, data = api("GET", f"spectrum/{spectrum_id}", token=upload_data_token)
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]["groups"]) == 1
+    assert len(sp.fetch_spectrum(spectrum_id).groups) == 1
 
 
 def test_can_post_spectrum_empty_groups_list(
     upload_data_token, public_source, public_group, lris
 ):
-    status, data = api(
-        "POST",
-        "spectrum",
-        data={
-            "obj_id": str(public_source.id),
-            "observed_at": str(datetime.datetime.now()),
-            "instrument_id": lris.id,
-            "wavelengths": [664, 665, 666],
-            "fluxes": [234.2, 232.1, 235.3],
-            "group_ids": [],
-        },
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp = client(upload_data_token)
+    spectrum_id = sp.post_spectrum(
+        SpectrumPost(
+            obj_id=str(public_source.id),
+            observed_at=str(datetime.datetime.now()),
+            instrument_id=lris.id,
+            wavelengths=[664, 665, 666],
+            fluxes=[234.2, 232.1, 235.3],
+            group_ids=[],
+        )
+    ).id
 
-    spectrum_id = data["data"]["id"]
-    status, data = api("GET", f"spectrum/{spectrum_id}", token=upload_data_token)
-    assert status == 200
-    assert data["status"] == "success"
-    assert len(data["data"]["groups"]) == 1
+    assert len(sp.fetch_spectrum(spectrum_id).groups) == 1
 
 
 def test_jsonify_spectrum_data(
@@ -1827,55 +1253,50 @@ def test_jsonify_spectrum_data(
 ):
     for filename in glob(f"{os.path.dirname(__file__)}/../../data/ZTF*.ascii"):
         with open(filename) as f:
-            status, data = api(
-                "POST",
-                "spectrum/parse/ascii",
-                data={
-                    "fluxerr_column": (
+            parsed = client(upload_data_token).parse_spectrum_ascii(
+                SpectrumAsciiParse(
+                    fluxerr_column=(
                         3
                         if "ZTF20abpuxna_20200915_Keck1_v1.ascii" in filename
                         else 2
                         if "P60" in filename
                         else None
                     ),
-                    "ascii": f.read(),
-                },
-                token=upload_data_token,
+                    ascii=f.read(),
+                )
             )
-        assert status == 200
-        assert data["status"] == "success"
 
         answer = np.genfromtxt(filename, dtype=float, encoding="ascii")
 
         if answer.shape[-1] == 2:
             np.testing.assert_allclose(
-                np.asarray(data["data"]["wavelengths"], dtype=float), answer[:, 0]
+                np.asarray(parsed.wavelengths, dtype=float), answer[:, 0]
             )
             np.testing.assert_allclose(
-                np.asarray(data["data"]["fluxes"], dtype=float), answer[:, 1]
+                np.asarray(parsed.fluxes, dtype=float), answer[:, 1]
             )
 
         elif answer.shape[-1] == 3:
             np.testing.assert_allclose(
-                np.asarray(data["data"]["wavelengths"], dtype=float), answer[:, 0]
+                np.asarray(parsed.wavelengths, dtype=float), answer[:, 0]
             )
             np.testing.assert_allclose(
-                np.asarray(data["data"]["fluxes"], dtype=float), answer[:, 1]
+                np.asarray(parsed.fluxes, dtype=float), answer[:, 1]
             )
             np.testing.assert_allclose(
-                np.asarray(data["data"]["errors"], dtype=float), answer[:, 2]
+                np.asarray(parsed.errors, dtype=float), answer[:, 2]
             )
 
         else:
             # this is the long one from Keck
             np.testing.assert_allclose(
-                np.asarray(data["data"]["wavelengths"], dtype=float), answer[:, 0]
+                np.asarray(parsed.wavelengths, dtype=float), answer[:, 0]
             )
             np.testing.assert_allclose(
-                np.asarray(data["data"]["fluxes"], dtype=float), answer[:, 1]
+                np.asarray(parsed.fluxes, dtype=float), answer[:, 1]
             )
             np.testing.assert_allclose(
-                np.asarray(data["data"]["errors"], dtype=float), answer[:, 3]
+                np.asarray(parsed.errors, dtype=float), answer[:, 3]
             )
 
 
@@ -1887,56 +1308,47 @@ def test_upload_bad_spectrum_from_ascii_file(
             content = f.read()
             observed_at = str(datetime.datetime.now())
 
-            status, data = api(
-                "POST",
-                "spectrum/ascii",
-                data={
-                    "obj_id": str(public_source.id),
-                    "observed_at": observed_at,
-                    "instrument_id": lris.id,
-                    "group_ids": [public_group.id],
-                    "fluxerr_column": (
-                        3
-                        if "ZTF20abpuxna_20200915_Keck1_v1.ascii" in filename
-                        else 2
-                        if "P60" in filename
-                        else None
-                    ),
-                    "ascii": content,
-                    "filename": filename,
-                },
-                token=upload_data_token,
-            )
-
-            assert status == 400
-            assert data["status"] == "error"
+            with pytest.raises(SkyPortalError) as err:
+                client(upload_data_token).post_spectrum_ascii(
+                    SpectrumAsciiPost(
+                        obj_id=str(public_source.id),
+                        observed_at=observed_at,
+                        instrument_id=lris.id,
+                        group_ids=[public_group.id],
+                        fluxerr_column=(
+                            3
+                            if "ZTF20abpuxna_20200915_Keck1_v1.ascii" in filename
+                            else 2
+                            if "P60" in filename
+                            else None
+                        ),
+                        ascii=content,
+                        filename=filename,
+                    )
+                )
+            assert err.value.status_code == 400
 
 
 def test_token_user_post_to_foreign_group_and_retrieve(
     upload_data_token, public_source_two_groups, public_group2, lris
 ):
-    status, data = api(
-        "POST",
-        "spectrum",
-        data={
-            "obj_id": str(public_source_two_groups.id),
-            "observed_at": str(datetime.datetime.now()),
-            "instrument_id": lris.id,
-            "wavelengths": [664, 665, 666],
-            "fluxes": [234.2, 232.1, 235.3],
-            "group_ids": [public_group2.id],
-        },
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp = client(upload_data_token)
+    spectrum_id = sp.post_spectrum(
+        SpectrumPost(
+            obj_id=str(public_source_two_groups.id),
+            observed_at=str(datetime.datetime.now()),
+            instrument_id=lris.id,
+            wavelengths=[664, 665, 666],
+            fluxes=[234.2, 232.1, 235.3],
+            group_ids=[public_group2.id],
+        )
+    ).id
 
-    spectrum_id = data["data"]["id"]
-    status, data = api("GET", f"spectrum/{spectrum_id}", token=upload_data_token)
-    assert status == 200
+    sp.fetch_spectrum(spectrum_id)
 
 
 def test_parse_integer_spectrum_ascii(upload_data_token):
+    # raw api: asserts the server serializes wavelengths as floats in raw JSON, which pydantic coercion would mask
     status, data = api(
         "POST",
         "spectrum/parse/ascii",
@@ -1954,64 +1366,49 @@ def test_parse_integer_spectrum_ascii(upload_data_token):
 def test_spectrum_external_reducer_and_observer(
     upload_data_token, public_source, public_group, lris, user
 ):
-    status, data = api(
-        "POST",
-        "spectrum",
-        data={
-            "obj_id": str(public_source.id),
-            "observed_at": str(datetime.datetime.now()),
-            "instrument_id": lris.id,
-            "wavelengths": [664, 665, 666],
-            "fluxes": [234.2, 232.1, 235.3],
-            "group_ids": [public_group.id],
-            "reduced_by": [user.id],
-            "external_reducer": "Test external reducer",
-            "observed_by": [user.id],
-            "external_observer": "Test external observer",
-            "pi": [user.id],
-            "external_pi": "Test external PI",
-        },
-        token=upload_data_token,
-    )
-    print(data)
-    assert status == 200
-    assert data["status"] == "success"
+    sp = client(upload_data_token)
+    spectrum_id = sp.post_spectrum(
+        SpectrumPost(
+            obj_id=str(public_source.id),
+            observed_at=str(datetime.datetime.now()),
+            instrument_id=lris.id,
+            wavelengths=[664, 665, 666],
+            fluxes=[234.2, 232.1, 235.3],
+            group_ids=[public_group.id],
+            reduced_by=[user.id],
+            external_reducer="Test external reducer",
+            observed_by=[user.id],
+            external_observer="Test external observer",
+            pi=[user.id],
+            external_pi="Test external PI",
+        )
+    ).id
 
-    spectrum_id = data["data"]["id"]
-    status, data = api("GET", f"spectrum/{spectrum_id}", token=upload_data_token)
-    assert status == 200
-    assert data["status"] == "success"
-    assert data["data"]["reducers"][0]["id"] == user.id
-    assert data["data"]["observers"][0]["id"] == user.id
-    assert data["data"]["pis"][0]["id"] == user.id
-    assert data["data"]["external_reducer"] == "Test external reducer"
-    assert data["data"]["external_observer"] == "Test external observer"
-    assert data["data"]["external_pi"] == "Test external PI"
+    spectrum = sp.fetch_spectrum(spectrum_id)
+    assert spectrum.reducers[0].id == user.id
+    assert spectrum.observers[0].id == user.id
+    assert spectrum.pis[0].id == user.id
+    assert spectrum.external_reducer == "Test external reducer"
+    assert spectrum.external_observer == "Test external observer"
+    assert spectrum.external_pi == "Test external PI"
 
 
 def test_post_get_spectrum_type(upload_data_token, public_source, public_group, lris):
-    # post this spectrum without a type (should default to "source")
-    status, data = api(
-        "POST",
-        "spectrum",
-        data={
-            "obj_id": str(public_source.id),
-            "observed_at": str(datetime.datetime.now()),
-            "instrument_id": lris.id,
-            "wavelengths": [664, 665, 666],
-            "fluxes": [234.2, 232.1, 235.3],
-            "group_ids": [public_group.id],
-        },
-        token=upload_data_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    spectrum_id = data["data"]["id"]
+    sp = client(upload_data_token)
 
-    status, data = api("GET", f"spectrum/{spectrum_id}", token=upload_data_token)
-    assert status == 200
-    assert data["status"] == "success"
-    assert data["data"]["type"] == default_spectrum_type
+    # post this spectrum without a type (should default to "source")
+    spectrum_id = sp.post_spectrum(
+        SpectrumPost(
+            obj_id=str(public_source.id),
+            observed_at=str(datetime.datetime.now()),
+            instrument_id=lris.id,
+            wavelengths=[664, 665, 666],
+            fluxes=[234.2, 232.1, 235.3],
+            group_ids=[public_group.id],
+        )
+    ).id
+
+    assert sp.fetch_spectrum(spectrum_id).type == default_spectrum_type
 
     assert default_spectrum_type in ALLOWED_SPECTRUM_TYPES
 
@@ -2019,100 +1416,68 @@ def test_post_get_spectrum_type(upload_data_token, public_source, public_group, 
         new_allowed_types = list(ALLOWED_SPECTRUM_TYPES)
         new_allowed_types.remove(default_spectrum_type)
 
-        status, data = api(
-            "POST",
-            "spectrum",
-            data={
-                "obj_id": str(public_source.id),
-                "observed_at": str(datetime.datetime.now()),
-                "instrument_id": lris.id,
-                "wavelengths": [664, 665, 666],
-                "fluxes": [234.2, 232.1, 235.3],
-                "group_ids": [public_group.id],
-                "type": new_allowed_types[0],
-            },
-            token=upload_data_token,
-        )
-        assert status == 200
-        assert data["status"] == "success"
-        spectrum_id = data["data"]["id"]
+        spectrum_id = sp.post_spectrum(
+            SpectrumPost(
+                obj_id=str(public_source.id),
+                observed_at=str(datetime.datetime.now()),
+                instrument_id=lris.id,
+                wavelengths=[664, 665, 666],
+                fluxes=[234.2, 232.1, 235.3],
+                group_ids=[public_group.id],
+                type=new_allowed_types[0],
+            )
+        ).id
 
-        status, data = api("GET", f"spectrum/{spectrum_id}", token=upload_data_token)
-        assert status == 200
-        assert data["status"] == "success"
-        assert data["data"]["type"] == new_allowed_types[0]
+        assert sp.fetch_spectrum(spectrum_id).type == new_allowed_types[0]
 
 
 def test_post_wrong_spectrum_type(upload_data_token, public_source, public_group, lris):
     # post this spectrum with the wrong type
-    status, data = api(
-        "POST",
-        "spectrum",
-        data={
-            "obj_id": str(public_source.id),
-            "observed_at": str(datetime.datetime.now()),
-            "instrument_id": lris.id,
-            "wavelengths": [664, 665, 666],
-            "fluxes": [234.2, 232.1, 235.3],
-            "group_ids": [public_group.id],
-            "type": str(uuid.uuid4()),
-        },
-        token=upload_data_token,
-    )
-    assert status == 400
-    assert "Must be one of: " in data["message"]
+    with pytest.raises(SkyPortalError, match="Must be one of: ") as err:
+        client(upload_data_token).post_spectrum(
+            SpectrumPost(
+                obj_id=str(public_source.id),
+                observed_at=str(datetime.datetime.now()),
+                instrument_id=lris.id,
+                wavelengths=[664, 665, 666],
+                fluxes=[234.2, 232.1, 235.3],
+                group_ids=[public_group.id],
+                type=str(uuid.uuid4()),
+            )
+        )
+    assert err.value.status_code == 400
 
 
 def test_bulk_spectra(
     super_admin_user, super_admin_token, public_source, public_group, lris
 ):
-    status, data = api(
-        "POST",
-        "spectrum",
-        data={
-            "obj_id": public_source.id,
-            "observed_at": "2020-01-10T00:00:00",
-            "instrument_id": lris.id,
-            "wavelengths": [664, 665, 666],
-            "fluxes": [234.3, 232.1, 235.3],
-            "group_ids": [public_group.id],
-        },
-        token=super_admin_token,
+    sp = client(super_admin_token)
+    sp.post_spectrum(
+        SpectrumPost(
+            obj_id=public_source.id,
+            observed_at="2020-01-10T00:00:00",
+            instrument_id=lris.id,
+            wavelengths=[664, 665, 666],
+            fluxes=[234.3, 232.1, 235.3],
+            group_ids=[public_group.id],
+        )
     )
-    assert status == 200
-    assert data["status"] == "success"
 
     def check(result):
-        source_ids = [s["id"] for s in result["sources"]]
+        source_ids = [s.id for s in result.sources]
         assert public_source.id in source_ids
-        src = next(s for s in result["sources"] if s["id"] == public_source.id)
+        src = next(s for s in result.sources if s.id == public_source.id)
         # Phase anchors are always present (values may be null without a PhotStat).
         for key in ("redshift", "first_detected_mjd", "peak_mjd", "tns_discovery_date"):
-            assert key in src
-        spectra = [sp for sp in result["spectra"] if sp["obj_id"] == public_source.id]
+            assert hasattr(src, key)
+        spectra = [sp for sp in result.spectra if sp.obj_id == public_source.id]
         assert len(spectra) >= 1
-        assert spectra[0]["wavelengths"][0] == 664
-        assert spectra[0]["fluxes"][0] == 234.3
-        assert spectra[0]["observed_at"] is not None
+        assert spectra[0].wavelengths[0] == 664
+        assert spectra[0].fluxes[0] == 234.3
+        assert spectra[0].observed_at is not None
 
     # Select by explicit object list.
-    status, data = api(
-        "POST",
-        "spectra/bulk",
-        data={"obj_ids": [public_source.id]},
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    check(data["data"])
+    check(sp.post_spectra_bulk(obj_ids=[public_source.id]))
 
     # Select by group.
-    status, data = api(
-        "POST",
-        "spectra/bulk",
-        data={"group_id": public_group.id},
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    check(data["data"])
+    check(sp.post_spectra_bulk(group_id=public_group.id))

--- a/skyportal/tests/api_tests/spectra_misc/test_summary_query.py
+++ b/skyportal/tests/api_tests/spectra_misc/test_summary_query.py
@@ -1,34 +1,43 @@
-from skyportal.tests import api
+import pytest
+from skyportal_py import SkyPortalError
+from skyportal_py.summary_query import SummaryQueryPost
+
+from skyportal.tests import client
 
 
 def test_bad_queries(view_only_token):
+    sp = client(view_only_token)
     # no query
-    query_data = {}
-    status, data = api("POST", "summary_query", data=query_data, token=view_only_token)
-    assert status == 400
-    assert data["message"].find("Missing one of the required") != -1
+    with pytest.raises(SkyPortalError, match="Missing one of the required") as err:
+        sp.post_summary_query(SummaryQueryPost())
+    assert err.value.status_code == 400
 
     # bad z range
-    query_data = {
-        "q": "Test query. This is my test query on the sources?",
-        "z_min": 0.2,
-        "z_max": 0.1,
-    }
-    status, data = api("POST", "summary_query", data=query_data, token=view_only_token)
-    assert status == 400
-    assert data["message"].find("z_min must be <= z_max") != -1
+    with pytest.raises(SkyPortalError, match="z_min must be <= z_max") as err:
+        sp.post_summary_query(
+            SummaryQueryPost(
+                q="Test query. This is my test query on the sources?",
+                z_min=0.2,
+                z_max=0.1,
+            )
+        )
+    assert err.value.status_code == 400
 
     # bad k
-    query_data = {"q": "Test query. This is my test query on the sources?", "k": 101}
-    status, data = api("POST", "summary_query", data=query_data, token=view_only_token)
-    assert status == 400
-    assert data["message"].find("k must be 1<=k<=100") != -1
+    with pytest.raises(SkyPortalError, match="k must be 1<=k<=100") as err:
+        sp.post_summary_query(
+            SummaryQueryPost(
+                q="Test query. This is my test query on the sources?", k=101
+            )
+        )
+    assert err.value.status_code == 400
 
     # send both a query and objID
-    query_data = {
-        "q": "Test query. This is my test query on the sources?",
-        "objID": "ZTF20abm",
-    }
-    status, data = api("POST", "summary_query", data=query_data, token=view_only_token)
-    assert status == 400
-    assert data["message"].find("Cannot specify both") != -1
+    with pytest.raises(SkyPortalError, match="Cannot specify both") as err:
+        sp.post_summary_query(
+            SummaryQueryPost(
+                q="Test query. This is my test query on the sources?",
+                obj_id="ZTF20abm",
+            )
+        )
+    assert err.value.status_code == 400

--- a/skyportal/tests/api_tests/spectra_misc/test_synthphot.py
+++ b/skyportal/tests/api_tests/spectra_misc/test_synthphot.py
@@ -1,94 +1,60 @@
 import datetime
 import uuid
 
-from skyportal.tests import api
+import pytest
+from skyportal_py import SkyPortalError
+from skyportal_py.instruments import InstrumentPost
+from skyportal_py.spectra import SpectrumPost
+from skyportal_py.telescopes import TelescopePost
+
+from skyportal.tests import client
 
 
 def test_synthetic_photometry(super_admin_token, public_source, public_group):
+    sp = client(super_admin_token)
     telescope_name = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "telescope",
-        data={
-            "name": telescope_name,
-            "nickname": telescope_name,
-            "lat": 0.0,
-            "lon": 0.0,
-            "elevation": 0.0,
-            "diameter": 10.0,
-        },
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    telescope_id = data["data"]["id"]
+    telescope_id = sp.post_telescope(
+        TelescopePost(
+            name=telescope_name,
+            nickname=telescope_name,
+            lat=0.0,
+            lon=0.0,
+            elevation=0.0,
+            diameter=10.0,
+        )
+    ).id
 
     instrument_name = str(uuid.uuid4())
-    status, data = api(
-        "POST",
-        "instrument",
-        data={
-            "name": instrument_name,
-            "type": "spectrograph",
-            "telescope_id": telescope_id,
-        },
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    instrument_id = data["data"]["id"]
+    instrument_id = sp.post_instrument(
+        InstrumentPost(
+            name=instrument_name,
+            type="spectrograph",
+            telescope_id=telescope_id,
+        )
+    ).id
 
-    status, data = api(
-        "POST",
-        "spectrum",
-        data={
-            "obj_id": public_source.id,
-            "observed_at": str(datetime.datetime.now()),
-            "instrument_id": instrument_id,
-            "wavelengths": [1000, 3000, 5000, 7000, 9000],
-            "fluxes": [232.1, 234.2, 232.1, 235.3, 232.1],
-            "units": "erg/s/cm/cm/AA",
-            "group_ids": [public_group.id],
-        },
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    spectrum_id = data["data"]["id"]
+    spectrum_id = sp.post_spectrum(
+        SpectrumPost(
+            obj_id=public_source.id,
+            observed_at=str(datetime.datetime.now()),
+            instrument_id=instrument_id,
+            wavelengths=[1000, 3000, 5000, 7000, 9000],
+            fluxes=[232.1, 234.2, 232.1, 235.3, 232.1],
+            units="erg/s/cm/cm/AA",
+            group_ids=[public_group.id],
+        )
+    ).id
 
     filters = ["ztfg", "ztfr", "ztfi"]
-    status, data = api(
-        "POST",
-        f"spectra/synthphot/{spectrum_id}",
-        data={
-            "filters": filters,
-        },
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp.post_synthetic_photometry(spectrum_id, filters)
 
     # Check for single GET call as well
-    status, data = api(
-        "GET",
-        f"sources/{public_source.id}",
-        params={"includePhotometry": "true"},
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["data"]["id"] == public_source.id
+    source = sp.fetch_source(public_source.id, include_photometry=True)
+    assert source.id == public_source.id
     for filt in filters:
-        assert any(p["filter"] == filt for p in data["data"]["photometry"])
+        assert any(p.filter == filt for p in source.photometry)
 
     filters = ["f140w", "f153m", "f160w"]
-    status, data = api(
-        "POST",
-        f"spectra/synthphot/{spectrum_id}",
-        data={
-            "filters": filters,
-        },
-        token=super_admin_token,
-    )
-    assert status == 400
-    data["status"] == "error"
-    assert "outside spectral range" in data["message"]
+    with pytest.raises(SkyPortalError, match="outside spectral range") as err:
+        sp.post_synthetic_photometry(spectrum_id, filters)
+    assert err.value.status_code == 400

--- a/skyportal/tests/api_tests/spectra_misc/test_token.py
+++ b/skyportal/tests/api_tests/spectra_misc/test_token.py
@@ -1,61 +1,33 @@
 import uuid
 
-from skyportal.tests import api
+import pytest
+from skyportal_py import SkyPortalError
+
+from skyportal.tests import client
 
 
 def test_add_and_delete_tokens(super_admin_token, user):
+    sp = client(super_admin_token)
     token_name = str(uuid.uuid4())
 
-    data = {
-        "acls": ["Classify", "Annotate", "Comment"],
-        "user_id": user.id,
-        "name": token_name,
-    }
+    token_id = sp.post_token(
+        token_name, ["Classify", "Annotate", "Comment"], user_id=user.id
+    ).token_id
 
-    status, data = api("POST", "internal/tokens", token=super_admin_token, data=data)
-    assert status == 200
-    token_id = data["data"]["token_id"]
+    assert any(token.id == token_id for token in sp.fetch_tokens())
 
-    status, data = api("GET", "internal/tokens", token=super_admin_token)
-    assert status == 200
-    assert any(token["id"] == token_id for token in data["data"])
+    sp.delete_token(token_id)
 
-    status, data = api("DELETE", f"internal/tokens/{token_id}", token=super_admin_token)
-    assert status == 200
-
-    status, data = api("GET", "internal/tokens", token=super_admin_token)
-    assert status == 200
-    assert all(token["id"] != token_id for token in data["data"])
+    assert all(token.id != token_id for token in sp.fetch_tokens())
 
 
 def test_multiple_tokens(super_admin_token, user, annotation_token):
-    token_name_1 = str(uuid.uuid4())
+    sp = client(super_admin_token)
+    acls = ["Classify", "Annotate", "Comment"]
 
-    data = {
-        "acls": ["Classify", "Annotate", "Comment"],
-        "user_id": user.id,
-        "name": token_name_1,
-    }
+    sp.post_token(str(uuid.uuid4()), acls, user_id=user.id)
+    sp.post_token(str(uuid.uuid4()), acls, user_id=user.id)
 
-    status, data = api("POST", "internal/tokens", token=super_admin_token, data=data)
-    assert status == 200
-
-    token_name_2 = str(uuid.uuid4())
-    data = {
-        "acls": ["Classify", "Annotate", "Comment"],
-        "user_id": user.id,
-        "name": token_name_2,
-    }
-
-    status, data = api("POST", "internal/tokens", token=super_admin_token, data=data)
-    assert status == 200
-
-    token_name_3 = str(uuid.uuid4())
-    data = {
-        "acls": ["Classify", "Annotate", "Comment"],
-        "user_id": user.id,
-        "name": token_name_3,
-    }
-
-    status, data = api("POST", "internal/tokens", token=annotation_token, data=data)
-    assert status == 400
+    with pytest.raises(SkyPortalError) as err:
+        client(annotation_token).post_token(str(uuid.uuid4()), acls, user_id=user.id)
+    assert err.value.status_code == 400

--- a/skyportal/tests/api_tests/spectra_misc/test_versioned_requests.py
+++ b/skyportal/tests/api_tests/spectra_misc/test_versioned_requests.py
@@ -3,6 +3,7 @@ from skyportal.tests import api
 
 
 def test_versioned_request(view_only_token, public_source):
+    # raw api: raw-JSON envelope ("version") assertion the typed client would mask
     response = api(
         "GET", "sources/{public_source.id}", token=view_only_token, raw_response=True
     )

--- a/skyportal/tests/api_tests/spectra_misc/test_weather.py
+++ b/skyportal/tests/api_tests/spectra_misc/test_weather.py
@@ -1,48 +1,43 @@
 import uuid
 
-from skyportal.tests import api
+from skyportal_py.profile import ProfilePatch
+from skyportal_py.telescopes import TelescopePost
+
+from skyportal.tests import client
 
 
 def test_weather_api(upload_data_token, super_admin_token):
     name = str(uuid.uuid4())
-    post_data = {
-        "name": name,
-        "nickname": name,
-        "lat": 0.0,
-        "lon": 0.0,
-        "elevation": 0.0,
-        "diameter": 10.0,
-        "skycam_link": "http://www.lulin.ncu.edu.tw/wea/cur_sky.jpg",
-        "weather_link": "http://www.lulin.ncu.edu.tw/",
-        "robotic": True,
-    }
-
-    status, data = api("POST", "telescope", data=post_data, token=super_admin_token)
-    assert status == 200
-    assert data["status"] == "success"
-
-    telescope_id = data["data"]["id"]
+    telescope_id = (
+        client(super_admin_token)
+        .post_telescope(
+            TelescopePost(
+                name=name,
+                nickname=name,
+                lat=0.0,
+                lon=0.0,
+                elevation=0.0,
+                diameter=10.0,
+                skycam_link="http://www.lulin.ncu.edu.tw/wea/cur_sky.jpg",
+                weather_link="http://www.lulin.ncu.edu.tw/",
+                robotic=True,
+            )
+        )
+        .id
+    )
 
     # update the user pref
-    patch_data = {"preferences": {"weather": {"telescopeID": telescope_id}}}
-    status, data = api(
-        "PATCH", "internal/profile", data=patch_data, token=upload_data_token
+    sp = client(upload_data_token)
+    sp.update_profile(
+        ProfilePatch(preferences={"weather": {"telescopeID": telescope_id}})
     )
-    assert status == 200
-    assert data["status"] == "success"
 
     # get the weather for the user preference telescope
-    status, data = api("GET", "weather", token=upload_data_token)
-    assert status == 200
-    assert data["status"] == "success"
+    weather = sp.fetch_weather()
 
     # get the weather for this telescope id
-    status, data_specific_id = api(
-        "GET", f"weather?telescope_id={telescope_id}", token=upload_data_token
-    )
-    assert status == 200
-    assert data_specific_id["status"] == "success"
+    weather_specific_id = sp.fetch_weather(telescope_id=telescope_id)
 
     # did we get the same results?
-    assert data_specific_id["data"]["telescope_name"] == data["data"]["telescope_name"]
-    assert data_specific_id["data"]["weather"] == data["data"]["weather"]
+    assert weather_specific_id.telescope_name == weather.telescope_name
+    assert weather_specific_id.weather == weather.weather

--- a/skyportal/tests/api_tests/test_acls.py
+++ b/skyportal/tests/api_tests/test_acls.py
@@ -1,51 +1,35 @@
-from skyportal.tests import api
+import pytest
+from skyportal_py import SkyPortalError
+
+from skyportal.tests import api, client
 
 
 def test_list_acls(view_only_token):
     """GET /api/acls returns the full ACL catalog to any authenticated user."""
-    status, data = api("GET", "acls", token=view_only_token)
-    assert status == 200
-    assert data["status"] == "success"
-    assert isinstance(data["data"], list)
+    acls = client(view_only_token).fetch_acls()
+    assert isinstance(acls, list)
     # Sanity-check that core ACLs are present.
     for required in ("Comment", "Annotate", "Upload data"):
-        assert required in data["data"], f"missing ACL: {required}"
+        assert required in acls, f"missing ACL: {required}"
 
 
 def test_grant_and_revoke_user_acl(super_admin_token, user):
     """POST then DELETE a single ACL on a user, verifying both endpoints
     and that the in-between state survives a read-back via /api/user/<id>.
     """
+    sp = client(super_admin_token)
     acl_to_grant = "Annotate"
 
-    # Grant
-    status, data = api(
-        "POST",
-        f"user/{user.id}/acls",
-        data={"aclIds": [acl_to_grant]},
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp.post_user_acl(user.id, [acl_to_grant])
+    assert acl_to_grant in sp.fetch_user(user.id).acls
 
-    status, data = api("GET", f"user/{user.id}", token=super_admin_token)
-    assert status == 200
-    assert acl_to_grant in data["data"]["acls"]
-
-    # Revoke
-    status, data = api(
-        "DELETE", f"user/{user.id}/acls/{acl_to_grant}", token=super_admin_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
-
-    status, data = api("GET", f"user/{user.id}", token=super_admin_token)
-    assert status == 200
-    assert acl_to_grant not in data["data"]["acls"]
+    sp.delete_user_acl(user.id, acl_to_grant)
+    assert acl_to_grant not in sp.fetch_user(user.id).acls
 
 
 def test_grant_user_acl_requires_array(super_admin_token, user):
     """The POST endpoint enforces a list-of-strings shape on aclIds."""
+    # raw api: intentionally malformed payload the typed client can't produce
     status, data = api(
         "POST",
         f"user/{user.id}/acls",
@@ -58,22 +42,13 @@ def test_grant_user_acl_requires_array(super_admin_token, user):
 
 def test_grant_unknown_acl_is_rejected(super_admin_token, user):
     """Posting an ACL id that doesn't exist returns 400 without mutating state."""
-    status, data = api(
-        "POST",
-        f"user/{user.id}/acls",
-        data={"aclIds": ["DefinitelyNotARealACL"]},
-        token=super_admin_token,
-    )
-    assert status == 400
-    assert data["status"] == "error"
+    with pytest.raises(SkyPortalError) as err:
+        client(super_admin_token).post_user_acl(user.id, ["DefinitelyNotARealACL"])
+    assert err.value.status_code == 400
 
 
 def test_non_admin_cannot_grant_acls(view_only_token, user):
     """Granting ACLs requires the Manage users permission."""
-    status, data = api(
-        "POST",
-        f"user/{user.id}/acls",
-        data={"aclIds": ["Annotate"]},
-        token=view_only_token,
-    )
-    assert status == 401
+    with pytest.raises(SkyPortalError) as err:
+        client(view_only_token).post_user_acl(user.id, ["Annotate"])
+    assert err.value.status_code == 401

--- a/skyportal/tests/api_tests/test_brokers.py
+++ b/skyportal/tests/api_tests/test_brokers.py
@@ -5,9 +5,11 @@ from urllib.parse import parse_qs
 
 import pytest
 import responses
+from skyportal_py import SkyPortalError
+from skyportal_py.brokers import BrokerPost
 
 from skyportal.broker_apis import GENERICBROKER, BrokerAPI
-from skyportal.tests import api
+from skyportal.tests import api, client
 
 
 def _force_active(broker_id):
@@ -35,200 +37,140 @@ def _broker_payload(**overrides):
 
 def test_broker_crud(super_admin_token):
     payload = _broker_payload()
-    status, data = api("POST", "brokers", data=payload, token=super_admin_token)
-    assert status == 200
-    broker_id = data["data"]["id"]
+    sp = client(super_admin_token)
+    broker_id = sp.post_broker(BrokerPost(**payload)).id
 
     # system admin sees decrypted altdata + capabilities
-    status, data = api("GET", f"brokers/{broker_id}", token=super_admin_token)
-    assert status == 200
-    assert data["data"]["name"] == payload["name"]
-    assert data["data"]["broker_classname"] == "GENERICBROKER"
-    assert data["data"]["altdata"]["base_url"] == "https://broker.test"
-    assert data["data"]["capabilities"]["query_alerts"] is True
-    assert data["data"]["capabilities"]["cone_search"] is False
+    broker = sp.fetch_broker(broker_id)
+    assert broker.name == payload["name"]
+    assert broker.broker_classname == "GENERICBROKER"
+    assert broker.altdata["base_url"] == "https://broker.test"
+    assert broker.capabilities.query_alerts is True
+    assert broker.capabilities.cone_search is False
 
     # update
-    status, data = api(
-        "PATCH", f"brokers/{broker_id}", data={"active": False}, token=super_admin_token
-    )
-    assert status == 200
-    status, data = api("GET", f"brokers/{broker_id}", token=super_admin_token)
-    assert data["data"]["active"] is False
+    sp.update_broker(broker_id, active=False)
+    assert sp.fetch_broker(broker_id).active is False
 
     # delete
-    status, data = api("DELETE", f"brokers/{broker_id}", token=super_admin_token)
-    assert status == 200
-    status, data = api("GET", f"brokers/{broker_id}", token=super_admin_token)
-    assert status == 400
+    sp.delete_broker(broker_id)
+    with pytest.raises(SkyPortalError) as err:
+        sp.fetch_broker(broker_id)
+    assert err.value.status_code == 400
 
 
 def test_broker_capabilities_expose_cross_match_catalogs(super_admin_token):
     """GET /brokers surfaces cross_match_catalogs in capabilities -- the flag the
     source-page centroid overlay reads to pick a reference-catalog broker (so it
     only cone_searches BOOM, never alert-only brokers)."""
-    status, data = api(
-        "POST",
-        "brokers",
-        data=_broker_payload(
-            broker_classname="BOOMBROKER",
-            altdata={"host": "boom.test", "username": "x", "password": "y"},
-        ),
-        token=super_admin_token,
-    )
-    assert status == 200, data
-    boom_id = data["data"]["id"]
+    sp = client(super_admin_token)
+    boom_id = sp.post_broker(
+        BrokerPost(
+            **_broker_payload(
+                broker_classname="BOOMBROKER",
+                altdata={"host": "boom.test", "username": "x", "password": "y"},
+            )
+        )
+    ).id
 
-    status, data = api(
-        "POST", "brokers", data=_broker_payload(), token=super_admin_token
-    )
-    assert status == 200, data
-    generic_id = data["data"]["id"]
+    generic_id = sp.post_broker(BrokerPost(**_broker_payload())).id
 
     try:
-        status, data = api("GET", f"brokers/{boom_id}", token=super_admin_token)
-        assert status == 200, data
-        assert data["data"]["capabilities"]["cross_match_catalogs"] is True
+        assert sp.fetch_broker(boom_id).capabilities.cross_match_catalogs is True
 
-        status, data = api("GET", f"brokers/{generic_id}", token=super_admin_token)
-        assert status == 200, data
-        assert data["data"]["capabilities"]["cross_match_catalogs"] is False
+        assert sp.fetch_broker(generic_id).capabilities.cross_match_catalogs is False
     finally:
-        api("DELETE", f"brokers/{boom_id}", token=super_admin_token)
-        api("DELETE", f"brokers/{generic_id}", token=super_admin_token)
+        sp.delete_broker(boom_id)
+        sp.delete_broker(generic_id)
 
 
 def test_activation_checks_credentials(super_admin_token):
-    status, data = api(
-        "POST",
-        "brokers",
-        data=_broker_payload(
-            broker_classname="BOOMBROKER",
-            altdata={"host": "boom.test"},
-            active=True,
-        ),
-        token=super_admin_token,
-    )
-    assert status == 200, data
-    boom_id = data["data"]["id"]
+    sp = client(super_admin_token)
+    boom_id = sp.post_broker(
+        BrokerPost(
+            **_broker_payload(
+                broker_classname="BOOMBROKER",
+                altdata={"host": "boom.test"},
+                active=True,
+            )
+        )
+    ).id
 
-    status, data = api(
-        "POST", "brokers", data=_broker_payload(active=False), token=super_admin_token
-    )
-    assert status == 200, data
-    generic_id = data["data"]["id"]
+    generic_id = sp.post_broker(BrokerPost(**_broker_payload(active=False))).id
 
     try:
-        status, data = api("GET", f"brokers/{boom_id}", token=super_admin_token)
-        assert data["data"]["active"] is False
+        assert sp.fetch_broker(boom_id).active is False
 
-        status, data = api(
-            "PATCH",
-            f"brokers/{boom_id}",
-            data={"active": True},
-            token=super_admin_token,
-        )
-        assert status == 400, data
+        with pytest.raises(SkyPortalError) as err:
+            sp.update_broker(boom_id, active=True)
+        assert err.value.status_code == 400
         # the handler names the refused action and the underlying reason
-        assert "cannot be activated" in data["message"]
-        assert "username" in data["message"] and "password" in data["message"]
+        assert "cannot be activated" in str(err.value)
+        assert "username" in str(err.value) and "password" in str(err.value)
 
-        status, data = api("GET", f"brokers/{boom_id}", token=super_admin_token)
-        assert data["data"]["active"] is False
+        assert sp.fetch_broker(boom_id).active is False
 
-        status, data = api(
-            "PATCH",
-            f"brokers/{generic_id}",
-            data={"active": True},
-            token=super_admin_token,
-        )
-        assert status == 200, data
-        status, data = api("GET", f"brokers/{generic_id}", token=super_admin_token)
-        assert data["data"]["active"] is True
+        sp.update_broker(generic_id, active=True)
+        assert sp.fetch_broker(generic_id).active is True
     finally:
-        api("DELETE", f"brokers/{boom_id}", token=super_admin_token)
-        api("DELETE", f"brokers/{generic_id}", token=super_admin_token)
+        sp.delete_broker(boom_id)
+        sp.delete_broker(generic_id)
 
 
 def test_default_requires_the_capability(super_admin_token):
-    status, data = api(
-        "POST", "brokers", data=_broker_payload(), token=super_admin_token
-    )
-    assert status == 200, data
-    generic_id = data["data"]["id"]
+    sp = client(super_admin_token)
+    generic_id = sp.post_broker(BrokerPost(**_broker_payload())).id
 
     try:
-        status, data = api(
-            "PATCH",
-            f"brokers/{generic_id}",
-            data={"default_crossmatch": True},
-            token=super_admin_token,
-        )
-        assert status == 400, data
-        assert "cross_match_catalogs" in data["message"]
+        with pytest.raises(SkyPortalError) as err:
+            sp.update_broker(generic_id, default_crossmatch=True)
+        assert err.value.status_code == 400
+        assert "cross_match_catalogs" in str(err.value)
 
-        status, data = api("GET", f"brokers/{generic_id}", token=super_admin_token)
-        assert data["data"]["default_crossmatch"] is False
+        assert sp.fetch_broker(generic_id).default_crossmatch is False
 
-        status, data = api(
-            "PATCH",
-            f"brokers/{generic_id}",
-            data={"default_alert_search": True},
-            token=super_admin_token,
-        )
-        assert status == 200, data
+        sp.update_broker(generic_id, default_alert_search=True)
     finally:
-        api("DELETE", f"brokers/{generic_id}", token=super_admin_token)
+        sp.delete_broker(generic_id)
 
 
 def test_broker_defaults_are_exclusive(super_admin_token):
-    status, data = api(
-        "POST",
-        "brokers",
-        data=_broker_payload(
-            broker_classname="BOOMBROKER",
-            altdata={"host": "boom.test"},
-            default_alert_search=True,
-            default_crossmatch=True,
-        ),
-        token=super_admin_token,
-    )
-    assert status == 200, data
-    first_id = data["data"]["id"]
+    sp = client(super_admin_token)
+    first_id = sp.post_broker(
+        BrokerPost(
+            **_broker_payload(
+                broker_classname="BOOMBROKER",
+                altdata={"host": "boom.test"},
+                default_alert_search=True,
+                default_crossmatch=True,
+            )
+        )
+    ).id
 
-    status, data = api(
-        "POST", "brokers", data=_broker_payload(), token=super_admin_token
-    )
-    assert status == 200, data
-    second_id = data["data"]["id"]
+    second_id = sp.post_broker(BrokerPost(**_broker_payload())).id
 
     try:
-        status, data = api("GET", f"brokers/{first_id}", token=super_admin_token)
-        assert data["data"]["default_alert_search"] is True
-        assert data["data"]["default_crossmatch"] is True
+        first = sp.fetch_broker(first_id)
+        assert first.default_alert_search is True
+        assert first.default_crossmatch is True
 
-        status, data = api(
-            "PATCH",
-            f"brokers/{second_id}",
-            data={"default_alert_search": True},
-            token=super_admin_token,
-        )
-        assert status == 200, data
+        sp.update_broker(second_id, default_alert_search=True)
 
-        status, data = api("GET", f"brokers/{second_id}", token=super_admin_token)
-        assert data["data"]["default_alert_search"] is True
-        assert data["data"]["default_crossmatch"] is False
+        second = sp.fetch_broker(second_id)
+        assert second.default_alert_search is True
+        assert second.default_crossmatch is False
 
-        status, data = api("GET", f"brokers/{first_id}", token=super_admin_token)
-        assert data["data"]["default_alert_search"] is False
-        assert data["data"]["default_crossmatch"] is True
+        first = sp.fetch_broker(first_id)
+        assert first.default_alert_search is False
+        assert first.default_crossmatch is True
     finally:
-        api("DELETE", f"brokers/{first_id}", token=super_admin_token)
-        api("DELETE", f"brokers/{second_id}", token=super_admin_token)
+        sp.delete_broker(first_id)
+        sp.delete_broker(second_id)
 
 
 def test_broker_invalid_classname(super_admin_token):
     payload = _broker_payload(broker_classname="NOTAREALBROKER")
+    # raw api: intentionally malformed payload the typed client can't produce
     status, data = api("POST", "brokers", data=payload, token=super_admin_token)
     assert status == 400
 
@@ -236,22 +178,21 @@ def test_broker_invalid_classname(super_admin_token):
 def test_broker_invalid_config(super_admin_token):
     # GENERICBROKER.validate_config requires base_url
     payload = _broker_payload(altdata={})
-    status, data = api("POST", "brokers", data=payload, token=super_admin_token)
-    assert status == 400
+    with pytest.raises(SkyPortalError) as err:
+        client(super_admin_token).post_broker(BrokerPost(**payload))
+    assert err.value.status_code == 400
 
 
 def test_broker_requires_admin_and_redacts_altdata(super_admin_token, view_only_token):
     # non-admin cannot create
-    status, data = api("POST", "brokers", data=_broker_payload(), token=view_only_token)
-    assert status != 200
+    with pytest.raises(SkyPortalError):
+        client(view_only_token).post_broker(BrokerPost(**_broker_payload()))
 
-    status, data = api(
-        "POST", "brokers", data=_broker_payload(), token=super_admin_token
-    )
-    assert status == 200
-    broker_id = data["data"]["id"]
+    sp = client(super_admin_token)
+    broker_id = sp.post_broker(BrokerPost(**_broker_payload())).id
 
     # non-admin can read the broker, but altdata is redacted
+    # raw api: raw-JSON shape assertion the typed model would mask
     status, data = api("GET", f"brokers/{broker_id}", token=view_only_token)
     assert status == 200
     assert "altdata" not in data["data"]
@@ -259,21 +200,13 @@ def test_broker_requires_admin_and_redacts_altdata(super_admin_token, view_only_
 
     # admins get the config, minus the credentials (GENERICBROKER renders
     # `token` as a password field)
-    status, data = api("GET", f"brokers/{broker_id}", token=super_admin_token)
-    assert status == 200
-    assert data["data"]["altdata"]["base_url"] == "https://broker.test"
-    assert "token" not in data["data"]["altdata"]
+    broker = sp.fetch_broker(broker_id)
+    assert broker.altdata["base_url"] == "https://broker.test"
+    assert "token" not in broker.altdata
 
     # so editing another field must not wipe the stored credential
-    status, _ = api(
-        "PATCH",
-        f"brokers/{broker_id}",
-        data={"altdata": {"base_url": "https://broker2.test"}},
-        token=super_admin_token,
-    )
-    assert status == 200
-    status, data = api("GET", f"brokers/{broker_id}", token=super_admin_token)
-    assert data["data"]["altdata"]["base_url"] == "https://broker2.test"
+    sp.update_broker(broker_id, altdata={"base_url": "https://broker2.test"})
+    assert sp.fetch_broker(broker_id).altdata["base_url"] == "https://broker2.test"
 
 
 def test_altdata_merge_and_redaction():
@@ -322,6 +255,7 @@ def test_secret_config_fields_cover_every_provider():
 
 
 def test_broker_apis_discovery(view_only_token):
+    # raw api: internal dashboard-config endpoint, outside skyportal-py's scope
     status, data = api("GET", "internal/broker_apis", token=view_only_token)
     assert status == 200
     assert "GENERICBROKER" in data["data"]
@@ -333,12 +267,11 @@ def test_broker_apis_discovery(view_only_token):
 
 
 def test_broker_alerts_inactive(super_admin_token):
-    payload = _broker_payload(active=False)
-    status, data = api("POST", "brokers", data=payload, token=super_admin_token)
-    assert status == 200
-    broker_id = data["data"]["id"]
-    status, data = api("GET", f"brokers/{broker_id}/alerts", token=super_admin_token)
-    assert status == 400
+    sp = client(super_admin_token)
+    broker_id = sp.post_broker(BrokerPost(**_broker_payload(active=False))).id
+    with pytest.raises(SkyPortalError) as err:
+        sp.fetch_broker_alerts(broker_id)
+    assert err.value.status_code == 400
 
 
 # --- provider-level unit tests (no running server needed) ---
@@ -578,20 +511,18 @@ def test_boombroker_cone_search():
 
 @pytest.fixture
 def lasair_broker_id(super_admin_token):
-    status, data = api(
-        "POST",
-        "brokers",
-        data=_broker_payload(
-            broker_classname="LASAIRBROKER",
-            altdata={"token": "t", "endpoint": "https://x/api"},
-        ),
-        token=super_admin_token,
-    )
-    assert status == 200, data
-    broker_id = data["data"]["id"]
+    sp = client(super_admin_token)
+    broker_id = sp.post_broker(
+        BrokerPost(
+            **_broker_payload(
+                broker_classname="LASAIRBROKER",
+                altdata={"token": "t", "endpoint": "https://x/api"},
+            )
+        )
+    ).id
     _force_active(broker_id)
     yield broker_id
-    api("DELETE", f"brokers/{broker_id}", token=super_admin_token)
+    sp.delete_broker(broker_id)
 
 
 def test_filter_module_round_trip_normalizes_streams(
@@ -600,22 +531,13 @@ def test_filter_module_round_trip_normalizes_streams(
     """A module saved with a full stream name is stored under the bare survey
     token -- the builder filters saved modules on the token, so anything else is
     invisible in the builder that wrote it."""
-    status, data = api(
-        "POST",
-        f"brokers/{lasair_broker_id}/filter_modules/myvar",
-        data={"elements": "variables", "data": {"streams": ["ZTF (1, 2)"], "x": 1}},
-        token=super_admin_token,
+    sp = client(super_admin_token)
+    sp.post_broker_filter_module(
+        lasair_broker_id, "myvar", "variables", {"streams": ["ZTF (1, 2)"], "x": 1}
     )
-    assert status == 200, data
 
-    status, data = api(
-        "GET",
-        f"brokers/{lasair_broker_id}/filter_modules",
-        params={"elements": "variables"},
-        token=super_admin_token,
-    )
-    assert status == 200, data
-    assert data["data"]["variables"] == [
+    modules = sp.fetch_broker_filter_modules(lasair_broker_id, elements="variables")
+    assert modules["variables"] == [
         {"name": "myvar", "streams": ["ZTF"], "x": 1},
     ]
 
@@ -623,89 +545,49 @@ def test_filter_module_round_trip_normalizes_streams(
 def test_filter_module_lookup_by_name(lasair_broker_id, super_admin_token):
     """The by-name read backs the builder's name-availability check: a real doc
     for a hit, null for a miss (never an empty list, which reads as a hit)."""
-    status, _ = api(
-        "POST",
-        f"brokers/{lasair_broker_id}/filter_modules/known",
-        data={"elements": "blocks", "data": {"streams": ["ZTF Alerts"]}},
-        token=super_admin_token,
+    sp = client(super_admin_token)
+    sp.post_broker_filter_module(
+        lasair_broker_id, "known", "blocks", {"streams": ["ZTF Alerts"]}
     )
-    assert status == 200
 
-    status, data = api(
-        "GET",
-        f"brokers/{lasair_broker_id}/filter_modules/known",
-        params={"elements": "blocks"},
-        token=super_admin_token,
-    )
-    assert status == 200, data
-    assert data["data"]["blocks"]["name"] == "known"
-    assert data["data"]["blocks"]["streams"] == ["ZTF"]
+    module = sp.fetch_broker_filter_module(lasair_broker_id, "known", elements="blocks")
+    assert module["blocks"]["name"] == "known"
+    assert module["blocks"]["streams"] == ["ZTF"]
 
-    status, data = api(
-        "GET",
-        f"brokers/{lasair_broker_id}/filter_modules/nope",
-        params={"elements": "blocks"},
-        token=super_admin_token,
-    )
-    assert status == 200, data
-    assert data["data"]["blocks"] is None
+    module = sp.fetch_broker_filter_module(lasair_broker_id, "nope", elements="blocks")
+    assert module["blocks"] is None
 
 
 def test_filter_module_update(lasair_broker_id, super_admin_token):
-    status, _ = api(
-        "POST",
-        f"brokers/{lasair_broker_id}/filter_modules/v",
-        data={"elements": "variables", "data": {"streams": ["ZTF"], "x": 1}},
-        token=super_admin_token,
+    sp = client(super_admin_token)
+    sp.post_broker_filter_module(
+        lasair_broker_id, "v", "variables", {"streams": ["ZTF"], "x": 1}
     )
-    assert status == 200
 
-    status, data = api(
-        "PUT",
-        f"brokers/{lasair_broker_id}/filter_modules/v",
-        data={"elements": "variables", "data": {"x": 2}},
-        token=super_admin_token,
-    )
-    assert status == 200, data
+    sp.update_broker_filter_module(lasair_broker_id, "v", "variables", {"x": 2})
 
-    status, data = api(
-        "GET",
-        f"brokers/{lasair_broker_id}/filter_modules/v",
-        params={"elements": "variables"},
-        token=super_admin_token,
-    )
-    assert data["data"]["variables"]["x"] == 2
+    module = sp.fetch_broker_filter_module(lasair_broker_id, "v", elements="variables")
+    assert module["variables"]["x"] == 2
 
     # updating a module that does not exist is an error, not an insert
-    status, data = api(
-        "PUT",
-        f"brokers/{lasair_broker_id}/filter_modules/ghost",
-        data={"elements": "variables", "data": {"x": 1}},
-        token=super_admin_token,
-    )
-    assert status == 400
-    assert "No variables named 'ghost'" in data["message"]
+    with pytest.raises(SkyPortalError) as err:
+        sp.update_broker_filter_module(lasair_broker_id, "ghost", "variables", {"x": 1})
+    assert err.value.status_code == 400
+    assert "No variables named 'ghost'" in str(err.value)
 
 
 def test_filter_module_invalid_elements(lasair_broker_id, super_admin_token):
     """'elements' is validated on read too -- it used to reach the store as an
     arbitrary collection name."""
-    status, data = api(
-        "GET",
-        f"brokers/{lasair_broker_id}/filter_modules",
-        params={"elements": "; drop"},
-        token=super_admin_token,
-    )
-    assert status == 400
-    assert "must be 'schema' or one of" in data["message"]
+    sp = client(super_admin_token)
+    with pytest.raises(SkyPortalError) as err:
+        sp.fetch_broker_filter_modules(lasair_broker_id, elements="; drop")
+    assert err.value.status_code == 400
+    assert "must be 'schema' or one of" in str(err.value)
 
-    status, data = api(
-        "POST",
-        f"brokers/{lasair_broker_id}/filter_modules/x",
-        data={"elements": "bogus", "data": {}},
-        token=super_admin_token,
-    )
-    assert status == 400
+    with pytest.raises(SkyPortalError) as err:
+        sp.post_broker_filter_module(lasair_broker_id, "x", "bogus", {})
+    assert err.value.status_code == 400
 
 
 def test_normalize_module_streams():
@@ -832,29 +714,20 @@ def test_boom_write_filter_module(monkeypatch):
 
 def test_broker_cone_search_unsupported(super_admin_token):
     """A broker whose provider does not implement cone_search is rejected."""
-    status, data = api(
-        "POST", "brokers", data=_broker_payload(), token=super_admin_token
-    )
-    assert status == 200
-    broker_id = data["data"]["id"]
+    sp = client(super_admin_token)
+    broker_id = sp.post_broker(BrokerPost(**_broker_payload())).id
 
-    status, data = api(
-        "GET",
-        f"brokers/{broker_id}/cone_search",
-        params={"ra": 10.0, "dec": 20.0, "radius": 5.0},
-        token=super_admin_token,
-    )
-    assert status == 400
-    assert "does not support cone_search" in data["message"]
+    with pytest.raises(SkyPortalError) as err:
+        sp.fetch_broker_cone_search(broker_id, ra=10.0, dec=20.0, radius=5.0)
+    assert err.value.status_code == 400
+    assert "does not support cone_search" in str(err.value)
 
 
 def test_broker_cone_search_missing_params(super_admin_token):
-    status, data = api(
-        "POST", "brokers", data=_broker_payload(), token=super_admin_token
-    )
-    assert status == 200
-    broker_id = data["data"]["id"]
+    sp = client(super_admin_token)
+    broker_id = sp.post_broker(BrokerPost(**_broker_payload())).id
 
+    # raw api: intentionally malformed payload the typed client can't produce
     status, data = api(
         "GET", f"brokers/{broker_id}/cone_search", token=super_admin_token
     )
@@ -872,17 +745,15 @@ def test_boom_filter_activation_requires_validation(
 
     from skyportal.models import DBSession, Filter
 
-    status, data = api(
-        "POST",
-        "brokers",
-        data=_broker_payload(
-            broker_classname="BOOMBROKER",
-            altdata={"host": "boom.test", "username": "x", "password": "y"},
-        ),
-        token=super_admin_token,
-    )
-    assert status == 200
-    broker_id = data["data"]["id"]
+    sp = client(super_admin_token)
+    broker_id = sp.post_broker(
+        BrokerPost(
+            **_broker_payload(
+                broker_classname="BOOMBROKER",
+                altdata={"host": "boom.test", "username": "x", "password": "y"},
+            )
+        )
+    ).id
     _force_active(broker_id)
     try:
         # Mark the filter broker-managed with no validation on record.
@@ -895,23 +766,19 @@ def test_boom_filter_activation_requires_validation(
         flag_modified(f, "altdata")
         DBSession().commit()
 
-        status, data = api(
-            "PATCH",
-            f"brokers/{broker_id}/filters/{public_filter.id}",
-            data={"active": True, "active_fid": "v1"},
-            token=upload_data_token,
-        )
-        assert status == 400
-        assert "validat" in data["message"].lower()
+        with pytest.raises(SkyPortalError) as err:
+            client(upload_data_token).update_broker_filter(
+                broker_id, public_filter.id, active=True, active_fid="v1"
+            )
+        assert err.value.status_code == 400
+        assert "validat" in str(err.value).lower()
 
         # An admin bypasses the gate: it gets past validation and only then fails
         # at the unreachable test BOOM, so the error is not the validation one.
-        status, data = api(
-            "PATCH",
-            f"brokers/{broker_id}/filters/{public_filter.id}",
-            data={"active": True, "active_fid": "v1"},
-            token=super_admin_token,
-        )
-        assert "validat" not in (data.get("message") or "").lower()
+        with pytest.raises(SkyPortalError) as err:
+            sp.update_broker_filter(
+                broker_id, public_filter.id, active=True, active_fid="v1"
+            )
+        assert "validat" not in str(err.value).lower()
     finally:
-        api("DELETE", f"brokers/{broker_id}", token=super_admin_token)
+        sp.delete_broker(broker_id)

--- a/skyportal/tests/api_tests/test_config_handler.py
+++ b/skyportal/tests/api_tests/test_config_handler.py
@@ -1,4 +1,7 @@
-from skyportal.tests import api
+import pytest
+from skyportal_py import SkyPortalError
+
+from skyportal.tests import client
 
 # Keys the ConfigHandler advertises in its docstring schema. If the handler
 # ever drops one of these, this test should catch it.
@@ -35,10 +38,7 @@ def test_config_returns_required_keys(view_only_token):
     Any authenticated user can read the config (it's frontend bootstrap
     data, not sensitive). This test pins the contract.
     """
-    status, data = api("GET", "config", token=view_only_token)
-    assert status == 200
-    assert data["status"] == "success"
-    cfg = data["data"]
+    cfg = client(view_only_token).fetch_config()
     assert isinstance(cfg, dict)
     missing = _REQUIRED_KEYS - set(cfg)
     assert not missing, f"config missing keys: {sorted(missing)}"
@@ -58,9 +58,7 @@ def test_config_cosmology_params_full_precision(view_only_token):
     rounds some values (e.g. H0 to 67.7 instead of 67.66)."""
     from skyportal.models import cosmo
 
-    status, data = api("GET", "config", token=view_only_token)
-    assert status == 200
-    params = data["data"]["cosmologyParams"]
+    params = client(view_only_token).fetch_config()["cosmologyParams"]
     assert isinstance(params, list) and params
     assert all(set(row) == {"name", "value"} for row in params)
 
@@ -73,5 +71,6 @@ def test_config_cosmology_params_full_precision(view_only_token):
 
 def test_config_requires_authentication():
     """The endpoint is gated by auth_or_token."""
-    status, _ = api("GET", "config")  # no token
-    assert status == 401
+    with pytest.raises(SkyPortalError) as err:
+        client().fetch_config()  # no token
+    assert err.value.status_code == 401

--- a/skyportal/tests/api_tests/test_roles.py
+++ b/skyportal/tests/api_tests/test_roles.py
@@ -1,63 +1,45 @@
-from skyportal.tests import api
+import pytest
+from skyportal_py import SkyPortalError
+
+from skyportal.tests import api, client
 
 
 def test_list_roles(view_only_token):
     """GET /api/roles returns every role with its associated ACL ids."""
-    status, data = api("GET", "roles", token=view_only_token)
-    assert status == 200
-    assert data["status"] == "success"
-    role_ids = {r["id"] for r in data["data"]}
+    roles = client(view_only_token).fetch_roles()
+    role_ids = {role.id for role in roles}
     # Sanity-check that the built-in roles are present.
     for required in ("Super admin", "Full user", "View only"):
         assert required in role_ids, f"missing role: {required}"
     # Every role exposes its ACL list (may be empty).
-    for role in data["data"]:
-        assert "acls" in role and isinstance(role["acls"], list)
+    for role in roles:
+        assert isinstance(role.acls, list)
 
 
 def test_grant_and_revoke_user_role(super_admin_token, user):
     """POST grants a role; DELETE revokes it. Read-back via /api/user/<id>
     confirms the in-between state.
     """
+    sp = client(super_admin_token)
     role_to_grant = "Group admin"
 
-    status, data = api(
-        "POST",
-        f"user/{user.id}/roles",
-        data={"roleIds": [role_to_grant]},
-        token=super_admin_token,
-    )
-    assert status == 200
-    assert data["status"] == "success"
+    sp.post_user_role(user.id, [role_to_grant])
+    assert role_to_grant in sp.fetch_user(user.id).roles
 
-    status, data = api("GET", f"user/{user.id}", token=super_admin_token)
-    assert status == 200
-    assert role_to_grant in data["data"]["roles"]
-
-    status, data = api(
-        "DELETE", f"user/{user.id}/roles/{role_to_grant}", token=super_admin_token
-    )
-    assert status == 200
-
-    status, data = api("GET", f"user/{user.id}", token=super_admin_token)
-    assert status == 200
-    assert role_to_grant not in data["data"]["roles"]
+    sp.delete_user_role(user.id, role_to_grant)
+    assert role_to_grant not in sp.fetch_user(user.id).roles
 
 
 def test_grant_unknown_role_is_rejected(super_admin_token, user):
     """Posting a non-existent role id returns 400 and lists the invalid ids."""
-    status, data = api(
-        "POST",
-        f"user/{user.id}/roles",
-        data={"roleIds": ["DefinitelyNotARealRole"]},
-        token=super_admin_token,
-    )
-    assert status == 400
-    assert "DefinitelyNotARealRole" in data["message"]
+    with pytest.raises(SkyPortalError, match="DefinitelyNotARealRole") as err:
+        client(super_admin_token).post_user_role(user.id, ["DefinitelyNotARealRole"])
+    assert err.value.status_code == 400
 
 
 def test_grant_role_requires_array_of_strings(super_admin_token, user):
     """The POST endpoint enforces shape on roleIds."""
+    # raw api: intentionally malformed payload the typed client can't produce
     status, data = api(
         "POST",
         f"user/{user.id}/roles",
@@ -69,10 +51,6 @@ def test_grant_role_requires_array_of_strings(super_admin_token, user):
 
 def test_non_admin_cannot_grant_roles(view_only_token, user):
     """Granting roles requires the Manage users permission."""
-    status, data = api(
-        "POST",
-        f"user/{user.id}/roles",
-        data={"roleIds": ["Group admin"]},
-        token=view_only_token,
-    )
-    assert status == 401
+    with pytest.raises(SkyPortalError) as err:
+        client(view_only_token).post_user_role(user.id, ["Group admin"])
+    assert err.value.status_code == 401

--- a/skyportal/tests/api_tests/test_source_exists.py
+++ b/skyportal/tests/api_tests/test_source_exists.py
@@ -1,50 +1,47 @@
-from skyportal.tests import api
+import pytest
+from skyportal_py import SkyPortalError
+
+from skyportal.tests import api, client
 
 
 def test_source_exists_by_id_hit(view_only_token, public_source):
     """A known obj_id is reported as existing."""
-    status, data = api(
-        "GET", f"source_exists/{public_source.id}", token=view_only_token
-    )
-    assert status == 200
-    assert data["status"] == "success"
-    assert data["data"]["source_exists"] is True
-    assert public_source.id in data["data"]["message"]
+    result = client(view_only_token).fetch_source_exists(public_source.id)
+    assert result.source_exists is True
+    assert public_source.id in result.message
 
 
 def test_source_exists_by_id_miss(view_only_token):
     """An obj_id that doesn't exist (and no coords given) reports false."""
-    status, data = api(
-        "GET", "source_exists/ZTFnonexistent12345-async-test", token=view_only_token
+    result = client(view_only_token).fetch_source_exists(
+        "ZTFnonexistent12345-async-test"
     )
-    assert status == 200
-    assert data["data"]["source_exists"] is False
+    assert result.source_exists is False
 
 
 def test_source_exists_by_id_miss_with_coords_no_neighbours(view_only_token):
     """When the obj_id misses, the handler falls through to a cone search;
     a far-from-everything point should still come back negative."""
-    status, data = api(
-        "GET",
-        "source_exists/ZTFnonexistent12345-async-test"
-        "?ra=359.99&dec=-89.99&radius=0.001",
-        token=view_only_token,
+    result = client(view_only_token).fetch_source_exists(
+        "ZTFnonexistent12345-async-test", ra=359.99, dec=-89.99, radius=0.001
     )
-    assert status == 200
-    assert data["data"]["source_exists"] is False
+    assert result.source_exists is False
 
 
 def test_source_exists_requires_id_or_coords(view_only_token):
     """The endpoint refuses requests with neither an obj_id nor a cone."""
-    status, data = api("GET", "source_exists", token=view_only_token)
-    assert status == 400
-    assert "obj_id" in data["message"] or "ra" in data["message"]
+    with pytest.raises(SkyPortalError) as err:
+        client(view_only_token).fetch_source_exists()
+    assert err.value.status_code == 400
+    assert "obj_id" in str(err.value) or "ra" in str(err.value)
 
 
 def test_source_exists_rejects_non_numeric_coords(view_only_token):
     """Non-float coord values fall back to None (via the type=float
     coercion in get_query_argument), so the request degrades to the
     'no spatial filter, no id' error path rather than 500ing."""
+    # raw api: intentionally malformed payload the typed client can't produce
+    # (non-numeric ra/dec/radius query values)
     status, data = api(
         "GET",
         "source_exists?ra=not-a-float&dec=not-a-float&radius=not-a-float",

--- a/uv.lock
+++ b/uv.lock
@@ -4245,8 +4245,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "jeepney", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -4508,6 +4508,7 @@ dev = [
     { name = "pytest-playwright" },
     { name = "pytest-randomly" },
     { name = "pytest-rerunfailures" },
+    { name = "skyportal-py" },
 ]
 docs = [
     { name = "eralchemy2" },
@@ -4632,6 +4633,7 @@ dev = [
     { name = "pytest-playwright", specifier = "==0.8.0" },
     { name = "pytest-randomly", specifier = "==4.1.0" },
     { name = "pytest-rerunfailures", specifier = ">=14.0" },
+    { name = "skyportal-py", specifier = "==0.2.0" },
 ]
 docs = [
     { name = "eralchemy2" },
@@ -4641,6 +4643,19 @@ docs = [
     { name = "recommonmark" },
     { name = "sphinx", marker = "python_full_version >= '3.12'", specifier = ">=9.1.0" },
     { name = "sphinx-book-theme" },
+]
+
+[[package]]
+name = "skyportal-py"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/d1/3e2731a6e78ff44f48f9d9fe7149b84f44c1ffab7ac396f17362cdbbc3c4/skyportal_py-0.2.0.tar.gz", hash = "sha256:b153f058d7c919c4a6557995b35f5aba9f03e9bad6c423ac7f727c82c7238304", size = 147483, upload-time = "2026-08-18T21:43:19.109Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/04/1c525d771483edbf8e22dfdf62269395f2139b38b6a06f43a8c6dabbb3a5/skyportal_py-0.2.0-py3-none-any.whl", hash = "sha256:73176f98d131f50cd8b9e1dd6fad69cc26fd70ef2cbf35db84942bc899e2d3aa", size = 154843, upload-time = "2026-08-18T21:43:17.799Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -4633,7 +4633,7 @@ dev = [
     { name = "pytest-playwright", specifier = "==0.8.0" },
     { name = "pytest-randomly", specifier = "==4.1.0" },
     { name = "pytest-rerunfailures", specifier = ">=14.0" },
-    { name = "skyportal-py", specifier = "==0.2.0" },
+    { name = "skyportal-py", specifier = "==0.3.0" },
 ]
 docs = [
     { name = "eralchemy2" },
@@ -4647,15 +4647,15 @@ docs = [
 
 [[package]]
 name = "skyportal-py"
-version = "0.2.0"
+version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/79/d1/3e2731a6e78ff44f48f9d9fe7149b84f44c1ffab7ac396f17362cdbbc3c4/skyportal_py-0.2.0.tar.gz", hash = "sha256:b153f058d7c919c4a6557995b35f5aba9f03e9bad6c423ac7f727c82c7238304", size = 147483, upload-time = "2026-08-18T21:43:19.109Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/53/fe75e34fc77a7fa51bd6d697d66e78d325593973558fdce852050eb8ee63/skyportal_py-0.3.0.tar.gz", hash = "sha256:0d63a016d296d116bdb37c1478af90808b9dbed0611761b4434939733c37fecb", size = 161768, upload-time = "2026-08-19T16:07:01.305Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5e/04/1c525d771483edbf8e22dfdf62269395f2139b38b6a06f43a8c6dabbb3a5/skyportal_py-0.2.0-py3-none-any.whl", hash = "sha256:73176f98d131f50cd8b9e1dd6fad69cc26fd70ef2cbf35db84942bc899e2d3aa", size = 154843, upload-time = "2026-08-18T21:43:17.799Z" },
+    { url = "https://files.pythonhosted.org/packages/96/c6/55941c33e0b889b0de3a5fa399c1d007314a1c5fb1ae43b454219fb1f356/skyportal_py-0.3.0-py3-none-any.whl", hash = "sha256:19570cd92e28d804209849900aaf677a5f8a6b4e88cfb2c1766c139b2821672f", size = 167775, upload-time = "2026-08-19T16:06:59.988Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -4633,7 +4633,7 @@ dev = [
     { name = "pytest-playwright", specifier = "==0.8.0" },
     { name = "pytest-randomly", specifier = "==4.1.0" },
     { name = "pytest-rerunfailures", specifier = ">=14.0" },
-    { name = "skyportal-py", specifier = "==0.3.0" },
+    { name = "skyportal-py", specifier = "==0.3.1" },
 ]
 docs = [
     { name = "eralchemy2" },
@@ -4647,15 +4647,15 @@ docs = [
 
 [[package]]
 name = "skyportal-py"
-version = "0.3.0"
+version = "0.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/61/53/fe75e34fc77a7fa51bd6d697d66e78d325593973558fdce852050eb8ee63/skyportal_py-0.3.0.tar.gz", hash = "sha256:0d63a016d296d116bdb37c1478af90808b9dbed0611761b4434939733c37fecb", size = 161768, upload-time = "2026-08-19T16:07:01.305Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/7e/e28dc9d41be18539ecb3e8edc90ac99c857d2e2d2fcbc1c1cfca83354a34/skyportal_py-0.3.1.tar.gz", hash = "sha256:0f0238d657752569d92e8168d82c157ce30a585188d21e8b2d3f23f12a023bfc", size = 163865, upload-time = "2026-08-20T20:06:53.949Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/c6/55941c33e0b889b0de3a5fa399c1d007314a1c5fb1ae43b454219fb1f356/skyportal_py-0.3.0-py3-none-any.whl", hash = "sha256:19570cd92e28d804209849900aaf677a5f8a6b4e88cfb2c1766c139b2821672f", size = 167775, upload-time = "2026-08-19T16:06:59.988Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/17/3514596329dd678f897c9349f7074cbefd9eee8f48ad7f9809d98650b133/skyportal_py-0.3.1-py3-none-any.whl", hash = "sha256:0d1fefc258b4f4617d386da024791c90653faf13550c50c1a94560d6cb47eb39", size = 168099, upload-time = "2026-08-20T20:06:52.654Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -4633,7 +4633,7 @@ dev = [
     { name = "pytest-playwright", specifier = "==0.8.0" },
     { name = "pytest-randomly", specifier = "==4.1.0" },
     { name = "pytest-rerunfailures", specifier = ">=14.0" },
-    { name = "skyportal-py", specifier = "==0.3.1" },
+    { name = "skyportal-py", specifier = "==0.3.3" },
 ]
 docs = [
     { name = "eralchemy2" },
@@ -4647,15 +4647,15 @@ docs = [
 
 [[package]]
 name = "skyportal-py"
-version = "0.3.1"
+version = "0.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1a/7e/e28dc9d41be18539ecb3e8edc90ac99c857d2e2d2fcbc1c1cfca83354a34/skyportal_py-0.3.1.tar.gz", hash = "sha256:0f0238d657752569d92e8168d82c157ce30a585188d21e8b2d3f23f12a023bfc", size = 163865, upload-time = "2026-08-20T20:06:53.949Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/97/53/faebdc95079007f80ec91344b45b973c7aa7da9bd0759b42e18d67071201/skyportal_py-0.3.3.tar.gz", hash = "sha256:19f49a7c83e5201dafc63acc55eefcbbb2676e1d6b0c06883796d7776f386b85", size = 163933, upload-time = "2026-08-20T20:56:43.106Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/17/3514596329dd678f897c9349f7074cbefd9eee8f48ad7f9809d98650b133/skyportal_py-0.3.1-py3-none-any.whl", hash = "sha256:0d1fefc258b4f4617d386da024791c90653faf13550c50c1a94560d6cb47eb39", size = 168099, upload-time = "2026-08-20T20:06:52.654Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/00/0880b8939e0731f2a6ecf84eaf3d9305acf1d1770658cbf3109553bb930c/skyportal_py-0.3.3-py3-none-any.whl", hash = "sha256:4c7322a4d5d8d40d14e8f96892e1e79b97786619c6ef8c69e048d34585fa6684", size = 168113, upload-time = "2026-08-20T20:56:41.636Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
We have a python api client that has strict models defined for the api responses: https://github.com/leonitousconforti/skyportal-py

All the api inputs have models in here now (path params, query arguments, and bodies) and this api client defines response models

My idea is to start dogfooding this throughout the tests, so that we can know if the hand-derived response models are correct. My end vision is maybe some sort of monorepo? So this skyportal client would live in this repo too. Right now playing around with [this structure](https://github.com/skyportal/skyportal/tree/monorepo/projects) but maybe something like [namespace packages](https://packaging.python.org/en/latest/guides/packaging-namespace-packages/) is more what we want. Can't do that right now though because there is the root `skyportal` folder