### PR TITLE
backend source-list query cache

### DIFF
--- a/static/js/components/source/SourceList.tsx
+++ b/static/js/components/source/SourceList.tsx
@@ -39,6 +39,10 @@ const SourceList = () => {
       ...filterData,
       pageNumber,
       numPerPage,
+      // Reuse the backend's cached obj_id list for this query instead of
+      // re-running the full ordering aggregate on every page. Only valid past
+      // page 1 — the duck drops it otherwise, matching the handler's contract.
+      queryID: pageNumber > 1 ? (sourcesState?.queryID ?? null) : null,
     };
     if (sortData && Object.keys(sortData).length > 0) {
       data.sortBy = sortData.name;
@@ -70,6 +74,10 @@ const SourceList = () => {
       dispatch(showNotification("No sources to download", "warning"));
     } else {
       setDownloadProgressTotal(sourcesState.totalMatches);
+      // Carried from page 1 onwards so each subsequent page reads the backend's
+      // cached obj_id list. Without it every page of the download re-runs the
+      // full ordering aggregate, which dominates the download for large results.
+      let downloadQueryID: string | null = null;
       for (
         let i = 1;
         i <= Math.ceil(sourcesState.totalMatches / sourcesState.numPerPage);
@@ -79,10 +87,12 @@ const SourceList = () => {
           ...queryParams,
           pageNumber: i,
           numPerPage: sourcesState.numPerPage,
+          queryID: i > 1 ? downloadQueryID : null,
         };
         /* eslint-disable no-await-in-loop */
         try {
           const result: any = await fetchSourcesTrigger(data).unwrap();
+          downloadQueryID = result?.queryID ?? downloadQueryID;
           sourceAll.push(...result.sources);
           setDownloadProgressCurrent(sourceAll.length);
           setDownloadProgressTotal(sourcesState.totalMatches);

--- a/static/js/ducks/sources.ts
+++ b/static/js/ducks/sources.ts
@@ -33,6 +33,11 @@ export interface SourcesResult {
   totalMatches: number;
   pageNumber: number;
   numPerPage: number;
+  /**
+   * Handle for the backend's cached obj_id list, assigned on the first page.
+   * Echo it back on later pages to skip re-running the full ordering query.
+   */
+  queryID?: string | null;
   [key: string]: any;
 }
 
@@ -49,9 +54,50 @@ const addFilterParamDefaults = (filterParams: FilterParams): FilterParams => {
   return params;
 };
 
+/**
+ * Opt into the backend's server-side query cache (`useCache` + `queryID`).
+ *
+ * `/api/sources` has no LIMIT on its ordering query: it aggregates
+ * MAX(saved_at) over *every* matching source to build the full ordered obj_id
+ * list, because `totalMatches` is the length of that list. On a Fritz-sized
+ * database that is a ~2-3s full scan, and without a queryID it is repeated on
+ * every single page request.
+ *
+ * Passing `useCache=true` makes the backend persist that list and hand back a
+ * `queryID`; echoing the id on later pages serves them from the cached list
+ * instead (measured ~3.3s -> ~1.0s per page). This is the same mechanism the
+ * scanning page already uses via `getCandidates`.
+ *
+ * The handler validates the pairing strictly, so mirror its contract exactly:
+ *   - page 1 must NOT carry a queryID (the backend assigns one)
+ *   - page > 1 must carry one, or the request is rejected
+ * Anything that would violate it falls back to an uncached query rather than
+ * erroring.
+ */
+const withQueryCache = (params: FilterParams): FilterParams => {
+  const p = { ...params };
+  const pageNumber = Number(p["pageNumber"] ?? 1);
+  if (!Number.isFinite(pageNumber) || pageNumber <= 1) {
+    delete p["queryID"];
+    p["useCache"] = true;
+  } else if (p["queryID"]) {
+    p["useCache"] = true;
+  } else {
+    // Page > 1 with no queryID (e.g. a deep-linked page, or a cache entry the
+    // backend has since expired): ask for the full query instead of tripping
+    // the handler's validation.
+    delete p["useCache"];
+  }
+  return p;
+};
+
 /** Build a `/api/sources?...` URL from a filterParams object. */
 const buildSourcesUrl = (params: FilterParams, removeFalse = true): string => {
-  const filtered = filterOutEmptyValues(params, true, removeFalse);
+  const filtered = filterOutEmptyValues(
+    withQueryCache(params),
+    true,
+    removeFalse,
+  );
   const queryString = buildQueryString(filtered);
   return `/api/sources?${queryString}`;
 };


### PR DESCRIPTION
This PR uses the backend source-list query cache for pagination and download.