### PR TITLE
add groups saved to and fix other surveys detections

### DIFF
--- a/skyportal/handlers/api/candidate/scan_report_item.py
+++ b/skyportal/handlers/api/candidate/scan_report_item.py
@@ -40,6 +40,39 @@ log = make_log("api/scan_report_item")
 # named "desi_*" (e.g. "desi_dr1").
 DESI_ORIGIN_PREFIX = "desi_"
 
+# FollowUpAPI classes (Instrument.api_classname) whose requests are always
+# photometric or always spectroscopic -- instrument.type is often too coarse
+# (e.g. "imager"/"imaging spectrograph" doesn't capture LCO's per-camera split),
+# so the API class itself is the reliable signal for these.
+_PHOTOMETRY_ONLY_APIS = {
+    "ATLASAPI",
+    "PS1API",
+    "ZTFAPI",
+    "BLANCOAPI",
+    "NEWFIRMAPI",
+    "COLIBRIAPI",
+    "KAITAPI",
+    "SINISTROAPI",
+    "SPECTRALAPI",
+    "MUSCATAPI",
+    "IOOAPI",
+    "IOIAPI",
+    "SOARGHTSIMAGERAPI",
+    "TAROTAPI",
+    "TESSAPI",
+    "TRTAPI",
+    "TTTAPI",
+    "WINTERAPI",
+    "SPRINGAPI",
+}
+_SPECTROSCOPY_ONLY_APIS = {
+    "FLOYDSAPI",
+    "SPRATAPI",
+    "NGPSAPI",
+    "SOARGHTSAPI",
+    "SOARTSPECAPI",
+}
+
 
 def _survey_of(band):
     """Map a band name to its survey label for the detections summary."""
@@ -57,16 +90,50 @@ def _followup_request_type(allocation, instrument, payload=None):
     """Classify a follow-up request as forced photometry, spectroscopy or photometry."""
     if allocation and allocation.types and "forced_photometry" in allocation.types:
         return "forced_photometry"
+
+    payload = payload or {}
+    api_classname = getattr(instrument, "api_classname", None)
+
     if instrument and instrument.name == "SEDM":
         # SEDM is an "imaging spectrograph" but most of its request modes
         # (e.g. "3-shot (gri)") are pure photometry; only modes that include
         # the IFU are spectroscopy.
-        payload = payload or {}
         observation_type = payload.get("observation_type") or ""
         observation_choices = payload.get("observation_choices") or []
         if "IFU" in observation_type or "IFU" in observation_choices:
             return "spectroscopy"
         return "photometry"
+
+    if api_classname == "SEDMV2API":
+        # observation_choice is a filter (g/r/i/z) for photometry, or "IFU".
+        return (
+            "spectroscopy"
+            if payload.get("observation_choice") == "IFU"
+            else "photometry"
+        )
+
+    if api_classname in ("BINOSPECAPI", "MMIRSAPI"):
+        # MMT's imaging/spectroscopy modes on the same instrument+API class.
+        return (
+            "spectroscopy"
+            if payload.get("observation_type") == "Spectroscopy"
+            else "photometry"
+        )
+
+    if api_classname == "UVOTXRTAPI":
+        # obs_type is one of Spectroscopy/Light Curve/Position/Timing; only
+        # the first is spectroscopic, the rest are photometric/timing.
+        return (
+            "spectroscopy"
+            if payload.get("obs_type") == "Spectroscopy"
+            else "photometry"
+        )
+
+    if api_classname in _PHOTOMETRY_ONLY_APIS:
+        return "photometry"
+    if api_classname in _SPECTROSCOPY_ONLY_APIS:
+        return "spectroscopy"
+
     if instrument and instrument.type in ("spectrograph", "imaging spectrograph"):
         return "spectroscopy"
     return "photometry"

--- a/skyportal/handlers/api/candidate/scan_report_item.py
+++ b/skyportal/handlers/api/candidate/scan_report_item.py
@@ -44,33 +44,31 @@ DESI_ORIGIN_PREFIX = "desi_"
 # photometric or always spectroscopic -- instrument.type is often too coarse
 # (e.g. "imager"/"imaging spectrograph" doesn't capture LCO's per-camera split),
 # so the API class itself is the reliable signal for these.
-_PHOTOMETRY_ONLY_APIS = {
-    "ATLASAPI",
-    "PS1API",
-    "ZTFAPI",
-    "BLANCOAPI",
-    "NEWFIRMAPI",
-    "COLIBRIAPI",
-    "KAITAPI",
-    "SINISTROAPI",
-    "SPECTRALAPI",
-    "MUSCATAPI",
-    "IOOAPI",
-    "IOIAPI",
-    "SOARGHTSIMAGERAPI",
-    "TAROTAPI",
-    "TESSAPI",
-    "TRTAPI",
-    "TTTAPI",
-    "WINTERAPI",
-    "SPRINGAPI",
-}
-_SPECTROSCOPY_ONLY_APIS = {
-    "FLOYDSAPI",
-    "SPRATAPI",
-    "NGPSAPI",
-    "SOARGHTSAPI",
-    "SOARTSPECAPI",
+_API_CLASSNAME_TYPE = {
+    "ATLASAPI": "photometry",
+    "PS1API": "photometry",
+    "ZTFAPI": "photometry",
+    "BLANCOAPI": "photometry",
+    "NEWFIRMAPI": "photometry",
+    "COLIBRIAPI": "photometry",
+    "KAITAPI": "photometry",
+    "SINISTROAPI": "photometry",
+    "SPECTRALAPI": "photometry",
+    "MUSCATAPI": "photometry",
+    "IOOAPI": "photometry",
+    "IOIAPI": "photometry",
+    "SOARGHTSIMAGERAPI": "photometry",
+    "TAROTAPI": "photometry",
+    "TESSAPI": "photometry",
+    "TRTAPI": "photometry",
+    "TTTAPI": "photometry",
+    "WINTERAPI": "photometry",
+    "SPRINGAPI": "photometry",
+    "FLOYDSAPI": "spectroscopy",
+    "SPRATAPI": "spectroscopy",
+    "NGPSAPI": "spectroscopy",
+    "SOARGHTSAPI": "spectroscopy",
+    "SOARTSPECAPI": "spectroscopy",
 }
 
 
@@ -129,10 +127,9 @@ def _followup_request_type(allocation, instrument, payload=None):
             else "photometry"
         )
 
-    if api_classname in _PHOTOMETRY_ONLY_APIS:
-        return "photometry"
-    if api_classname in _SPECTROSCOPY_ONLY_APIS:
-        return "spectroscopy"
+    fixed_type = _API_CLASSNAME_TYPE.get(api_classname)
+    if fixed_type:
+        return fixed_type
 
     if instrument and instrument.type in ("spectrograph", "imaging spectrograph"):
         return "spectroscopy"

--- a/skyportal/handlers/api/candidate/scan_report_item.py
+++ b/skyportal/handlers/api/candidate/scan_report_item.py
@@ -72,6 +72,100 @@ def _followup_request_type(allocation, instrument, payload=None):
     return "photometry"
 
 
+def _detections_by_survey(photstat, now_mjd):
+    """First/first-real/peak/last detection per survey, read off a single object's
+    (already-loaded) PhotStat -- no queries. PhotStat carries the object's
+    global first/last detection and the peak per filter; grouping those filters by
+    survey (via ``_survey_of``) gives per-survey first/peak/last in one pass.
+    """
+    if photstat is None:
+        return {}
+    ps = photstat
+
+    def _entry(mjd, mag, filt, fp=None):
+        if mjd is None:
+            return None
+        entry = {
+            "mag": safe_round(mag, 3),
+            "mjd": safe_round(mjd, 5),
+            "filter": filt,
+            "days_ago": safe_round(now_mjd - mjd, 2),
+        }
+        if fp is not None:
+            entry["fp"] = fp
+        return entry
+
+    # The global first detection can be a forced-photometry point; PhotStat
+    # separately tracks the first non-forced-phot detection, which is >= it
+    # (a strict superset filtered down), so a mismatch means the true first
+    # detection was FP.
+    is_first_fp = ps.first_detected_mjd is not None and (
+        ps.first_detected_no_forced_phot_mjd is None
+        or ps.first_detected_no_forced_phot_mjd > ps.first_detected_mjd
+    )
+    first_entry = _entry(
+        ps.first_detected_mjd,
+        ps.first_detected_mag,
+        ps.first_detected_filter,
+        fp=is_first_fp,
+    )
+    first_survey = _survey_of(ps.first_detected_filter)
+
+    # If the first detection is FP, also surface the first "real" (non-FP)
+    # detection so scanners aren't misled by an FP-only rise.
+    first_real_entry = None
+    first_real_survey = None
+    if is_first_fp:
+        first_real_entry = _entry(
+            ps.first_detected_no_forced_phot_mjd,
+            ps.first_detected_no_forced_phot_mag,
+            ps.first_detected_no_forced_phot_filter,
+            fp=False,
+        )
+        first_real_survey = _survey_of(ps.first_detected_no_forced_phot_filter)
+
+    # The object's most recent detection, same FP-vs-real distinction as "first".
+    is_last_fp = ps.last_detected_mjd is not None and (
+        ps.last_detected_no_forced_phot_mjd is None
+        or ps.last_detected_no_forced_phot_mjd < ps.last_detected_mjd
+    )
+    last_entry = _entry(
+        ps.last_detected_mjd,
+        ps.last_detected_mag,
+        ps.last_detected_filter,
+        fp=is_last_fp,
+    )
+    last_survey = _survey_of(ps.last_detected_filter)
+
+    # survey -> (mag, mjd, filter), brightest (min mag) across the survey's filters
+    peak_by_survey = {}
+    peak_mjd_per_filter = ps.peak_mjd_per_filter or {}
+    for band, mag in (ps.peak_mag_per_filter or {}).items():
+        if mag is None:
+            continue
+        survey = _survey_of(band)
+        current = peak_by_survey.get(survey)
+        if current is None or mag < current[0]:
+            peak_by_survey[survey] = (mag, peak_mjd_per_filter.get(band), band)
+
+    surveys = (
+        set(peak_by_survey)
+        | ({first_survey} if first_survey else set())
+        | ({first_real_survey} if first_real_survey else set())
+        | ({last_survey} if last_survey else set())
+    )
+    result = {}
+    for survey in surveys:
+        peak = peak_by_survey.get(survey)
+        result[survey] = {
+            "first": first_entry if survey == first_survey else None,
+            "first_real": first_real_entry if survey == first_real_survey else None,
+            "peak": _entry(peak[1], peak[0], peak[2]) if peak else None,
+            "last": last_entry if survey == last_survey else None,
+        }
+    return result
+
+
 def _host_offset(obj):
     """Angular (arcsec) and physical (kpc) separation from the obj to its host galaxy."""
     if not obj.host:
@@ -103,6 +197,8 @@ def _build_scan_report_item(
     desi_annotation=None,
     associated_objs=None,
     previous=None,
+    associated_photstats=None,
+    groups_saved_to=None,
 ):
     """Build a report item from data already fetched for this obj (no queries)."""
     if obj.photstats:
@@ -179,86 +275,17 @@ def _build_scan_report_item(
         for assignment in assignment_rows
     ] or None
 
-    # First and peak detection per survey, read from the (already-loaded) PhotStat so
-    # we don't scan raw photometry (which doesn't scale to long report windows).
-    # PhotStat carries the global first detection and the peak per filter; a report is
-    # generated per single-survey group, so the global first is that survey's first,
-    # and peak per survey is the brightest across the survey's filters.
-    detections_by_survey = {}
-    if obj.photstats:
-        ps = obj.photstats[0]
-
-        def _entry(mjd, mag, filt, fp=None):
-            if mjd is None:
-                return None
-            entry = {
-                "mag": safe_round(mag, 3),
-                "mjd": safe_round(mjd, 5),
-                "filter": filt,
-                "days_ago": safe_round(now_mjd - mjd, 2),
-            }
-            if fp is not None:
-                entry["fp"] = fp
-            return entry
-
-        # The global first detection can be a forced-photometry point; PhotStat
-        # separately tracks the first non-forced-phot detection, which is >= it
-        # (a strict superset filtered down), so a mismatch means the true first
-        # detection was FP.
-        is_first_fp = ps.first_detected_mjd is not None and (
-            ps.first_detected_no_forced_phot_mjd is None
-            or ps.first_detected_no_forced_phot_mjd > ps.first_detected_mjd
-        )
-        first_entry = _entry(
-            ps.first_detected_mjd,
-            ps.first_detected_mag,
-            ps.first_detected_filter,
-            fp=is_first_fp,
-        )
-        first_survey = _survey_of(ps.first_detected_filter)
-
-        # If the first detection is FP, also surface the first "real" (non-FP)
-        # detection so scanners aren't misled by an FP-only rise.
-        first_real_entry = None
-        first_real_survey = None
-        if is_first_fp:
-            first_real_entry = _entry(
-                ps.first_detected_no_forced_phot_mjd,
-                ps.first_detected_no_forced_phot_mag,
-                ps.first_detected_no_forced_phot_filter,
-                fp=False,
-            )
-            first_real_survey = _survey_of(ps.first_detected_no_forced_phot_filter)
-
-        # survey -> (mag, mjd, filter), brightest (min mag) across the survey's filters
-        peak_by_survey = {}
-        peak_mjd_per_filter = ps.peak_mjd_per_filter or {}
-        for band, mag in (ps.peak_mag_per_filter or {}).items():
-            if mag is None:
-                continue
-            survey = _survey_of(band)
-            current = peak_by_survey.get(survey)
-            if current is None or mag < current[0]:
-                peak_by_survey[survey] = (
-                    mag,
-                    peak_mjd_per_filter.get(band),
-                    band,
-                )
-
-        surveys = (
-            set(peak_by_survey)
-            | ({first_survey} if first_survey else set())
-            | ({first_real_survey} if first_real_survey else set())
-        )
-        for survey in surveys:
-            peak = peak_by_survey.get(survey)
-            detections_by_survey[survey] = {
-                "first": first_entry if survey == first_survey else None,
-                "first_real": (
-                    first_real_entry if survey == first_real_survey else None
-                ),
-                "peak": _entry(peak[1], peak[0], peak[2]) if peak else None,
-            }
+    # First/first-real/peak/last detection per survey. Primarily from this obj's
+    # own PhotStat, but a report's object is only ever detected in one survey
+    # (e.g. ZTF), so an associated obj from another survey (e.g. a linked LSST
+    # detection, see ``associated_objs``) is merged in too -- its own survey(s)
+    # only, never overriding this obj's.
+    detections_by_survey = _detections_by_survey(
+        obj.photstats[0] if obj.photstats else None, now_mjd
+    )
+    for assoc_photstat in associated_photstats or []:
+        for survey, entry in _detections_by_survey(assoc_photstat, now_mjd).items():
+            detections_by_survey.setdefault(survey, entry)
     detections_by_survey = detections_by_survey or None
 
     host_offset_arcsec, host_offset_kpc = _host_offset(obj)
@@ -293,6 +320,10 @@ def _build_scan_report_item(
             "previous_filter": (previous or {}).get("filter"),
             "classifications": classifications,
             "saved_info": saved_info,
+            # All groups the obj is *currently* an active Source of, regardless of
+            # this report's own group scope or saved-date window (unlike
+            # `saved_info`, which only covers the report's group_ids/window).
+            "groups_saved_to": groups_saved_to,
             "followups": followups,
             "assignments": assignments,
             "detections_by_survey": detections_by_survey,
@@ -380,6 +411,8 @@ async def create_scan_report_items(
     desi_by_obj = {}  # obj_id -> most recent DESI crossmatch Annotation
     associated_by_obj = defaultdict(dict)  # obj_id -> {assoc_obj_id: aliases}
     previous_by_obj = {}  # obj_id -> {mag, mjd, filter} of the detection before the last
+    photstat_by_assoc_obj = {}  # assoc_obj_id -> PhotStat, for associated_objs' surveys
+    groups_by_obj = defaultdict(list)  # obj_id -> group names currently saved to
 
     # Fetch in chunks of objects: a single ``obj_id IN (...)`` over a long report
     # window (thousands of objects) pushes the planner off the obj_id index onto a
@@ -451,6 +484,22 @@ async def create_scan_report_items(
         ).all():
             sources_by_obj[source.obj_id].append(source)
 
+        # Every group the obj is *currently* an active Source of, not just the
+        # report's own group_ids/window (that's what `saved_info` above covers) --
+        # so a scanner can see all groups it's saved to, even ones outside this
+        # report's scope.
+        for source in (
+            await session.scalars(
+                Source.select(user_or_token, mode="read")
+                .options(selectinload(Source.group))
+                .where(
+                    Source.obj_id.in_(chunk_obj_ids),
+                    Source.active.is_(True),
+                )
+            )
+        ).all():
+            groups_by_obj[source.obj_id].append(source.group.name)
+
         for followup in (
             await session.scalars(
                 FollowupRequest.select(user_or_token, mode="read")
@@ -513,6 +562,7 @@ async def create_scan_report_items(
         accessible_objs = Obj.select(user_or_token, mode="read").subquery()
         o2s_this = aliased(ObjToSuperObj)
         o2s_other = aliased(ObjToSuperObj)
+        chunk_assoc_obj_ids = set()
         for obj_id, assoc_obj_id, assoc_alias in await session.execute(
             sa.select(o2s_this.obj_id, accessible_objs.c.id, accessible_objs.c.alias)
             .select_from(o2s_this)
@@ -524,6 +574,21 @@ async def create_scan_report_items(
             )
         ):
             associated_by_obj[obj_id][assoc_obj_id] = assoc_alias
+            chunk_assoc_obj_ids.add(assoc_obj_id)
+
+        # PhotStat of each associated obj (e.g. a linked LSST detection), so its
+        # survey's first/peak/last detection can be merged into detections_by_survey
+        # alongside this obj's own.
+        if chunk_assoc_obj_ids:
+            for assoc_obj in (
+                await session.scalars(
+                    Obj.select(user_or_token, mode="read")
+                    .options(selectinload(Obj.photstats))
+                    .where(Obj.id.in_(chunk_assoc_obj_ids))
+                )
+            ).all():
+                if assoc_obj.photstats:
+                    photstat_by_assoc_obj[assoc_obj.id] = assoc_obj.photstats[0]
 
     now_mjd = Time.now().mjd
     items = []
@@ -550,6 +615,13 @@ async def create_scan_report_items(
                     ).items()
                 ]
                 or None,
+                associated_photstats=[
+                    photstat_by_assoc_obj[assoc_obj_id]
+                    for assoc_obj_id in associated_by_obj.get(obj_id, {})
+                    if assoc_obj_id in photstat_by_assoc_obj
+                ]
+                or None,
+                groups_saved_to=sorted(groups_by_obj.get(obj_id, [])) or None,
             )
         )
     return items

--- a/skyportal/tests/api_tests/sources_candidates/test_scan_reports.py
+++ b/skyportal/tests/api_tests/sources_candidates/test_scan_reports.py
@@ -6,18 +6,14 @@ import sqlalchemy as sa
 from skyportal.models import (
     Candidate,
     DBSession,
+    GroupUser,
     PhotStat,
     ScanReport,
     Source,
     SuperObj,
 )
 from skyportal.tests import api
-from skyportal.tests.fixtures import (
-    CommentFactory,
-    GroupFactory,
-    ObjFactory,
-    PhotometryFactory,
-)
+from skyportal.tests.fixtures import CommentFactory, ObjFactory, PhotometryFactory
 from skyportal.utils.naive_datetime import utcnow_naive
 
 
@@ -45,6 +41,7 @@ def cleanup_reports():
 def test_scan_report_item_includes_followup_and_assignment(
     public_filter,
     public_group,
+    public_group2,
     user,
     upload_data_token,
     public_group_sedm_allocation,
@@ -72,12 +69,13 @@ def test_scan_report_item_includes_followup_and_assignment(
         )
     )
     # Also currently saved to a second group outside the report's own group_ids,
-    # to confirm "groups_saved_to" isn't limited to the report's scope.
-    other_group = GroupFactory()
+    # to confirm "groups_saved_to" isn't limited to the report's scope. `user`
+    # must belong to it too, or Source.select(mode="read") filters it out.
+    DBSession.add(GroupUser(user_id=user.id, group_id=public_group2.id))
     DBSession.add(
         Source(
             obj_id=obj.id,
-            group_id=other_group.id,
+            group_id=public_group2.id,
             saved_by_id=user.id,
             saved_at=now,
         )
@@ -208,9 +206,9 @@ def test_scan_report_item_includes_followup_and_assignment(
     assert survey_detections["last"]["days_ago"] > 0
 
     # Every group the obj is currently an active Source of, including
-    # `other_group` which isn't part of this report's own group_ids/window.
+    # `public_group2` which isn't part of this report's own group_ids/window.
     assert sorted(item["data"]["groups_saved_to"]) == sorted(
-        [public_group.name, other_group.name]
+        [public_group.name, public_group2.name]
     )
 
 

--- a/skyportal/tests/api_tests/sources_candidates/test_scan_reports.py
+++ b/skyportal/tests/api_tests/sources_candidates/test_scan_reports.py
@@ -12,7 +12,12 @@ from skyportal.models import (
     SuperObj,
 )
 from skyportal.tests import api
-from skyportal.tests.fixtures import CommentFactory, ObjFactory, PhotometryFactory
+from skyportal.tests.fixtures import (
+    CommentFactory,
+    GroupFactory,
+    ObjFactory,
+    PhotometryFactory,
+)
 from skyportal.utils.naive_datetime import utcnow_naive
 
 
@@ -66,6 +71,17 @@ def test_scan_report_item_includes_followup_and_assignment(
             saved_at=now,
         )
     )
+    # Also currently saved to a second group outside the report's own group_ids,
+    # to confirm "groups_saved_to" isn't limited to the report's scope.
+    other_group = GroupFactory()
+    DBSession.add(
+        Source(
+            obj_id=obj.id,
+            group_id=other_group.id,
+            saved_by_id=user.id,
+            saved_at=now,
+        )
+    )
     DBSession.commit()
 
     # A follow-up request (SEDM is an imaging spectrograph -> "spectroscopy").
@@ -106,8 +122,9 @@ def test_scan_report_item_includes_followup_and_assignment(
     )
 
     # Detections are read from PhotStat (not raw photometry): a fainter first
-    # detection and a brighter peak, both ZTF filters. ObjFactory already creates a
-    # PhotStat (obj_id is unique), so update it rather than inserting a second one.
+    # detection, a brighter peak, and a later last detection, all ZTF filters.
+    # ObjFactory already creates a PhotStat (obj_id is unique), so update it
+    # rather than inserting a second one.
     photstat = DBSession().scalar(sa.select(PhotStat).where(PhotStat.obj_id == obj.id))
     if photstat is None:
         photstat = PhotStat(obj_id=obj.id)
@@ -117,6 +134,9 @@ def test_scan_report_item_includes_followup_and_assignment(
     photstat.first_detected_filter = "ztfg"
     photstat.peak_mag_per_filter = {"ztfg": 18.9, "ztfr": 16.4}
     photstat.peak_mjd_per_filter = {"ztfg": 60000.0, "ztfr": 60010.0}
+    photstat.last_detected_mjd = 60020.0
+    photstat.last_detected_mag = 17.2
+    photstat.last_detected_filter = "ztfi"
     DBSession.commit()
 
     window = {
@@ -173,7 +193,7 @@ def test_scan_report_item_includes_followup_and_assignment(
     assert assignment["status"] is not None
     assert assignment["requester"] == user.username
 
-    # First/peak detection per survey (mag, mjd, filter, days-ago), from PhotStat.
+    # First/peak/last detection per survey (mag, mjd, filter, days-ago), from PhotStat.
     detections = item["data"]["detections_by_survey"]
     assert detections is not None
     survey_detections = detections["ZTF"]
@@ -181,8 +201,17 @@ def test_scan_report_item_includes_followup_and_assignment(
     assert survey_detections["first"]["filter"] == "ztfg"
     assert survey_detections["peak"]["mag"] == 16.4
     assert survey_detections["peak"]["filter"] == "ztfr"
+    assert survey_detections["last"]["mag"] == 17.2
+    assert survey_detections["last"]["filter"] == "ztfi"
     assert survey_detections["first"]["days_ago"] > 0
     assert survey_detections["peak"]["days_ago"] > 0
+    assert survey_detections["last"]["days_ago"] > 0
+
+    # Every group the obj is currently an active Source of, including
+    # `other_group` which isn't part of this report's own group_ids/window.
+    assert sorted(item["data"]["groups_saved_to"]) == sorted(
+        [public_group.name, other_group.name]
+    )
 
 
 def test_scan_report_item_includes_associated_objs(
@@ -197,6 +226,8 @@ def test_scan_report_item_includes_associated_objs(
     obj = ObjFactory(groups=[public_group])
     # Another survey's detection of the same physical object (e.g. LSST), with
     # its own alias, linked via a SuperObj -- distinct from `obj`'s own alias.
+    # Note the alias/id don't need to start with "lsst": survey is inferred from
+    # the photometry filter/band (see `_survey_of`), not the obj's name.
     assoc_obj = ObjFactory(groups=[public_group], alias=["LSST_123"])
     DBSession.add(SuperObj(objs=[obj, assoc_obj]))
     DBSession.add(
@@ -210,6 +241,23 @@ def test_scan_report_item_includes_associated_objs(
             saved_at=now,
         )
     )
+    DBSession.commit()
+
+    # The associated obj's own detections (LSST filter), so they should surface
+    # under a distinct "LSST" key in the report item's detections_by_survey,
+    # alongside `obj`'s own (ZTF) survey.
+    assoc_photstat = DBSession().scalar(
+        sa.select(PhotStat).where(PhotStat.obj_id == assoc_obj.id)
+    )
+    if assoc_photstat is None:
+        assoc_photstat = PhotStat(obj_id=assoc_obj.id)
+        DBSession.add(assoc_photstat)
+    assoc_photstat.first_detected_mjd = 60005.0
+    assoc_photstat.first_detected_mag = 19.5
+    assoc_photstat.first_detected_filter = "lsstg"
+    assoc_photstat.last_detected_mjd = 60025.0
+    assoc_photstat.last_detected_mag = 18.1
+    assoc_photstat.last_detected_filter = "lssti"
     DBSession.commit()
 
     window = {
@@ -246,6 +294,16 @@ def test_scan_report_item_includes_associated_objs(
     assert associated_objs is not None
     assoc = next(a for a in associated_objs if a["obj_id"] == assoc_obj.id)
     assert assoc["aliases"] == ["LSST_123"]
+
+    # The associated obj's own (LSST) detections are merged into
+    # detections_by_survey under their own survey key, alongside `obj`'s (ZTF).
+    detections = item["data"]["detections_by_survey"]
+    assert detections is not None
+    assert "LSST" in detections
+    assert detections["LSST"]["first"]["mag"] == 19.5
+    assert detections["LSST"]["first"]["filter"] == "lsstg"
+    assert detections["LSST"]["last"]["mag"] == 18.1
+    assert detections["LSST"]["last"]["filter"] == "lssti"
 
 
 def test_scan_report_item_includes_previous_mag(

--- a/skyportal/tests/api_tests/sources_candidates/test_scan_reports.py
+++ b/skyportal/tests/api_tests/sources_candidates/test_scan_reports.py
@@ -1,8 +1,10 @@
 from datetime import timedelta
+from types import SimpleNamespace
 
 import pytest
 import sqlalchemy as sa
 
+from skyportal.handlers.api.candidate.scan_report_item import _followup_request_type
 from skyportal.models import (
     Candidate,
     DBSession,
@@ -647,3 +649,99 @@ def test_scan_report_rejects_inaccessible_gcn_event(
     )
     assert status == 400, data
     assert "not found or not accessible" in data["message"]
+
+
+def _followup_request_case(
+    api_classname, instrument_type="imager", instrument_name="Test", payload=None
+):
+    allocation = SimpleNamespace(types=[])
+    instrument = SimpleNamespace(
+        name=instrument_name, type=instrument_type, api_classname=api_classname
+    )
+    return _followup_request_type(allocation, instrument, payload)
+
+
+def test_followup_request_type_classification():
+    """Distinguish photometry vs spectroscopy requests, per Instrument.api_classname
+    and (for API classes that submit both) the request payload -- not just
+    instrument.type, which is too coarse for e.g. LCO's per-camera API split."""
+    # allocation.types takes precedence over everything else.
+    assert (
+        _followup_request_type(
+            SimpleNamespace(types=["forced_photometry"]),
+            SimpleNamespace(name="ATLAS", type="imager", api_classname="ATLASAPI"),
+        )
+        == "forced_photometry"
+    )
+
+    # SEDM: IFU vs any other (imaging) choice, from observation_type/observation_choices.
+    assert (
+        _followup_request_case(
+            "SEDMAPI",
+            instrument_name="SEDM",
+            payload={"observation_type": "IFU"},
+        )
+        == "spectroscopy"
+    )
+    assert (
+        _followup_request_case(
+            "SEDMAPI",
+            instrument_name="SEDM",
+            payload={"observation_choices": ["3-shot (gri)"]},
+        )
+        == "photometry"
+    )
+
+    # SEDMv2: observation_choice is "IFU" or a filter (g/r/i/z).
+    assert (
+        _followup_request_case("SEDMV2API", payload={"observation_choice": "IFU"})
+        == "spectroscopy"
+    )
+    assert (
+        _followup_request_case("SEDMV2API", payload={"observation_choice": "g"})
+        == "photometry"
+    )
+
+    # MMT (Binospec/MMIRS): same API class submits both, split by observation_type.
+    for api_classname in ("BINOSPECAPI", "MMIRSAPI"):
+        assert (
+            _followup_request_case(
+                api_classname, payload={"observation_type": "Spectroscopy"}
+            )
+            == "spectroscopy"
+        )
+        assert (
+            _followup_request_case(
+                api_classname, payload={"observation_type": "Imaging"}
+            )
+            == "photometry"
+        )
+
+    # Swift UVOT/XRT: obs_type is one of Spectroscopy/Light Curve/Position/Timing.
+    assert (
+        _followup_request_case("UVOTXRTAPI", payload={"obs_type": "Spectroscopy"})
+        == "spectroscopy"
+    )
+    assert (
+        _followup_request_case("UVOTXRTAPI", payload={"obs_type": "Light Curve"})
+        == "photometry"
+    )
+
+    # Photometry-only and spectroscopy-only API classes ignore the payload entirely.
+    assert (
+        _followup_request_case("PS1API", payload={"observation_type": "Spectroscopy"})
+        == "photometry"
+    )
+    assert (
+        _followup_request_case("FLOYDSAPI", payload={"observation_type": "Imaging"})
+        == "spectroscopy"
+    )
+
+    # An API class not in either set falls back to instrument.type.
+    assert (
+        _followup_request_case("SOMEOTHERAPI", instrument_type="spectrograph")
+        == "spectroscopy"
+    )
+    assert (
+        _followup_request_case("SOMEOTHERAPI", instrument_type="imager") == "photometry"
+    )

--- a/static/js/components/candidate/scan_reports/ReportItems.tsx
+++ b/static/js/components/candidate/scan_reports/ReportItems.tsx
@@ -85,6 +85,7 @@ const ReportItem = ({ reportId, isMultiGroup }: ReportItemProps) => {
             <FieldTitle sx={{ flex: 1 }}>date</FieldTitle>
             <FieldTitle>scanner</FieldTitle>
             {isMultiGroup && <FieldTitle>group</FieldTitle>}
+            <FieldTitle>groups</FieldTitle>
             <FieldTitle>Source</FieldTitle>
             <FieldTitle>TNS name</FieldTitle>
             <FieldTitle>aliases</FieldTitle>
@@ -151,6 +152,17 @@ const ReportItem = ({ reportId, isMultiGroup }: ReportItemProps) => {
                     )}
                   </Field>
                 )}
+                <Field>
+                  {reportItem.data.groups_saved_to?.map(
+                    (groupName: string, index: number) => (
+                      <Chip
+                        label={groupName.substring(0, 15)}
+                        size="small"
+                        key={index}
+                      />
+                    ),
+                  )}
+                </Field>
                 <Field>
                   <Link
                     to={`/source/${reportItem.obj_id}`}
@@ -281,7 +293,7 @@ const ReportItem = ({ reportId, isMultiGroup }: ReportItemProps) => {
                           );
                         if (det.last)
                           parts.push(
-                            `last ${det.last.mag} ${det.last.filter} (${det.last.days_ago}d)`,
+                            `last ${det.last.mag} ${det.last.filter} (${det.last.days_ago}d)${det.last.fp ? " [FP]" : ""}`,
                           );
                         return (
                           <Tooltip


### PR DESCRIPTION
Add a columns groups which shows groups the obj is currently saved to.
Edits the way associated objs are displayed in the detections column.
Adds the last detection in the detections column as well. 

Make a distinction between PHOT / Spec requests info In the scanning report item. (#5576) 