### PR TITLE
empty observation page

### DIFF
--- a/static/js/components/observation/ObservationPage.tsx
+++ b/static/js/components/observation/ObservationPage.tsx
@@ -101,18 +101,14 @@ const QueuedObservationList = ({
   handleFilterSubmit,
   downloadCallback,
 }: ObservationListProps) => {
-  if (!observations?.observations) {
-    return <p>No observations available...</p>;
-  }
-
   return (
     <QueuedObservationsTable
-      observations={observations.observations}
+      observations={observations?.observations ?? []}
       pageNumber={fetchParams.pageNumber}
       numPerPage={fetchParams.numPerPage}
       handleTableChange={handleTableChange}
       handleFilterSubmit={handleFilterSubmit}
-      totalMatches={observations.totalMatches}
+      totalMatches={observations?.totalMatches ?? 0}
       downloadCallback={downloadCallback}
     />
   );


### PR DESCRIPTION
This PR displays an empty table instead of a string when no observations available.