### PR TITLE
Fix query param parsing for autosaveGroupIds and hasTNSname

### DIFF
--- a/skyportal/handlers/api/candidate/candidate.py
+++ b/skyportal/handlers/api/candidate/candidate.py
@@ -829,6 +829,13 @@ class CandidateHandler(BaseHandler):
         list_name_reject = self.get_query_argument("listNameReject", None)
         autosave = self.get_query_argument("autosave", False)
         autosave_group_ids = self.get_query_argument("autosaveGroupIds", None)
+        if autosave_group_ids is not None:
+            # parse here: passing the raw comma-separated string through to
+            # post_source_async would iterate it character by character
+            try:
+                autosave_group_ids = [int(gid) for gid in autosave_group_ids.split(",")]
+            except ValueError:
+                return self.error("Invalid autosaveGroupIds value.")
         photometry_annotations_filter = self.get_query_argument(
             "photometryAnnotationsFilter", None
         )

--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -2258,8 +2258,14 @@ class SourceHandler(BaseHandler):
         alias = self.get_query_argument("alias", None)
         origin = self.get_query_argument("origin", None)
         tns_name = self.get_query_argument("TNSname", None)
-        has_tns_name = self.get_query_argument("hasTNSname", None)
-        has_no_tns_name = self.get_query_argument("hasNoTNSname", None)
+        # None default skips baselayer's bool coercion, so normalize here or
+        # any non-empty value, including "false", would enable the filter
+        has_tns_name = str_to_bool(
+            self.get_query_argument("hasTNSname", None), default=False
+        )
+        has_no_tns_name = str_to_bool(
+            self.get_query_argument("hasNoTNSname", None), default=False
+        )
         has_been_labelled = self.get_query_argument("hasBeenLabelled", False)
         has_not_been_labelled = self.get_query_argument("hasNotBeenLabelled", False)
         current_user_labeller = self.get_query_argument("currentUserLabeller", False)

--- a/skyportal/tests/api_tests/sources_candidates/test_candidates.py
+++ b/skyportal/tests/api_tests/sources_candidates/test_candidates.py
@@ -125,6 +125,45 @@ def test_token_user_post_candidate_numeric_id(
     assert data["data"]["id"] == str(obj_id)
 
 
+def test_candidate_autosave_group_ids(
+    upload_data_token_two_groups, public_filter, public_group, public_group2
+):
+    """autosaveGroupIds is a comma-separated list; it used to be handed to
+    post_source_async as a raw string, whose per-element int() then ran on
+    single characters."""
+    obj_id = str(uuid.uuid4())
+    status, data = api(
+        "POST",
+        "candidates",
+        data={
+            "id": obj_id,
+            "ra": 234.22,
+            "dec": -22.33,
+            "filter_ids": [public_filter.id],
+            "passed_at": str(utcnow_naive()),
+        },
+        token=upload_data_token_two_groups,
+    )
+    assert status == 200
+
+    status, data = api(
+        "GET",
+        "candidates",
+        params={
+            "groupIDs": f"{public_group.id}",
+            "autosave": "true",
+            "autosaveGroupIds": f"{public_group.id},{public_group2.id}",
+        },
+        token=upload_data_token_two_groups,
+    )
+    assert status == 200
+
+    status, data = api("GET", f"sources/{obj_id}", token=upload_data_token_two_groups)
+    assert status == 200
+    saved_group_ids = {g["id"] for g in data["data"]["groups"]}
+    assert {public_group.id, public_group2.id}.issubset(saved_group_ids)
+
+
 def test_candidate_name_only_search(
     upload_data_token,
     view_only_token,

--- a/skyportal/tests/api_tests/sources_candidates/test_sources.py
+++ b/skyportal/tests/api_tests/sources_candidates/test_sources.py
@@ -2050,6 +2050,17 @@ def test_sources_filter_by_has_tns_name(
     assert len(data["data"]["sources"]) == 1
     assert data["data"]["sources"][0]["id"] == obj_id1
 
+    # An explicit "false" must not enable the filter (it used to be truthy)
+    status, data = api(
+        "GET",
+        "sources",
+        params={"hasTNSname": "false", "group_ids": f"{public_group.id}"},
+        token=view_only_token,
+    )
+    assert status == 200
+    returned_ids = {s["id"] for s in data["data"]["sources"]}
+    assert {obj_id1, obj_id2}.issubset(returned_ids)
+
 
 def test_sources_filter_by_has_spectrum(
     view_only_token,


### PR DESCRIPTION
Two query param parsing bugs found while auditing the API surface:

- `autosaveGroupIds` (candidates scanner autosave) was handed to `post_source_async` as the raw comma-separated string. Its per-element `int()` then ran on single characters, so a multi-id list always failed and a multi-digit group id silently saved the source to the wrong groups (e.g. `"12"` saved to groups 1 and 2). It is now parsed into a list of ints at the read site, with a 400 on invalid values.
- `hasTNSname` / `hasNoTNSname` are read with a `None` default, which skips the bool coercion `get_query_argument` applies when the default is a bool, so any non-empty value, including `"false"`, enabled the filter. Both are now normalized with `str_to_bool`.

Includes regression tests for both: a two-group autosave via the candidates endpoint, and `hasTNSname=false` no longer filtering.