### PR TITLE
Fix boom mongo dialog rawpipeline

### DIFF
--- a/static/js/components/filter/boom/dialog/MongoQueryDialog.tsx
+++ b/static/js/components/filter/boom/dialog/MongoQueryDialog.tsx
@@ -252,8 +252,8 @@ const MongoQueryDialog = () => {
   }, [filter_stream, selectedCollection, dispatch]);
 
   const defaultStartDate = new Date();
+  defaultStartDate.setDate(defaultStartDate.getDate() - 1);
   const defaultEndDate = new Date();
-  defaultEndDate.setDate(defaultEndDate.getDate() + 1);
 
   const { getValues, control, watch } = useForm({
     startDate: defaultStartDate,

--- a/static/js/contexts/UnifiedBuilderContext.tsx
+++ b/static/js/contexts/UnifiedBuilderContext.tsx
@@ -13,6 +13,7 @@ import {
   convertArithmeticExpression,
 } from "../utils/mongoPipelineBuilder";
 import { flattenFieldOptions } from "../constants/filterConstants";
+import { isRawMongoPipeline } from "../components/filter/boom/pipelineFormat";
 
 export const UnifiedBuilderContext = createContext<any>(undefined);
 
@@ -122,6 +123,12 @@ export const UnifiedBuilderProvider = ({
 
   // MongoDB aggregation conversion
   const generateMongoQuery = () => {
+    // Imported filters are already a raw Mongo pipeline (not a block tree);
+    // the block-tree converter below can't read them, so pass them through.
+    if (isRawMongoPipeline(filters)) {
+      return filters;
+    }
+
     // Determine if we're in annotation mode (projections exist)
     const hasAnnotations = projectionFields && projectionFields.length > 0;
 
@@ -366,6 +373,11 @@ export const UnifiedBuilderProvider = ({
     // Use localFilterData if it exists and has been modified, otherwise use filters
     const dataToCheck =
       hasBeenModified && localFilterData ? localFilterData : filters;
+    // Already a raw pipeline (active in boom); no need to re-run the
+    // block-tree validator over it.
+    if (isRawMongoPipeline(dataToCheck)) {
+      return true;
+    }
     const pipeline = convertToMongoAggregation(
       dataToCheck,
       schema,


### PR DESCRIPTION
For filters generated to support the kowalski to boom transition, the pipeline was not properly sent to the MongoQueryDialog, which would result in bad request when trying to run the filter. 

Also changed the default time range on the dialog from `today -> tomorrow `to `yesterday -> today`