### PR TITLE
Skip auto-save for objects already in a filter's ignore-groups

### DIFF
--- a/skyportal/broker_apis/_save.py
+++ b/skyportal/broker_apis/_save.py
@@ -308,19 +308,20 @@ async def _ingest_object(
                     )
                 )
 
-        # Auto-save: a filter with `autosave` set also saves the passing object as
-        # a Source in the filter's group, so it skips manual scanning. Skip if
-        # already saved to that group.
+        # Auto-save the passing object to the filter's group. Skip if it's already
+        # an active Source there or in a filter `autoSaveIgnoreGroupIds` (junk).
         autosave_filters = (
             await session.scalars(
                 sa.select(Filter).where(Filter.id.in_(filter_ids), Filter.autosave)
             )
         ).all()
         for f in autosave_filters:
+            ignore_group_ids = (f.altdata or {}).get("autoSaveIgnoreGroupIds") or []
             already = await session.scalar(
                 sa.select(Source).where(
                     Source.obj_id == object_id,
-                    Source.group_id == f.group_id,
+                    Source.group_id.in_([f.group_id, *ignore_group_ids]),
+                    Source.active.is_(True),
                 )
             )
             if already is None:

--- a/skyportal/handlers/api/broker.py
+++ b/skyportal/handlers/api/broker.py
@@ -1369,6 +1369,12 @@ class BrokerFiltersHandler(BaseHandler):
                 # autoSave is the UI's name for the column ingestion reads.
                 if "autoSave" in data:
                     set_autosave(f, data["autoSave"])
+                # Groups whose members are not auto-saved (e.g. junk).
+                if "autoSaveIgnoreGroupIds" in data:
+                    f.altdata["autoSaveIgnoreGroupIds"] = [
+                        int(g) for g in (data["autoSaveIgnoreGroupIds"] or [])
+                    ]
+                    flag_modified(f, "altdata")
             except Exception as e:
                 return self.error(f"Error updating filter on {broker.name}: {e}")
             session.commit()

--- a/skyportal/tests/api_tests/test_broker_ingest_annotation.py
+++ b/skyportal/tests/api_tests/test_broker_ingest_annotation.py
@@ -162,3 +162,49 @@ def test_broker_ingest_leaves_another_authors_annotation_alone(
     annotation = fetch_annotation(obj_id, public_filter)
     assert annotation.data == {"posted_by": "user"}
     assert annotation.author_id == user.id
+
+
+def _save_to_group(obj_id, group, user):
+    """Pre-create the object and an active Source in `group` (e.g. a junk group)."""
+    DBSession().add(Obj(id=obj_id, ra=10.0, dec=20.0))
+    DBSession().flush()
+    DBSession().add(
+        Source(obj_id=obj_id, group_id=group.id, saved_by_id=user.id, active=True)
+    )
+    DBSession().commit()
+
+
+def test_broker_ingest_autosave_skips_ignored_group(
+    super_admin_user, public_filter, public_group2, ztf_instrument, obj_id
+):
+    """autosave skips an object already actively saved to one of the filter's
+    `autoSaveIgnoreGroupIds` (e.g. a junk group)."""
+    _save_to_group(obj_id, public_group2, super_admin_user)
+    public_filter.autosave = True
+    public_filter.altdata = {"autoSaveIgnoreGroupIds": [public_group2.id]}
+    DBSession().add(public_filter)
+    DBSession().commit()
+
+    ingest(obj_id, super_admin_user.id, public_filter.id, {})
+
+    assert fetch_source(obj_id, public_filter) is None, (
+        "object in an ignored group should not be auto-saved to the filter group"
+    )
+
+
+def test_broker_ingest_autosave_ignore_is_group_specific(
+    super_admin_user, public_filter, public_group2, ztf_instrument, obj_id
+):
+    """An object saved to a group that is NOT in `autoSaveIgnoreGroupIds` is
+    still auto-saved."""
+    _save_to_group(obj_id, public_group2, super_admin_user)
+    public_filter.autosave = True
+    public_filter.altdata = {"autoSaveIgnoreGroupIds": []}  # junk group not ignored
+    DBSession().add(public_filter)
+    DBSession().commit()
+
+    ingest(obj_id, super_admin_user.id, public_filter.id, {})
+
+    assert fetch_source(obj_id, public_filter) is not None, (
+        "object should be auto-saved when not in an ignored group"
+    )

--- a/static/js/components/filter/boom/BoomFilterPlugins.tsx
+++ b/static/js/components/filter/boom/BoomFilterPlugins.tsx
@@ -31,6 +31,7 @@ import {
   useBoomFilterVersion,
   useEditBoomFilterVersionMutation,
   useUpdateBoomGroupFilterMutation,
+  useUpdateBoomFilterFlagsMutation,
   useValidateBoomFilterMutation,
 } from "../../../ducks/boom_filter";
 import { useGetGroupsQuery } from "../../../ducks/groups";
@@ -124,6 +125,7 @@ const BoomFilterPlugins = (_props: BoomFilterPluginsProps) => {
     useBoomFilterVersion();
   const [editFilterVersion] = useEditBoomFilterVersionMutation();
   const [updateGroupFilter] = useUpdateBoomGroupFilterMutation();
+  const [updateFilterFlags] = useUpdateBoomFilterFlagsMutation();
   const [validateFilter] = useValidateBoomFilterMutation();
   const { data: profile } = useGetProfileQuery();
   const isAdmin = (profile?.permissions ?? []).includes("System admin");
@@ -149,6 +151,28 @@ const BoomFilterPlugins = (_props: BoomFilterPluginsProps) => {
   allGroups?.forEach((g: any) => {
     groupLookUp[g.id] = g;
   });
+
+  // Auto-actions run when an object passes: save to the filter's group (skipping
+  // objects already in an ignore/junk group), annotate, and/or trigger followup.
+  // Stored in the filter's altdata.
+  const autoSaveOn = !!filter_v?.altdata?.autoSave;
+  const autoAnnotateOn = !!filter_v?.altdata?.autoAnnotate;
+  const autoFollowupOn = !!filter_v?.altdata?.autoFollowup;
+  const ignoreGroupIds: number[] =
+    filter_v?.altdata?.autoSaveIgnoreGroupIds ?? [];
+  const handleFlagToggle =
+    (flag: "autoSave" | "autoAnnotate" | "autoFollowup") =>
+    async (checked: boolean) => {
+      await updateFilterFlags({ filter_id: filter_v.id, [flag]: checked });
+      refetchFilterVersion();
+    };
+  const handleIgnoreGroupsChange = async (ids: number[]) => {
+    await updateFilterFlags({
+      filter_id: filter_v.id,
+      autoSaveIgnoreGroupIds: ids,
+    });
+    refetchFilterVersion();
+  };
 
   const [panelboomExpanded, setPanelboomExpanded] = useState<any>(true);
 
@@ -288,6 +312,70 @@ const BoomFilterPlugins = (_props: BoomFilterPluginsProps) => {
           </Typography>
         </Box>
       ) : null}
+    </Box>
+  );
+
+  const autoSaveControls = (
+    <Box
+      sx={{ display: "flex", alignItems: "center", gap: 1.5, flexWrap: "wrap" }}
+    >
+      <FormControlLabel
+        control={
+          <Switch
+            size="small"
+            checked={autoSaveOn}
+            onChange={(e) => handleFlagToggle("autoSave")(e.target.checked)}
+          />
+        }
+        label="Auto-save to group"
+      />
+      <FormControlLabel
+        control={
+          <Switch
+            size="small"
+            checked={autoAnnotateOn}
+            onChange={(e) => handleFlagToggle("autoAnnotate")(e.target.checked)}
+          />
+        }
+        label="Auto-annotate"
+      />
+      <FormControlLabel
+        control={
+          <Switch
+            size="small"
+            checked={autoFollowupOn}
+            onChange={(e) => handleFlagToggle("autoFollowup")(e.target.checked)}
+          />
+        }
+        label="Auto-trigger follow-up"
+      />
+      {autoSaveOn && (
+        <FormControl size="small" sx={{ minWidth: 240 }}>
+          <InputLabel id={`ignore-groups-${filter_v.id}`}>
+            Skip if already in
+          </InputLabel>
+          <Select
+            multiple
+            labelId={`ignore-groups-${filter_v.id}`}
+            label="Skip if already in"
+            value={ignoreGroupIds}
+            onChange={(e) =>
+              handleIgnoreGroupsChange(e.target.value as number[])
+            }
+            renderValue={(sel) =>
+              (sel as number[])
+                .map((id) => groupLookUp[id]?.name ?? id)
+                .join(", ")
+            }
+          >
+            {allGroups?.map((g: any) => (
+              <MenuItem key={g.id} value={g.id}>
+                {g.name}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      )}
     </Box>
   );
 
@@ -524,6 +612,9 @@ const BoomFilterPlugins = (_props: BoomFilterPluginsProps) => {
             <>
               {filter_v?.fv && (
                 <div className={classes.infoLine}>{activationControls}</div>
+              )}
+              {filter_v?.fv && (
+                <div className={classes.infoLine}>{autoSaveControls}</div>
               )}
               <div
                 style={{

--- a/static/js/ducks/boom_filter.ts
+++ b/static/js/ducks/boom_filter.ts
@@ -38,6 +38,24 @@ export const boomFilterApi = skyportalApi.injectEndpoints({
         body: { altdata, filters, name },
       }),
     }),
+    // Toggle a filter's auto-save/annotate/followup flags and its auto-save
+    // ignore-groups (stored in the filter's altdata; PATCH).
+    updateBoomFilterFlags: build.mutation<
+      any,
+      {
+        filter_id: any;
+        autoSave?: boolean;
+        autoAnnotate?: boolean;
+        autoFollowup?: boolean;
+        autoSaveIgnoreGroupIds?: number[];
+      }
+    >({
+      query: ({ filter_id, ...flags }) => ({
+        url: `${brokerFilterBase()}/filters/${filter_id}`,
+        method: "PATCH",
+        body: flags,
+      }),
+    }),
     // Slow: runs the filter over a night of alerts on the broker. Records the
     // verdict server-side (keyed on fid) so the version can then be activated.
     validateBoomFilter: build.mutation<any, { filter_id: any; fid?: any }>({
@@ -54,6 +72,7 @@ export const {
   useGetBoomFilterVersionQuery,
   useEditBoomFilterVersionMutation,
   useUpdateBoomGroupFilterMutation,
+  useUpdateBoomFilterFlagsMutation,
   useValidateBoomFilterMutation,
 } = boomFilterApi;
 


### PR DESCRIPTION
This PR skips auto-save for objects already in a filter's ignore-groups.