### PR TITLE
keep invitation per-group flag arrays same length as the number of groups

### DIFF
--- a/alembic/versions/e2b7c4d81f39_repair_invitation_flag_arrays.py
+++ b/alembic/versions/e2b7c4d81f39_repair_invitation_flag_arrays.py
@@ -1,0 +1,63 @@
+"""resize invitation flag arrays to match their groups
+
+Editing an invitation's groups used to leave the per-group flag arrays at their
+original length. Onboarding zips them against the groups strictly, so any
+invitation edited that way raised on sign-in and locked the invitee out.
+
+Revision ID: e2b7c4d81f39
+Revises: a7c94e1d6b30
+Create Date: 2026-08-25
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "e2b7c4d81f39"
+down_revision = "a7c94e1d6b30"
+branch_labels = None
+depends_on = None
+
+# Pad with false, or truncate, so each array is exactly one entry per group.
+# New entries default to false: the safe direction for a permission flag.
+RESIZE = """
+UPDATE invitations AS i
+SET {column} = (
+    SELECT coalesce(
+        array_agg(coalesce(i.{column}[n], false) ORDER BY n), ARRAY[]::boolean[]
+    )
+    FROM generate_series(1, g.group_count) AS n
+)
+FROM (
+    SELECT invitation_id, count(*) AS group_count
+    FROM group_invitations
+    GROUP BY invitation_id
+) AS g
+WHERE g.invitation_id = i.id
+  AND coalesce(array_length(i.{column}, 1), 0) <> g.group_count
+"""
+
+# An invitation with no groups at all should hold empty arrays, not stale ones.
+CLEAR = """
+UPDATE invitations
+SET {column} = ARRAY[]::boolean[]
+WHERE id NOT IN (SELECT invitation_id FROM group_invitations)
+  AND coalesce(array_length({column}, 1), 0) <> 0
+"""
+
+COLUMNS = (
+    "admin_for_groups",
+    "can_save_to_groups",
+    "can_share_photometry_for_groups",
+)
+
+
+def upgrade():
+    for column in COLUMNS:
+        op.execute(RESIZE.format(column=column))
+        op.execute(CLEAR.format(column=column))
+
+
+def downgrade():
+    # The original lengths are not recoverable, and were the defect.
+    pass

--- a/skyportal/handlers/api/invitations.py
+++ b/skyportal/handlers/api/invitations.py
@@ -212,6 +212,9 @@ class InvitationHandler(BaseHandler):
                     .where(GroupStream.group_id.in_(group_ids))
                 )
                 streams = streams_result.all()
+            # The flag arrays below are positional against the caller's
+            # `group_ids`, which `IN` does not preserve.
+            groups = sorted(groups, key=lambda group: group_ids.index(group.id))
             admin_for_groups = (
                 body.groupAdmin
                 if body.groupAdmin is not None
@@ -453,7 +456,24 @@ class InvitationHandler(BaseHandler):
                     "stream IDs list. Please try again."
                 )
             if group_ids is not None:
+                # The flag arrays are positional against `groups`, so they have
+                # to be rebuilt with it; a group that stays keeps its flags.
+                previous = {
+                    group.id: flags
+                    for group, *flags in zip(
+                        invitation.groups,
+                        invitation.admin_for_groups,
+                        invitation.can_save_to_groups,
+                        invitation.can_share_photometry_for_groups,
+                    )
+                }
+                flags = [
+                    previous.get(group.id, [False, False, False]) for group in groups
+                ]
                 invitation.groups = groups
+                invitation.admin_for_groups = [f[0] for f in flags]
+                invitation.can_save_to_groups = [f[1] for f in flags]
+                invitation.can_share_photometry_for_groups = [f[2] for f in flags]
             if stream_ids is not None:
                 invitation.streams = streams
             if role_id is not None:

--- a/skyportal/tests/api_tests/groups_users_analysis/test_invitations.py
+++ b/skyportal/tests/api_tests/groups_users_analysis/test_invitations.py
@@ -176,3 +176,85 @@ def test_delete_invitation(
         token=manage_users_token,
     )
     assert status == 200
+
+
+def invitation_arrays(invitation_id, token):
+    """The per-group flag arrays alongside the groups they are positional against."""
+    status, data = api("GET", "invitations", token=token)
+    assert status == 200
+    invitation = next(
+        i for i in data["data"]["invitations"] if i["id"] == invitation_id
+    )
+    return (
+        [g["id"] for g in invitation["groups"]],
+        invitation["admin_for_groups"],
+        invitation["can_save_to_groups"],
+        invitation["can_share_photometry_for_groups"],
+    )
+
+
+def test_patch_invitation_keeps_flag_arrays_aligned(
+    manage_users_token, public_stream, public_group, public_group2
+):
+    """Onboarding zips the flags against the groups strictly.
+
+    Editing the groups used to leave the arrays at their original length, which
+    raised at sign-in and locked the invitee out entirely.
+    """
+    status, data = api(
+        "POST",
+        "invitations",
+        data={
+            "userEmail": str(uuid.uuid4()),
+            "streamIDs": [public_stream.id],
+            "groupIDs": [public_group.id],
+            "groupAdmin": [True],
+            "canSave": [True],
+            "canSharePhotometry": [True],
+        },
+        token=manage_users_token,
+    )
+    assert status == 200
+    invitation_id = data["data"]["id"]
+
+    # Add a second group: every array has to grow with it.
+    status, _ = api(
+        "PATCH",
+        f"invitations/{invitation_id}",
+        data={"groupIDs": [public_group.id, public_group2.id]},
+        token=manage_users_token,
+    )
+    assert status == 200
+
+    groups, admin, can_save, can_share = invitation_arrays(
+        invitation_id, manage_users_token
+    )
+    assert len(groups) == 2
+    for array in (admin, can_save, can_share):
+        assert len(array) == len(groups)
+
+    # The original group keeps the flags it was invited with; the new one gets
+    # defaults rather than inheriting them.
+    first = groups.index(public_group.id)
+    second = groups.index(public_group2.id)
+    assert admin[first] is True
+    assert can_save[first] is True
+    assert can_share[first] is True
+    assert admin[second] is False
+    assert can_save[second] is False
+    assert can_share[second] is False
+
+    # Removing a group takes its entry with it.
+    status, _ = api(
+        "PATCH",
+        f"invitations/{invitation_id}",
+        data={"groupIDs": [public_group2.id]},
+        token=manage_users_token,
+    )
+    assert status == 200
+    groups, admin, can_save, can_share = invitation_arrays(
+        invitation_id, manage_users_token
+    )
+    assert groups == [public_group2.id]
+    for array in (admin, can_save, can_share):
+        assert len(array) == 1


### PR DESCRIPTION
This PR keeps invitation per-group flag arrays same length as the number of groups. (fixes Sentry issue from today).