### PR TITLE
Keep the photometry plot's zoom when new points arrive

### DIFF
--- a/skyportal/tests/frontend/sources_and_observingruns_etc/test_photometry_plot_zoom.py
+++ b/skyportal/tests/frontend/sources_and_observingruns_etc/test_photometry_plot_zoom.py
@@ -1,0 +1,100 @@
+from skyportal.tests import api
+
+PLOT = "#photometry-plot .js-plotly-plot"
+DRAG_LAYER = f"{PLOT} .nsewdrag"
+
+# Total points drawn across every trace, and the x range currently in view.
+POINT_COUNT = f"""() => {{
+    const el = document.querySelector({PLOT!r});
+    return el?.data ? el.data.reduce((n, t) => n + (t.x ? t.x.length : 0), 0) : -1;
+}}"""
+X_RANGE = f"""() => {{
+    const el = document.querySelector({PLOT!r});
+    return el?._fullLayout?.xaxis?.range ?? null;
+}}"""
+
+
+def _drag_zoom(page):
+    """Zoom by dragging a box across the middle of the plot, as a user does.
+
+    Plotly is imported as a module, so there is no window.Plotly to relayout
+    through; the zoom has to come from real mouse events on the drag layer.
+    """
+    drag = page.locator(DRAG_LAYER).first
+    drag.scroll_into_view_if_needed()
+    page.wait_for_timeout(500)
+    box = drag.bounding_box()
+    assert box, "photometry plot has no drag layer to zoom on"
+    y = box["y"] + box["height"] / 2
+    page.mouse.move(box["x"] + box["width"] * 0.35, y)
+    page.mouse.down()
+    page.mouse.move(box["x"] + box["width"] * 0.65, y, steps=10)
+    page.mouse.up()
+    page.wait_for_timeout(1000)
+
+
+def test_zoom_survives_new_photometry(
+    page, super_admin_user, super_admin_token, public_source, public_group, ztf_camera
+):
+    """New points arriving over the websocket must not throw away the zoom.
+
+    Photometry refetched into an open plot is the same axes with more data on
+    them, so the view the user dragged to still means what they chose. Only a
+    change of what an axis represents -- flux against magnitude, linear against
+    log, a different time origin -- invalidates it.
+    """
+    page.goto(f"/become_user/{super_admin_user.id}")
+    page.goto(f"/source/{public_source.id}")
+    page.wait_for_selector(PLOT)
+    page.wait_for_timeout(2000)
+
+    before_count = page.evaluate(POINT_COUNT)
+    assert before_count > 0, "expected the source to have photometry plotted"
+
+    _drag_zoom(page)
+    zoomed = page.evaluate(X_RANGE)
+    full = page.evaluate(
+        f"""() => {{
+        const el = document.querySelector({PLOT!r});
+        return el?._fullLayout?.xaxis?._rangeInitial ?? null;
+    }}"""
+    )
+    assert zoomed, "no x range to read after dragging"
+    assert zoomed != full, "the drag did not actually zoom the plot"
+
+    # refresh is a query parameter, and defaults to false: without it the
+    # server stores the point but pushes nothing, and nothing refetches.
+    status, _ = api(
+        "POST",
+        "photometry",
+        data={
+            "obj_id": public_source.id,
+            "mjd": 59801.3,
+            "instrument_id": ztf_camera.id,
+            "filter": "ztfg",
+            "group_ids": [public_group.id],
+            "mag": 18.1,
+            "magerr": 0.1,
+            "limiting_mag": 22.0,
+            "magsys": "ab",
+        },
+        params={"refresh": "true"},
+        token=super_admin_token,
+    )
+    assert status == 200
+
+    # Wait for the point to land in the plot, so a push that never arrives
+    # fails here rather than leaving the zoom assertion below to pass vacuously.
+    page.wait_for_function(
+        f"""() => {{
+        const el = document.querySelector({PLOT!r});
+        const n = el?.data ? el.data.reduce((a, t) => a + (t.x ? t.x.length : 0), 0) : -1;
+        return n > {before_count};
+    }}""",
+        timeout=30000,
+    )
+
+    after = page.evaluate(X_RANGE)
+    assert after == zoomed, (
+        f"the zoom was reset by new photometry: {zoomed} became {after}"
+    )

--- a/skyportal/tests/frontend/sources_and_observingruns_etc/test_photometry_plot_zoom.py
+++ b/skyportal/tests/frontend/sources_and_observingruns_etc/test_photometry_plot_zoom.py
@@ -14,12 +14,9 @@ X_RANGE = f"""() => {{
 }}"""
 
 
+# Plotly is imported as a module, so there is no window.Plotly to relayout
+# through: the zoom has to come from real mouse events on the drag layer.
 def _drag_zoom(page):
-    """Zoom by dragging a box across the middle of the plot, as a user does.
-
-    Plotly is imported as a module, so there is no window.Plotly to relayout
-    through; the zoom has to come from real mouse events on the drag layer.
-    """
     drag = page.locator(DRAG_LAYER).first
     drag.scroll_into_view_if_needed()
     page.wait_for_timeout(500)
@@ -36,12 +33,10 @@ def _drag_zoom(page):
 def test_zoom_survives_new_photometry(
     page, super_admin_user, super_admin_token, public_source, public_group, ztf_camera
 ):
-    """New points arriving over the websocket must not throw away the zoom.
+    """Photometry arriving over the websocket leaves the user's zoom alone.
 
-    Photometry refetched into an open plot is the same axes with more data on
-    them, so the view the user dragged to still means what they chose. Only a
-    change of what an axis represents -- flux against magnitude, linear against
-    log, a different time origin -- invalidates it.
+    Refetched points are the same axes with more data on them. Only a change of
+    what an axis represents resets the view.
     """
     page.goto(f"/become_user/{super_admin_user.id}")
     page.goto(f"/source/{public_source.id}")

--- a/static/js/components/plot/PhotometryPlot.tsx
+++ b/static/js/components/plot/PhotometryPlot.tsx
@@ -1,6 +1,6 @@
 import { useTheme } from "@mui/material/styles";
 import { useGetProfileQuery } from "../../ducks/profile";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import Plotly from "plotly.js-basic-dist";
 import createPlotlyComponent from "react-plotly.js/factory";
@@ -80,6 +80,26 @@ import CornerPlot from "./CornerPlot";
 // effectiveModelFits memo every render → setState-in-effect → render loop.
 const EMPTY_MODEL_FITS: ModelFit[] = [];
 const MODEL_DASHES = ["solid", "dash", "dot", "dashdot"];
+
+/** New layouts, but keeping the axis ranges already declared.
+ *
+ * Recomputing a range from new points changes the value Plotly compares
+ * against when deciding whether a user's zoom still applies, and the
+ * programmatic range then wins. Reusing the declared range leaves that
+ * comparison unchanged, so the zoom survives points arriving underneath it.
+ */
+const keepDeclaredRanges = (next: any, current: any): any => {
+  if (!current) {
+    return next;
+  }
+  const merged = { ...next };
+  ["xaxis", "xaxis2", "yaxis", "yaxis2"].forEach((axis) => {
+    if (merged[axis]?.range && current[axis]?.range) {
+      merged[axis] = { ...merged[axis], range: current[axis].range };
+    }
+  });
+  return merged;
+};
 
 // True when an analysis ran on extinction-corrected (dereddened) photometry, so
 // its model overlay is dereddened-native. analysis_parameters may store the flag
@@ -671,6 +691,11 @@ const PhotometryPlot = ({
   // is unchanged -- which threw away the user's zoom, pan and legend state on
   // any re-render of the source page. Bumped only where we mean to reset.
   const [layoutRevision, setLayoutRevision] = useState(0);
+  // Whether the view on screen is one the user dragged to rather than the one
+  // we declared. Plotly holds a user's zoom under a stable uirevision only
+  // while the declared range stays put, so while this is set the ranges below
+  // are held to what was declared when they zoomed.
+  const userZoomed = useRef(false);
 
   const [filter2color, setFilter2Color] = useState<any>(
     config?.bandpassesColors,
@@ -1630,8 +1655,11 @@ const PhotometryPlot = ({
         dm,
         showExtinctionCorrection,
       );
-      setLayouts(newLayouts);
-      setLayoutRevision((revision) => revision + 1);
+      setLayouts((current: any) =>
+        userZoomed.current
+          ? keepDeclaredRanges(newLayouts, current)
+          : newLayouts,
+      );
       setInitialized(true);
     }
   }, [
@@ -1647,6 +1675,25 @@ const PhotometryPlot = ({
     fluxUnit,
     showOnlyValidated,
     shownModelFits,
+  ]);
+
+  // Only an axis whose meaning changed invalidates the user's zoom. New or
+  // refetched points reuse the revision, so Plotly keeps the current view.
+  useEffect(() => {
+    if (initialized) {
+      userZoomed.current = false;
+      setLayoutRevision((revision) => revision + 1);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    displayXAxisSinceT0,
+    displayXAxisInlog,
+    displayFluxAxisInLog,
+    fluxUnit,
+    dm,
+    t0,
+    tabIndex,
+    phase,
   ]);
 
   // The main object's photometry (including extinction toggle and magsys) is
@@ -1689,7 +1736,6 @@ const PhotometryPlot = ({
         showExtinctionCorrection,
       );
       setLayouts(newLayouts);
-      setLayoutRevision((revision) => revision + 1);
     }
   }, [tabIndex, phase, shownModelFits]);
 
@@ -2022,12 +2068,22 @@ const PhotometryPlot = ({
                 name: "Reset",
                 icon: Plotly.Icons.home,
                 click: () => {
+                  userZoomed.current = false;
                   setLayoutReset(true);
                 },
               },
             ],
           }}
           useResizeHandler
+          onRelayout={(event: any) => {
+            const keys = Object.keys(event || {});
+            if (keys.some((key) => key.includes(".range"))) {
+              userZoomed.current = true;
+            }
+            if (keys.some((key) => key.endsWith(".autorange"))) {
+              userZoomed.current = false;
+            }
+          }}
           onClick={(event: any) => {
             const point = (event?.points || []).find(
               (p: any) => p?.data?.name === UNSHARED_SPECTRUM,

--- a/static/js/components/plot/PhotometryPlot.tsx
+++ b/static/js/components/plot/PhotometryPlot.tsx
@@ -81,13 +81,9 @@ import CornerPlot from "./CornerPlot";
 const EMPTY_MODEL_FITS: ModelFit[] = [];
 const MODEL_DASHES = ["solid", "dash", "dot", "dashdot"];
 
-/** New layouts, but keeping the axis ranges already declared.
- *
- * Recomputing a range from new points changes the value Plotly compares
- * against when deciding whether a user's zoom still applies, and the
- * programmatic range then wins. Reusing the declared range leaves that
- * comparison unchanged, so the zoom survives points arriving underneath it.
- */
+// New layouts, keeping the axis ranges already declared. Plotly holds a user's
+// zoom only while the declared range it compares against stays put, so a range
+// recomputed from new points would hand the axis back to us.
 const keepDeclaredRanges = (next: any, current: any): any => {
   if (!current) {
     return next;
@@ -687,14 +683,11 @@ const PhotometryPlot = ({
   const [photStats, setPhotStats] = useState<any>(null);
   const [layouts, setLayouts] = useState<any>({});
   // Passed to Plotly as uirevision. The layout prop is rebuilt on every render,
-  // and Plotly.react re-applies the declared axis ranges each time unless this
-  // is unchanged -- which threw away the user's zoom, pan and legend state on
-  // any re-render of the source page. Bumped only where we mean to reset.
+  // and Plotly.react re-applies the declared axis ranges unless this is
+  // unchanged. Bumped only where the user's view is meant to reset.
   const [layoutRevision, setLayoutRevision] = useState(0);
   // Whether the view on screen is one the user dragged to rather than the one
-  // we declared. Plotly holds a user's zoom under a stable uirevision only
-  // while the declared range stays put, so while this is set the ranges below
-  // are held to what was declared when they zoomed.
+  // we declared. While it is, the declared ranges are held still.
   const userZoomed = useRef(false);
 
   const [filter2color, setFilter2Color] = useState<any>(

--- a/static/js/ducks/photometry.ts
+++ b/static/js/ducks/photometry.ts
@@ -12,6 +12,7 @@
  */
 import { skyportalApi } from "../api/skyportalApi";
 import { invalidateOnMessage } from "../api/wsInvalidation";
+import { photometryTag } from "./photometryTags";
 import store from "../store";
 import { configApi } from "./config";
 import type { RouteData } from "../types/routeSchemaMap";
@@ -56,7 +57,7 @@ export const photometryApi = skyportalApi.injectEndpoints({
           },
         };
       },
-      providesTags: ["Photometry"],
+      providesTags: (_result, _error, arg) => photometryTag(arg.id),
     }),
     deletePhotometry: build.mutation<
       RouteData<"DELETE /api/photometry/{photometry_id}">,
@@ -90,11 +91,10 @@ export const photometryApi = skyportalApi.injectEndpoints({
   }),
 });
 
-// Websocket-driven invalidation: refresh photometry on
-// REFRESH_SOURCE_PHOTOMETRY. Active queries already keyed to the pushed obj_id
-// will refetch; others stay untouched.
+// Scoped to the pushed object, so a push about one source does not refetch the
+// photometry another page is showing.
 invalidateOnMessage(REFRESH_SOURCE_PHOTOMETRY, (payload) =>
-  payload?.obj_id != null ? ["Photometry"] : null,
+  payload?.obj_id != null ? photometryTag(payload.obj_id) : null,
 );
 
 export const {

--- a/static/js/ducks/photometryTags.test.ts
+++ b/static/js/ducks/photometryTags.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "bun:test";
+
+import { photometryTag } from "./photometryTags";
+
+// A photometry push carries one obj_id. Tagging per id is what stops it
+// refetching the photometry another open page is showing, which resets that
+// plot's zoom.
+describe("photometryTag", () => {
+  it("returns a per-id tag for an obj_id", () => {
+    expect(photometryTag("ZTF23abc")).toEqual([
+      { type: "Photometry", id: "ZTF23abc" },
+    ]);
+  });
+
+  it("stringifies a numeric id so provider and invalidation match", () => {
+    // Providers key off the query arg and pushes off the payload; one may be a
+    // number and the other a string for the same object.
+    expect(photometryTag(42)).toEqual([{ type: "Photometry", id: "42" }]);
+    expect(photometryTag("42")).toEqual(photometryTag(42));
+  });
+
+  it("falls back to the broad tag when the id is missing", () => {
+    expect(photometryTag(undefined)).toEqual([{ type: "Photometry" }]);
+    expect(photometryTag(null)).toEqual([{ type: "Photometry" }]);
+    expect(photometryTag()).toEqual([{ type: "Photometry" }]);
+  });
+
+  it("does not match a different object", () => {
+    expect(photometryTag("ZTF23abc")).not.toEqual(photometryTag("ZTF23xyz"));
+  });
+});

--- a/static/js/ducks/photometryTags.ts
+++ b/static/js/ducks/photometryTags.ts
@@ -1,0 +1,12 @@
+// Per-id Photometry cache invalidation helper, shared by the photometry queries
+// and the websocket push.
+//
+// The per-source photometry queries are tagged `{ type: "Photometry", id }`, so
+// a push about one object refetches only that object's photometry instead of
+// every "Photometry"-tagged query. When the id is unknown we fall back to the
+// broad `{ type: "Photometry" }` tag, which matches every photometry query.
+export const photometryTag = (
+  id?: number | string | null,
+): { type: "Photometry"; id?: string }[] => [
+  id != null ? { type: "Photometry", id: String(id) } : { type: "Photometry" },
+];

--- a/static/js/ducks/photometry_minimal.ts
+++ b/static/js/ducks/photometry_minimal.ts
@@ -14,6 +14,7 @@
  * this duck.
  */
 import { skyportalApi } from "../api/skyportalApi";
+import { photometryTag } from "./photometryTags";
 
 export interface MinimalPhotometryDatum {
   id: number;
@@ -75,7 +76,7 @@ export const photometryMinimalApi = skyportalApi.injectEndpoints({
             ? null
             : (datum.origin ?? null),
         })),
-      providesTags: ["Photometry"],
+      providesTags: (_result, _error, arg) => photometryTag(arg),
     }),
     // Photometry for the Source Statistics overlays. When `includeExtinction`
     // is set, the backend adds `mag_corr` (Galactic-extinction-corrected mag,
@@ -105,7 +106,7 @@ export const photometryMinimalApi = skyportalApi.injectEndpoints({
           extinction:
             (datum["extinction"] as number | null | undefined) ?? null,
         })),
-      providesTags: ["Photometry"],
+      providesTags: (_result, _error, arg) => photometryTag(arg.id),
     }),
   }),
 });


### PR DESCRIPTION
This PR keeps the photometry plot's zoom when new points arrive.