### PR TITLE
data availability and spectra cache refreshes

### DIFF
--- a/static/js/ducks/dataAccessRequests.ts
+++ b/static/js/ducks/dataAccessRequests.ts
@@ -1,5 +1,6 @@
 import { skyportalApi } from "../api/skyportalApi";
-import { invalidateOnMessage } from "../api/wsInvalidation";
+import { invalidateOnMessage, findCachedQueryArg } from "../api/wsInvalidation";
+import { dataAvailabilityTag } from "./dataAvailabilityTags";
 import { sourceTag } from "./sourceTags";
 
 export interface DataOwner {
@@ -76,7 +77,7 @@ export const dataAccessRequestsApi = skyportalApi.injectEndpoints({
   endpoints: (build) => ({
     getDataAvailability: build.query<DataAvailability, string>({
       query: (obj_id) => `api/sources/${obj_id}/data_availability`,
-      providesTags: ["DataAvailability"],
+      providesTags: (_result, _error, obj_id) => dataAvailabilityTag(obj_id),
     }),
     getDataAccessRequests: build.query<
       DataAccessRequestPage,
@@ -108,7 +109,7 @@ export const dataAccessRequestsApi = skyportalApi.injectEndpoints({
         body,
       }),
       invalidatesTags: (_result, _error, { objId }) => [
-        "DataAvailability",
+        ...dataAvailabilityTag(objId),
         "DataAccessRequest",
         ...sourceTag(objId),
       ],
@@ -135,11 +136,22 @@ export const dataAccessRequestsApi = skyportalApi.injectEndpoints({
 });
 
 // A grant lands as new photometry/spectra on the source the requester is
-// looking at, so refresh it alongside the request list.
-invalidateOnMessage("skyportal/REFRESH_SOURCE", (payload) => [
-  "DataAvailability",
-  ...sourceTag(payload?.obj_key as string | undefined),
-]);
+// looking at. REFRESH_SOURCE is broadcast to every client for every source, and
+// carries the source's internal_key, so translate that to the obj id and
+// refresh only that source's availability. Without an obj id there is nothing
+// to refresh: an unscoped tag here matches every open source page.
+invalidateOnMessage("skyportal/REFRESH_SOURCE", (payload, getState) => {
+  const objKey = payload?.obj_key as string | undefined;
+  if (!objKey) {
+    return null;
+  }
+  const objId = findCachedQueryArg(
+    getState,
+    "getSource",
+    (data) => data?.internal_key === objKey,
+  ) as string | null;
+  return objId != null ? dataAvailabilityTag(objId) : null;
+});
 
 export const {
   useGetDataAvailabilityQuery,

--- a/static/js/ducks/dataAvailabilityTags.test.ts
+++ b/static/js/ducks/dataAvailabilityTags.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "bun:test";
+
+import { dataAvailabilityTag } from "./dataAvailabilityTags";
+
+describe("dataAvailabilityTag", () => {
+  it("scopes the tag to one object", () => {
+    expect(dataAvailabilityTag("ZTF26abpgdyr")).toEqual([
+      { type: "DataAvailability", id: "ZTF26abpgdyr" },
+    ]);
+  });
+
+  it("falls back to the broad tag when the object is unknown", () => {
+    expect(dataAvailabilityTag()).toEqual([{ type: "DataAvailability" }]);
+    expect(dataAvailabilityTag(null)).toEqual([{ type: "DataAvailability" }]);
+  });
+
+  // A per-object tag must not match another object's cache entry: that is what
+  // made every open source page refetch on any source's REFRESH_SOURCE.
+  it("does not match a different object", () => {
+    expect(dataAvailabilityTag("ZTF26abpgdyr")).not.toEqual(
+      dataAvailabilityTag("ZTF26aazzexf"),
+    );
+  });
+});

--- a/static/js/ducks/dataAvailabilityTags.ts
+++ b/static/js/ducks/dataAvailabilityTags.ts
@@ -1,0 +1,12 @@
+// Per-object DataAvailability cache invalidation helper.
+//
+// getDataAvailability is tagged `{ type: "DataAvailability", id }` so a refresh
+// for one source leaves every other open source page alone. The broad
+// `{ type: "DataAvailability" }` fallback matches every availability query, and
+// is for the mutations that answer a request without knowing which object it
+// was about.
+export const dataAvailabilityTag = (
+  id?: string | null,
+): { type: "DataAvailability"; id?: string }[] => [
+  id != null ? { type: "DataAvailability", id } : { type: "DataAvailability" },
+];

--- a/static/js/ducks/spectra.ts
+++ b/static/js/ducks/spectra.ts
@@ -11,7 +11,8 @@
  * invalidation via `invalidateOnMessage`.
  */
 import { skyportalApi } from "../api/skyportalApi";
-import { invalidateOnMessage } from "../api/wsInvalidation";
+import { invalidateOnMessage, findCachedQueryArg } from "../api/wsInvalidation";
+import { spectraTag } from "./spectraTags";
 import type { RouteData } from "../types/routeSchemaMap";
 
 const REFRESH_SOURCE_SPECTRA = "skyportal/REFRESH_SOURCE_SPECTRA";
@@ -58,7 +59,10 @@ export const spectraApi = skyportalApi.injectEndpoints({
       BulkSpectraArgs
     >({
       query: (body) => ({ url: "/api/spectra/bulk", method: "POST", body }),
-      providesTags: ["Spectra"],
+      providesTags: (result) =>
+        result?.sources?.length
+          ? result.sources.flatMap((source) => spectraTag(source.id))
+          : spectraTag(),
     }),
     // The spectrum shape is highly dynamic across SkyPortal apps; consumers read
     // many optional fields, so the element type is `any` (the `Spectrum`
@@ -75,7 +79,7 @@ export const spectraApi = skyportalApi.injectEndpoints({
         }`,
       transformResponse: (data: { spectra?: Spectrum[] }) =>
         data?.spectra ?? [],
-      providesTags: ["Spectra"],
+      providesTags: (_result, _error, { id }) => spectraTag(id),
     }),
     // Single spectrum WITH the raw uploaded file (original_file_string), which is
     // deferred from the source-spectra payload. Fetched on demand for download.
@@ -135,9 +139,22 @@ export const spectraApi = skyportalApi.injectEndpoints({
 });
 
 // Websocket-driven invalidation: refresh spectra on REFRESH_SOURCE_SPECTRA.
-invalidateOnMessage(REFRESH_SOURCE_SPECTRA, (payload) =>
-  payload?.obj_internal_key != null ? ["Spectra"] : null,
-);
+// Broadcast to every client for every source, carrying the source's
+// internal_key: translate it to the obj id so only that source's spectra
+// refetch. Without an obj id there is nothing to refresh, since an unscoped tag
+// here matches every open source page.
+invalidateOnMessage(REFRESH_SOURCE_SPECTRA, (payload, getState) => {
+  const objKey = payload?.obj_internal_key as string | undefined;
+  if (!objKey) {
+    return null;
+  }
+  const objId = findCachedQueryArg(
+    getState,
+    "getSource",
+    (data) => data?.internal_key === objKey,
+  ) as string | number | null;
+  return objId != null ? spectraTag(objId) : null;
+});
 
 export const {
   useGetBulkSpectraQuery,

--- a/static/js/ducks/spectraTags.test.ts
+++ b/static/js/ducks/spectraTags.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "bun:test";
+
+import { spectraTag } from "./spectraTags";
+
+describe("spectraTag", () => {
+  it("scopes the tag to one object", () => {
+    expect(spectraTag("ZTF26abpgdyr")).toEqual([
+      { type: "Spectra", id: "ZTF26abpgdyr" },
+    ]);
+  });
+
+  it("falls back to the broad tag when the object is unknown", () => {
+    expect(spectraTag()).toEqual([{ type: "Spectra" }]);
+    expect(spectraTag(null)).toEqual([{ type: "Spectra" }]);
+  });
+
+  // A per-object tag must not match another object's cache entry: that is what
+  // made every open source page refetch on any source's spectra changing.
+  it("does not match a different object", () => {
+    expect(spectraTag("ZTF26abpgdyr")).not.toEqual(spectraTag("ZTF26aazzexf"));
+  });
+
+  // The bulk query tags itself with every source it returned, so a refresh for
+  // any one of them reaches it.
+  it("builds one tag per source for a bulk result", () => {
+    const sources = [{ id: "ZTF26abpgdyr" }, { id: "ZTF26aazzexf" }];
+    expect(sources.flatMap((source) => spectraTag(source.id))).toEqual([
+      { type: "Spectra", id: "ZTF26abpgdyr" },
+      { type: "Spectra", id: "ZTF26aazzexf" },
+    ]);
+  });
+});

--- a/static/js/ducks/spectraTags.ts
+++ b/static/js/ducks/spectraTags.ts
@@ -1,0 +1,12 @@
+// Per-object Spectra cache invalidation helper.
+//
+// The per-source spectra queries are tagged `{ type: "Spectra", id: objId }`, so
+// a refresh for one source leaves every other open source page alone. The broad
+// `{ type: "Spectra" }` fallback matches every spectra query, and is for the
+// mutations keyed on a spectrum id, which do not know the object it belongs to.
+// Invalidating the broad tag still matches the per-object entries.
+export const spectraTag = (
+  id?: number | string | null,
+): { type: "Spectra"; id?: number | string }[] => [
+  id != null ? { type: "Spectra", id } : { type: "Spectra" },
+];


### PR DESCRIPTION
This PR scope source data availability and spectra cache refreshes to the changed source (lot of Sentry spans this month).