### PR TITLE
Fix swifttools bump

### DIFF
--- a/data/tests/test_server_recordings_static.yaml
+++ b/data/tests/test_server_recordings_static.yaml
@@ -241,50 +241,6 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhcGlfbmFtZSI6IlN3aWZ0X1RPT19SZXF1ZXN0IiwiYXBpX3ZlcnNpb24iOiIxLjIiLCJhcGlfZGF0YSI6eyJ1c2VybmFtZSI6ImFub255bW91cyIsInNvdXJjZV9uYW1lIjoiMTc1ZTZkMjNiMWEzNDM4YTljYjA1YTg2YzBmYzM2NTQiLCJzb3VyY2VfdHlwZSI6Ik9wdGljYWwgZmFzdCB0cmFuc2llbnQiLCJyYSI6MC4wLCJkZWMiOjAuMCwicG9zZXJyIjowLjAsImluc3RydW1lbnQiOiJYUlQiLCJ1cmdlbmN5IjozLCJ4cnRfY291bnRyYXRlIjowLjAwMjUsImltbWVkaWF0ZV9vYmplY3RpdmUiOiJXZSB3aXNoIHRvIG1lYXN1cmUgdGhlIFgtcmF5IGVtaXNzaW9uIG9mIGFuIG9wdGljYWxseSBkaXNjb3ZlcmVkIHBvdGVudGlhbCBvcnBoYW4gYWZ0ZXJnbG93L2tpbG9ub3ZhLiIsInNjaWVuY2VfanVzdCI6IkFuIFgtcmF5IGRldGVjdGlvbiBvZiB0aGlzIHRyYW5zaWVudCB3aWxsIGZ1cnRoZXIgYXNzb2NpYXRlIHRoaXMgb2JqZWN0IHRvIGEgcmVsYXRpdmlzdGljIGV4cGxvc2lvbiBhbmQgd2lsbCBoZWxwIHVudmVpbCB0aGUgbmF0dXJlIG9mIHRoZSBwcm9nZW5pdG9yIHR5cGUuIiwiZXhwb3N1cmUiOjQwMDAsImV4cF90aW1lX2p1c3QiOiJBdCB-Mi41ZS0zIGNvdW50cy9zZWMsIDRrcyBzaG91bGQgc3VmZmljZSB0byBhY2hpZXZlIGEgaGlnaCBTTlIsIGFzc3VtaW5nIGEgYmFja2dyb3VuZCBvZiB-MWUtNCBjb3VudHMvc2VjIChQYWdhbmkgZXQgYWwuIDIwMDcpIiwiZXhwX3RpbWVfcGVyX3Zpc2l0Ijo0MDAwLCJudW1fb2ZfdmlzaXRzIjoxLCJtb25pdG9yaW5nX2ZyZXEiOiIxIGRheXMiLCJ4cnRfbW9kZSI6IlBDIiwidXZvdF9tb2RlIjoiZGVmYXVsdCIsIm9ic19uIjoic2luZ2xlIiwib2JzX3R5cGUiOiJMaWdodCBDdXJ2ZSIsInZhbGlkYXRlX29ubHkiOmZhbHNlfX0.PrzYHA42kdg5apdpJD_7xRn7RsW0eGHGj3TDTw0jN5c
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate, br
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '1280'
-      Content-Type:
-      - application/x-www-form-urlencoded
-      Host:
-      - localhost:64502
-      User-Agent:
-      - python-requests/2.26.0
-    method: POST
-    uri: https://www.swift.psu.edu/toop/submit_json.php
-  response:
-    body:
-      string: '
-
-
-        {"api_name":"Swift_TOO_Status","api_version":"1.2","api_data":{"status":"Rejected","errors":["Cannot
-        submit TOOs from anonymous user."]}}'
-    headers:
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '139'
-      Content-Type:
-      - text/html; charset=UTF-8
-      Date:
-      - Fri, 19 Nov 2021 22:05:56 GMT
-      Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - Apache/2.4.6 (CentOS) OpenSSL/1.0.2k-fips PHP/5.4.16 mod_wsgi/3.4 Python/2.7.5
-      X-Powered-By:
-      - PHP/5.4.16
-    status:
-      code: 200
-      message: OK
-- request:
     body: '{"name": "d74a126b2614455bb21763ad3f7a3f1c", "ra": 0.0, "dec": 0.0, "filters":
       "U", "exposure": "long"}'
     headers:

--- a/skyportal/facility_apis/swift.py
+++ b/skyportal/facility_apis/swift.py
@@ -7,6 +7,7 @@ import tarfile
 import tempfile
 import traceback
 from datetime import timedelta
+from urllib.parse import urlsplit
 
 import aiohttp
 import pandas as pd
@@ -14,7 +15,6 @@ import sqlalchemy as sa
 from astropy.time import Time
 from sqlalchemy.orm import scoped_session, selectinload, sessionmaker
 from swifttools.swift_too import Data, ObsQuery, Swift_TOO, UVOT_Mode
-from swifttools.swift_too.base.constants import API_VERSION
 from swifttools.xrt_prods import XRTProductRequest
 from tornado.ioloop import IOLoop
 
@@ -32,9 +32,8 @@ env, cfg = load_env()
 # Submission URL
 XRT_URL = f"{cfg['app.swift_xrt_endpoint']}/run_userobject.php"
 # swifttools posts ToO requests itself and defaults to the production API
-TOO_API_BASE = (
-    f"{cfg['app.swift.protocol']}://{cfg['app.swift.host']}"
-    f":{cfg['app.swift.port']}/api/v{API_VERSION}"
+SWIFT_TOO_ORIGIN = (
+    f"{cfg['app.swift.protocol']}://{cfg['app.swift.host']}:{cfg['app.swift.port']}"
 )
 
 log = make_log("facility_apis/swift")
@@ -564,7 +563,8 @@ class UVOTXRTAPI(FollowUpAPI):
                 # It signs and posts the request itself now (v2 API) and no
                 # longer exposes the JWT that used to be posted to submit_api.php.
                 swiftreq = UVOTXRTRequest(request)
-                swiftreq.requestgroup._api_base = TOO_API_BASE
+                api_path = urlsplit(swiftreq.requestgroup._api_base).path
+                swiftreq.requestgroup._api_base = SWIFT_TOO_ORIGIN + api_path
                 accepted = swiftreq.requestgroup.submit()
                 return accepted, swiftreq.requestgroup
 

--- a/skyportal/facility_apis/swift.py
+++ b/skyportal/facility_apis/swift.py
@@ -14,6 +14,7 @@ import sqlalchemy as sa
 from astropy.time import Time
 from sqlalchemy.orm import scoped_session, selectinload, sessionmaker
 from swifttools.swift_too import Data, ObsQuery, Swift_TOO, UVOT_Mode
+from swifttools.swift_too.base.constants import API_VERSION
 from swifttools.xrt_prods import XRTProductRequest
 from tornado.ioloop import IOLoop
 
@@ -30,6 +31,11 @@ env, cfg = load_env()
 
 # Submission URL
 XRT_URL = f"{cfg['app.swift_xrt_endpoint']}/run_userobject.php"
+# swifttools posts ToO requests itself and defaults to the production API
+TOO_API_BASE = (
+    f"{cfg['app.swift.protocol']}://{cfg['app.swift.host']}"
+    f":{cfg['app.swift.port']}/api/v{API_VERSION}"
+)
 
 log = make_log("facility_apis/swift")
 
@@ -558,6 +564,7 @@ class UVOTXRTAPI(FollowUpAPI):
                 # It signs and posts the request itself now (v2 API) and no
                 # longer exposes the JWT that used to be posted to submit_api.php.
                 swiftreq = UVOTXRTRequest(request)
+                swiftreq.requestgroup._api_base = TOO_API_BASE
                 accepted = swiftreq.requestgroup.submit()
                 return accepted, swiftreq.requestgroup
 

--- a/skyportal/services/test_server/test_api_server.py
+++ b/skyportal/services/test_server/test_api_server.py
@@ -212,28 +212,6 @@ def ztf_request_matcher(r1, r2):
     assert r1_is_ztf and r2_is_ztf and r1.method == r2.method
 
 
-def swift_request_matcher(r1, r2):
-    """
-    Helper function to help determine if two requests to the Swift API are equivalent
-    """
-
-    # A request matches a Swift request if the URI and method matches
-    r1_uri = r1.uri.replace(":443", "")
-    r2_uri = r2.uri.replace(":443", "")
-
-    def is_swift_request(uri):
-        pattern = r"/toop/submit_json.php"
-        if re.search(pattern, uri) is not None:
-            return True
-
-        return False
-
-    r1_is_swift = is_swift_request(r1_uri)
-    r2_is_swift = is_swift_request(r2_uri)
-
-    assert r1_is_swift and r2_is_swift and r1.method == r2.method
-
-
 def kait_request_matcher(r1, r2):
     """
     Helper function to help determine if two requests to the KAIT API are equivalent
@@ -558,7 +536,6 @@ class TestRouteHandler(tornado.web.RequestHandler):
     def post(self):
         cached_urls = [
             ".*/api/requestgroups/.*",
-            ".*/toop/submit_json.php$",
             ".*/cgi-bin/internal/process_kait_ztf_request.py$",
             ".*/api/triggers/ztf/.*",
             ".*/node_agent2/node_agent/.*",
@@ -585,8 +562,6 @@ class TestRouteHandler(tornado.web.RequestHandler):
             match_on = ["kait"]
         elif self.request.uri == "/api/v1/pointings":
             match_on = ["treasuremap"]
-        elif "/toop/submit_json.php" in self.request.uri:
-            match_on = ["swift"]
         elif self.request.uri.startswith("/too/winter") or self.request.uri.startswith(
             "/too/spring"
         ):
@@ -687,7 +662,6 @@ if __name__ == "__main__":
     my_vcr.register_matcher("ztf", ztf_request_matcher)
     my_vcr.register_matcher("kait", kait_request_matcher)
     my_vcr.register_matcher("treasuremap", treasuremap_request_matcher)
-    my_vcr.register_matcher("swift", swift_request_matcher)
     if "test_server" in cfg:
         app = make_app()
         server = tornado.httpserver.HTTPServer(app)

--- a/test_config.yaml
+++ b/test_config.yaml
@@ -106,7 +106,6 @@ test_server:
     /api/triggers/ztf: http://skipper.caltech.edu:4000 # ZTF
     /cgi-bin/internal/process_kait_ztf_request.py: http://herculesii.astro.berkeley.edu # KAIT
     /api/v0/pointings: https://treasuremap.space
-    /toop/submit_json.php: https://www.swift.psu.edu # Swift
     /api/v0.1/panstarrs/dr2/: https://catalogs.mast.stsci.edu # PS1
     /too/winter: http://winter.caltech.edu:82 # WINTER
     /too/spring: http://winter.caltech.edu:82 # SPRING


### PR DESCRIPTION
Route Swift ToO submissions through the configured host again. swifttools 4.x posts the request itself and defaults to the production API, so dropping API_URL would have sent test submissions to the real observatory.
The test server route goes away too: with no route it answers 500, swifttools
degrades to `Rejected`, and the test passes with no network at all.