### PR TITLE
Fix reminder

### DIFF
--- a/skyportal/handlers/api/reminder.py
+++ b/skyportal/handlers/api/reminder.py
@@ -3,7 +3,7 @@ from typing import Annotated
 import arrow
 from pydantic import BaseModel, ConfigDict, Field
 
-from baselayer.app.access import auth_or_token, permissions
+from baselayer.app.access import auth_or_token
 from baselayer.app.custom_exceptions import AccessError
 from baselayer.app.flow import Flow
 from skyportal.models.source import Source
@@ -409,7 +409,7 @@ class ReminderHandler(BaseHandler):
         except Exception as e:
             return self.error(str(e))
 
-    @permissions(["Reminder"])
+    @auth_or_token
     async def post(
         self,
         associated_resource_type: AssociatedResourceType,
@@ -545,7 +545,7 @@ class ReminderHandler(BaseHandler):
                 await session.rollback()
                 return self.error(str(e))
 
-    @permissions(["Reminder"])
+    @auth_or_token
     async def patch(
         self,
         associated_resource_type: AssociatedResourceType,
@@ -735,7 +735,7 @@ class ReminderHandler(BaseHandler):
             except Exception as e:
                 return self.error(str(e))
 
-    @permissions(["Reminder"])
+    @auth_or_token
     async def delete(
         self,
         associated_resource_type: AssociatedResourceType,

--- a/skyportal/handlers/api/reminder.py
+++ b/skyportal/handlers/api/reminder.py
@@ -341,7 +341,7 @@ class ReminderHandler(BaseHandler):
                             f'Unsupported associated resource type "{associated_resource_type}".'
                         )
                     list_result = await session.scalars(stmt)
-                    reminders = list_result.all()
+                    reminders = list_result.unique().all()
                     await session.commit()
                     return self.success(
                         data={

--- a/static/js/types/api.ts
+++ b/static/js/types/api.ts
@@ -6153,7 +6153,7 @@ export interface paths {
         post?: never;
         /**
          * Delete a reminder
-         * @description <b>Permission(s) required:</b> <em>Reminder (or System admin)</em><br><br>Delete a reminder
+         * @description Delete a reminder
          */
         delete: {
             parameters: {
@@ -6184,7 +6184,7 @@ export interface paths {
         head?: never;
         /**
          * Update a reminder
-         * @description <b>Permission(s) required:</b> <em>Reminder (or System admin)</em><br><br>Update a reminder
+         * @description Update a reminder
          */
         patch: {
             parameters: {
@@ -6271,7 +6271,7 @@ export interface paths {
         put?: never;
         /**
          * Post a reminder
-         * @description <b>Permission(s) required:</b> <em>Reminder (or System admin)</em><br><br>Post a reminder
+         * @description Post a reminder
          */
         post: {
             parameters: {


### PR DESCRIPTION
This PR is fixing reminders. Before, the "Reminder" permission was required but since it's not listed on the file `model_util.py`, only Super Admin can create reminders. I choose to remove this permission type because I think that anyone should be able to create personal reminders on shift, sources etc.