### PR TITLE
Fix async photometry patch

### DIFF
--- a/skyportal/handlers/api/photometry.py
+++ b/skyportal/handlers/api/photometry.py
@@ -2674,6 +2674,7 @@ class PhotometryHandler(BaseHandler):
             ).first()
             if phot_stat is None:
                 phot_stat = PhotStat(obj_id=photometry.obj_id)
+                session.add(phot_stat)
 
             # The edit above is still pending, so flush it or the stats are
             # recomputed from the pre-edit rows -- and the expunge below would
@@ -3108,12 +3109,13 @@ class ObjPhotometryHandler(BaseHandler):
                     )
                 )
             ).first()
-            all_phot = (
-                await session.scalars(
-                    sa.select(Photometry).where(Photometry.obj_id == obj_id)
-                )
-            ).all()
-            stat.full_update(all_phot)
+            if stat is not None:
+                all_phot = (
+                    await session.scalars(
+                        sa.select(Photometry).where(Photometry.obj_id == obj_id)
+                    )
+                ).all()
+                stat.full_update(all_phot)
 
             await session.commit()
             return self.success(f"Deleted {n} photometry point(s) of {obj_id}.")
@@ -3173,6 +3175,8 @@ class BulkDeletePhotometryHandler(BaseHandler):
                         )
                     )
                 ).first()
+                if stat is None:
+                    continue
                 all_phot = (
                     await session.scalars(
                         sa.select(Photometry).where(Photometry.obj_id == oid)

--- a/skyportal/handlers/api/photometry.py
+++ b/skyportal/handlers/api/photometry.py
@@ -2665,8 +2665,6 @@ class PhotometryHandler(BaseHandler):
                             )
                         )
 
-            await session.flush()
-
             phot_stat = (
                 await session.scalars(
                     PhotStat.select(session.user_or_token, mode="update").where(
@@ -2778,9 +2776,6 @@ class PhotometryHandler(BaseHandler):
                 )
             ).first()
             if phot_stat is not None:
-                # Flush the delete first, or it is still one of the rows the
-                # stats are recomputed from.
-                await session.flush()
                 all_phot = (
                     await session.scalars(
                         sa.select(Photometry).where(Photometry.obj_id == obj_id)

--- a/skyportal/handlers/api/photometry.py
+++ b/skyportal/handlers/api/photometry.py
@@ -2665,6 +2665,8 @@ class PhotometryHandler(BaseHandler):
                             )
                         )
 
+            await session.flush()
+
             phot_stat = (
                 await session.scalars(
                     PhotStat.select(self.associated_user_object, mode="update").where(
@@ -2761,6 +2763,8 @@ class PhotometryHandler(BaseHandler):
             obj_id = photometry.obj_id
 
             await session.delete(photometry)
+
+            await session.flush()
 
             phot_stat = (
                 await session.scalars(
@@ -3093,6 +3097,8 @@ class ObjPhotometryHandler(BaseHandler):
             for phot in photometry_to_delete:
                 await session.delete(phot)
 
+            await session.flush()
+
             stat = (
                 await session.scalars(
                     PhotStat.select(self.associated_user_object, mode="update").where(
@@ -3154,6 +3160,9 @@ class BulkDeletePhotometryHandler(BaseHandler):
                 await session.delete(phot)
 
             obj_ids = {phot.obj_id for phot in photometry_to_delete}
+
+            await session.flush()
+
             for oid in obj_ids:
                 stat = (
                     await session.scalars(

--- a/skyportal/handlers/api/photometry.py
+++ b/skyportal/handlers/api/photometry.py
@@ -3016,9 +3016,14 @@ class ObjPhotometryHandler(BaseHandler):
                 series = (
                     (
                         await session.scalars(
-                            PhotometricSeries.select(session.user_or_token).where(
-                                PhotometricSeries.obj_id == obj_id
-                            )
+                            PhotometricSeries.select(
+                                session.user_or_token,
+                                options=[
+                                    joinedload(PhotometricSeries.instrument).joinedload(
+                                        Instrument.telescope
+                                    )
+                                ],
+                            ).where(PhotometricSeries.obj_id == obj_id)
                         )
                     )
                     .unique()

--- a/skyportal/tests/api_tests/photometry_followup/test_photometry.py
+++ b/skyportal/tests/api_tests/photometry_followup/test_photometry.py
@@ -3159,6 +3159,28 @@ def test_photometry_stream_patch_access(
     assert status == 200
     assert data["status"] == "success"
 
+    # repeating it loads the StreamPhotometry row created above, exercising the
+    # access check on a join table whose primary key is composite
+    status, data = api(
+        "PATCH",
+        f"photometry/{phot_id}",
+        data={
+            "obj_id": str(public_source.id),
+            "mjd": 58001.0,
+            "instrument_id": ztf_camera.id,
+            "flux": 13.24,
+            "fluxerr": 0.031,
+            "zp": 25.0,
+            "magsys": "ab",
+            "filter": "ztfg",
+            "stream_ids": [public_stream2.id],
+            "altdata": {"some_key": "some_value"},
+        },
+        token=upload_data_token_no_groups_two_streams,
+    )
+    assert status == 200
+    assert data["status"] == "success"
+
 
 def test_token_user_delete_object_photometry(
     super_admin_token, upload_data_token, view_only_token, ztf_camera, public_group

--- a/static/js/components/group/Group.tsx
+++ b/static/js/components/group/Group.tsx
@@ -77,7 +77,7 @@ const Group = () => {
 
   if (groupLoadError) return groupLoadError;
 
-  if (group == null) return <CircularProgress />;
+  if (group == null || currentUser == null) return <CircularProgress />;
 
   const isAdmin = (aUser: any) => {
     const currentGroupUser = group?.["users"]?.filter(


### PR DESCRIPTION
- Persist the `PhotStat` created when patching photometry: it was instantiated but never added to the session, so the recomputed stats were silently dropped.
- Flush the pending deletes before recomputing photometry stats, in the single, per object and bulk delete handlers: the async session has autoflush off, so the stats were rebuilt from a set that still contained the deleted points.
- Guard those two bulk deletes against a missing `PhotStat`: deleting the photometry of an object that had no stats row raised a 500.
- Eager load the instrument and telescope of an object's photometric series, which `get_data_with_extra_columns()` reads: since the handler became async, requesting the photometry of any source having a series returned a 500.
- Wait for `currentUser` before rendering the group page instead of rendering with a null user.
- Bump baselayer to pick up cesium-ml/baselayer#464, which fixes the commit time access check on join tables with a composite primary key.
- Add a test patching the same photometry point twice with a stream, so the `StreamPhotometry` row is loaded back and that composite primary key check is exercised.