### PR TITLE
exempt API tokens from the terms of service gate

### DIFF
--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -521,6 +521,8 @@ app:
     X-ray Flash: XRFcandidate
     XRF: XRF
     XRF candidate: XRFcandidate
+    UV Ceti: Stellar
+    UV Ceti candidate: Stellarcandidate
 
   homepage_widgets:
     # This section describes the specific widgets shown on the Home Page and how

--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -52,6 +52,9 @@ app:
     title: Terms of Service
     text: ""
     text_file: ""
+    # A token cannot be shown the dialog, so gating it blocks every script and
+    # service until its owner logs in and accepts.
+    exempt_tokens: false
 
   # Anonymous read-only access. When true, visitors who are not signed in are
   # served as `anonymous_user` (a "View only" account) so pages render without a
@@ -511,10 +514,13 @@ app:
       xs: 4
 
   gcn_extraction_tags:
-    # Taxonomy class reported by a circular extraction -> obj tag applied to the
-    # objects of that event. An unmapped class tags nothing. The tag must already
-    # exist as an ObjTagOption.
+    # Class or subtype reported by a circular extraction -> obj tag applied to
+    # the objects of that event. The subtype is looked up first, since it is the
+    # more specific of the two. An unmapped class tags nothing, and the tag must
+    # already exist as an ObjTagOption.
     X-ray Flash: XRFcandidate
+    XRF: XRF
+    XRF candidate: XRFcandidate
 
   homepage_widgets:
     # This section describes the specific widgets shown on the Home Page and how

--- a/services/gcn_service/gcn_service.py
+++ b/services/gcn_service/gcn_service.py
@@ -353,6 +353,7 @@ def poll_events(*args, **kwargs):
                                     request_body, timeout=30
                                 )
                             except Exception as e:
+                                traceback.print_exc()
                                 log(
                                     f"Failed to ingest skymap for gcn_event: {dateobs}, notice_id: {notice_id}: {e}"
                                 )

--- a/services/notification_queue/notification_queue.py
+++ b/services/notification_queue/notification_queue.py
@@ -51,6 +51,7 @@ from skyportal.utils.gcn import get_skymap_properties
 from skyportal.utils.gcn_extraction_tags import (
     apply_tags,
     classification_of,
+    tag_event,
     wants_classification,
 )
 from skyportal.utils.notifications import (
@@ -790,10 +791,21 @@ def api(queue):
                             tagged = apply_tags(
                                 session, extraction, extraction.sent_by_id
                             )
-                            if tagged:
+                            # The event carries the tag too, since a circular can
+                            # classify a trigger that has no object to tag.
+                            event_tag = tag_event(
+                                session, extraction, extraction.sent_by_id
+                            )
+                            if tagged or event_tag:
                                 session.commit()
+                            if tagged:
                                 log(
                                     f"tagged {', '.join(tagged)} from extraction {target_id}"
+                                )
+                            if event_tag:
+                                log(
+                                    f"tagged event {extraction.dateobs} "
+                                    f"{event_tag} from extraction {target_id}"
                                 )
 
                     failure_count = 0

--- a/skyportal/handlers/api/gcn.py
+++ b/skyportal/handlers/api/gcn.py
@@ -926,8 +926,12 @@ async def post_skymap_from_notice(
     """Post skymap to database from gcn notice."""
     user = await session.get(User, user_id)
 
+    # `content` is deferred, and reading it below would emit lazy IO the async
+    # session cannot serve.
     gcn_notice = await session.scalar(
-        GcnNotice.select(user).where(GcnNotice.id == notice_id)
+        GcnNotice.select(user)
+        .options(undefer(GcnNotice.content))
+        .where(GcnNotice.id == notice_id)
     )
 
     if gcn_notice is None:

--- a/skyportal/handlers/base.py
+++ b/skyportal/handlers/base.py
@@ -15,7 +15,7 @@ from ..utils.api_validate import (
     path_adapters_for,
     query_dict_from,
 )
-from ..utils.terms_of_service import has_accepted, terms_of_service
+from ..utils.terms_of_service import has_accepted, terms_of_service, tokens_exempt
 
 
 def format_doc(**kwargs):
@@ -59,6 +59,8 @@ class BaseHandler(BaselayerHandler):
         terms = terms_of_service()
         if terms is None or self.request.method in self.terms_of_service_exempt:
             return
+        if self.token_from_header() is not None and tokens_exempt():
+            return
         user_id = self.acting_user_id()
         if user_id is None or has_accepted(user_id, terms["version"]):
             return
@@ -68,15 +70,20 @@ class BaseHandler(BaselayerHandler):
         )
         raise Finish()
 
+    def token_from_header(self):
+        """The API token this request authenticates with, if it uses one."""
+        header = self.request.headers.get("Authorization") or ""
+        if not header.startswith("token "):
+            return None
+        return header.removeprefix("token").strip()
+
     def acting_user_id(self):
         # prepare() runs before auth_or_token, so the token is not resolved yet.
-        header = self.request.headers.get("Authorization") or ""
-        if header.startswith("token "):
+        token = self.token_from_header()
+        if token is not None:
             with DBSession() as session:
                 return session.scalar(
-                    sa.select(Token.created_by_id).where(
-                        Token.id == header.removeprefix("token").strip()
-                    )
+                    sa.select(Token.created_by_id).where(Token.id == token)
                 )
         if self.current_user is None or getattr(self, "is_anonymous_user", False):
             return None

--- a/skyportal/tests/utils/test_gcn_extraction_tags.py
+++ b/skyportal/tests/utils/test_gcn_extraction_tags.py
@@ -11,6 +11,10 @@ from skyportal.utils.gcn_extraction_tags import (
     wants_classification,
 )
 
+FLARE = {
+    "classification": {"classification": "UV Ceti", "subtype": "UV Ceti candidate"}
+}
+
 XRF = {"classification": {"classification": "X-ray Flash", "probability": 1.0}}
 
 
@@ -63,3 +67,15 @@ def test_extraction_without_a_subtype():
     assert subtype_of({"classification": {"classification": "GRB"}}) is None
     assert subtype_of({"classification": None}) is None
     assert subtype_of(None) is None
+
+
+def test_a_flaring_star_maps_to_a_tag():
+    """A trigger classified as a stellar flare is tagged so it can be filtered out."""
+    assert tag_name_for("UV Ceti") == "Stellar"
+    assert tag_name_for("UV Ceti candidate") == "Stellarcandidate"
+
+
+def test_the_hedged_flare_keeps_its_own_tag():
+    # subtype wins over the class, so a hedge is not filed as a certainty
+    assert tag_name_for(subtype_of(FLARE)) == "Stellarcandidate"
+    assert tag_name_for(classification_of(FLARE)) == "Stellar"

--- a/skyportal/tests/utils/test_gcn_extraction_tags.py
+++ b/skyportal/tests/utils/test_gcn_extraction_tags.py
@@ -6,6 +6,7 @@ against the extraction shape Circex writes.
 
 from skyportal.utils.gcn_extraction_tags import (
     classification_of,
+    subtype_of,
     tag_name_for,
     wants_classification,
 )
@@ -49,3 +50,16 @@ def test_unmapped_class_tags_nothing():
 
 def test_configured_class_maps_to_its_tag():
     assert tag_name_for("X-ray Flash") == "XRFcandidate"
+
+
+def test_subtype_read_from_the_extraction():
+    """An X-ray flash is a GRB the taxonomy has no node for, so it is a subtype."""
+    grb_xrf = {"classification": {"classification": "GRB", "subtype": "XRF candidate"}}
+    assert subtype_of(grb_xrf) == "XRF candidate"
+    assert classification_of(grb_xrf) == "GRB"
+
+
+def test_extraction_without_a_subtype():
+    assert subtype_of({"classification": {"classification": "GRB"}}) is None
+    assert subtype_of({"classification": None}) is None
+    assert subtype_of(None) is None

--- a/skyportal/tests/utils/test_terms_of_service.py
+++ b/skyportal/tests/utils/test_terms_of_service.py
@@ -4,8 +4,13 @@ The API tests only cover the disabled default: the test server runs in its own
 process, so enabling the terms there would block every other frontend test.
 """
 
-import pytest
+from types import SimpleNamespace
 
+import pytest
+from tornado.web import Finish
+
+from skyportal.handlers import base as base_module
+from skyportal.handlers.base import BaseHandler
 from skyportal.tests import api
 from skyportal.utils import terms_of_service as tos_module
 
@@ -98,6 +103,65 @@ def test_file_is_read_once(terms_config, tmp_path):
     assert tos_module.terms_of_service()["text"] == "First."
     terms_file.write_text("Second.")
     assert tos_module.terms_of_service()["text"] == "First."
+
+
+def test_tokens_are_gated_by_default():
+    assert tos_module.tokens_exempt() is False
+
+
+def test_tokens_exempt_when_configured(terms_config):
+    terms_config(exempt_tokens=True)
+    assert tos_module.tokens_exempt() is True
+
+
+class _StubHandler:
+    """Enough of a handler to exercise the gate without a running server."""
+
+    terms_of_service_exempt = ()
+    token_from_header = BaseHandler.token_from_header
+
+    def __init__(self, authorization):
+        headers = {"Authorization": authorization} if authorization else {}
+        self.request = SimpleNamespace(headers=headers, method="GET")
+        self.errors = []
+
+    def acting_user_id(self):
+        return 999
+
+    def error(self, message, status=None):
+        self.errors.append((message, status))
+
+
+def _run_gate(authorization):
+    handler = _StubHandler(authorization)
+    try:
+        BaseHandler.enforce_terms_of_service(handler)
+    except Finish:
+        pass
+    return handler.errors
+
+
+def test_a_token_is_refused_until_its_owner_accepts(terms_config, monkeypatch):
+    terms_config(enabled=True, text="Some terms.", exempt_tokens=False)
+    monkeypatch.setattr(base_module, "has_accepted", lambda *_: False)
+    errors = _run_gate("token abc123")
+    assert [status for _, status in errors] == [403]
+
+
+def test_an_exempt_token_acts_before_its_owner_accepts(terms_config, monkeypatch):
+    terms_config(enabled=True, text="Some terms.", exempt_tokens=True)
+    monkeypatch.setattr(base_module, "has_accepted", lambda *_: False)
+    assert _run_gate("token abc123") == []
+
+
+def test_a_browser_session_is_still_gated_when_tokens_are_exempt(
+    terms_config, monkeypatch
+):
+    """The exemption is for tokens only; a signed-in human still sees the dialog."""
+    terms_config(enabled=True, text="Some terms.", exempt_tokens=True)
+    monkeypatch.setattr(base_module, "has_accepted", lambda *_: False)
+    errors = _run_gate(None)
+    assert [status for _, status in errors] == [403]
 
 
 def test_not_required_when_instance_configures_none(view_only_token):

--- a/skyportal/utils/gcn_extraction_tags.py
+++ b/skyportal/utils/gcn_extraction_tags.py
@@ -21,6 +21,16 @@ def classification_of(extraction_data):
     return classification.get("classification")
 
 
+def subtype_of(extraction_data):
+    """The finer class an extraction reports, or None.
+
+    A class the taxonomy has no node for rides on the subtype (an X-ray flash is
+    reported as a GRB with subtype "XRF"), and it is the more specific of the two.
+    """
+    classification = (extraction_data or {}).get("classification") or {}
+    return classification.get("subtype")
+
+
 def wants_classification(preferences, label):
     """Whether a user's notification preferences ask for this class.
 
@@ -44,7 +54,9 @@ def tag_name_for(label):
 
 def apply_tags(session, extraction, author_id):
     """Tag every object linked to the extraction's event. Returns the obj ids tagged."""
-    tag_name = tag_name_for(classification_of(extraction.data))
+    tag_name = tag_name_for(subtype_of(extraction.data)) or tag_name_for(
+        classification_of(extraction.data)
+    )
     if tag_name is None:
         return []
 

--- a/skyportal/utils/gcn_extraction_tags.py
+++ b/skyportal/utils/gcn_extraction_tags.py
@@ -9,7 +9,7 @@ import sqlalchemy as sa
 from baselayer.app.env import load_env
 from baselayer.log import make_log
 
-from ..models import GcnEventObj, ObjTag, ObjTagOption
+from ..models import GcnEventObj, GcnTag, ObjTag, ObjTagOption
 
 env, cfg = load_env()
 log = make_log("gcn_extraction_tags")
@@ -50,6 +50,29 @@ def tag_name_for(label):
         return None
     mapping = cfg.get("app.gcn_extraction_tags") or {}
     return mapping.get(label)
+
+
+def tag_event(session, extraction, author_id):
+    """Tag the event itself. Returns the tag written, or None.
+
+    A circular can classify a trigger without there being any object to tag:
+    "the EP-WXT trigger is likely a stellar flare" names no counterpart.
+    """
+    tag_name = tag_name_for(subtype_of(extraction.data)) or tag_name_for(
+        classification_of(extraction.data)
+    )
+    if tag_name is None:
+        return None
+
+    exists = session.scalar(
+        sa.select(GcnTag).where(
+            GcnTag.dateobs == extraction.dateobs, GcnTag.text == tag_name
+        )
+    )
+    if exists is not None:
+        return None
+    session.add(GcnTag(dateobs=extraction.dateobs, text=tag_name, sent_by_id=author_id))
+    return tag_name
 
 
 def apply_tags(session, extraction, author_id):

--- a/skyportal/utils/terms_of_service.py
+++ b/skyportal/utils/terms_of_service.py
@@ -1,4 +1,4 @@
-__all__ = ["has_accepted", "terms_of_service"]
+__all__ = ["has_accepted", "terms_of_service", "tokens_exempt"]
 
 from functools import cache
 from pathlib import Path
@@ -39,6 +39,15 @@ def terms_of_service():
         "title": terms.get("title") or "Terms of Service",
         "text": text,
     }
+
+
+def tokens_exempt():
+    """Whether an API token may act before its owner has accepted the terms.
+
+    A token cannot be shown a dialog, so gating it blocks every script and
+    service until a human logs in and clicks through.
+    """
+    return bool((cfg.get("app.terms_of_service") or {}).get("exempt_tokens"))
 
 
 def has_accepted(user_id, version):


### PR DESCRIPTION
This PR allows for a deployment exempt API tokens from the terms of service gate. 

This is useful for existing deployments where we can deploy the ToS in stages, e.g. first encourage the users to accept the ToS in the app so that their tokens running cron jobs do not immediately start failing.