### PR TITLE
Fix invalid sx on the GCN event tabs

### DIFF
--- a/static/js/components/gcn/GcnSelectionForm.tsx
+++ b/static/js/components/gcn/GcnSelectionForm.tsx
@@ -1002,11 +1002,9 @@ const GcnSelectionForm = ({ dateobs }: GcnSelectionFormProps) => {
           variant="scrollable"
           {...({ xs: 12 } as any)}
           sx={{
-            display: {
-              maxWidth: "95vw",
-              width: "100&",
-              "& > button": { lineHeight: "1.5rem" },
-            },
+            maxWidth: "95vw",
+            width: "100%",
+            "& > button": { lineHeight: "1.5rem" },
           }}
         >
           {/* the first tab called skymap has to be hidden until we reach the sm breakpoint */}


### PR DESCRIPTION
Remove useless left arrow displayed by scrollable Tabs when there is no overflow

<img width="1425" height="635" alt="image" src="https://github.com/user-attachments/assets/d1793e7b-4cb6-4823-8f7f-aa97954072dc" />
