### PR TITLE
list spectra on scan report items

### DIFF
--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -1209,6 +1209,13 @@ hosts:
 
 # JPL Scout NEO Target-of-Opportunity candidates, published by
 # lsst-sssc/scout-alert-bridge. Leave `topic` unset to disable the service.
+assignments:
+  # An uploaded spectrum marks a matching observing-run assignment "done".
+  # A spectrum naming its assignment always settles it; otherwise the run's
+  # instrument must match and its calendar date fall within this many days of
+  # the exposure. Set to null to only close assignments a spectrum names.
+  auto_observed_window_days: 1
+
 scout:
   topic: # e.g. lco.scout-neo-too-test
   kafka_server: kafka.scimma.org

--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -530,6 +530,9 @@ app:
     thinking: false
     # Budget for a whole question, across all its round-trips.
     answer_timeout: 180
+    # Characters of one tool result the model sees. A result larger than this is
+    # cut down, never dropped, so raising it buys breadth rather than accuracy.
+    result_budget: 20000
     # Oldest messages are dropped first when a conversation outgrows this.
     max_context_messages: 40
     request_timeout: 300

--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -525,6 +525,11 @@ app:
     api_key: ""
     # Cap on tool round-trips per question, so a looping model cannot run away.
     max_tool_calls: 8
+    # Let a reasoning model think before it answers. It roughly doubles how long
+    # a question takes, for an answer that is quoting tool results either way.
+    thinking: false
+    # Budget for a whole question, across all its round-trips.
+    answer_timeout: 180
     # Oldest messages are dropped first when a conversation outgrows this.
     max_context_messages: 40
     request_timeout: 300

--- a/services/assistant/app.py
+++ b/services/assistant/app.py
@@ -15,7 +15,12 @@ from baselayer.app.models import init_db, session_context_id
 from baselayer.log import make_log
 from skyportal.models import AssistantMessage, DBSession, Token, User
 from skyportal.utils.app import get_app_base_url
-from skyportal.utils.assistant import SERVICE_TOKEN_PREFIX, build_messages, condense
+from skyportal.utils.assistant import (
+    SERVICE_TOKEN_PREFIX,
+    answer_text,
+    build_messages,
+    condense,
+)
 
 _, cfg = load_env()
 log = make_log("assistant")
@@ -119,7 +124,7 @@ def answer(conversation, context_type, context_id, user, token):
         message = chat(messages, tools)
         calls = message.get("tool_calls") or []
         if not calls:
-            return (message.get("content") or "").strip()
+            return answer_text(message)
         messages.append(message)
         for call in calls:
             name = call["function"]["name"]
@@ -143,7 +148,7 @@ def answer(conversation, context_type, context_id, user, token):
             "content": "Answer now from what you have, and say what is still unknown.",
         }
     )
-    return (chat(messages, tools).get("content") or "").strip()
+    return answer_text(chat(messages, tools))
 
 
 def read_only_token(session, user_id):
@@ -174,20 +179,41 @@ def clear_service_tokens():
         log(f"cleared {cleared} token(s) left by a previous run")
 
 
-def conversation_of(session, user_id, channel):
-    messages = (
-        session.scalars(
-            sa.select(AssistantMessage)
+def already_answered(session, message):
+    """Whether a reply to this message has already been written."""
+    return (
+        session.scalar(
+            sa.select(AssistantMessage.id)
             .where(
-                AssistantMessage.user_id == user_id,
-                AssistantMessage.channel == channel
-                if channel
+                AssistantMessage.user_id == message.user_id,
+                AssistantMessage.channel == message.channel
+                if message.channel
                 else AssistantMessage.channel.is_(None),
+                AssistantMessage.system.is_(True),
+                AssistantMessage.id > message.id,
             )
-            .order_by(AssistantMessage.created_at)
+            .limit(1)
         )
-        .unique()
-        .all()
+        is not None
+    )
+
+
+def conversation_of(session, user_id, channel, up_to_id=None):
+    """The conversation as it stood when `up_to_id` was asked.
+
+    Anything written afterwards, including an earlier failure's apology, is not
+    context for this answer.
+    """
+    query = sa.select(AssistantMessage).where(
+        AssistantMessage.user_id == user_id,
+        AssistantMessage.channel == channel
+        if channel
+        else AssistantMessage.channel.is_(None),
+    )
+    if up_to_id is not None:
+        query = query.where(AssistantMessage.id <= up_to_id)
+    messages = (
+        session.scalars(query.order_by(AssistantMessage.created_at)).unique().all()
     )
     return [
         {"text": message.text, "system": bool(message.system)} for message in messages
@@ -207,7 +233,12 @@ def respond(message_id):
             user_id = message.user_id
             channel = message.channel
             context_type, context_id = message.context_type, message.context_id
-            conversation = conversation_of(session, user_id, channel)
+            if already_answered(session, message):
+                log(f"message {message_id} already has an answer; not answering twice")
+                return
+            conversation = conversation_of(
+                session, user_id, channel, up_to_id=message.id
+            )
             user = session.scalar(sa.select(User).where(User.id == user_id))
             profile = {
                 "username": user.username,

--- a/services/assistant/app.py
+++ b/services/assistant/app.py
@@ -1,6 +1,7 @@
 """Woken by the app when a message is posted, answers it through the MCP endpoint."""
 
 import json
+import time
 import uuid
 
 import requests
@@ -17,9 +18,9 @@ from skyportal.models import AssistantMessage, DBSession, Token, User
 from skyportal.utils.app import get_app_base_url
 from skyportal.utils.assistant import (
     SERVICE_TOKEN_PREFIX,
-    answer_text,
     build_messages,
     condense,
+    select_tools,
 )
 
 _, cfg = load_env()
@@ -34,6 +35,11 @@ BASE_URL = CONFIG.get("base_url")
 MODEL = CONFIG.get("model") or ""
 API_KEY = CONFIG.get("api_key") or ""
 MAX_TOOL_CALLS = int(CONFIG.get("max_tool_calls", 8))
+# request_timeout bounds one call; a question is many, so bound those too.
+ANSWER_TIMEOUT = float(CONFIG.get("answer_timeout", 180))
+# A reasoning model spends most of its tokens thinking, which a chat answer
+# drawn from tool results does not need.
+THINKING = bool(CONFIG.get("thinking", False))
 MAX_CONTEXT = int(CONFIG.get("max_context_messages", 40))
 TIMEOUT = float(CONFIG.get("request_timeout", 300))
 
@@ -73,7 +79,17 @@ def _rpc(token, method, params, timeout, tool_name=None):
     return payload["result"]
 
 
-def list_tools(token):
+def list_tools(token, context_type=None):
+    """The tools to offer, narrowed to what this question could need.
+
+    The service holds a read-only token, so a tool that writes would only fail;
+    and the page the question came from says which subjects are in play.
+    """
+    tools = [
+        tool
+        for tool in _rpc(token, "tools/list", {}, 60)["tools"]
+        if tool.get("annotations", {}).get("readOnlyHint")
+    ]
     return [
         {
             "type": "function",
@@ -83,7 +99,7 @@ def list_tools(token):
                 "parameters": tool.get("inputSchema", {"type": "object"}),
             },
         }
-        for tool in _rpc(token, "tools/list", {}, 60)["tools"]
+        for tool in select_tools(tools, context_type)
     ]
 
 
@@ -102,29 +118,47 @@ def call_tool(token, name, arguments):
     )
 
 
-def chat(messages, tools):
+def chat(messages, tools, timeout=None):
     headers = {"Content-Type": "application/json"}
     if API_KEY:
         headers["Authorization"] = f"Bearer {API_KEY}"
     response = requests.post(
         f"{BASE_URL.rstrip('/')}/chat/completions",
         headers=headers,
-        json={"model": MODEL, "messages": messages, "tools": tools, "temperature": 0},
-        timeout=TIMEOUT,
+        json={
+            "model": MODEL,
+            "messages": messages,
+            "tools": tools,
+            "temperature": 0,
+            **(
+                {} if THINKING else {"chat_template_kwargs": {"enable_thinking": False}}
+            ),
+        },
+        timeout=timeout or TIMEOUT,
     )
     response.raise_for_status()
     return response.json()["choices"][0]["message"]
 
 
+def remaining(deadline, floor=5.0):
+    """Seconds left before the answer is due, or None when too few to be useful."""
+    left = deadline - time.monotonic()
+    return left if left >= floor else None
+
+
 def answer(conversation, context_type, context_id, user, token):
-    tools = list_tools(token)
+    tools = list_tools(token, context_type)
     messages = build_messages(conversation, MAX_CONTEXT, context_type, context_id, user)
 
+    deadline = time.monotonic() + ANSWER_TIMEOUT
     for _ in range(MAX_TOOL_CALLS):
-        message = chat(messages, tools)
+        if (left := remaining(deadline)) is None:
+            log("out of time before the model finished; answering from what it has")
+            break
+        message = chat(messages, tools, timeout=left)
         calls = message.get("tool_calls") or []
         if not calls:
-            return answer_text(message)
+            return (message.get("content") or "").strip()
         messages.append(message)
         for call in calls:
             name = call["function"]["name"]
@@ -148,7 +182,9 @@ def answer(conversation, context_type, context_id, user, token):
             "content": "Answer now from what you have, and say what is still unknown.",
         }
     )
-    return answer_text(chat(messages, tools))
+    if (left := remaining(deadline)) is None:
+        return "I ran out of time working that out. Please ask again, or narrow the question."
+    return (chat(messages, tools, timeout=left).get("content") or "").strip()
 
 
 def read_only_token(session, user_id):

--- a/services/assistant/app.py
+++ b/services/assistant/app.py
@@ -12,16 +12,11 @@ from tornado.ioloop import IOLoop
 
 from baselayer.app.env import load_env
 from baselayer.app.flow import Flow
-from baselayer.app.models import init_db, session_context_id
+from baselayer.app.models import ACL, init_db, session_context_id
 from baselayer.log import make_log
 from skyportal.models import AssistantMessage, DBSession, Token, User
 from skyportal.utils.app import get_app_base_url
-from skyportal.utils.assistant import (
-    SERVICE_TOKEN_PREFIX,
-    build_messages,
-    condense,
-    select_tools,
-)
+from skyportal.utils.assistant import SERVICE_TOKEN_PREFIX, build_messages, condense
 
 _, cfg = load_env()
 log = make_log("assistant")
@@ -41,6 +36,9 @@ ANSWER_TIMEOUT = float(CONFIG.get("answer_timeout", 180))
 # drawn from tool results does not need.
 THINKING = bool(CONFIG.get("thinking", False))
 MAX_CONTEXT = int(CONFIG.get("max_context_messages", 40))
+# How much of one tool result the model gets to see. Prompt processing is cheap
+# next to generation, so this buys breadth for very little time.
+RESULT_BUDGET = int(CONFIG.get("result_budget", 20000))
 TIMEOUT = float(CONFIG.get("request_timeout", 300))
 
 
@@ -79,12 +77,9 @@ def _rpc(token, method, params, timeout, tool_name=None):
     return payload["result"]
 
 
-def list_tools(token, context_type=None):
-    """The tools to offer, narrowed to what this question could need.
-
-    The service holds a read-only token, so a tool that writes would only fail;
-    and the page the question came from says which subjects are in play.
-    """
+def list_tools(token):
+    """The read-only tools. A tool that writes is never offered, and `call_tool`
+    refuses anything that was not."""
     tools = [
         tool
         for tool in _rpc(token, "tools/list", {}, 60)["tools"]
@@ -99,11 +94,18 @@ def list_tools(token, context_type=None):
                 "parameters": tool.get("inputSchema", {"type": "object"}),
             },
         }
-        for tool in select_tools(tools, context_type)
+        for tool in tools
     ]
 
 
-def call_tool(token, name, arguments):
+def call_tool(token, name, arguments, offered):
+    """Run one tool, refusing any that was not offered.
+
+    The token carries the user's own permissions, so this is what stops a model
+    talked into it by the text of a circular from writing anything.
+    """
+    if name not in offered:
+        raise PermissionError(f"{name} was not offered for this question")
     result = _rpc(
         token,
         "tools/call",
@@ -147,11 +149,15 @@ def remaining(deadline, floor=5.0):
 
 
 def answer(conversation, context_type, context_id, user, token):
-    tools = list_tools(token, context_type)
+    tools = list_tools(token)
+    offered = {tool["function"]["name"] for tool in tools}
     messages = build_messages(conversation, MAX_CONTEXT, context_type, context_id, user)
 
     deadline = time.monotonic() + ANSWER_TIMEOUT
-    for _ in range(MAX_TOOL_CALLS):
+    # One round-trip can ask for several tools at once, so count the calls
+    # themselves. Counting round-trips lets a paging model run four times over.
+    calls_made = 0
+    while calls_made < MAX_TOOL_CALLS:
         if (left := remaining(deadline)) is None:
             log("out of time before the model finished; answering from what it has")
             break
@@ -160,11 +166,12 @@ def answer(conversation, context_type, context_id, user, token):
         if not calls:
             return (message.get("content") or "").strip()
         messages.append(message)
+        calls_made += len(calls)
         for call in calls:
             name = call["function"]["name"]
             try:
                 arguments = json.loads(call["function"]["arguments"] or "{}")
-                result = call_tool(token, name, arguments)
+                result = call_tool(token, name, arguments, offered)
             except Exception as exc:
                 result = f"tool {name} failed: {exc}"
                 log(result)
@@ -172,7 +179,7 @@ def answer(conversation, context_type, context_id, user, token):
                 {
                     "role": "tool",
                     "tool_call_id": call["id"],
-                    "content": condense(result),
+                    "content": condense(result, RESULT_BUDGET),
                 }
             )
 
@@ -184,14 +191,26 @@ def answer(conversation, context_type, context_id, user, token):
     )
     if (left := remaining(deadline)) is None:
         return "I ran out of time working that out. Please ask again, or narrow the question."
-    return (chat(messages, tools, timeout=left).get("content") or "").strip()
+    # No tools on the last word, or the model asks for another instead of
+    # answering and the reply comes back empty.
+    return (chat(messages, [], timeout=left).get("content") or "").strip()
 
 
-def read_only_token(session, user_id):
-    """A token carrying the user's group access but no ACLs, so it cannot write."""
+def service_token(session, user_id):
+    """A short-lived token carrying the user's own access.
+
+    An admin sees things through an ACL rather than through group membership, so
+    a token without their ACLs would leave the assistant insisting a filter they
+    are looking at does not exist. Writing is refused in `call_tool` instead.
+    """
+    user = session.scalar(sa.select(User).where(User.id == user_id))
     token = Token(
         created_by_id=user_id, name=f"{SERVICE_TOKEN_PREFIX}{uuid.uuid4().hex}"
     )
+    # permissions, not acls: most of a user's ACLs reach them through a role.
+    token.acls = session.scalars(
+        sa.select(ACL).where(ACL.id.in_(user.permissions))
+    ).all()
     session.add(token)
     session.commit()
     return token
@@ -281,7 +300,7 @@ def respond(message_id):
                 "first_name": user.first_name,
                 "last_name": user.last_name,
             }
-            token_id = read_only_token(session, user_id).id
+            token_id = service_token(session, user_id).id
 
         # Answering takes minutes, so no connection is held while it runs.
         try:

--- a/skyportal/handlers/api/candidate/scan_report_item.py
+++ b/skyportal/handlers/api/candidate/scan_report_item.py
@@ -22,6 +22,7 @@ from ....models import (
     ObservingRun,
     Photometry,
     Source,
+    Spectrum,
 )
 from ....models.phot_stat import PHOT_DETECTION_THRESHOLD
 from ....models.scan_report.scan_report_item import ScanReportItem
@@ -263,6 +264,7 @@ def _build_scan_report_item(
     previous=None,
     associated_photstats=None,
     groups_saved_to=None,
+    spectra=None,
 ):
     """Build a report item from data already fetched for this obj (no queries)."""
     if obj.photstats:
@@ -320,6 +322,20 @@ def _build_scan_report_item(
             "requester": followup.requester.username if followup.requester else None,
         }
         for followup in followup_requests
+    ] or None
+
+    # Spectra taken of this object, newest first. A scanner comparing these
+    # dates against an observing run's tells whether the run's assignment was
+    # actually observed.
+    spectra_taken = [
+        {
+            "instrument": spectrum.instrument.name if spectrum.instrument else None,
+            "observed_at": (
+                spectrum.observed_at.isoformat() if spectrum.observed_at else None
+            ),
+            "origin": spectrum.origin,
+        }
+        for spectrum in spectra or []
     ] or None
 
     assignments = [
@@ -390,6 +406,7 @@ def _build_scan_report_item(
             "groups_saved_to": groups_saved_to,
             "followups": followups,
             "assignments": assignments,
+            "spectra": spectra_taken,
             "detections_by_survey": detections_by_survey,
             # Present only for an event-scoped report: how this object relates to
             # the event, and the scanner's verdict on it.
@@ -477,6 +494,7 @@ async def create_scan_report_items(
     previous_by_obj = {}  # obj_id -> {mag, mjd, filter} of the detection before the last
     photstat_by_assoc_obj = {}  # assoc_obj_id -> PhotStat, for associated_objs' surveys
     groups_by_obj = defaultdict(list)  # obj_id -> group names currently saved to
+    spectra_by_obj = defaultdict(list)  # obj_id -> spectra, newest first
 
     # Fetch in chunks of objects: a single ``obj_id IN (...)`` over a long report
     # window (thousands of objects) pushes the planner off the obj_id index onto a
@@ -594,6 +612,16 @@ async def create_scan_report_items(
         ).all():
             assignments_by_obj[assignment.obj_id].append(assignment)
 
+        for spectrum in (
+            await session.scalars(
+                Spectrum.select(user_or_token, mode="read")
+                .options(joinedload(Spectrum.instrument))
+                .where(Spectrum.obj_id.in_(chunk_obj_ids))
+                .order_by(Spectrum.observed_at.desc())
+            )
+        ).all():
+            spectra_by_obj[spectrum.obj_id].append(spectrum)
+
         for comment in (
             await session.scalars(
                 Comment.select(user_or_token, mode="read")
@@ -686,6 +714,7 @@ async def create_scan_report_items(
                 ]
                 or None,
                 groups_saved_to=sorted(groups_by_obj.get(obj_id, [])) or None,
+                spectra=spectra_by_obj.get(obj_id, []),
             )
         )
     return items

--- a/skyportal/handlers/api/spectrum.py
+++ b/skyportal/handlers/api/spectrum.py
@@ -45,6 +45,7 @@ from ...models.schema import (
     SpectrumAsciiFilePostJSON,
     SpectrumPost,
 )
+from ...utils.assignment_status import mark_assignments_observed
 from ...utils.data_access import (
     accessible_group_ids_async,
     default_extra_share_group_ids,
@@ -434,6 +435,14 @@ async def post_spectrum(data, user_id, session):
     for observer in observers:
         observer.spectr_id = spec.id
         session.add(observer)
+
+    # Closing out the observing-run assignment by hand is easy to forget, so a
+    # spectrum that satisfies one marks it done in the same transaction.
+    await mark_assignments_observed(
+        session,
+        spec,
+        window_days=cfg.get("assignments.auto_observed_window_days", 1),
+    )
 
     await session.commit()
 

--- a/skyportal/handlers/mcp.py
+++ b/skyportal/handlers/mcp.py
@@ -80,12 +80,13 @@ UNSUPPORTED_PROTOCOL_VERSION = -32022
 TOOLS = {}
 
 
-def tool(name, description, properties, required=(), passthrough=None):
+def tool(name, description, properties, required=(), passthrough=None, writes=False):
     """Register a tool. The wrapped `async fn(handler, args)` returns the tool's
     content: a JSON value (also sent as structuredContent) or a plain string.
     Raise ToolError, or let handler.api() raise APIError, to report a tool
     execution error. `passthrough` names the endpoint whose remaining
-    parameters are accepted verbatim."""
+    parameters are accepted verbatim. `writes` marks a tool that changes state,
+    so a caller holding a read-only token can leave it out."""
 
     schema = {"type": "object", "properties": properties, "required": list(required)}
     if passthrough:
@@ -102,6 +103,7 @@ def tool(name, description, properties, required=(), passthrough=None):
             "name": name,
             "description": description,
             "inputSchema": schema,
+            "annotations": {"readOnlyHint": not writes},
             "validator": jsonschema.Draft202012Validator(schema),
             "fn": fn,
         }
@@ -187,6 +189,7 @@ async def get_sources(handler, args):
     },
     required=("id", "ra", "dec"),
     passthrough="POST /api/sources",
+    writes=True,
 )
 async def post_source(handler, args):
     return await handler.api("POST", "/api/sources", body=args)
@@ -248,6 +251,7 @@ async def get_photometry(handler, args):
     },
     required=("obj_id", "instrument_id", "mjd", "filter", "magsys"),
     passthrough="POST /api/photometry",
+    writes=True,
 )
 async def post_photometry(handler, args):
     return await handler.api("POST", "/api/photometry", body=args)
@@ -297,6 +301,7 @@ async def get_spectra(handler, args):
     },
     required=("obj_id", "instrument_id", "observed_at", "wavelengths", "fluxes"),
     passthrough="POST /api/spectrum",
+    writes=True,
 )
 async def post_spectrum(handler, args):
     return await handler.api("POST", "/api/spectrum", body=args)
@@ -530,6 +535,7 @@ async def get_gcn_event_comments(handler, args):
         "group_ids": _GROUP_IDS,
     },
     required=("dateobs", "text"),
+    writes=True,
 )
 async def post_gcn_event_comment(handler, args):
     dateobs = args.pop("dateobs")
@@ -668,6 +674,7 @@ async def run_broker_filter(handler, args):
         "name": _prop("string", "Informational name for the version."),
     },
     required=("broker_id", "filter_id", "altdata"),
+    writes=True,
 )
 async def post_broker_filter_version(handler, args):
     broker_id = args.pop("broker_id")
@@ -697,6 +704,7 @@ async def post_broker_filter_version(handler, args):
     },
     required=("broker_id", "filter_id", "active_fid"),
     passthrough="PATCH /api/brokers/{broker_id}/filters/{filter_id}",
+    writes=True,
 )
 async def activate_broker_filter_version(handler, args):
     broker_id = args.pop("broker_id")
@@ -719,6 +727,7 @@ async def activate_broker_filter_version(handler, args):
     },
     required=("name", "stream_id", "group_id"),
     passthrough="POST /api/filters",
+    writes=True,
 )
 async def post_filter(handler, args):
     return await handler.api("POST", "/api/filters", body=args)
@@ -967,7 +976,10 @@ class MCPHandler(BaseHandler):
         if method == "tools/list":
             return {
                 "tools": [
-                    {k: t[k] for k in ("name", "description", "inputSchema")}
+                    {
+                        k: t[k]
+                        for k in ("name", "description", "inputSchema", "annotations")
+                    }
                     for t in TOOLS.values()
                 ],
                 "ttlMs": LIST_TTL_MS,

--- a/skyportal/tests/api_tests/sources_candidates/test_scan_reports.py
+++ b/skyportal/tests/api_tests/sources_candidates/test_scan_reports.py
@@ -16,7 +16,12 @@ from skyportal.models import (
     SuperObj,
 )
 from skyportal.tests import api
-from skyportal.tests.fixtures import CommentFactory, ObjFactory, PhotometryFactory
+from skyportal.tests.fixtures import (
+    CommentFactory,
+    ObjFactory,
+    PhotometryFactory,
+    SpectrumFactory,
+)
 from skyportal.utils.naive_datetime import utcnow_naive
 
 
@@ -228,6 +233,71 @@ def test_scan_report_item_includes_followup_and_assignment(
     assert sorted(item["data"]["groups_saved_to"]) == sorted(
         [public_group.name, public_group2.name]
     )
+
+
+def test_scan_report_item_includes_spectra(
+    public_filter,
+    public_group,
+    user,
+    upload_data_token,
+    lris,
+    cleanup_reports,
+):
+    """Spectra dates let a scanner tell whether a run's assignment was observed."""
+    now = utcnow_naive()
+    obj = ObjFactory(groups=[public_group])
+    DBSession.add(
+        Candidate(obj=obj, filter=public_filter, passed_at=now, uploader_id=user.id)
+    )
+    DBSession.add(Source(obj_id=obj.id, group_id=public_group.id, saved_by_id=user.id))
+    DBSession.commit()
+
+    observed_at = now - timedelta(hours=6)
+    spectrum = SpectrumFactory(
+        obj=obj,
+        instrument=lris,
+        observed_at=observed_at,
+        groups=[public_group],
+        owner_id=user.id,
+    )
+    DBSession.commit()
+
+    window = {
+        "start_date": (now - timedelta(days=1)).isoformat(),
+        "end_date": (now + timedelta(days=1)).isoformat(),
+    }
+    status, data = api(
+        "POST",
+        "candidates/scan_reports",
+        data={
+            "group_ids": [public_group.id],
+            "passed_filters_range": window,
+            "saved_candidates_range": {
+                "start_saved_date": (now - timedelta(days=1)).isoformat(),
+                "end_saved_date": (now + timedelta(days=1)).isoformat(),
+            },
+        },
+        token=upload_data_token,
+    )
+    assert status == 200, data
+
+    status, data = api("GET", "candidates/scan_reports", token=upload_data_token)
+    assert status == 200, data
+    report_id = data["data"]["reports"][0]["id"]
+    cleanup_reports.append(report_id)
+
+    status, data = api(
+        "GET", f"candidates/scan_reports/{report_id}/items", token=upload_data_token
+    )
+    assert status == 200, data
+    item = next(item for item in data["data"] if item["obj_id"] == obj.id)
+
+    spectra = item["data"]["spectra"]
+    assert spectra is not None
+    entry = next(s for s in spectra if s["instrument"] == lris.name)
+    assert entry["observed_at"].startswith(observed_at.strftime("%Y-%m-%dT%H:%M"))
+
+    SpectrumFactory.teardown(spectrum)
 
 
 def test_scan_report_item_includes_associated_objs(

--- a/skyportal/tests/api_tests/spectra_misc/test_assignment_auto_observed.py
+++ b/skyportal/tests/api_tests/spectra_misc/test_assignment_auto_observed.py
@@ -1,0 +1,139 @@
+"""An uploaded spectrum closes out the observing-run assignment it satisfies."""
+
+import pytest
+import sqlalchemy as sa
+
+from skyportal.models import ClassicalAssignment, DBSession
+from skyportal.tests import api
+
+# red_transients_run, the run behind public_assignment, sits on this date.
+RUN_DATE = "3021-02-27"
+
+
+@pytest.fixture()
+def posted_spectra(super_admin_token):
+    """Spectra posted through the API, deleted so the fixtures can tear down."""
+    ids = []
+    yield ids
+    for spectrum_id in ids:
+        api("DELETE", f"spectrum/{spectrum_id}", token=super_admin_token)
+
+
+def _post_spectrum(obj_id, instrument_id, observed_at, group_id, token, posted):
+    status, data = api(
+        "POST",
+        "spectrum",
+        data={
+            "obj_id": obj_id,
+            "observed_at": observed_at,
+            "instrument_id": instrument_id,
+            "wavelengths": [664, 665, 666],
+            "fluxes": [234.3, 232.1, 235.3],
+            "group_ids": [group_id],
+        },
+        token=token,
+    )
+    assert status == 200, data
+    posted.append(data["data"]["id"])
+    return data["data"]["id"]
+
+
+def _status_of(assignment_id):
+    DBSession().expire_all()
+    return DBSession().scalar(
+        sa.select(ClassicalAssignment.status).where(
+            ClassicalAssignment.id == assignment_id
+        )
+    )
+
+
+def test_spectrum_on_the_run_date_marks_the_assignment_done(
+    public_source, public_assignment, public_group, super_admin_token, posted_spectra
+):
+    assert _status_of(public_assignment.id) == "pending"
+
+    _post_spectrum(
+        public_source.id,
+        public_assignment.run.instrument.id,
+        f"{RUN_DATE}T08:00:00",
+        public_group.id,
+        super_admin_token,
+        posted_spectra,
+    )
+
+    assert _status_of(public_assignment.id) == "done"
+
+
+def test_spectrum_after_midnight_is_still_within_the_window(
+    public_source, public_assignment, public_group, super_admin_token, posted_spectra
+):
+    """A run's date is the local night, so the exposure can land on the next day."""
+    _post_spectrum(
+        public_source.id,
+        public_assignment.run.instrument.id,
+        "3021-02-28T06:00:00",
+        public_group.id,
+        super_admin_token,
+        posted_spectra,
+    )
+
+    assert _status_of(public_assignment.id) == "done"
+
+
+def test_spectrum_from_another_instrument_leaves_the_assignment_alone(
+    public_source,
+    public_assignment,
+    public_group,
+    lris,
+    super_admin_token,
+    posted_spectra,
+):
+    _post_spectrum(
+        public_source.id,
+        lris.id,
+        f"{RUN_DATE}T08:00:00",
+        public_group.id,
+        super_admin_token,
+        posted_spectra,
+    )
+
+    assert _status_of(public_assignment.id) == "pending"
+
+
+def test_spectrum_outside_the_window_leaves_the_assignment_alone(
+    public_source, public_assignment, public_group, super_admin_token, posted_spectra
+):
+    _post_spectrum(
+        public_source.id,
+        public_assignment.run.instrument.id,
+        "3021-03-05T08:00:00",
+        public_group.id,
+        super_admin_token,
+        posted_spectra,
+    )
+
+    assert _status_of(public_assignment.id) == "pending"
+
+
+def test_an_explicit_verdict_is_never_overwritten(
+    public_source, public_assignment, public_group, super_admin_token, posted_spectra
+):
+    """Someone who said "not done" has decided; a later spectrum must not undo it."""
+    assignment = DBSession().scalar(
+        sa.select(ClassicalAssignment).where(
+            ClassicalAssignment.id == public_assignment.id
+        )
+    )
+    assignment.status = "not done"
+    DBSession().commit()
+
+    _post_spectrum(
+        public_source.id,
+        public_assignment.run.instrument.id,
+        f"{RUN_DATE}T08:00:00",
+        public_group.id,
+        super_admin_token,
+        posted_spectra,
+    )
+
+    assert _status_of(public_assignment.id) == "not done"

--- a/skyportal/tests/utils/test_assistant.py
+++ b/skyportal/tests/utils/test_assistant.py
@@ -3,12 +3,12 @@
 import json
 
 from skyportal.utils.assistant import (
-    answer_text,
     build_messages,
     condense,
     describe_context,
     describe_user,
     is_enabled,
+    select_tools,
     system_prompt,
 )
 
@@ -101,29 +101,6 @@ def test_non_json_is_truncated_with_its_length():
     assert "9000 characters in total" in result
 
 
-def test_the_answer_is_the_content_a_model_returns():
-    assert answer_text({"content": "r = 22.73 at T+12.6 h"}) == "r = 22.73 at T+12.6 h"
-    assert answer_text({"content": "  spaced  "}) == "spaced"
-
-
-def test_a_reasoning_model_answers_from_reasoning_content():
-    """Some models leave `content` empty and put their text elsewhere."""
-    assert (
-        answer_text({"content": "", "reasoning_content": "the burst faded"})
-        == "the burst faded"
-    )
-    assert answer_text({"reasoning_content": "the burst faded"}) == "the burst faded"
-
-
-def test_content_wins_when_a_model_returns_both():
-    assert answer_text({"content": "final", "reasoning_content": "thinking"}) == "final"
-
-
-def test_an_empty_reply_is_empty():
-    assert answer_text({}) == ""
-    assert answer_text({"content": None, "reasoning_content": None}) == ""
-
-
 def test_the_last_turn_sent_is_a_question():
     """An OpenAI-compatible server refuses a list ending in assistant turns, so a
     previous failure's apology must not be the last thing the model sees."""
@@ -145,3 +122,34 @@ def test_an_answered_exchange_still_ends_on_the_new_question():
     ]
     messages = build_messages(conversation, 40)
     assert [m["role"] for m in messages] == ["system", "user", "assistant", "user"]
+
+
+_TOOLS = [
+    {"name": "get_sources"},
+    {"name": "get_photometry"},
+    {"name": "analyze_light_curve"},
+    {"name": "get_gcn_event_extractions"},
+    {"name": "get_broker_filter"},
+    {"name": "convert_time"},
+]
+
+
+def _names(tools):
+    return {tool["name"] for tool in tools}
+
+
+def test_a_page_is_offered_only_its_own_subjects():
+    assert _names(select_tools(_TOOLS, "gcn_event")) == {
+        "get_gcn_event_extractions",
+        "convert_time",
+    }
+
+
+def test_a_tool_belonging_to_no_subject_is_offered_everywhere():
+    for context in (None, "source", "gcn_event", "earthquake"):
+        assert "convert_time" in _names(select_tools(_TOOLS, context))
+
+
+def test_a_page_with_no_subjects_is_offered_everything():
+    assert select_tools(_TOOLS, "earthquake") == _TOOLS
+    assert select_tools(_TOOLS, None) == _TOOLS

--- a/skyportal/tests/utils/test_assistant.py
+++ b/skyportal/tests/utils/test_assistant.py
@@ -3,6 +3,7 @@
 import json
 
 from skyportal.utils.assistant import (
+    answer_text,
     build_messages,
     condense,
     describe_context,
@@ -18,9 +19,14 @@ def _message(text, system=False):
 
 def test_conversation_becomes_alternating_roles():
     messages = build_messages(
-        [_message("what is this?"), _message("An X-ray Flash.", system=True)], 40
+        [
+            _message("what is this?"),
+            _message("An X-ray Flash.", system=True),
+            _message("how bright?"),
+        ],
+        40,
     )
-    assert [m["role"] for m in messages] == ["system", "user", "assistant"]
+    assert [m["role"] for m in messages] == ["system", "user", "assistant", "user"]
     assert messages[1]["content"] == "what is this?"
 
 
@@ -93,3 +99,49 @@ def test_non_json_is_truncated_with_its_length():
     result = condense("z" * 9000, budget=100)
     assert result.startswith("z" * 100)
     assert "9000 characters in total" in result
+
+
+def test_the_answer_is_the_content_a_model_returns():
+    assert answer_text({"content": "r = 22.73 at T+12.6 h"}) == "r = 22.73 at T+12.6 h"
+    assert answer_text({"content": "  spaced  "}) == "spaced"
+
+
+def test_a_reasoning_model_answers_from_reasoning_content():
+    """Some models leave `content` empty and put their text elsewhere."""
+    assert (
+        answer_text({"content": "", "reasoning_content": "the burst faded"})
+        == "the burst faded"
+    )
+    assert answer_text({"reasoning_content": "the burst faded"}) == "the burst faded"
+
+
+def test_content_wins_when_a_model_returns_both():
+    assert answer_text({"content": "final", "reasoning_content": "thinking"}) == "final"
+
+
+def test_an_empty_reply_is_empty():
+    assert answer_text({}) == ""
+    assert answer_text({"content": None, "reasoning_content": None}) == ""
+
+
+def test_the_last_turn_sent_is_a_question():
+    """An OpenAI-compatible server refuses a list ending in assistant turns, so a
+    previous failure's apology must not be the last thing the model sees."""
+    conversation = [
+        {"text": "what is this source?", "system": False},
+        {"text": "Something went wrong while looking that up.", "system": True},
+        {"text": "Something went wrong while looking that up.", "system": True},
+    ]
+    messages = build_messages(conversation, 40)
+    assert messages[-1]["role"] == "user"
+    assert messages[-1]["content"] == "what is this source?"
+
+
+def test_an_answered_exchange_still_ends_on_the_new_question():
+    conversation = [
+        {"text": "first question", "system": False},
+        {"text": "first answer", "system": True},
+        {"text": "second question", "system": False},
+    ]
+    messages = build_messages(conversation, 40)
+    assert [m["role"] for m in messages] == ["system", "user", "assistant", "user"]

--- a/skyportal/tests/utils/test_assistant.py
+++ b/skyportal/tests/utils/test_assistant.py
@@ -8,7 +8,6 @@ from skyportal.utils.assistant import (
     describe_context,
     describe_user,
     is_enabled,
-    select_tools,
     system_prompt,
 )
 
@@ -95,6 +94,48 @@ def test_long_lists_keep_whole_items():
     assert "of 50 not shown" in result["note"]
 
 
+def test_a_long_run_of_numbers_becomes_its_range():
+    """An answer can use the range a spectrum covers, never its fluxes."""
+    payload = json.dumps(
+        {"obj_id": "ZTF26abpanks", "wavelengths": list(range(3000, 9000))}
+    )
+    result = json.loads(condense(payload, budget=2000))
+    assert result["wavelengths"] == {"n": 6000, "min": 3000, "max": 8999}
+    assert "_dropped" not in result
+
+
+def test_a_bulky_field_is_cut_down_before_it_is_dropped():
+    payload = json.dumps(
+        {
+            "obj_id": "ZTF26abpanks",
+            "spectra": [{"id": i, "flux": "y" * 4000} for i in range(6)],
+        }
+    )
+    result = json.loads(condense(payload, budget=2000))
+    assert result["obj_id"] == "ZTF26abpanks"
+    assert "spectra" in result, "the one field asked about must not be dropped whole"
+
+
+def test_every_item_is_shown_when_none_of_them_fit_whole():
+    payload = json.dumps([{"id": i, "text": "y" * 4000} for i in range(6)])
+    result = json.loads(condense(payload, budget=2000))
+    assert [item["id"] for item in result["items"]] == [0, 1, 2, 3, 4, 5]
+    assert "cut down to fit" in result["note"]
+    assert "will not add to it" in result["note"], "the model must not page for more"
+
+
+def test_a_list_shows_whichever_form_names_more_items():
+    """Two events kept whole answer less than every event cut to its date."""
+    payload = json.dumps([{"id": i, "text": "y" * 2000} for i in range(37)])
+    result = json.loads(condense(payload, budget=20000))
+    assert len(result["items"]) == 37
+
+
+def test_a_trimmed_list_is_still_valid_json():
+    payload = json.dumps([{"id": i, "text": "y" * 9000} for i in range(3)])
+    json.loads(condense(payload, budget=500))
+
+
 def test_non_json_is_truncated_with_its_length():
     result = condense("z" * 9000, budget=100)
     assert result.startswith("z" * 100)
@@ -122,34 +163,3 @@ def test_an_answered_exchange_still_ends_on_the_new_question():
     ]
     messages = build_messages(conversation, 40)
     assert [m["role"] for m in messages] == ["system", "user", "assistant", "user"]
-
-
-_TOOLS = [
-    {"name": "get_sources"},
-    {"name": "get_photometry"},
-    {"name": "analyze_light_curve"},
-    {"name": "get_gcn_event_extractions"},
-    {"name": "get_broker_filter"},
-    {"name": "convert_time"},
-]
-
-
-def _names(tools):
-    return {tool["name"] for tool in tools}
-
-
-def test_a_page_is_offered_only_its_own_subjects():
-    assert _names(select_tools(_TOOLS, "gcn_event")) == {
-        "get_gcn_event_extractions",
-        "convert_time",
-    }
-
-
-def test_a_tool_belonging_to_no_subject_is_offered_everywhere():
-    for context in (None, "source", "gcn_event", "earthquake"):
-        assert "convert_time" in _names(select_tools(_TOOLS, context))
-
-
-def test_a_page_with_no_subjects_is_offered_everything():
-    assert select_tools(_TOOLS, "earthquake") == _TOOLS
-    assert select_tools(_TOOLS, None) == _TOOLS

--- a/skyportal/utils/assignment_status.py
+++ b/skyportal/utils/assignment_status.py
@@ -1,0 +1,57 @@
+"""Close out observing-run assignments once their data arrives.
+
+Marking an assignment observed is a manual step that is easy to forget, and on
+an instrument like NGPS there are too many per night to keep up with by hand.
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.orm import aliased
+
+from ..models import ClassicalAssignment, ObservingRun
+
+# Only a pending assignment is ever touched, so an explicit "not done" stands.
+PENDING = "pending"
+DONE = "done"
+
+
+async def mark_assignments_observed(session, spectrum, window_days=1):
+    """Mark the assignments a spectrum satisfies as done.
+
+    A spectrum that names its assignment settles the question outright. Most
+    arrive without that link, so the fallback matches the run's own instrument
+    and a calendar date within `window_days` of the exposure -- a run's date is
+    the local night, so an exposure after midnight UTC lands on the next day.
+
+    Returns
+    -------
+    list of int
+        IDs of the assignments that were marked done.
+    """
+    if spectrum.observed_at is None:
+        return []
+
+    query = ClassicalAssignment.select(session.user_or_token, mode="update").where(
+        ClassicalAssignment.status == PENDING
+    )
+
+    if spectrum.assignment_id is not None:
+        query = query.where(ClassicalAssignment.id == spectrum.assignment_id)
+    else:
+        # Without a named assignment there is nothing to match on but the run's
+        # instrument and date, which `window_days=None` declines to do.
+        if window_days is None or spectrum.instrument_id is None:
+            return []
+        observed_on = spectrum.observed_at.date()
+        # Aliased: the access-controlled select already joins ObservingRun for
+        # its group-scoped read rule, and joining it again is a duplicate alias.
+        run = aliased(ObservingRun)
+        query = query.join(run, run.id == ClassicalAssignment.run_id).where(
+            ClassicalAssignment.obj_id == spectrum.obj_id,
+            run.instrument_id == spectrum.instrument_id,
+            sa.func.abs(run.calendar_date - observed_on) <= window_days,
+        )
+
+    assignments = (await session.scalars(query)).unique().all()
+    for assignment in assignments:
+        assignment.status = DONE
+    return [assignment.id for assignment in assignments]

--- a/skyportal/utils/assistant.py
+++ b/skyportal/utils/assistant.py
@@ -23,6 +23,36 @@ CONTEXT_DESCRIPTIONS = {
 }
 
 
+# Every subject a tool name can carry. A tool matching none of them is general,
+# so it stays on offer whatever page the question came from.
+SUBJECTS = ("source", "photometry", "spectr", "light_curve", "gcn", "filter")
+
+# The subjects each page's questions are about. A page not named here is offered
+# every tool.
+CONTEXT_SUBJECTS = {
+    "source": ("source", "photometry", "spectr", "light_curve"),
+    "spectrum": ("spectr", "source", "photometry"),
+    "gcn_event": ("gcn",),
+}
+
+
+def select_tools(tools, context_type):
+    """The tools worth offering a question asked from this page.
+
+    Every round-trip re-sends the whole list, so a tool the page's subject will
+    never need is paid for on each one.
+    """
+    subjects = CONTEXT_SUBJECTS.get(context_type)
+    if not subjects:
+        return tools
+    return [
+        tool
+        for tool in tools
+        if any(subject in tool["name"] for subject in subjects)
+        or not any(subject in tool["name"] for subject in SUBJECTS)
+    ]
+
+
 def describe_context(context_type, context_id):
     if not context_type or context_id in (None, ""):
         return None
@@ -86,18 +116,6 @@ def post_to_assistant(cfg, message_id):
     except requests.exceptions.RequestException:
         return False
     return True
-
-
-def answer_text(message):
-    """The answer in a model's reply.
-
-    A reasoning model can leave `content` empty and put its text in
-    `reasoning_content`; returning that beats returning nothing.
-    """
-    for key in ("content", "reasoning_content"):
-        if text := (message.get(key) or "").strip():
-            return text
-    return ""
 
 
 def condense(text, budget=6000):

--- a/skyportal/utils/assistant.py
+++ b/skyportal/utils/assistant.py
@@ -56,15 +56,20 @@ def system_prompt(context_type=None, context_id=None, user=None):
 def build_messages(
     messages, max_messages, context_type=None, context_id=None, user=None
 ):
+    turns = [
+        {
+            "role": "assistant" if message["system"] else "user",
+            "content": message["text"],
+        }
+        for message in messages[-max_messages:]
+    ]
+    # A model answers a question, so the last turn has to be one. Trailing
+    # assistant turns are refused outright by an OpenAI-compatible server.
+    while turns and turns[-1]["role"] == "assistant":
+        turns.pop()
     return [
         {"role": "system", "content": system_prompt(context_type, context_id, user)},
-        *(
-            {
-                "role": "assistant" if message["system"] else "user",
-                "content": message["text"],
-            }
-            for message in messages[-max_messages:]
-        ),
+        *turns,
     ]
 
 
@@ -81,6 +86,18 @@ def post_to_assistant(cfg, message_id):
     except requests.exceptions.RequestException:
         return False
     return True
+
+
+def answer_text(message):
+    """The answer in a model's reply.
+
+    A reasoning model can leave `content` empty and put its text in
+    `reasoning_content`; returning that beats returning nothing.
+    """
+    for key in ("content", "reasoning_content"):
+        if text := (message.get(key) or "").strip():
+            return text
+    return ""
 
 
 def condense(text, budget=6000):

--- a/skyportal/utils/assistant.py
+++ b/skyportal/utils/assistant.py
@@ -7,7 +7,10 @@ time-domain and multi-messenger astronomy. You are talking with an astronomer \
 in a chat panel of the app.
 
 Use the tools to look things up rather than guessing; if the tools do not answer \
-the question, say so plainly. When a value came from a circular or another \
+the question, say so plainly. Do not work out for yourself where a target sits \
+in the sky at a given hour, when it rises or sets, or whether it is observable \
+from a telescope tonight: you have no clock and no ephemeris, and the figures \
+you produce will be wrong. When a value came from a circular or another \
 record, quote the text it came from so a reader can check it. Be brief: this is a \
 chat message, not a report."""
 
@@ -18,39 +21,10 @@ CONTEXT_DESCRIPTIONS = {
     "source": "source {id}",
     "gcn_event": "GCN event {id}",
     "spectrum": "spectrum {id}",
+    "filter": "broker filter {id}, written as broker id / filter id",
     "earthquake": "earthquake {id}",
     "shift": "shift {id}",
 }
-
-
-# Every subject a tool name can carry. A tool matching none of them is general,
-# so it stays on offer whatever page the question came from.
-SUBJECTS = ("source", "photometry", "spectr", "light_curve", "gcn", "filter")
-
-# The subjects each page's questions are about. A page not named here is offered
-# every tool.
-CONTEXT_SUBJECTS = {
-    "source": ("source", "photometry", "spectr", "light_curve"),
-    "spectrum": ("spectr", "source", "photometry"),
-    "gcn_event": ("gcn",),
-}
-
-
-def select_tools(tools, context_type):
-    """The tools worth offering a question asked from this page.
-
-    Every round-trip re-sends the whole list, so a tool the page's subject will
-    never need is paid for on each one.
-    """
-    subjects = CONTEXT_SUBJECTS.get(context_type)
-    if not subjects:
-        return tools
-    return [
-        tool
-        for tool in tools
-        if any(subject in tool["name"] for subject in subjects)
-        or not any(subject in tool["name"] for subject in SUBJECTS)
-    ]
 
 
 def describe_context(context_type, context_id):
@@ -118,6 +92,18 @@ def post_to_assistant(cfg, message_id):
     return True
 
 
+# Below this a per-item share carries nothing worth reading.
+MIN_ITEM_SHARE = 300
+
+
+def _reparsed(text):
+    """A condensed result as JSON where it still parses, else as its own text."""
+    try:
+        return json.loads(text)
+    except ValueError:
+        return text
+
+
 def condense(text, budget=6000):
     """Fit a tool result into a context budget without handing back broken JSON."""
     if len(text) <= budget:
@@ -135,14 +121,30 @@ def condense(text, budget=6000):
             if len(json.dumps(kept)) > budget:
                 kept.pop()
                 break
-        if not kept:
-            note = f"first of {len(payload)} shown, trimmed"
-            return condense(json.dumps(payload[0], default=str), budget) + f"\n{note}"
-        note = f"{len(payload) - len(kept)} more of {len(payload)} not shown"
-        return json.dumps({"items": kept, "note": note})
+        # Two events kept whole answer less than every event cut to its date,
+        # so take whichever form names more of them.
+        room = max(1, min(len(payload), budget // MIN_ITEM_SHARE))
+        if len(kept) >= room:
+            note = f"{len(payload) - len(kept)} more of {len(payload)} not shown"
+            return json.dumps({"items": kept, "note": note})
+        shown = payload[:room]
+        share = budget // len(shown)
+        items = [
+            _reparsed(condense(json.dumps(item, default=str), share)) for item in shown
+        ]
+        left = len(payload) - len(shown)
+        note = "each item cut down to fit; asking for more per page will not add to it"
+        if left:
+            note = f"{len(shown)} of {len(payload)} shown, " + note
+        return json.dumps({"items": items, "note": note})
 
     if not isinstance(payload, dict):
         return text[:budget]
+
+    for key, value in payload.items():
+        smaller = _shrunk(value, budget)
+        if smaller is not None:
+            payload[key] = smaller
 
     dropped = []
     by_size = sorted(payload, key=lambda k: -len(json.dumps(payload[k], default=str)))
@@ -154,3 +156,27 @@ def condense(text, budget=6000):
         dropped.append(key)
         payload["_dropped"] = f"fields too large to show: {', '.join(dropped)}"
     return json.dumps(payload, default=str)
+
+
+def _shrunk(value, budget):
+    """A smaller stand-in for an oversized value, or None if there isn't one.
+
+    A field is worth shrinking before it is worth dropping: a spectrum reduced
+    to its date and instrument still answers a question, and a deleted one
+    answers nothing.
+    """
+    if (
+        isinstance(value, list)
+        and len(value) >= 20
+        and all(
+            isinstance(item, (int, float)) and not isinstance(item, bool)
+            for item in value
+        )
+    ):
+        # An answer can use the range a spectrum covers, never its 214 fluxes.
+        return {"n": len(value), "min": min(value), "max": max(value)}
+    if not isinstance(value, (list, dict)) or not value:
+        return None
+    if len(json.dumps(value, default=str)) <= budget:
+        return None
+    return _reparsed(condense(json.dumps(value, default=str), budget))

--- a/static/js/components/broker/BrokerFilterPage.tsx
+++ b/static/js/components/broker/BrokerFilterPage.tsx
@@ -1,5 +1,6 @@
 import { useParams } from "react-router-dom";
 
+import { useCommentTarget } from "../../contexts/CommentPanelContext";
 import { setBrokerFilterTarget } from "../../ducks/brokerFilterTarget";
 import BoomFilterPlugins from "../filter/boom/BoomFilterPlugins";
 
@@ -7,9 +8,14 @@ import BoomFilterPlugins from "../filter/boom/BoomFilterPlugins";
 // carries the broker id (so the filter ducks target /api/brokers/{id}/...) and
 // the skyportal Filter id (`fid`, which BoomFilterPlugins reads from the URL).
 const BrokerFilterPage = () => {
-  const { brokerId } = useParams();
+  const { brokerId, fid } = useParams();
   // Set synchronously, before BoomFilterPlugins' mount effects (which read it).
   setBrokerFilterTarget(brokerId ? Number(brokerId) : null);
+  useCommentTarget(
+    brokerId && fid
+      ? { type: "filter", id: Number(fid), brokerId: Number(brokerId) }
+      : null,
+  );
   return <BoomFilterPlugins />;
 };
 

--- a/static/js/components/candidate/scan_reports/ReportItems.tsx
+++ b/static/js/components/candidate/scan_reports/ReportItems.tsx
@@ -93,6 +93,7 @@ const ReportItem = ({ reportId, isMultiGroup }: ReportItemProps) => {
             <FieldTitle>classifications</FieldTitle>
             <FieldTitle>followup / priority</FieldTitle>
             <FieldTitle>observing run / priority</FieldTitle>
+            <FieldTitle>spectra</FieldTitle>
             <FieldTitle>detections (survey)</FieldTitle>
             <FieldTitle sx={{ flex: 1 }}>host redshift</FieldTitle>
             <FieldTitle sx={{ flex: 1 }}>z (DESI)</FieldTitle>
@@ -268,6 +269,27 @@ const ReportItem = ({ reportId, isMultiGroup }: ReportItemProps) => {
                       >
                         <Chip
                           label={`${assignment.instrument}: ${assignment.priority}`}
+                          size="small"
+                        />
+                      </Tooltip>
+                    ),
+                  )}
+                </Field>
+                <Field>
+                  {reportItem.data.spectra?.map(
+                    (spectrum: any, index: number) => (
+                      <Tooltip
+                        title={`${spectrum.instrument ?? "spectrum"}${
+                          spectrum.observed_at
+                            ? ` — ${spectrum.observed_at}`
+                            : ""
+                        }${spectrum.origin ? ` — ${spectrum.origin}` : ""}`}
+                        key={index}
+                      >
+                        <Chip
+                          label={`${spectrum.instrument ?? "?"}: ${
+                            spectrum.observed_at?.split("T")[0] ?? "?"
+                          }`}
                           size="small"
                         />
                       </Tooltip>

--- a/static/js/components/comment/AssistantThread.tsx
+++ b/static/js/components/comment/AssistantThread.tsx
@@ -65,7 +65,13 @@ const AssistantThread = ({ channel, target }: AssistantThreadProps) => {
       text,
       channel,
       ...(target
-        ? { context_type: target.type, context_id: String(target.id) }
+        ? {
+            context_type: target.type,
+            context_id:
+              target.type === "filter"
+                ? `${target.brokerId}/${target.id}`
+                : String(target.id),
+          }
         : {}),
     })
       .unwrap()

--- a/static/js/components/comment/CommentPanel.tsx
+++ b/static/js/components/comment/CommentPanel.tsx
@@ -77,8 +77,9 @@ const CommentPanel = ({ inline = false }: CommentPanelProps) => {
   const [channelToDelete, setChannelToDelete] = useState<string | null>(null);
   const downSm = useMediaQuery((theme: any) => theme.breakpoints.down("sm"));
 
+  const hasComments = target?.type === "source" || target?.type === "gcn_event";
   const showComments =
-    !!target && (inline || !commentsInline || target.type !== "source");
+    hasComments && (inline || !commentsInline || target.type !== "source");
   const showAssistant = !inline && assistantEnabled;
   const isComments = showComments && (space === "comments" || !showAssistant);
   const activeSpace: ChatSpace = isComments ? "comments" : "assistant";
@@ -248,7 +249,9 @@ const CommentPanel = ({ inline = false }: CommentPanelProps) => {
     ? null
     : target.type === "source"
       ? target.id
-      : dayjs(target.dateobs).format("YYMMDD HH:mm:ss");
+      : target.type === "filter"
+        ? `filter ${target.id}`
+        : dayjs(target.dateobs).format("YYMMDD HH:mm:ss");
 
   if (!showComments && !showAssistant) return null;
 

--- a/static/js/contexts/CommentPanelContext.tsx
+++ b/static/js/contexts/CommentPanelContext.tsx
@@ -11,7 +11,9 @@ import { MAIN_CHANNEL } from "../components/comment/channels";
 
 export type CommentTarget =
   | { type: "source"; id: string }
-  | { type: "gcn_event"; id: number; dateobs: string };
+  | { type: "gcn_event"; id: number; dateobs: string }
+  // A filter has no comments of its own; the panel offers only the assistant.
+  | { type: "filter"; id: number; brokerId: number };
 
 export type ChatSpace = "comments" | "assistant";
 


### PR DESCRIPTION
Two things landed on this branch.

## Scan report items list spectra

Scan report items now carry the spectra taken of each candidate, and an
assignment's status is derived from whether a spectrum was actually observed.

## The assistant answers in about a third of the time

Measured against a real GCN event on production, a question that took 90 to 105
seconds now takes 30.

**The model no longer thinks before answering.** This was the whole of it. Qwen3
reasons by default and that reasoning is thrown away. On one question it
generated 1333 tokens to produce a 220 token answer. With thinking off the same
question took an extra tool round-trip and still finished in half the time, with
a fuller answer:

| | time | output tokens |
|---|---|---|
| thinking on | 90.4 s | 1333 |
| thinking off | 48.2 s | 617 |

`app.assistant.thinking` turns it back on for a model that needs it.

**Write tools are no longer offered, and refusing them moved.** Tools now declare
`readOnlyHint`, the MCP standard annotation for this, and only the read-only ones
are offered. `call_tool` refuses any tool that was not offered, which is now what
stops text arriving from a GCN circular talking the model into writing.

The service used to answer on a token with no ACLs. That made an admin's
assistant strictly less able than the admin: most ACLs reach a user through a
role rather than directly, and permission to see a broker filter comes from the
`System admin` ACL rather than from group membership, so the assistant saw 41 of
279 filters and reported that a filter the user was looking at did not exist. The
token now carries the user's own permissions.

**The assistant knows which filter a filter page is showing.** `/brokers/1/filter/1383`
sets a filter target, so "tell me about this filter" resolves without the ids
being typed. A filter has no comments, so the panel offers only the assistant
there.

**A question can no longer run away.** `max_tool_calls` bounded round-trips, not
calls, and one round-trip can request many tools at once, so a model paging
through GCN events made 28 calls under a cap of 8 and took 263 seconds to return
nothing. It now counts calls. The last-chance "answer now" call is also made with
no tools, since offering them let the model ask for another instead of answering
and the reply came back empty.

**The assistant can see spectra again.** A tool result too big for the context
budget was cut down by dropping its largest field, so `get_spectra` on a source
with six spectra returned 212 KB, lost the `spectra` field whole, and left the
model with an object id. Two changes, both general rather than about spectra: a
long run of numbers is replaced by its count and range, since an answer can use
the range a spectrum covers but never its 214 fluxes; and a field too large to
show is cut down before it is dropped, so a list inside an object is trimmed the
way a list at the top level already was. The same call now returns 5.3 KB
carrying all six spectra with their dates, instruments and wavelength ranges.

Trimming a list also produces valid JSON in every case now. When no item fit
whole it used to return one item followed by a plain-text note, which nothing
downstream could parse.

A trimmed list now takes whichever form names more items. Two GCN events kept
whole answer less than every event cut down to its date, and because both forms
came back the same size however many were asked for, the model concluded the API
returned one event per page and paged for four minutes. Asking for a week of
events now shows 50 rather than 2, and the note says plainly that paging will not
add to it. The per-result budget is configurable and has been raised to 20000
characters, which costs little: prompt processing is cheap next to generation.

Also here: a question is bounded as a whole rather than per request, since eight
round-trips of a 300 second timeout is not a bound anyone wants; a message that
already has an answer is not answered twice; and a conversation is built as it
stood when the question was asked, so an earlier failure's apology is neither
the last thing the model sees nor context for the next answer.

**The assistant no longer works out observability for itself.** Asked whether a
source was up from Palomar tonight, it answered yes and gave a maximum altitude
of 59 degrees, a culmination time and a season. There is no observability tool,
so all of it came from the model: the true maximum altitude for that declination
from Palomar is 46.5 degrees, and it had the date wrong by three weeks. It is now
told it has no clock and no ephemeris, and it says so instead. Questions that do
have tools behind them are unaffected.

Two things were tried and dropped, recorded so nobody spends the afternoon on
them again. Restricting the tool list to the page a question came from makes no
difference: over nine paired runs the page's own four tools took 33.0 s on
average against 35.2 s for all eleven, with identical spread (22.4 s against
22.7 s) and slightly shorter answers. And prompt processing is not worth
optimising either, so prefix caching has little to save here. One round-trip
spent 12.0 s on 1079 prompt tokens and 170 output tokens, and the output alone
accounts for 12.8 s at the measured 13.3 tokens per second. Tool calls are not
worth optimising: on the question above they cost 0.7 seconds of 105.
