### PR TITLE
Find the thumbnail folder without relying on the repository folder name

### DIFF
--- a/skyportal/handlers/api/thumbnail.py
+++ b/skyportal/handlers/api/thumbnail.py
@@ -90,14 +90,11 @@ async def post_thumbnail(data, user_id, session):
     if await session.scalar(Obj.select(user).where(Obj.id == obj_id)) is None:
         raise AttributeError(f"Invalid obj_id: {obj_id}")
 
-    basedir = Path(os.path.dirname(__file__)) / ".." / ".."
+    basedir = Path(__file__).parents[3]
     obj_hash = hashlib.sha256(obj_id.encode("utf-8")).hexdigest()
 
     required_depth = 2
     subfolders = "/".join(obj_hash[i * 2 : (i + 1) * 2] for i in range(required_depth))
-
-    if os.path.abspath(basedir).endswith("skyportal/skyportal"):
-        basedir = basedir / ".."
 
     # BOOM emits title-case names ("Ztf"), which the constraint reads as not "ZTF".
     survey = (data.get("survey") or "").strip().upper() or None


### PR DESCRIPTION
`post_thumbnail` looked for the `static/thumbnails` folder by checking whether the path ended with `skyportal/skyportal`, which is only true when the clone is named `skyportal`. Any other folder name (a second clone, a rename, some deployment layouts) failed the check, and thumbnails were written to `<repo>/skyportal/static/thumbnails/`, a folder the server never reads. The images then came back as 404 everywhere: source pages, dashboard widgets, finding charts.

The base folder is now taken from the file position, so the name of the clone no longer matters. This matches how `skyportal/utils/tess.py` finds the `data` folder and where `tools/clear_data.py` looks for the thumbnails.