### PR TITLE
Refresh the photometry and spectra tables after sharing data

### DIFF
--- a/static/js/ducks/source.ts
+++ b/static/js/ducks/source.ts
@@ -580,6 +580,7 @@ export const sourceApi = skyportalApi.injectEndpoints({
         method: "POST",
         body: data,
       }),
+      invalidatesTags: ["Photometry", "Spectra"],
     }),
     uploadPhotometry: build.mutation<any, Record<string, any>>({
       query: (data) => ({


### PR DESCRIPTION
The share mutation now invalidates the photometry and spectra caches, so the tables no longer rely on a websocket message to show the new groups.