### PR TITLE
make the autosave column the only store for filter auto-save

### DIFF
--- a/skyportal/handlers/api/broker.py
+++ b/skyportal/handlers/api/broker.py
@@ -11,7 +11,7 @@ from baselayer.log import make_log
 
 from ...broker_apis.interface import survey_permissions
 from ...enum_types import ALLOWED_BROKER_CLASSNAMES, ALLOWED_MAGSYSTEMS
-from ...models import Broker, Filter, GroupUser, Stream, set_autosave
+from ...models import Broker, Filter, GroupUser, Stream
 from ..base import BaseHandler
 
 log = make_log("api/broker")
@@ -1326,7 +1326,7 @@ class BrokerFiltersHandler(BaseHandler):
                     )
                 f.broker_id = broker.id
                 if "autosave" in body.model_fields_set:
-                    set_autosave(f, body.autosave)
+                    f.autosave = bool(body.autosave)
                 ad = dict(f.altdata) if isinstance(f.altdata, dict) else {}
                 ad["lasair"] = {
                     "selected": selected,
@@ -1371,7 +1371,6 @@ class BrokerFiltersHandler(BaseHandler):
                     f.altdata = {
                         "boom": {"filter_id": resp["id"]},
                         "autoAnnotate": True,
-                        "autoSave": False,
                         "autoFollowup": False,
                         "filters": [{"fid": new_fid, "version": body.filters}],
                     }
@@ -1480,13 +1479,13 @@ class BrokerFiltersHandler(BaseHandler):
                         active_fid=body.active_fid,
                         skip_validation=True,
                     )
-                for flag in ("autoAnnotate", "autoSave", "autoFollowup"):
+                for flag in ("autoAnnotate", "autoFollowup"):
                     if flag in body.model_fields_set:
                         f.altdata[flag] = getattr(body, flag)
                         flag_modified(f, "altdata")
                 # autoSave is the UI's name for the column ingestion reads.
                 if "autoSave" in body.model_fields_set:
-                    set_autosave(f, body.autoSave)
+                    f.autosave = bool(body.autoSave)
                 # Groups whose members are not auto-saved (e.g. junk).
                 if "autoSaveIgnoreGroupIds" in body.model_fields_set:
                     f.altdata["autoSaveIgnoreGroupIds"] = [

--- a/skyportal/handlers/api/filter.py
+++ b/skyportal/handlers/api/filter.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import joinedload, load_only
 
 from baselayer.app.access import auth_or_token, permissions
 
-from ...models import Broker, Filter, set_autosave
+from ...models import Broker, Filter
 from ..base import BaseHandler
 from .group import has_admin_access_for_group
 
@@ -281,7 +281,7 @@ class FilterHandler(BaseHandler):
             if body.altdata is not None:
                 f.altdata = body.altdata
             if body.autosave is not None:
-                set_autosave(f, body.autosave)
+                f.autosave = body.autosave
 
             await session.commit()
             return self.success()

--- a/skyportal/models/filter.py
+++ b/skyportal/models/filter.py
@@ -1,4 +1,4 @@
-__all__ = ["Filter", "set_autosave"]
+__all__ = ["Filter"]
 
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import JSONB
@@ -78,16 +78,3 @@ class Filter(Base):
         order_by="Candidate.passed_at",
         doc="Candidates that have passed the filter.",
     )
-
-
-def set_autosave(filter_, value):
-    """Set a Filter's autosave, keeping the broker UI's mirror in step.
-
-    Ingestion honours the `autosave` column; the broker filter UI reads
-    `altdata['autoSave']`. Writing one without the other lets a filter claim in
-    the UI that it auto-saves while ingestion ignores it.
-    """
-    value = bool(value)
-    filter_.autosave = value
-    if isinstance(filter_.altdata, dict) and "autoSave" in filter_.altdata:
-        filter_.altdata = {**filter_.altdata, "autoSave": value}

--- a/skyportal/tests/api_tests/sources_candidates/test_filters.py
+++ b/skyportal/tests/api_tests/sources_candidates/test_filters.py
@@ -235,33 +235,23 @@ def test_update_filter_autosave(manage_groups_token, public_filter):
     assert data["data"]["autosave"] is False
 
 
-def test_set_autosave_keeps_broker_ui_mirror_in_step():
-    """The broker UI reads altdata['autoSave']; it must not disagree with the column."""
-    from types import SimpleNamespace
+def test_update_filter_autosave_writes_no_altdata_mirror(
+    manage_groups_token, public_filter
+):
+    """The column is the only store: nothing mirrors it into altdata, where it
+    could drift and let a filter auto-save while the UI shows it off."""
+    status, _ = api(
+        "PATCH",
+        f"filters/{public_filter.id}",
+        data={"autosave": True},
+        token=manage_groups_token,
+    )
+    assert status == 200
 
-    from skyportal.models import set_autosave
-
-    # A broker filter carries the mirror, and it tracks the column.
-    f = SimpleNamespace(autosave=False, altdata={"boom": {}, "autoSave": False})
-    set_autosave(f, True)
-    assert f.autosave is True
-    assert f.altdata["autoSave"] is True
-
-    set_autosave(f, False)
-    assert f.autosave is False
-    assert f.altdata["autoSave"] is False
-
-    # A filter without the mirror gains no spurious key.
-    g = SimpleNamespace(autosave=False, altdata={"lasair": {}})
-    set_autosave(g, True)
-    assert g.autosave is True
-    assert "autoSave" not in g.altdata
-
-    # ... and neither does one with no altdata at all.
-    h = SimpleNamespace(autosave=False, altdata=None)
-    set_autosave(h, True)
-    assert h.autosave is True
-    assert h.altdata is None
+    status, data = api("GET", f"filters/{public_filter.id}", token=manage_groups_token)
+    assert status == 200
+    assert data["data"]["autosave"] is True
+    assert "autoSave" not in (data["data"].get("altdata") or {})
 
 
 def test_attach_a_broker_to_an_existing_filter(super_admin_token, public_filter):

--- a/static/js/components/filter/boom/BoomFilterPlugins.tsx
+++ b/static/js/components/filter/boom/BoomFilterPlugins.tsx
@@ -159,8 +159,8 @@ const BoomFilterPlugins = (_props: BoomFilterPluginsProps) => {
 
   // Auto-actions run when an object passes: save to the filter's group (skipping
   // objects already in an ignore/junk group), annotate, and/or trigger followup.
-  // Stored in the filter's altdata.
-  const autoSaveOn = !!filter_v?.altdata?.autoSave;
+  // Auto-save lives in the `autosave` column that ingestion reads; the rest in altdata.
+  const autoSaveOn = !!filter_v?.autosave;
   const autoAnnotateOn = !!filter_v?.altdata?.autoAnnotate;
   const autoFollowupOn = !!filter_v?.altdata?.autoFollowup;
   const ignoreGroupIds: number[] =


### PR DESCRIPTION
The broker filter UI read altdata['autoSave'] while ingestion read the autosave column, and set_autosave() kept the two in step only for requests that carried the autosave key. A PATCH on /api/filters rewriting altdata left the column untouched, so a filter could auto-save every passing alert while its toggle showed off.

Drop the mirror: the UI reads the autosave column, which the filter GET already returns, and nothing writes autoSave into altdata any more. The PATCH parameter keeps its autoSave name.