### PR TITLE
Fix gcn localization ingest and skymap leak

### DIFF
--- a/skyportal/handlers/api/gcn.py
+++ b/skyportal/handlers/api/gcn.py
@@ -4034,7 +4034,9 @@ class LocalizationNoticeHandler(BaseHandler):
         # first get the notice, if it exists
         async with self.AsyncSession() as session:
             gcn_notice = await session.scalar(
-                GcnNotice.select(session.user_or_token).where(
+                GcnNotice.select(session.user_or_token)
+                .options(undefer(GcnNotice.content))
+                .where(
                     GcnNotice.dateobs == dateobs_parsed,
                     GcnNotice.id == notice_id_int,
                 )

--- a/static/js/components/localization/LocalizationPlot.tsx
+++ b/static/js/components/localization/LocalizationPlot.tsx
@@ -204,6 +204,7 @@ const AladinGlobe = ({
   useEffect(() => {
     if (!supported) return undefined;
     let cancelled = false;
+    const container = containerRef.current;
     A.init
       .then(() => {
         if (cancelled || !containerRef.current || aladinRef.current) return;
@@ -315,6 +316,18 @@ const AladinGlobe = ({
       .catch(() => {});
     return () => {
       cancelled = true;
+      container
+        ?.querySelectorAll<HTMLCanvasElement>("canvas.aladin-imageCanvas")
+        .forEach((canvas) => {
+          canvas
+            .getContext("webgl2")
+            ?.getExtension("WEBGL_lose_context")
+            ?.loseContext();
+        });
+      container?.replaceChildren();
+      aladinRef.current = null;
+      layers.current = {};
+      didCenter.current = false;
     };
     // Mount once: Aladin is initialized a single time and the layer effects
     // below handle all subsequent data/selection updates.


### PR DESCRIPTION
Fixes the two issues Tomas Ahumada reported on https://fritz.science/gcn_events/2026-09-10T01:23:49:

- "Ingest Localization" returned a 500 (`greenlet_spawn has not been called`): `LocalizationNoticeHandler` read the deferred `GcnNotice.content` lazily from the async session. The column is now loaded in the initial query.
- The sky map went blank ("Too many active WebGL contexts", shader errors): `LocalizationPlot` never released its Aladin WebGL context on unmount, so remounts leaked one context each until Chrome hit its limit of 16. The context is now released through `WEBGL_lose_context` on unmount.