### PR TITLE
Improve logging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ dependencies = [
     "tornado>=6.5.6",
     "geojson==3.3.0",
     "typing-extensions==4.16.0",
-    "swifttools==4.0.4",
+    "swifttools==4.0.5",
     "gwemopt==0.4.2",
     "humanize==4.16.0",
     "xarray>=21.1",

--- a/services/health_monitor/health_monitor.py
+++ b/services/health_monitor/health_monitor.py
@@ -35,8 +35,8 @@ def migrated():
         )
         data = r.json()
         return data["migrated"]
-    except Exception as e:
-        print(f"Exception while retrieving migration status: {e}")
+    except Exception:
+        log("Migration manager not answering; assuming the database is not ready")
         return False
 
 

--- a/services/health_monitor/health_monitor.py
+++ b/services/health_monitor/health_monitor.py
@@ -16,6 +16,8 @@ ALLOWED_TIMES_DOWN = cfg["health_monitor.allowed_times_down"]
 REQUEST_TIMEOUT_SECONDS = cfg["health_monitor.request_timeout_seconds"]
 STARTUP_GRACE_SECONDS = cfg["health_monitor.startup_grace_seconds"]
 
+ALL_BACKENDS = set(range(cfg["server.processes"]))
+
 
 class DownStatus:
     def __init__(self, nr_times=0, timestamp=None):
@@ -33,31 +35,25 @@ def migrated():
             f"http://{cfg['hosts.migration_manager']}:{cfg['ports.migration_manager']}",
             timeout=30,
         )
-        data = r.json()
-        return data["migrated"]
+        return r.json()["migrated"]
     except Exception:
         log("Migration manager not answering; assuming the database is not ready")
         return False
 
 
+def backend_is_up(app_nr):
+    try:
+        r = requests.get(
+            f"http://localhost:{cfg['ports.app_internal'] + app_nr}/api/sysinfo",
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        )
+    except Exception:
+        return False
+    return r.status_code == 200
+
+
 def backends_down():
-    down = set()
-    for i in range(cfg["server.processes"]):
-        port = cfg["ports.app_internal"] + i
-        try:
-            r = requests.get(
-                f"http://localhost:{port}/api/sysinfo",
-                timeout=REQUEST_TIMEOUT_SECONDS,
-            )
-        except:  # noqa: E722
-            status_code = 0
-        else:
-            status_code = r.status_code
-
-        if status_code != 200:
-            down.add(i)
-
-    return down
+    return {app_nr for app_nr in ALL_BACKENDS if not backend_is_up(app_nr)}
 
 
 def restart_app(app_nr):
@@ -72,8 +68,7 @@ def restart_app(app_nr):
     try:
         subprocess.run(supervisorctl + cmd, check=True)
     except subprocess.CalledProcessError as e:
-        log(f"Failure calling supervisorctl; could not restart app {app_nr}")
-        log(f"Exception: {e}")
+        log(f"Could not restart app {app_nr}, supervisorctl failed: {e}")
 
 
 if __name__ == "__main__":
@@ -81,7 +76,6 @@ if __name__ == "__main__":
         f"Monitoring system health [{SECONDS_BETWEEN_CHECKS}s interval, max downtime {ALLOWED_DOWNTIME_SECONDS}s, max times down {ALLOWED_TIMES_DOWN}]"
     )
 
-    all_backends = set(range(cfg["server.processes"]))
     backends_seen = set()
     downtimes = {}
 
@@ -94,9 +88,8 @@ if __name__ == "__main__":
 
         down = backends_down()
 
-        # Update list of backends that have been seen healthy at least once.
-        # We don't start a counter against a backend until it's been seen.
-        up = all_backends - down
+        # Downtime is only counted against a backend once it has been seen healthy.
+        up = ALL_BACKENDS - down
         newly_seen = up - backends_seen
         if newly_seen:
             log(f"New healthy app(s) {newly_seen}")

--- a/skyportal/enum_types.py
+++ b/skyportal/enum_types.py
@@ -33,6 +33,7 @@ for additional_bandpasses in cfg.get("additional_bandpasses", []):
         log(
             f"Additional Bandpass name={name} is already in the sncosmo registry. Skipping."
         )
+        continue
     try:
         wavelength = np.array(additional_bandpasses.get("wavelength"))
         transmission = np.array(additional_bandpasses.get("transmission"))

--- a/skyportal/enum_types.py
+++ b/skyportal/enum_types.py
@@ -18,15 +18,11 @@ log = make_log("enum_types")
 
 _, cfg = load_env()
 
-# Point sncosmo at the vendored data dir (the skyportal-data submodule) before
-# any bandpass lookup, so app import reads local files instead of blocking on
-# the flaky SVO Filter Profile Service. A missing bandpass still falls back to a
-# network fetch into this directory.
+# Set before any bandpass lookup, else sncosmo blocks on the flaky remote SVO service.
 sncosmo_data_folder = cfg.get("misc.sncosmo_data_folder")
 if sncosmo_data_folder:
     sncosmo.conf.data_dir = sncosmo_data_folder
 
-# load additional bandpasses into the SN comso registry
 existing_bandpasses_names = [val["name"] for val in _BANDPASSES.get_loaders_metadata()]
 additional_bandpasses_names = []
 for additional_bandpasses in cfg.get("additional_bandpasses", []):
@@ -45,8 +41,7 @@ for additional_bandpasses in cfg.get("additional_bandpasses", []):
         log(f"Could not make bandpass for {name}: {e}")
         continue
 
-    # Seed the lazyproperty: it samples the band on a fixed 5 A grid, unusable
-    # for a radio band ~1e8 A wide. Same quantity, from the config points.
+    # Seed the lazyproperty: its fixed 5 A sampling grid is unusable for a band ~1e8 A wide.
     band.wave_eff = float(
         np.trapezoid(wavelength * transmission, wavelength)
         / np.trapezoid(transmission, wavelength)
@@ -55,7 +50,7 @@ for additional_bandpasses in cfg.get("additional_bandpasses", []):
     sncosmo.registry.register(band)
     additional_bandpasses_names.append(name)
 
-if len(additional_bandpasses_names) > 0:
+if additional_bandpasses_names:
     log(f"registered {len(additional_bandpasses_names)} custom bandpasses")
 
 
@@ -85,9 +80,7 @@ THUMBNAIL_TYPES = (
     "ref_gz",
     "sub_gz",
 )
-# Where an obj stands against a GCN event. "pending" means proposed (e.g. by the
-# crossmatch service) and still awaiting a scanner; "ambiguous" means a scanner
-# looked and could not decide -- reviewed, unlike pending.
+# "pending": proposed, not scanned yet. "ambiguous": scanned, but undecided.
 GCN_EVENT_OBJ_STATUSES = ("pending", "confirmed", "ambiguous", "rejected")
 
 INSTRUMENT_TYPES = ("imager", "spectrograph", "imaging spectrograph")
@@ -109,8 +102,7 @@ ANALYSIS_INPUT_TYPES = (
     "classifications",
 )
 DEFAULT_ANALYSIS_FILTER_TYPES = {"classifications": ["name", "probability"]}
-# Scalar (non list-of-dicts) source-filter keys. group_id triggers a default
-# analysis when a source is saved to that group (see create_default_analysis_on_save).
+# Scalar (not list-of-dicts) filter keys; see create_default_analysis_on_save.
 DEFAULT_ANALYSIS_SCALAR_FILTERS = {"group_id": int, "spectrum": str}
 AUTHENTICATION_TYPES = (
     "none",

--- a/skyportal/enum_types.py
+++ b/skyportal/enum_types.py
@@ -56,7 +56,7 @@ for additional_bandpasses in cfg.get("additional_bandpasses", []):
     additional_bandpasses_names.append(name)
 
 if len(additional_bandpasses_names) > 0:
-    log(f"registered custom bandpasses: {additional_bandpasses_names}")
+    log(f"registered {len(additional_bandpasses_names)} custom bandpasses")
 
 
 def force_render_enum_markdown(values):

--- a/skyportal/handlers/api/summary_query.py
+++ b/skyportal/handlers/api/summary_query.py
@@ -113,8 +113,6 @@ else:
     if cfg["database.database"] == "skyportal_test":
         USE_PINECONE = True
         log("Setting USE_PINECONE=True as it seems like we are in a test environment")
-    else:
-        log("No valid pinecone configuration found. Please check the config file.")
 
 summary_config = copy.deepcopy(cfg["analysis_services.openai_analysis_service.summary"])
 if summary_config.get("api_key"):

--- a/skyportal/handlers/api/summary_query.py
+++ b/skyportal/handlers/api/summary_query.py
@@ -11,16 +11,13 @@ from baselayer.app.access import auth_or_token
 from baselayer.app.env import load_env
 from baselayer.log import make_log
 
-from ...models import (
-    User,
-)
+from ...models import User
 from ..base import BaseHandler
 
 _, cfg = load_env()
 log = make_log("query")
 
 
-# add in this new search method to the Pinecone class
 def search_sources(
     client: Pinecone,
     query: str,
@@ -70,22 +67,16 @@ def search_sources(
     sources = []
     for res in results["matches"]:
         try:
-            source = {
-                "id": res["id"],
-                "score": res["score"],
-                "metadata": res["metadata"],
-            }
-            sources.append(source)
+            sources.append(
+                {"id": res["id"], "score": res["score"], "metadata": res["metadata"]}
+            )
         except Exception as e:
             log(f"Error: {e}")
-            continue
     return sources
 
 
 pinecone_client = None
 
-# Preamble: get the embeddings and summary parameters ready
-# for now, we only support pinecone embeddings
 summarize_embedding_config = cfg[
     "analysis_services.openai_analysis_service.embeddings_store.summary"
 ]
@@ -109,17 +100,14 @@ if (
         index.name for index in pinecone_client.list_indexes().indexes
     ]:
         USE_PINECONE = True
-else:
-    if cfg["database.database"] == "skyportal_test":
-        USE_PINECONE = True
-        log("Setting USE_PINECONE=True as it seems like we are in a test environment")
+elif cfg["database.database"] == "skyportal_test":
+    USE_PINECONE = True
+    log("Setting USE_PINECONE=True as it seems like we are in a test environment")
 
 summary_config = copy.deepcopy(cfg["analysis_services.openai_analysis_service.summary"])
 if summary_config.get("api_key"):
-    # there may be a global API key set in the config file
     openai_api_key = summary_config.pop("api_key")
 elif os.path.exists(".secret"):
-    # try to get this key from the dev environment, useful for debugging
     openai_api_key = yaml.safe_load(open(".secret")).get("OPENAI_API_KEY")
 elif cfg["database.database"] == "skyportal_test":
     openai_api_key = "TEST_KEY"
@@ -215,48 +203,33 @@ class SummaryQueryHandler(BaseHandler):
 
         query = body.q
         objID = body.objID
-        if query in [None, ""] and objID in [None, ""]:
+        if not query and not objID:
             return self.error('Missing one of the required: "q" or "objID"')
         if query is not None and objID is not None:
             return self.error('Cannot specify both "q" and "objID"')
 
-        search_by_string = query not in [None, ""]
         k = body.k
         if k < 1 or k > 100:
             return self.error("k must be 1<=k<=100")
-        z_min = body.z_min
-        z_max = body.z_max
+        z_min, z_max = body.z_min, body.z_max
         if z_min is not None and z_max is not None and z_min > z_max:
             return self.error("z_min must be <= z_max")
-        classification_types = body.classificationTypes
 
-        # construct the filter
-        if z_min is not None and z_max is None:
-            z_filt = {"redshift": {"$gte": z_min}}
-        elif z_min is None and z_max is not None:
-            z_filt = {"redshift": {"$lte": z_max}}
-        elif z_min is not None and z_max is not None:
-            z_filt = {
-                "$and": [{"redshift": {"$gte": z_min}}, {"redshift": {"$lte": z_max}}]
-            }
-        else:
-            z_filt = None
-        if classification_types not in [None, []]:
-            class_filt = {"class": {"$in": classification_types}}
-        else:
-            class_filt = None
-
-        if class_filt is not None and z_filt is not None:
-            filt = {"$and": [class_filt, z_filt]}
-        elif class_filt is not None:
-            filt = class_filt
-        elif z_filt is not None:
-            filt = z_filt
-        else:
+        filters = []
+        if z_min is not None:
+            filters.append({"redshift": {"$gte": z_min}})
+        if z_max is not None:
+            filters.append({"redshift": {"$lte": z_max}})
+        if body.classificationTypes:
+            filters.append({"class": {"$in": body.classificationTypes}})
+        if not filters:
             filt = {}
+        elif len(filters) == 1:
+            filt = filters[0]
+        else:
+            filt = {"$and": filters}
 
-        if search_by_string:
-            # get the top k sources
+        if query:
             try:
                 results = search_sources(
                     pinecone_client,
@@ -270,8 +243,6 @@ class SummaryQueryHandler(BaseHandler):
             except Exception as e:
                 return self.error(f"Could not search sources: {e}")
         else:
-            # search by objID. Will return an empty list if objID not in
-            # vector database.
             try:
                 index = pinecone_client.Index(summarize_embedding_index_name)
                 query_response = index.query(

--- a/skyportal/handlers/api/summary_query.py
+++ b/skyportal/handlers/api/summary_query.py
@@ -192,10 +192,9 @@ class SummaryQueryHandler(BaseHandler):
                 if user.preferences is not None and user.preferences.get(
                     "summary", {}
                 ).get("OpenAI", {}).get("active", False):
-                    user_pref_openai = user.preferences["summary"]["OpenAI"].get(
+                    user_openai_key = user.preferences["summary"]["OpenAI"].get(
                         "apikey"
                     )
-                    user_openai_key = user_pref_openai["apikey"]
         else:
             user_openai_key = openai_api_key
         if not user_openai_key:

--- a/skyportal/utils/cosmology.py
+++ b/skyportal/utils/cosmology.py
@@ -16,30 +16,23 @@ def establish_cosmology(cfg=cfg):
 
     elif isinstance(user_cosmo, dict):
         try:
+            params = {
+                "Tcmb0": user_cosmo.get("Tcmb0", 2.725),
+                "Neff": user_cosmo.get("Neff", 3.04),
+                "m_nu": u.Quantity(user_cosmo.get("m_nu", [0.0, 0.0, 0.0]), u.eV),
+                "name": user_cosmo.get("name", "user_cosmology"),
+                "Ob0": user_cosmo.get("Ob0", 0.0455),
+            }
             if user_cosmo.get("flat"):
                 cosmo = cosmology.FlatLambdaCDM(
-                    user_cosmo["H0"],
-                    user_cosmo["Om0"],
-                    Tcmb0=user_cosmo.get("Tcmb0", 2.725),
-                    Neff=user_cosmo.get("Neff", 3.04),
-                    m_nu=u.Quantity(user_cosmo.get("m_nu", [0.0, 0.0, 0.0]), u.eV),
-                    name=user_cosmo.get("name", "user_cosmology"),
-                    Ob0=user_cosmo.get("Ob0", 0.0455),
+                    user_cosmo["H0"], user_cosmo["Om0"], **params
                 )
             else:
                 cosmo = cosmology.LambdaCDM(
-                    user_cosmo["H0"],
-                    user_cosmo["Om0"],
-                    user_cosmo["Ode0"],
-                    Tcmb0=user_cosmo.get("Tcmb0", 2.725),
-                    Neff=user_cosmo.get("Neff", 3.04),
-                    m_nu=u.Quantity(user_cosmo.get("m_nu", [0.0, 0.0, 0.0]), u.eV),
-                    name=user_cosmo.get("name", "user_cosmology"),
-                    Ob0=user_cosmo.get("Ob0", 0.0455),
+                    user_cosmo["H0"], user_cosmo["Om0"], user_cosmo["Ode0"], **params
                 )
         except (KeyError, NameError) as e:
-            log(f"{e}")
-            log("Exception while processing user-defined cosmology")
+            log(f"Exception while processing user-defined cosmology: {e}")
             raise RuntimeError("Error parsing user-defined cosmology")
 
     else:

--- a/skyportal/utils/cosmology.py
+++ b/skyportal/utils/cosmology.py
@@ -47,6 +47,6 @@ def establish_cosmology(cfg=cfg):
         log(f"Try setting it to one of [{cosmology.realizations.available}]")
         raise RuntimeError("No valid cosmology specified")
 
-    log(f"Using {cosmo} for cosmological calculations")
+    log(f"Using {cosmo.name} for cosmological calculations")
 
     return cosmo

--- a/skyportal/utils/services.py
+++ b/skyportal/utils/services.py
@@ -13,8 +13,7 @@ REQUEST_TIMEOUT_SECONDS = cfg["health_monitor.request_timeout_seconds"]
 
 HOST = get_app_base_url()
 
-# Probed directly, because through nginx a failed probe marks a worker down for
-# server.fail_timeout seconds.
+# Probed directly: behind nginx, a failed probe takes a worker down for server.fail_timeout.
 READINESS_PORTS = [
     cfg["ports.app_internal"] + i for i in range(cfg["server.processes"])
 ]
@@ -31,29 +30,18 @@ def is_loaded():
             continue
         if r.status_code == 200:
             return True
-
     return False
 
 
-# Decorator that defers a function until the app is loaded: when the wrapped
-# function is called, poll until the app responds, then run it (passing through
-# the args given to check_loaded, e.g. logger=log).
-#
-# The wait/run happens at *call* time rather than at decoration time so that
-# importing the module has no side effects and the decorated name stays callable.
-# (Previously this ran the function during decoration and returned None, so a
-# service whose function returned early -- e.g. on missing config -- left
-# `service` bound to None and the `service()` call in __main__ blew up with
-# "'NoneType' object is not callable" instead of exiting cleanly.)
+# Polls at call time, not at decoration time, so the decorated name stays callable.
 def check_loaded(*args, **kwargs):
     def decorator(func):
         @functools.wraps(func)
         def wrapper(*_wrapper_args, **_wrapper_kwargs):
-            while True:
-                if is_loaded():
-                    break
-                elif kwargs.get("logger") is not None and callable(kwargs["logger"]):
-                    kwargs["logger"]("Waiting for the app to start...")
+            logger = kwargs.get("logger")
+            while not is_loaded():
+                if callable(logger):
+                    logger("Waiting for the app to start...")
                 time.sleep(10)
 
             return func(*args, **kwargs)

--- a/skyportal/utils/services.py
+++ b/skyportal/utils/services.py
@@ -13,19 +13,26 @@ REQUEST_TIMEOUT_SECONDS = cfg["health_monitor.request_timeout_seconds"]
 
 HOST = get_app_base_url()
 
+# Probed directly, because through nginx a failed probe marks a worker down for
+# server.fail_timeout seconds.
+READINESS_PORTS = [
+    cfg["ports.app_internal"] + i for i in range(cfg["server.processes"])
+]
+
 
 def is_loaded():
-    try:
-        r = requests.get(f"{HOST}/api/sysinfo", timeout=REQUEST_TIMEOUT_SECONDS)
-    except Exception:
-        status_code = 0
-    else:
-        status_code = r.status_code
+    for port in READINESS_PORTS:
+        try:
+            r = requests.get(
+                f"http://localhost:{port}/api/sysinfo",
+                timeout=REQUEST_TIMEOUT_SECONDS,
+            )
+        except Exception:
+            continue
+        if r.status_code == 200:
+            return True
 
-    if status_code == 200:
-        return True
-    else:
-        return False
+    return False
 
 
 # Decorator that defers a function until the app is loaded: when the wrapped

--- a/uv.lock
+++ b/uv.lock
@@ -2470,8 +2470,8 @@ wheels = [
 
 [[package]]
 name = "m4opt"
-version = "0.1.dev876+g5bba6e405"
-source = { git = "https://github.com/skyportal/m4opt?rev=5bba6e4#5bba6e4054904c2b0f7c4163a6af70c4bf9dad12" }
+version = "0.1.dev877+g9ca530e1e"
+source = { git = "https://github.com/skyportal/m4opt?rev=9ca530e#9ca530e1efe92ed4f23ea78722a0b3e1a3d45d5b" }
 dependencies = [
     { name = "aep8" },
     { name = "antiprism-python" },
@@ -4781,7 +4781,7 @@ requires-dist = [
     { name = "langchain-openai", specifier = "==1.2.2" },
     { name = "ligo-skymap", specifier = "==2.5.4" },
     { name = "lxml", specifier = "==6.1.1" },
-    { name = "m4opt", extras = ["scip"], marker = "extra == 'm4opt'", git = "https://github.com/skyportal/m4opt?rev=5bba6e4" },
+    { name = "m4opt", extras = ["scip"], marker = "extra == 'm4opt'", git = "https://github.com/skyportal/m4opt?rev=9ca530e" },
     { name = "marshmallow", specifier = "==4.3.0" },
     { name = "marshmallow-sqlalchemy", specifier = "==1.5.0" },
     { name = "matplotlib", specifier = "==3.11.1" },
@@ -4824,7 +4824,7 @@ requires-dist = [
     { name = "skyportal", extras = ["pittgoogle"], marker = "extra == 'brokers-all'" },
     { name = "sncosmo", specifier = "==2.13.0" },
     { name = "suds-py3", specifier = "==1.4.5.0" },
-    { name = "swifttools", specifier = "==4.0.4" },
+    { name = "swifttools", specifier = "==4.0.5" },
     { name = "tables", specifier = ">=3.10.1,<4.0.0" },
     { name = "tdtax", specifier = "==0.1.7" },
     { name = "tiktoken", specifier = "==0.14.0" },
@@ -5177,7 +5177,7 @@ wheels = [
 
 [[package]]
 name = "swifttools"
-version = "4.0.4"
+version = "4.0.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "astropy" },
@@ -5191,9 +5191,9 @@ dependencies = [
     { name = "tabulate" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/43/83/69f226d475afd8c240754fe019ceccfdae5e46baa48bec32bb78e06e386d/swifttools-4.0.4.tar.gz", hash = "sha256:ec1b6857ec741d222fd96f59b0a2c5095196f2ad679cf984db2400a65b36d02d", size = 673823, upload-time = "2026-08-18T15:41:23.976Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d2/31/75cfa976aff9b3e73d47cdcf26180e6f00995f64c923ceaadd413b604666/swifttools-4.0.5.tar.gz", hash = "sha256:826ef7b220392e35ea9598cf8fc1b885af6e955cf6a405a980907b2b323dd1b2", size = 674625, upload-time = "2026-09-11T16:53:15.82Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/2c/5d071ed0a87752ac9e6e8f7d018f1740767523b56d768f3236faece47841/swifttools-4.0.4-py3-none-any.whl", hash = "sha256:17eb22a8dca602121218d1f13b779dd93b86bf59b7a1a45dc68fbdb344ddf23c", size = 642361, upload-time = "2026-08-18T15:41:22.266Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/d5/5fc63de399066e06c6b8b528c721087a6ce029d411bc46309ddd9fdad026/swifttools-4.0.5-py3-none-any.whl", hash = "sha256:cbb27d8e4ac23c6c29b65c6f8c72aa64f47802a50642db6a6a103239d1b57d93", size = 642467, upload-time = "2026-09-11T16:53:14.268Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Log the number of custom bandpasses instead of the full list, which was printed once per service at startup.
- Log the cosmology name instead of its full repr.
- Probe the app workers directly for readiness, instead of going through nginx where a failed probe marks a worker down for `server.fail_timeout` seconds.
- Replace the raw exception print in the health monitor with a single readable line.
- Drop the "no valid pinecone configuration" line, which fired on every start of a normal deployment.