### PR TITLE
Sort All observing runs tab

### DIFF
--- a/static/js/components/observing_run/ObservingRunPage.tsx
+++ b/static/js/components/observing_run/ObservingRunPage.tsx
@@ -107,7 +107,9 @@ const ObservingRunList = ({
       }
     });
   } else {
-    observingRunsToShow = [...observingRuns];
+    observingRunsToShow = [...observingRuns].sort((a, b) =>
+      dayjs(b.calendar_date).diff(dayjs(a.calendar_date)),
+    );
   }
 
   const deleteObservingRun = async () => {


### PR DESCRIPTION
Right now, on the observing runs page, if you look at the `All` tab, you will see oldest runs first (6yo). This PR sorts the runs the other way so upcoming runs appear first on the list.