### PR TITLE
Use new_session for database work outside a web request

### DIFF
--- a/services/tns_retrieval_queue/tns_retrieval_queue.py
+++ b/services/tns_retrieval_queue/tns_retrieval_queue.py
@@ -13,7 +13,6 @@ import sqlalchemy as sa
 import tornado.escape
 import tornado.ioloop
 import tornado.web
-from sqlalchemy.orm import scoped_session, sessionmaker
 
 from baselayer.app import models
 from baselayer.app.env import load_env
@@ -41,8 +40,6 @@ env, cfg = load_env()
 log = make_log("tns_queue")
 
 init_db(**cfg["database"])
-
-Session = scoped_session(sessionmaker())
 
 USER_ID = 1  # super admin user ID
 DEFAULT_RADIUS = 2.0 / 3600  # 2 arcsec in degrees

--- a/skyportal/app_server.py
+++ b/skyportal/app_server.py
@@ -279,7 +279,7 @@ from skyportal.handlers.public import (
 )
 
 from . import model_util, openapi
-from .models import DBSession, init_db
+from .models import db_engine, init_db
 from .utils.observability import setup_observability
 
 log = make_log("app_server")
@@ -877,7 +877,7 @@ def make_app(cfg, baselayer_handlers, baselayer_settings, process=None, env=None
     # create_tables() is a no-op outside debug mode, so an unmigrated database
     # reaches this point empty and every later step fails on a missing table or
     # type -- once per worker, on every supervisor restart. Say so instead.
-    if not sa.inspect(DBSession.session_factory.kw["bind"]).has_table("users"):
+    if not sa.inspect(db_engine()).has_table("users"):
         raise RuntimeError(
             "No tables found in the database. Create the schema first: "
             "`make db_create_tables` (or `alembic upgrade head` where "

--- a/skyportal/facility_apis/atlas.py
+++ b/skyportal/facility_apis/atlas.py
@@ -9,7 +9,7 @@ import requests
 import sqlalchemy as sa
 from astropy.time import Time
 from marshmallow.exceptions import ValidationError
-from sqlalchemy.orm import scoped_session, selectinload, sessionmaker
+from sqlalchemy.orm import selectinload
 
 from baselayer.app.env import load_env
 from baselayer.app.flow import Flow
@@ -99,16 +99,9 @@ def commit_photometry(
         Session to use for database transactions. If None, a new session will be created.
     """
 
-    from ..models import DBSession, FollowupRequest, Instrument
+    from ..models import FollowupRequest, Instrument, new_session
 
-    if parent_session is None:
-        Session = scoped_session(sessionmaker())
-        if Session.registry.has():
-            session = Session()
-        else:
-            session = Session(bind=DBSession.session_factory.kw["bind"])
-    else:
-        session = parent_session
+    session = new_session() if parent_session is None else parent_session
 
     try:
         request = session.get(FollowupRequest, request_id)
@@ -277,7 +270,6 @@ def commit_photometry(
     finally:
         if parent_session is None:
             session.close()
-            Session.remove()
 
 
 class ATLASAPI(FollowUpAPI):

--- a/skyportal/facility_apis/lco.py
+++ b/skyportal/facility_apis/lco.py
@@ -7,7 +7,7 @@ from datetime import UTC, timedelta
 import aiohttp
 import arrow
 import sqlalchemy as sa
-from sqlalchemy.orm import scoped_session, selectinload, sessionmaker
+from sqlalchemy.orm import selectinload
 from tornado.ioloop import IOLoop
 
 from baselayer.app.env import load_env
@@ -516,13 +516,9 @@ def download_observations(request_id, results, count):
         Number of frames returned by the archive query
     """
 
-    from ..models import Comment, DBSession, FollowupRequest, Group
+    from ..models import Comment, FollowupRequest, Group, new_session
 
-    Session = scoped_session(sessionmaker())
-    if Session.registry.has():
-        session = Session()
-    else:
-        session = Session(bind=DBSession.session_factory.kw["bind"])
+    session = new_session()
 
     try:
         req = session.scalars(
@@ -554,7 +550,6 @@ def download_observations(request_id, results, count):
         log(f"Unable to post data for {request_id}: {e}")
     finally:
         session.close()
-        Session.remove()
 
 
 class LCOAPI(FollowUpAPI):

--- a/skyportal/facility_apis/ps1.py
+++ b/skyportal/facility_apis/ps1.py
@@ -2,7 +2,7 @@ import aiohttp
 import astropy
 import numpy as np
 import sqlalchemy as sa
-from sqlalchemy.orm import scoped_session, selectinload, sessionmaker
+from sqlalchemy.orm import selectinload
 from tornado.ioloop import IOLoop
 
 from baselayer.app.env import load_env
@@ -36,13 +36,9 @@ def commit_photometry(text_response, request_id, instrument_id, user_id):
         User SkyPortal ID
     """
 
-    from ..models import DBSession, FollowupRequest, Instrument
+    from ..models import FollowupRequest, Instrument, new_session
 
-    Session = scoped_session(sessionmaker())
-    if Session.registry.has():
-        session = Session()
-    else:
-        session = Session(bind=DBSession.session_factory.kw["bind"])
+    session = new_session()
 
     try:
         request = session.get(FollowupRequest, request_id)
@@ -134,7 +130,6 @@ def commit_photometry(text_response, request_id, instrument_id, user_id):
         log(f"Unable to commit photometry for {request_id}: {e}")
     finally:
         session.close()
-        Session.remove()
 
 
 class PS1API(FollowUpAPI):

--- a/skyportal/facility_apis/sedmv2.py
+++ b/skyportal/facility_apis/sedmv2.py
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 from astropy.time import Time, TimeDelta
 from paramiko import AutoAddPolicy, SSHClient
 from requests.auth import HTTPBasicAuth
-from sqlalchemy.orm import scoped_session, selectinload, sessionmaker
+from sqlalchemy.orm import selectinload
 from tornado.ioloop import IOLoop
 
 from baselayer.app.env import load_env
@@ -589,13 +589,9 @@ def fetch_nightly_logs(instrument_id, altdata, request_start, request_end):
         End time for the request.
     """
 
-    from ..models import DBSession, InstrumentLog
+    from ..models import InstrumentLog, new_session
 
-    Session = scoped_session(sessionmaker())
-    if Session.registry.has():
-        session = Session()
-    else:
-        session = Session(bind=DBSession.session_factory.kw["bind"])
+    session = new_session()
 
     try:
         days = np.arange(np.floor(request_start.mjd), np.ceil(request_end.mjd) + 1)
@@ -642,4 +638,3 @@ def fetch_nightly_logs(instrument_id, altdata, request_start, request_end):
         log(f"Unable to commit logs for instrument with ID {instrument_id}: {e}")
     finally:
         session.close()
-        Session.remove()

--- a/skyportal/facility_apis/swift.py
+++ b/skyportal/facility_apis/swift.py
@@ -13,7 +13,7 @@ import aiohttp
 import pandas as pd
 import sqlalchemy as sa
 from astropy.time import Time
-from sqlalchemy.orm import scoped_session, selectinload, sessionmaker
+from sqlalchemy.orm import selectinload
 from swifttools.swift_too import Data, ObsQuery, Swift_TOO, UVOT_Mode
 from swifttools.xrt_prods import XRTProductRequest
 from tornado.ioloop import IOLoop
@@ -338,13 +338,9 @@ def download_observations(request_id, oq):
         Swift observation query
     """
 
-    from ..models import Comment, DBSession, FollowupRequest, Group
+    from ..models import Comment, FollowupRequest, Group, new_session
 
-    Session = scoped_session(sessionmaker())
-    if Session.registry.has():
-        session = Session()
-    else:
-        session = Session(bind=DBSession.session_factory.kw["bind"])
+    session = new_session()
 
     try:
         req = session.scalars(
@@ -410,7 +406,6 @@ def download_observations(request_id, oq):
         log(f"Unable to post data for {request_id}: {e}")
     finally:
         session.close()
-        Session.remove()
 
 
 class UVOTXRTAPI(FollowUpAPI):

--- a/skyportal/facility_apis/tess.py
+++ b/skyportal/facility_apis/tess.py
@@ -4,7 +4,7 @@ import numpy as np
 import sqlalchemy as sa
 from astropy.table import Table
 from astropy.time import Time, TimeDelta
-from sqlalchemy.orm import scoped_session, selectinload, sessionmaker
+from sqlalchemy.orm import selectinload
 from tornado.ioloop import IOLoop
 
 from baselayer.app.env import load_env
@@ -37,13 +37,9 @@ def commit_photometry(lc, request_id, instrument_id, user_id):
         User SkyPortal ID
     """
 
-    from ..models import DBSession, FollowupRequest, PhotometricSeries
+    from ..models import FollowupRequest, PhotometricSeries, new_session
 
-    Session = scoped_session(sessionmaker())
-    if Session.registry.has():
-        session = Session()
-    else:
-        session = Session(bind=DBSession.session_factory.kw["bind"])
+    session = new_session()
 
     try:
         request = session.get(FollowupRequest, request_id)
@@ -164,7 +160,6 @@ def commit_photometry(lc, request_id, instrument_id, user_id):
         log(f"Unable to commit photometry for {request_id}: {e}")
     finally:
         session.close()
-        Session.remove()
 
 
 class TESSAPI(FollowUpAPI):

--- a/skyportal/facility_apis/ztf.py
+++ b/skyportal/facility_apis/ztf.py
@@ -15,7 +15,7 @@ from astropy.time import Time
 from marshmallow.exceptions import ValidationError
 from requests import Session
 from requests.auth import HTTPBasicAuth
-from sqlalchemy.orm import scoped_session, selectinload, sessionmaker
+from sqlalchemy.orm import selectinload
 from tornado.ioloop import IOLoop
 
 from baselayer.app import models as baselayer_models
@@ -340,16 +340,9 @@ def commit_photometry(
         SQLAlchemy session object. If None, a new session is created.
     """
 
-    from ..models import DBSession, FollowupRequest, Instrument
+    from ..models import FollowupRequest, Instrument, new_session
 
-    if parent_session is None:
-        Session = scoped_session(sessionmaker())
-        if Session.registry.has():
-            session = Session()
-        else:
-            session = Session(bind=DBSession.session_factory.kw["bind"])
-    else:
-        session = parent_session
+    session = new_session() if parent_session is None else parent_session
 
     try:
         request = session.get(FollowupRequest, request_id)
@@ -482,7 +475,6 @@ def commit_photometry(
     finally:
         if parent_session is None:
             session.close()
-            Session.remove()
 
 
 class ZTFAPI(FollowUpAPI):

--- a/skyportal/handlers/api/catalog_services.py
+++ b/skyportal/handlers/api/catalog_services.py
@@ -14,7 +14,7 @@ from astropy.table import Table
 from astropy.time import Time, TimeDelta
 from marshmallow.exceptions import ValidationError
 from pydantic import BaseModel, ConfigDict, Field
-from sqlalchemy.orm import scoped_session, selectinload, sessionmaker
+from sqlalchemy.orm import selectinload
 from tornado.ioloop import IOLoop
 
 from baselayer.app.access import auth_or_token
@@ -26,7 +26,6 @@ from ...models import (
     Allocation,
     CatalogQuery,
     Comment,
-    DBSession,
     Group,
     Instrument,
     Localization,
@@ -35,6 +34,7 @@ from ...models import (
     Telescope,
     User,
     UserNotification,
+    new_session,
 )
 from ...models.schema import CatalogQueryPost
 from ...utils.catalog import get_conesearch_centers, query_fink
@@ -50,8 +50,6 @@ _, cfg = load_env()
 TESS_URL = cfg["app.tess_endpoint"]
 
 log = make_log("api/catalogs")
-
-Session = scoped_session(sessionmaker())
 
 
 class CatalogQueryPostBody(BaseModel):
@@ -206,10 +204,7 @@ def fetch_transients(allocation_id, user_id, group_ids, payload):
         Payload for the catalog query
     """
 
-    if Session.registry.has():
-        session = Session()
-    else:
-        session = Session(bind=DBSession.session_factory.kw["bind"])
+    session = new_session()
 
     obj_ids = []
 
@@ -381,6 +376,8 @@ def fetch_transients(allocation_id, user_id, group_ids, payload):
 
     except Exception as e:
         return log(f"Unable to commit transient catalog: {e}")
+    finally:
+        session.close()
 
 
 class SwiftLSXPSQueryHandler(BaseHandler):
@@ -446,10 +443,7 @@ def fetch_swift_transients(instrument_id, user_id, group_ids):
         List of group IDs to save to
     """
 
-    if Session.registry.has():
-        session = Session()
-    else:
-        session = Session(bind=DBSession.session_factory.kw["bind"])
+    session = new_session()
 
     obj_ids = []
 
@@ -585,6 +579,8 @@ def fetch_swift_transients(instrument_id, user_id, group_ids):
 
     except Exception as e:
         return log(f"Unable to commit Swift XRT transient catalog: {e}")
+    finally:
+        session.close()
 
 
 class GaiaPhotometricAlertsQueryHandler(BaseHandler):
@@ -661,10 +657,7 @@ def fetch_gaia_transients(instrument_id, user_id, group_ids, payload):
         Dictionary containing filtering parameters
     """
 
-    if Session.registry.has():
-        session = Session()
-    else:
-        session = Session(bind=DBSession.session_factory.kw["bind"])
+    session = new_session()
 
     obj_ids = []
 
@@ -782,6 +775,8 @@ def fetch_gaia_transients(instrument_id, user_id, group_ids, payload):
         return obj_ids
     except Exception as e:
         return log(f"Unable to commit Gaia Photometric Alert catalog: {e}")
+    finally:
+        session.close()
 
 
 class TessTransientsQueryHandler(BaseHandler):
@@ -860,10 +855,7 @@ def fetch_tess_transients(instrument_id, user_id, group_ids, payload):
         Dictionary containing filtering parameters
     """
 
-    if Session.registry.has():
-        session = Session()
-    else:
-        session = Session(bind=DBSession.session_factory.kw["bind"])
+    session = new_session()
 
     obj_ids = []
 
@@ -1015,3 +1007,5 @@ def fetch_tess_transients(instrument_id, user_id, group_ids, payload):
         return obj_ids
     except Exception as e:
         return log(f"Unable to commit TESS transient catalog: {e}")
+    finally:
+        session.close()

--- a/skyportal/handlers/api/galaxy.py
+++ b/skyportal/handlers/api/galaxy.py
@@ -17,7 +17,6 @@ from pydantic import BaseModel, ConfigDict, Field
 from scipy.integrate import quad
 from scipy.stats import norm
 from sqlalchemy import func, nulls_last
-from sqlalchemy.orm import scoped_session, sessionmaker
 from tornado.ioloop import IOLoop
 
 from baselayer.app.access import auth_or_token, permissions
@@ -31,6 +30,7 @@ from ...models import (
     Localization,
     LocalizationTile,
     Obj,
+    new_session,
 )
 from ...utils.asynchronous import run_async
 from ...utils.naive_datetime import utcnow_naive
@@ -38,8 +38,6 @@ from ..base import BaseHandler, format_doc
 
 log = make_log("api/galaxy")
 env, cfg = load_env()
-
-Session = scoped_session(sessionmaker())
 
 MAX_GALAXIES = 10000
 
@@ -892,10 +890,7 @@ def delete_galaxies(catalog_id):
 
 
 def add_galaxies(catalog_metadata, catalog_data):
-    if Session.registry.has():
-        session = Session()
-    else:
-        session = Session(bind=DBSession.session_factory.kw["bind"])
+    session = new_session()
 
     try:
         # check if the catalog already exists. If not, create it
@@ -974,7 +969,6 @@ def add_galaxies(catalog_metadata, catalog_data):
         return log(f"Unable to generate galaxy table: {e}")
     finally:
         session.close()
-        Session.remove()
 
 
 class GalaxyASCIIFileHandler(BaseHandler):

--- a/skyportal/handlers/api/gcn.py
+++ b/skyportal/handlers/api/gcn.py
@@ -38,9 +38,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import (
     joinedload,
-    scoped_session,
     selectinload,
-    sessionmaker,
     undefer,
 )
 from sqlalchemy.orm.attributes import flag_modified
@@ -62,7 +60,6 @@ from ...models import (
     Allocation,
     CatalogQuery,
     CommentOnGCN,
-    DBSession,
     DefaultGcnTag,
     DefaultObservationPlanRequest,
     EventObservationPlan,
@@ -96,6 +93,7 @@ from ...models import (
     SurveyEfficiencyForObservations,
     User,
     UserNotification,
+    new_session,
 )
 from ...utils.crossmatch import skymap_overlap_integral
 from ...utils.gcn import (
@@ -141,8 +139,6 @@ from .source import (
 log = make_log("api/gcn_event")
 
 env, cfg = load_env()
-
-Session = scoped_session(sessionmaker())
 
 MAX_GCNEVENTS = 1000
 
@@ -3294,13 +3290,7 @@ def add_tiles_and_properties_and_contour(
     properties=None,
     tags=None,
 ):
-    if parent_session is None:
-        if Session.registry.has():
-            session = Session()
-        else:
-            session = Session(bind=DBSession.session_factory.kw["bind"])
-    else:
-        session = parent_session
+    session = new_session() if parent_session is None else parent_session
 
     try:
         user = session.scalar(sa.select(User).where(User.id == user_id))
@@ -3419,7 +3409,6 @@ def add_tiles_and_properties_and_contour(
     finally:
         if parent_session is None:
             session.close()
-            Session.remove()
 
 
 def add_default_gcn_tags(user, session, dateobs=None, localization=None):
@@ -3571,13 +3560,7 @@ async def add_default_gcn_tags_async(user, session, dateobs=None, localization=N
 
 
 def add_observation_plans(localization_id, user_id, parent_session=None):
-    if parent_session is None:
-        if Session.registry.has():
-            session = Session()
-        else:
-            session = Session(bind=DBSession.session_factory.kw["bind"])
-    else:
-        session = parent_session
+    session = new_session() if parent_session is None else parent_session
 
     try:
         user = session.scalar(sa.select(User).where(User.id == user_id))
@@ -3870,7 +3853,6 @@ def add_observation_plans(localization_id, user_id, parent_session=None):
     finally:
         if parent_session is None:
             session.close()
-            Session.remove()
 
 
 def add_tiles_properties_contour_and_obsplan(
@@ -3882,13 +3864,7 @@ def add_tiles_properties_contour_and_obsplan(
     properties=None,
     tags=None,
 ):
-    if parent_session is None:
-        if Session.registry.has():
-            session = Session()
-        else:
-            session = Session(bind=DBSession.session_factory.kw["bind"])
-    else:
-        session = parent_session
+    session = new_session() if parent_session is None else parent_session
 
     try:
         add_tiles_and_properties_and_contour(
@@ -3909,7 +3885,6 @@ def add_tiles_properties_contour_and_obsplan(
     finally:
         if parent_session is None:
             session.close()
-            Session.remove()
 
 
 class LocalizationGetQuery(BaseModel):
@@ -4243,10 +4218,7 @@ def add_gcn_summary(
     instrument_ids=None,
     acknowledgements=None,
 ):
-    if Session.registry.has():
-        session = Session()
-    else:
-        session = Session(bind=DBSession.session_factory.kw["bind"])
+    session = new_session()
 
     try:
         user = session.get(User, user_id)
@@ -4851,7 +4823,6 @@ def add_gcn_summary(
         raise e
     finally:
         session.close()
-        Session.remove()
 
 
 class GcnSummaryHandler(BaseHandler):
@@ -5246,10 +5217,7 @@ def add_gcn_report(
     stats_method="python",
     instrument_ids=None,
 ):
-    if Session.registry.has():
-        session = Session()
-    else:
-        session = Session(bind=DBSession.session_factory.kw["bind"])
+    session = new_session()
 
     try:
         user = session.get(User, user_id)
@@ -5498,7 +5466,6 @@ def add_gcn_report(
         raise e
     finally:
         session.close()
-        Session.remove()
 
 
 class GcnReportPostResponse(BaseModel):
@@ -6685,10 +6652,7 @@ def crossmatch_gcn_objects(obj_id, event_ids, user_id, integrated_probability=0.
         Confidence level up to which to perform crossmatch
     """
 
-    if Session.registry.has():
-        session = Session()
-    else:
-        session = Session(bind=DBSession.session_factory.kw["bind"])
+    session = new_session()
 
     user = session.scalar(sa.select(User).where(User.id == user_id))
 
@@ -6807,7 +6771,6 @@ def crossmatch_gcn_objects(obj_id, event_ids, user_id, integrated_probability=0.
         log(f"Unable to generate GCN crossmatch for {obj_id}: {e}")
     finally:
         session.close()
-        Session.remove()
 
 
 class DefaultGcnTagHandler(BaseHandler):

--- a/skyportal/handlers/api/gcn_gracedb.py
+++ b/skyportal/handlers/api/gcn_gracedb.py
@@ -5,7 +5,6 @@ import arrow
 import sqlalchemy as sa
 from ligo.gracedb.rest import GraceDb
 from pydantic import Field
-from sqlalchemy.orm import scoped_session, sessionmaker
 from tornado.ioloop import IOLoop
 
 from baselayer.app.access import permissions
@@ -13,10 +12,8 @@ from baselayer.app.env import load_env
 from baselayer.app.flow import Flow
 from baselayer.log import make_log
 
-from ...models import CommentOnGCN, DBSession, GcnEvent, Group, User
+from ...models import CommentOnGCN, GcnEvent, Group, User, new_session
 from ..base import BaseHandler
-
-Session = scoped_session(sessionmaker())
 
 log = make_log("api/gcn_gracedb")
 
@@ -31,10 +28,7 @@ else:
 
 
 def post_gracedb_data(dateobs, gracedb_id, user_id):
-    if Session.registry.has():
-        session = Session()
-    else:
-        session = Session(bind=DBSession.session_factory.kw["bind"])
+    session = new_session()
 
     try:
         flow = Flow()
@@ -112,7 +106,6 @@ def post_gracedb_data(dateobs, gracedb_id, user_id):
         log(f"Failed to post GraceDB data for {dateobs}: {str(e)}")
     finally:
         session.close()
-        Session.remove()
 
 
 class GcnGraceDBHandler(BaseHandler):

--- a/skyportal/handlers/api/gcn_tach.py
+++ b/skyportal/handlers/api/gcn_tach.py
@@ -6,7 +6,6 @@ import requests
 import sqlalchemy as sa
 from astropy.time import Time
 from pydantic import Field
-from sqlalchemy.orm import scoped_session, sessionmaker
 from sqlalchemy.orm.attributes import flag_modified
 from tornado.ioloop import IOLoop
 
@@ -14,10 +13,8 @@ from baselayer.app.access import auth_or_token, permissions
 from baselayer.app.flow import Flow
 from baselayer.log import make_log
 
-from ...models import DBSession, GcnEvent, User
+from ...models import GcnEvent, User, new_session
 from ..base import BaseHandler
-
-Session = scoped_session(sessionmaker())
 
 log = make_log("api/gcn_tach")
 
@@ -217,10 +214,7 @@ def get_tach_event_aliases(id, gcn_event):
 
 
 def post_aliases(dateobs, tach_id, user_id):
-    if Session.registry.has():
-        session = Session()
-    else:
-        session = Session(bind=DBSession.session_factory.kw["bind"])
+    session = new_session()
 
     try:
         flow = Flow()
@@ -267,7 +261,6 @@ def post_aliases(dateobs, tach_id, user_id):
         log(f"Failed to post aliases for {dateobs}")
     finally:
         session.close()
-        Session.remove()
 
 
 class GcnTachHandler(BaseHandler):

--- a/skyportal/handlers/api/instrument.py
+++ b/skyportal/handlers/api/instrument.py
@@ -1147,7 +1147,7 @@ def add_tiles(
                         )
                     session.add(field)
             session.commit()
-            return
+            return field_ids
 
         # Loop over the telescope tiles and create fields for each.
         # A survey whose footprint rolls between pointings (TESS's cameras roll
@@ -1423,7 +1423,8 @@ def add_tiles(
     finally:
         if own_session:
             session.close()
-        return field_ids
+
+    return field_ids
 
 
 class InstrumentFieldHandler(BaseHandler):

--- a/skyportal/handlers/api/instrument.py
+++ b/skyportal/handlers/api/instrument.py
@@ -16,9 +16,7 @@ from marshmallow.exceptions import ValidationError
 from pydantic import BaseModel, ConfigDict, Field
 from regions import CircleSkyRegion, PolygonSkyRegion, RectangleSkyRegion, Regions
 from sqlalchemy.orm import (
-    scoped_session,
     selectinload,
-    sessionmaker,
     undefer,
 )
 from tornado.ioloop import IOLoop
@@ -40,6 +38,7 @@ from ...models import (
     LocalizationTile,
     Photometry,
     Telescope,
+    new_session,
 )
 from ...utils.asynchronous import run_async
 from ...utils.cache import Cache, array_to_bytes, cache_folder
@@ -55,8 +54,6 @@ cache = Cache(
     max_age=cfg.get("misc.minutes_to_keep_localization_instrument_query_cache", 24 * 60)
     * 60,  # defaults to 1 day
 )
-
-Session = scoped_session(sessionmaker())
 
 
 class InstrumentGetQuery(BaseModel):
@@ -1113,11 +1110,9 @@ def add_tiles(
     session=None,
 ):
     field_ids = []
-    if session is None:
-        if Session.registry.has():
-            session = Session()
-        else:
-            session = Session(bind=DBSession.session_factory.kw["bind"])
+    own_session = session is None
+    if own_session:
+        session = new_session()
 
     try:
         if references is not None:
@@ -1426,7 +1421,8 @@ def add_tiles(
     except Exception as e:
         log(f"Unable to generate fields for instrument {instrument_id}: {e}")
     finally:
-        Session.remove()
+        if own_session:
+            session.close()
         return field_ids
 
 

--- a/skyportal/handlers/api/mpc.py
+++ b/skyportal/handlers/api/mpc.py
@@ -7,7 +7,6 @@ import requests
 from astropy.coordinates import Angle
 from astropy.time import Time
 from pydantic import BaseModel, ConfigDict, Field
-from sqlalchemy.orm import scoped_session, sessionmaker
 from tornado.ioloop import IOLoop
 
 from baselayer.app.access import auth_or_token
@@ -16,16 +15,14 @@ from baselayer.app.flow import Flow
 from baselayer.log import make_log
 
 from ...models import (
-    DBSession,
     Obj,
     User,
+    new_session,
 )
 from ..base import BaseHandler
 
 env, cfg = load_env()
 log = make_log("api/mpc")
-
-Session = scoped_session(sessionmaker())
 
 MPC_ENDPOINT = cfg["app.mpc_endpoint"]
 mpcheck_url = urllib.parse.urljoin(MPC_ENDPOINT, "cgi-bin/mpcheck.cgi")
@@ -178,10 +175,7 @@ def query_mpc(obj_id, user_id, url):
         MPC query URL
     """
 
-    if Session.registry.has():
-        session = Session()
-    else:
-        session = Session(bind=DBSession.session_factory.kw["bind"])
+    session = new_session()
 
     log(f"Querying MPC for {obj_id}: {url}")
 
@@ -231,4 +225,3 @@ def query_mpc(obj_id, user_id, url):
         session.rollback()
     finally:
         session.close()
-        Session.remove()

--- a/skyportal/handlers/api/observation.py
+++ b/skyportal/handlers/api/observation.py
@@ -20,9 +20,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from regions import Regions
 from sqlalchemy.orm import (
     joinedload,
-    scoped_session,
     selectinload,
-    sessionmaker,
     undefer,
 )
 from tornado.ioloop import IOLoop
@@ -35,7 +33,6 @@ from baselayer.log import make_log
 
 from ...models import (
     Allocation,
-    DBSession,
     ExecutedObservation,
     GcnEvent,
     Group,
@@ -48,6 +45,7 @@ from ...models import (
     SurveyEfficiencyForObservationPlan,
     SurveyEfficiencyForObservations,
     Telescope,
+    new_session,
 )
 from ...models.schema import ObservationExternalAPIHandlerPost
 from ...utils.cache import Cache, cache_folder
@@ -75,8 +73,6 @@ env, cfg = load_env()
 
 log = make_log("api/observation")
 
-Session = scoped_session(sessionmaker())
-
 cache_dir = f"{cache_folder}/localization_instrument_queries"
 cache = Cache(
     cache_dir=cache_dir,
@@ -96,10 +92,7 @@ def add_queued_observations(instrument_id, obstable):
         A dataframe returned from the ZTF scheduler queue
     """
 
-    if Session.registry.has():
-        session = Session()
-    else:
-        session = Session(bind=DBSession.session_factory.kw["bind"])
+    session = new_session()
 
     # Schedulers that report pointings by position (e.g. Rubin ObsLocTAP) rather
     # than a fixed field grid: create the fields on the fly, as add_observations does.
@@ -157,7 +150,6 @@ def add_queued_observations(instrument_id, obstable):
         )
     finally:
         session.close()
-        Session.remove()
 
 
 def add_observations(instrument_id, obstable):
@@ -179,10 +171,7 @@ def add_observations(instrument_id, obstable):
 4   ztfr                 1.0    None
      """
 
-    if Session.registry.has():
-        session = Session()
-    else:
-        session = Session(bind=DBSession.session_factory.kw["bind"])
+    session = new_session()
 
     # if the fields do not yet exist, we need to add them
     if ("RA" in obstable) and ("Dec" in obstable) and not ("field_id" in obstable):
@@ -293,7 +282,6 @@ def add_observations(instrument_id, obstable):
         return log(f"Unable to add observations for instrument {instrument_id}: {e}")
     finally:
         session.close()
-        Session.remove()
 
 
 @format_doc(MAX_OBSERVATIONS=MAX_OBSERVATIONS)
@@ -2391,7 +2379,7 @@ class ObservationSimSurveyHandler(BaseHandler):
             instrument_id_final = instrument.id
 
             def _run_simsurvey():
-                sync_session = Session(bind=DBSession.session_factory.kw["bind"])
+                sync_session = new_session()
                 try:
                     sync_session.user_or_token = self.current_user
                     retrieve_observations_and_simsurvey(
@@ -2405,7 +2393,6 @@ class ObservationSimSurveyHandler(BaseHandler):
                     )
                 finally:
                     sync_session.close()
-                    Session.remove()
 
             IOLoop.current().run_in_executor(None, _run_simsurvey)
 

--- a/skyportal/handlers/api/observation_plan.py
+++ b/skyportal/handlers/api/observation_plan.py
@@ -53,9 +53,7 @@ from sncosmo import get_bandpass
 from sqlalchemy import func
 from sqlalchemy.orm import (
     joinedload,
-    scoped_session,
     selectinload,
-    sessionmaker,
     undefer,
 )
 from tornado.ioloop import IOLoop
@@ -75,7 +73,6 @@ from skyportal.utils.observation_plan import (
 
 from ...models import (
     Allocation,
-    DBSession,
     DefaultObservationPlanRequest,
     EventObservationPlan,
     GcnEvent,
@@ -90,6 +87,7 @@ from ...models import (
     SurveyEfficiencyForObservations,
     Telescope,
     User,
+    new_session,
 )
 from ...models.schema import ObservationPlanPost
 from ...utils.earthquake import COUNTRIES_FILE
@@ -192,8 +190,6 @@ op_options = [
     "ge",
     "gt",
 ]
-
-Session = scoped_session(sessionmaker())
 
 MAX_OBSERVATION_PLAN_REQUESTS = 1000
 
@@ -3090,10 +3086,7 @@ def observation_simsurvey(
         Optional parameters to specify the injection type, along with a list of possible values (to be used in a dropdown UI)
     """
 
-    if Session.registry.has():
-        session = Session()
-    else:
-        session = Session(bind=DBSession.session_factory.kw["bind"])
+    session = new_session()
 
     try:
         localization = session.scalars(
@@ -3349,7 +3342,6 @@ def observation_simsurvey(
         )
     finally:
         session.close()
-        Session.remove()
 
 
 def observation_simsurvey_plot(

--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -36,9 +36,7 @@ from matplotlib import dates
 from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import func, or_
 from sqlalchemy.orm import (
-    scoped_session,
     selectinload,
-    sessionmaker,
 )
 from sqlalchemy.orm.attributes import set_committed_value
 from sqlalchemy.sql import bindparam, text
@@ -134,8 +132,6 @@ PHOT_DETECTION_THRESHOLD = cfg["misc.photometry_detection_threshold_nsigma"]
 log = make_log("api/source")
 
 MAX_LOCALIZATION_SOURCES = 50000
-
-Session = scoped_session(sessionmaker())
 
 
 def confirmed_in_gcn_status_to_str(status):

--- a/skyportal/handlers/api/spatial_catalog.py
+++ b/skyportal/handlers/api/spatial_catalog.py
@@ -7,7 +7,7 @@ import pandas as pd
 import sqlalchemy as sa
 from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import func
-from sqlalchemy.orm import scoped_session, selectinload, sessionmaker
+from sqlalchemy.orm import selectinload
 from tornado.ioloop import IOLoop
 
 from baselayer.app.access import auth_or_token, permissions
@@ -15,10 +15,10 @@ from baselayer.app.flow import Flow
 from baselayer.log import make_log
 
 from ...models import (
-    DBSession,
     SpatialCatalog,
     SpatialCatalogEntry,
     SpatialCatalogEntryTile,
+    new_session,
 )
 from ...utils.gcn import (
     from_cone,
@@ -28,8 +28,6 @@ from ..base import BaseHandler
 
 log = make_log("api/spatial_catalog")
 
-Session = scoped_session(sessionmaker())
-
 MAX_SPATIAL_CATALOG_ENTRIES = 1000
 
 
@@ -37,10 +35,7 @@ def add_catalog(catalog_id, catalog_data):
     log(f"Generating catalog with ID {catalog_id}")
     start = time.time()
 
-    if Session.registry.has():
-        session = Session()
-    else:
-        session = Session(bind=DBSession.session_factory.kw["bind"])
+    session = new_session()
 
     try:
         entries = []
@@ -118,16 +113,12 @@ def add_catalog(catalog_id, catalog_data):
         log(f"Unable to generate catalog: {e}")
     finally:
         session.close()
-        Session.remove()
 
 
 def delete_catalog(catalog_id):
     log(f"Deleting catalog with ID {catalog_id}")
 
-    if Session.registry.has():
-        session = Session()
-    else:
-        session = Session(bind=DBSession.session_factory.kw["bind"])
+    session = new_session()
 
     try:
         catalog = session.scalar(
@@ -147,7 +138,6 @@ def delete_catalog(catalog_id):
         log(f"Unable to delete catalog: {e}")
     finally:
         session.close()
-        Session.remove()
 
 
 class SpatialCatalogGetQuery(BaseModel):

--- a/skyportal/handlers/public/report.py
+++ b/skyportal/handlers/public/report.py
@@ -1,18 +1,16 @@
 import numpy as np
 import sqlalchemy as sa
-from sqlalchemy.orm import scoped_session, sessionmaker
 
 from baselayer.app.env import load_env
+from baselayer.app.models import DBSession
 from baselayer.log import make_log
 
-from ...models import DBSession, GcnReport
+from ...models import GcnReport
 from ...utils.cache import Cache, cache_folder
 from ..base import BaseHandler
 
 log = make_log("api/galaxy")
 env, cfg = load_env()
-
-Session = scoped_session(sessionmaker())
 
 cache_dir = f"{cache_folder}/public_pages/reports"
 cache = Cache(
@@ -53,20 +51,16 @@ class ReportHandler(BaseHandler):
             cache_key = f"{report_type}_{report_id}"
             cached = cache[cache_key]
             if cached is None:
-                if Session.registry.has():
-                    session = Session()
-                else:
-                    session = Session(bind=DBSession.session_factory.kw["bind"])
-
-                # if report_type == "gcn":
-                report = session.scalar(
-                    sa.select(GcnReport).where(GcnReport.id == report_id)
-                )
-                if report is None:
-                    return self.error(f"Could not load GCN report {report_id}")
-                if not report.published:
-                    return self.error(f"GCN report {report_id} not yet published")
-                report.generate_report()
+                with DBSession() as session:
+                    # if report_type == "gcn":
+                    report = session.scalar(
+                        sa.select(GcnReport).where(GcnReport.id == report_id)
+                    )
+                    if report is None:
+                        return self.error(f"Could not load GCN report {report_id}")
+                    if not report.published:
+                        return self.error(f"GCN report {report_id} not yet published")
+                    report.generate_report()
                 cached = cache[cache_key]
 
             data = np.load(cached, allow_pickle=True)
@@ -81,24 +75,21 @@ class ReportHandler(BaseHandler):
             else:
                 return self.error(f"Report {report_id} not yet published")
         else:
-            if Session.registry.has():
-                session = Session()
-            else:
-                session = Session(bind=DBSession.session_factory.kw["bind"])
-
-            if report_type == "gcn":
-                reports = session.scalars(
-                    sa.select(GcnReport)
-                    .where(GcnReport.published.is_(True))
-                    .order_by(GcnReport.dateobs.desc())
-                ).all()
-                reports = [
-                    {
-                        **report.to_dict(),
-                        "group_name": report.group.name,
-                    }
-                    for report in reports
-                ]
-                return self.render(
-                    "public_pages/reports/gcn_reports_template.html", reports=reports
-                )
+            with DBSession() as session:
+                if report_type == "gcn":
+                    reports = session.scalars(
+                        sa.select(GcnReport)
+                        .where(GcnReport.published.is_(True))
+                        .order_by(GcnReport.dateobs.desc())
+                    ).all()
+                    reports = [
+                        {
+                            **report.to_dict(),
+                            "group_name": report.group.name,
+                        }
+                        for report in reports
+                    ]
+                    return self.render(
+                        "public_pages/reports/gcn_reports_template.html",
+                        reports=reports,
+                    )

--- a/skyportal/utils/observation_plan.py
+++ b/skyportal/utils/observation_plan.py
@@ -13,7 +13,6 @@ from astropy.coordinates import SkyCoord
 from astropy.time import Time
 from ligo.skymap.bayestar import derasterize, rasterize
 from regions import Regions
-from sqlalchemy.orm import scoped_session, sessionmaker
 
 from baselayer.app.env import load_env
 from baselayer.app.flow import Flow
@@ -343,7 +342,6 @@ def generate_plan(
     from skyportal.handlers.api.instrument import add_tiles
 
     from ..models import (
-        DBSession,
         EventObservationPlan,
         InstrumentField,
         InstrumentFieldTile,
@@ -351,13 +349,10 @@ def generate_plan(
         ObservationPlanRequest,
         PlannedObservation,
         User,
+        new_session,
     )
 
-    Session = scoped_session(sessionmaker())
-    if Session.registry.has():
-        session = Session()
-    else:
-        session = Session(bind=DBSession.session_factory.kw["bind"])
+    session = new_session()
 
     plans, requests = [], []
     observation_plan_id_strings = [str(x) for x in observation_plan_ids]
@@ -368,7 +363,6 @@ def generate_plan(
             f"Creating observation plan(s) for ID(s): {','.join(observation_plan_id_strings)}"
         )
 
-        session = Session()
         for observation_plan_id, request_id in zip(observation_plan_ids, request_ids):
             plan = session.get(EventObservationPlan, observation_plan_id)
             request = session.get(ObservationPlanRequest, request_id)
@@ -945,7 +939,6 @@ def generate_plan(
         session.commit()
 
     session.close()
-    Session.remove()
 
 
 def convert_plan_to_rubin_format(plan):


### PR DESCRIPTION
Reopens #6470, which was merged by mistake.

Uses the two helpers added in cesium-ml/baselayer#449, and removes the session
setup that every background job was writing by hand.

- 29 jobs built their session with the same block: a `Session =
  scoped_session(sessionmaker())` of their own, an `if Session.registry.has()`
  test, and `Session(bind=DBSession.session_factory.kw["bind"])`. They all call
  `new_session()` now.
- The `if Session.registry.has()` branch never ran. A fresh
  `scoped_session(sessionmaker())` has an empty registry, so every call took the
  `else`.
- Removes the 21 `Session` objects, one per file, and the `Session.remove()`
  calls that went with them. Each file had its own registry, so they shared
  nothing with each other. Two of those objects, in `handlers/api/source.py` and
  in the TNS queue service, were not used at all.
- The four catalog jobs in `handlers/api/catalog_services.py` never closed their
  session. They close it in a `finally` now.
- `handlers/api/instrument.py`: `add_tiles` closes the session only when it
  opened one itself, so a session passed in by the caller stays open.
- `handlers/public/report.py` runs inside a request, so it uses
  `with DBSession() as session:` like the other public pages. The request already
  has its own session and the handler closes it.
- `app_server.py` asks `db_engine()` for the engine instead of reading it from
  the session factory.